### PR TITLE
ビューポート外リソースの遅延読み込みと先読み最適化

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1139,7 +1139,7 @@ void App::EvictOffscreenBitmaps()
     }
 
     // 画像: DiagramEntry のビットマップ参照のみ解放する。
-    // ImageLoader キャッシュは LRU（kMaxCacheEntries=16）に管理を委ね、
+    // ImageLoader キャッシュは LRU（kMaxCacheEntries）に管理を委ね、
     // スクロールで再び可視範囲に入った際に GetCachedImage() で
     // ディスクI/O なしに即座に再適用できるようにする。
     for (size_t i : doc_.GetImageNodeIndices()) {

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -660,7 +660,7 @@ void App::DoLoadMarkdownFile()
         LoadImages();
     }
     {
-        MENDO_PROFILE("RequestMermaidRenders(visible)");
+        MENDO_PROFILE("RequestMermaidRenders");
         RequestMermaidRenders();
     }
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -656,7 +656,7 @@ void App::DoLoadMarkdownFile()
     }
     {
         MENDO_PROFILE("RequestMermaidRenders(visible)");
-        RequestMermaidRenders(true);
+        RequestMermaidRenders();
     }
 
     // キャッシュ適用後にスクロール範囲を確定
@@ -784,7 +784,7 @@ void App::DoReloadCurrentFile()
 
     // キャッシュ済み画像/Mermaidを適用してY位置を正確にする
     LoadImages();
-    RequestMermaidRenders(true);
+    RequestMermaidRenders();
 
     SyncMaxScroll(md_height);
     UpdateScrollBar();
@@ -828,6 +828,12 @@ int App::ApplyCachedImages()
         return 0;
     }
 
+    const float viewport_top = viewport_.GetScrollY();
+    const float viewport_height = GetPaneLayout().md_rect.height;
+    const float buffer = viewport_height * PREFETCH_BUFFER_SCREENS;
+    const float range_top = viewport_top - buffer;
+    const float range_bottom = viewport_top + viewport_height + buffer;
+
     int applied = 0;
     auto& nodes = doc_.GetNodesMut();
     for (size_t i : doc_.GetImageNodeIndices()) {
@@ -838,6 +844,10 @@ int App::ApplyCachedImages()
         }
 
         if (!node.has_image() || node.image_data->src.find(L"://") != std::pmr::wstring::npos) {
+            continue;
+        }
+
+        if (viewport_height > 0.0f && IsOffscreen(layout_cache_[i].y_position, layout_cache_[i].height, range_top, range_bottom)) {
             continue;
         }
 
@@ -887,6 +897,7 @@ int App::ApplyCachedImages()
 
 void App::LoadImages()
 {
+    // ビューポート付近の画像のみ読み込み、遠方の画像はスクロール時に遅延読み込みする
     if (ApplyCachedImages() > 0) {
         layout_service_->RecomputeAfterDiagram(doc_, layout_cache_, renderer_.GetTheme());
         Invalidate();
@@ -900,6 +911,7 @@ void App::OnAppImageLoaded()
 
 void App::OnImageLoadComplete()
 {
+    // ビューポート付近の画像のみ反映し、遠方のノードへの再読み込み連鎖を防ぐ
     if (ApplyCachedImages() > 0) {
         const auto anchor = SaveAnchor();
         layout_service_->RecomputeAfterDiagram(doc_, layout_cache_, renderer_.GetTheme());
@@ -909,7 +921,7 @@ void App::OnImageLoadComplete()
     }
 }
 
-void App::RequestMermaidRenders(bool visible_only)
+void App::RequestMermaidRenders()
 {
     const float viewport_width = GetMarkdownPaneWidth();
     const float content_width = renderer_.GetTheme().ContentWidth(viewport_width);
@@ -945,9 +957,9 @@ void App::RequestMermaidRenders(bool visible_only)
     }
     last_mermaid_content_width_ = content_width;
 
-    // visible_only: ファイルキャッシュLookup（ディスクI/O+WICデコード）が重いため、
-    // 初回ロード/リロード時は可視範囲のMermaidノードのみ処理し、
-    // 残りは遅延レイアウト完了後に処理する。
+    // 可視範囲のMermaidノードのみ処理する。
+    // ファイルキャッシュLookup（ディスクI/O+WICデコード）が重いため、
+    // 遠方のノードはスクロール時に遅延読み込みする。
     const float viewport_top = viewport_.GetScrollY();
     const float viewport_bottom = viewport_top + GetPaneLayout().md_rect.height;
 
@@ -958,12 +970,8 @@ void App::RequestMermaidRenders(bool visible_only)
             continue;
         }
 
-        if (visible_only) {
-            const float y = layout_cache_[i].y_position;
-            const float h = layout_cache_[i].height;
-            if (y + h < viewport_top || y > viewport_bottom) {
-                continue;
-            }
+        if (IsOffscreen(layout_cache_[i].y_position, layout_cache_[i].height, viewport_top, viewport_bottom)) {
+            continue;
         }
 
         mermaid_renderer_.RequestRender(node, layout_cache_[i], diagram,
@@ -1008,6 +1016,12 @@ void App::ProcessMermaidBatch()
         return;
     }
 
+    const float viewport_top = viewport_.GetScrollY();
+    const float viewport_height = GetPaneLayout().md_rect.height;
+    const float buffer = viewport_height * EVICT_BUFFER_SCREENS;
+    const float range_top = viewport_top - buffer;
+    const float range_bottom = viewport_top + viewport_height + buffer;
+
     const bool dark_mode = theme_service_.IsDarkMode();
     const auto& indices = doc_.GetMermaidNodeIndices();
     const auto anchor = SaveAnchor();
@@ -1020,6 +1034,12 @@ void App::ProcessMermaidBatch()
     mermaid_batch_loading_ = true;
     while (mermaid_batch_next_ < indices.size()) {
         const size_t i = indices[mermaid_batch_next_];
+
+        if (viewport_height > 0.0f && IsOffscreen(layout_cache_[i].y_position, layout_cache_[i].height, range_top, range_bottom)) {
+            mermaid_batch_next_++;
+            continue;
+        }
+
         auto& node = doc_.GetNodesMut()[i];
         auto& diagram = layout_cache_.GetDiagram(i);
 
@@ -1052,6 +1072,111 @@ void App::ProcessMermaidBatch()
     if (mermaid_batch_next_ >= indices.size()) {
         KillTimer(hwnd_, TIMER_MERMAID_BATCH);
     }
+}
+
+// ============================================================
+// ビューポート外リソースの解放 / 再読み込み
+// ============================================================
+
+void App::EvictOffscreenBitmaps()
+{
+    const float viewport_top = viewport_.GetScrollY();
+    const float viewport_height = GetPaneLayout().md_rect.height;
+    if (viewport_height <= 0.0f) {
+        return;
+    }
+
+    const float buffer = viewport_height * EVICT_BUFFER_SCREENS;
+    const float evict_top = viewport_top - buffer;
+    const float evict_bottom = viewport_top + viewport_height + buffer;
+
+    const size_t node_count = doc_.GetNodes().size();
+
+    // テキストレイアウトの解放（最大のメモリ消費源）
+    // y_position と height は保持し、layout_dirty を設定する。
+    // スクロール時に EnsureVisibleLayout で再作成される。
+    // 二分探索で保持範囲の前後のみ走査する。
+    const int first_keep = FindFirstVisibleNodeIndex(layout_cache_, node_count, evict_top);
+    int last_keep = first_keep;
+    for (int i = first_keep; i < static_cast<int>(node_count); i++) {
+        if (layout_cache_[i].y_position > evict_bottom) {
+            break;
+        }
+        last_keep = i + 1;
+    }
+
+    auto evict_text_layout = [&](size_t i) {
+        auto& entry = layout_cache_[i];
+        if (!entry.text_layout && entry.cell_layouts.empty()) {
+            return;
+        }
+        entry.text_layout.Reset();
+        entry.effects_applied = false;
+        entry.inline_code_bgs.clear();
+        entry.cell_layouts.clear();
+        entry.cell_inline_code_bgs.clear();
+        entry.layout_dirty = true;
+    };
+
+    for (size_t i = 0; i < static_cast<size_t>(first_keep); i++) {
+        evict_text_layout(i);
+    }
+    for (size_t i = static_cast<size_t>(last_keep); i < node_count; i++) {
+        evict_text_layout(i);
+    }
+
+    // 画像: DiagramEntry と ImageLoader キャッシュの両方から解放
+    for (size_t i : doc_.GetImageNodeIndices()) {
+        auto& diagram = layout_cache_.GetDiagram(i);
+        if (!diagram.bitmap) {
+            continue;
+        }
+        if (IsOffscreen(layout_cache_[i].y_position, layout_cache_[i].height, evict_top, evict_bottom)) {
+            diagram.bitmap.Reset();
+            const auto path_it = resolved_image_paths_.find(i);
+            if (path_it != resolved_image_paths_.end()) {
+                image_loader_.RemoveCached(path_it->second);
+            }
+        }
+    }
+
+    // Mermaid: DiagramEntry を解放し、メモリキャッシュ全体をクリア
+    bool any_mermaid_evicted = false;
+    for (size_t i : doc_.GetMermaidNodeIndices()) {
+        auto& diagram = layout_cache_.GetDiagram(i);
+        if (!diagram.bitmap) {
+            continue;
+        }
+        if (IsOffscreen(layout_cache_[i].y_position, layout_cache_[i].height, evict_top, evict_bottom)) {
+            diagram.bitmap.Reset();
+            any_mermaid_evicted = true;
+        }
+    }
+    if (any_mermaid_evicted) {
+        // メモリキャッシュをクリア。可視ノードの DiagramEntry は ComPtr で
+        // ビットマップを保持し続けるため、表示には影響しない。
+        // ファイルキャッシュがバックアップとして機能する。
+        mermaid_renderer_.ClearCache();
+    }
+}
+
+void App::ScheduleBitmapManage()
+{
+    SetTimer(hwnd_, TIMER_BITMAP_MANAGE, 150, nullptr);
+}
+
+void App::OnBitmapManageTimer()
+{
+    KillTimer(hwnd_, TIMER_BITMAP_MANAGE);
+
+    EvictOffscreenBitmaps();
+
+    if (ApplyCachedImages() > 0) {
+        layout_service_->RecomputeAfterDiagram(doc_, layout_cache_, renderer_.GetTheme());
+    }
+    RequestMermaidRenders();     // Mermaid: 可視範囲のみ（メモリ/ファイルキャッシュ経由）
+
+    Invalidate();
 }
 
 // ============================================================
@@ -1138,6 +1263,7 @@ void App::ExecuteActions(const ActionList& actions)
                 if (viewport_.GetScrollY() != old_scroll) {
                     InvalidateHitPositions();
                     Invalidate();
+                    ScheduleBitmapManage();
                 }
             },
             [this](const DirectScrollByAction& a) {
@@ -1145,6 +1271,7 @@ void App::ExecuteActions(const ActionList& actions)
                 viewport_.DirectScrollBy(a.delta);
                 InvalidateHitPositions();
                 Invalidate();
+                ScheduleBitmapManage();
             },
             [this](const ScrollPaneAction& a) {
                 const auto pane_layout = GetPaneLayout();
@@ -1325,6 +1452,9 @@ void App::HandleTimer(UINT_PTR timer_id)
     case TIMER_MERMAID_BATCH:
         ProcessMermaidBatch();
         break;
+    case TIMER_BITMAP_MANAGE:
+        OnBitmapManageTimer();
+        break;
     default: break;
     }
 }
@@ -1371,6 +1501,7 @@ void App::OnDestroy()
     KillTimer(hwnd_, TIMER_SEARCH_CARET);
     KillTimer(hwnd_, TIMER_SEARCH_DEBOUNCE);
     KillTimer(hwnd_, TIMER_TOOLTIP);
+    KillTimer(hwnd_, TIMER_BITMAP_MANAGE);
     KillTimer(hwnd_, TIMER_MERMAID_BATCH);
 }
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -357,6 +357,11 @@ void App::OnPaint()
 
     const auto& layout = GetPaneLayout();
     if (!file_load_service_.IsLoading()) {
+        // 完了済みデコード結果とキャッシュ済みリソースを描画前に適用する。
+        // WM_APP_IMAGE_LOADED が WM_PAINT より後にキューされている場合でも
+        // プレースホルダーの表示を回避できる。
+        FlushPendingResources();
+
         // 現在表示中のダーティなノードを現在の幅でレイアウトする
         const auto anchor = SaveAnchor();
 
@@ -921,7 +926,7 @@ void App::OnImageLoadComplete()
     }
 }
 
-void App::RequestMermaidRenders()
+int App::RequestMermaidRenders()
 {
     const float viewport_width = GetMarkdownPaneWidth();
     const float content_width = renderer_.GetTheme().ContentWidth(viewport_width);
@@ -930,7 +935,7 @@ void App::RequestMermaidRenders()
     // 不正な幅でレンダリングしないようスキップする。
     // last_mermaid_content_width_ を更新しないことで、復帰時の幅変更検出を正しく保つ。
     if (content_width <= 0.0f) {
-        return;
+        return 0;
     }
 
     if (last_mermaid_content_width_ > 0.0f &&
@@ -957,12 +962,16 @@ void App::RequestMermaidRenders()
     }
     last_mermaid_content_width_ = content_width;
 
-    // 可視範囲のMermaidノードのみ処理する。
-    // ファイルキャッシュLookup（ディスクI/O+WICデコード）が重いため、
-    // 遠方のノードはスクロール時に遅延読み込みする。
+    // 先読みバッファ付きで Mermaid ノードを処理する。
+    // メモリキャッシュ・ファイルキャッシュヒット時は同期的に適用されるため、
+    // ビューポートに入る前に描画を完了できる。
     const float viewport_top = viewport_.GetScrollY();
-    const float viewport_bottom = viewport_top + GetPaneLayout().md_rect.height;
+    const float viewport_height = GetPaneLayout().md_rect.height;
+    const float buffer = viewport_height * PREFETCH_BUFFER_SCREENS;
+    const float range_top = viewport_top - buffer;
+    const float range_bottom = viewport_top + viewport_height + buffer;
 
+    int applied = 0;
     for (size_t i : doc_.GetMermaidNodeIndices()) {
         auto& node = doc_.GetNodesMut()[i];
         auto& diagram = layout_cache_.GetDiagram(i);
@@ -970,7 +979,7 @@ void App::RequestMermaidRenders()
             continue;
         }
 
-        if (IsOffscreen(layout_cache_[i].y_position, layout_cache_[i].height, viewport_top, viewport_bottom)) {
+        if (viewport_height > 0.0f && IsOffscreen(layout_cache_[i].y_position, layout_cache_[i].height, range_top, range_bottom)) {
             continue;
         }
 
@@ -978,7 +987,11 @@ void App::RequestMermaidRenders()
             content_width, theme_service_.IsDarkMode(),
             [](void* ctx) static { static_cast<App*>(ctx)->OnMermaidRenderComplete(); },
             this);
+        if (diagram.bitmap) {
+            ++applied;
+        }
     }
+    return applied;
 }
 
 void App::OnMermaidRenderComplete()
@@ -1125,7 +1138,10 @@ void App::EvictOffscreenBitmaps()
         evict_text_layout(i);
     }
 
-    // 画像: DiagramEntry と ImageLoader キャッシュの両方から解放
+    // 画像: DiagramEntry のビットマップ参照のみ解放する。
+    // ImageLoader キャッシュは LRU（kMaxCacheEntries=16）に管理を委ね、
+    // スクロールで再び可視範囲に入った際に GetCachedImage() で
+    // ディスクI/O なしに即座に再適用できるようにする。
     for (size_t i : doc_.GetImageNodeIndices()) {
         auto& diagram = layout_cache_.GetDiagram(i);
         if (!diagram.bitmap) {
@@ -1133,10 +1149,6 @@ void App::EvictOffscreenBitmaps()
         }
         if (IsOffscreen(layout_cache_[i].y_position, layout_cache_[i].height, evict_top, evict_bottom)) {
             diagram.bitmap.Reset();
-            const auto path_it = resolved_image_paths_.find(i);
-            if (path_it != resolved_image_paths_.end()) {
-                image_loader_.RemoveCached(path_it->second);
-            }
         }
     }
 
@@ -1160,8 +1172,30 @@ void App::EvictOffscreenBitmaps()
     }
 }
 
+void App::FlushPendingResources()
+{
+    // 完了した非同期画像デコードを ImageLoader キャッシュに反映
+    image_loader_.ProcessCompletedDecodes();
+
+    bool changed = (ApplyCachedImages() > 0);
+
+    // Mermaid のキャッシュヒット時コールバック (OnMermaidRenderComplete) が
+    // ヒットごとに RecomputeAfterDiagram を呼ぶのを抑制し、一括で処理する
+    mermaid_batch_loading_ = true;
+    changed |= (RequestMermaidRenders() > 0);
+    mermaid_batch_loading_ = false;
+
+    if (changed) {
+        layout_service_->RecomputeAfterDiagram(doc_, layout_cache_, renderer_.GetTheme());
+    }
+}
+
 void App::ScheduleBitmapManage()
 {
+    // デバウンスを待たずに先読み範囲のリソースを即座に適用する。
+    // 連続スクロール中でもキャッシュ済み画像/Mermaid図が次の WM_PAINT で描画される。
+    FlushPendingResources();
+    // エビクションはデバウンスして遅延実行（高頻度で走ると重いため）
     SetTimer(hwnd_, TIMER_BITMAP_MANAGE, 150, nullptr);
 }
 
@@ -1170,11 +1204,7 @@ void App::OnBitmapManageTimer()
     KillTimer(hwnd_, TIMER_BITMAP_MANAGE);
 
     EvictOffscreenBitmaps();
-
-    if (ApplyCachedImages() > 0) {
-        layout_service_->RecomputeAfterDiagram(doc_, layout_cache_, renderer_.GetTheme());
-    }
-    RequestMermaidRenders();     // Mermaid: 可視範囲のみ（メモリ/ファイルキャッシュ経由）
+    FlushPendingResources();
 
     Invalidate();
 }

--- a/src/app.h
+++ b/src/app.h
@@ -220,7 +220,7 @@ private:
     ::PaneZone PaneAtPoint(float dip_x, float dip_y) const;
     float GetMarkdownPaneWidth() const;
 
-    void RequestMermaidRenders(bool visible_only = false);
+    void RequestMermaidRenders();
     void OnMermaidRenderComplete();
     void CancelMermaidBatch();
     void ScheduleMermaidBatch();
@@ -228,6 +228,9 @@ private:
     void LoadImages();
     void OnImageLoadComplete();
     int ApplyCachedImages();
+    void EvictOffscreenBitmaps();
+    void ScheduleBitmapManage();
+    void OnBitmapManageTimer();
 
     // 検索
     void OnSearchOpen();
@@ -264,6 +267,10 @@ public:
     static constexpr UINT_PTR TIMER_TOOLTIP = 8;
     static constexpr UINT_PTR TIMER_SEARCH_DEBOUNCE = 9;
     static constexpr UINT_PTR TIMER_MERMAID_BATCH = 10;
+    static constexpr UINT_PTR TIMER_BITMAP_MANAGE = 11;
+    // ビューポート外リソース解放のバッファ倍率（±N画面）
+    static constexpr float EVICT_BUFFER_SCREENS = 5.0f;     // eviction / 遅延レイアウト: ±5画面 = 計11画面
+    static constexpr float PREFETCH_BUFFER_SCREENS = 3.0f;   // 画像先読み: ±3画面 = 計7画面
     // バッチ処理の時間予算（マイクロ秒）。16msフレーム内でレンダリング等の余地を残す。
     static constexpr int BATCH_TIME_BUDGET_US = 6000;
     static constexpr UINT WM_APP_LOAD_FILE = WM_APP + 1;

--- a/src/app.h
+++ b/src/app.h
@@ -220,7 +220,7 @@ private:
     ::PaneZone PaneAtPoint(float dip_x, float dip_y) const;
     float GetMarkdownPaneWidth() const;
 
-    void RequestMermaidRenders();
+    int RequestMermaidRenders();
     void OnMermaidRenderComplete();
     void CancelMermaidBatch();
     void ScheduleMermaidBatch();
@@ -228,6 +228,7 @@ private:
     void LoadImages();
     void OnImageLoadComplete();
     int ApplyCachedImages();
+    void FlushPendingResources();
     void EvictOffscreenBitmaps();
     void ScheduleBitmapManage();
     void OnBitmapManageTimer();

--- a/src/app_mouse.cpp
+++ b/src/app_mouse.cpp
@@ -517,13 +517,17 @@ void App::OnLButtonUp(int px, int py)
     ReleaseCapture();
 
     if (panes_.GetDragTarget() != PaneController::DragTarget::None) {
-        if (panes_.GetDragTarget() == PaneController::DragTarget::MdScrollbar) {
+        const bool was_md_scrollbar = (panes_.GetDragTarget() == PaneController::DragTarget::MdScrollbar);
+        if (was_md_scrollbar) {
             viewport_.SetScrollbarTracking(false);
         }
         panes_.EndDrag();
         RECT rc;
         GetClientRect(hwnd_, &rc);
         OnResize(static_cast<UINT>(rc.right - rc.left), static_cast<UINT>(rc.bottom - rc.top));
+        if (was_md_scrollbar) {
+            ScheduleBitmapManage();
+        }
         return;
     }
 

--- a/src/app_navigate.cpp
+++ b/src/app_navigate.cpp
@@ -39,6 +39,7 @@ void App::NavigateToAnchor(std::wstring_view anchor)
     viewport_.ScrollTo(target_y);
     UpdateScrollBar();
     InvalidateMdPane(layout.md_rect);
+    ScheduleBitmapManage();
 }
 
 void App::PushNavHistory()
@@ -60,6 +61,7 @@ void App::ApplyNavigateResult(const NavigationService::NavigateResult& result)
     const auto layout = GetPaneLayout();
     UpdateScrollBar();
     InvalidateMdPane(layout.md_rect);
+    ScheduleBitmapManage();
 }
 
 void App::NavigateBack()

--- a/src/app_scroll.cpp
+++ b/src/app_scroll.cpp
@@ -132,7 +132,7 @@ void App::OnDeferredLayout()
     bool more;
     {
         MENDO_PROFILE("ProcessDirtyBatch");
-        more = layout_service_->ProcessDirtyBatch(doc_, layout_cache_, md_width, 200, BATCH_TIME_BUDGET_US);
+        more = layout_service_->ProcessDirtyBatch(doc_, layout_cache_, md_width, 200, BATCH_TIME_BUDGET_US, md_height);
     }
 
 #if MENDO_PROFILE_ENABLED

--- a/src/app_scroll.cpp
+++ b/src/app_scroll.cpp
@@ -132,7 +132,7 @@ void App::OnDeferredLayout()
     bool more;
     {
         MENDO_PROFILE("ProcessDirtyBatch");
-        more = layout_service_->ProcessDirtyBatch(doc_, layout_cache_, md_width, 200, BATCH_TIME_BUDGET_US, md_height);
+        more = layout_service_->ProcessDirtyBatch(doc_, layout_cache_, md_width, 200, BATCH_TIME_BUDGET_US, md_height, EVICT_BUFFER_SCREENS);
     }
 
 #if MENDO_PROFILE_ENABLED

--- a/src/image_loader.cpp
+++ b/src/image_loader.cpp
@@ -313,6 +313,16 @@ void ImageLoader::EvictLruIfNeeded()
     }
 }
 
+void ImageLoader::InsertCacheEntry(const std::wstring& path, float width, float height)
+{
+    CachedImage cached;
+    cached.width = width;
+    cached.height = height;
+    cached.last_access = ++access_counter_;
+    cache_[path] = cached;
+    EvictLruIfNeeded();
+}
+
 void ImageLoader::CancelPending()
 {
     cancel_gen_.fetch_add(1);

--- a/src/image_loader.cpp
+++ b/src/image_loader.cpp
@@ -94,6 +94,7 @@ bool ImageLoader::LoadImage(const std::wstring& abs_path, DiagramEntry& out)
     // キャッシュ確認
     const auto it = cache_.find(abs_path);
     if (it != cache_.end()) {
+        it->second.last_access = ++access_counter_;
         out.bitmap = it->second.bitmap;
         out.width = it->second.width;
         out.height = it->second.height;
@@ -154,7 +155,9 @@ bool ImageLoader::LoadImage(const std::wstring& abs_path, DiagramEntry& out)
     cached.bitmap = bitmap;
     cached.width = static_cast<float>(w) / scale_x;
     cached.height = static_cast<float>(h) / scale_y;
+    cached.last_access = ++access_counter_;
     cache_[abs_path] = cached;
+    EvictLruIfNeeded();
 
     out.bitmap = bitmap;
     out.width = cached.width;
@@ -166,6 +169,7 @@ bool ImageLoader::GetCachedImage(const std::wstring& abs_path, DiagramEntry& out
 {
     const auto it = cache_.find(abs_path);
     if (it != cache_.end()) {
+        it->second.last_access = ++access_counter_;
         out.bitmap = it->second.bitmap;
         out.width = it->second.width;
         out.height = it->second.height;
@@ -279,6 +283,7 @@ void ImageLoader::ProcessCompletedDecodes()
                     cached.bitmap = bitmap;
                     cached.width = r.width / scale_x;
                     cached.height = r.height / scale_y;
+                    cached.last_access = ++access_counter_;
                     cache_[r.path] = cached;
                 }
             }
@@ -288,8 +293,23 @@ void ImageLoader::ProcessCompletedDecodes()
         last_data = r.user_data;
     }
 
+    EvictLruIfNeeded();
+
     if (last_cb) {
         last_cb(last_data);
+    }
+}
+
+void ImageLoader::EvictLruIfNeeded()
+{
+    while (cache_.size() > kMaxCacheEntries) {
+        auto oldest = cache_.begin();
+        for (auto it = cache_.begin(); it != cache_.end(); ++it) {
+            if (it->second.last_access < oldest->second.last_access) {
+                oldest = it;
+            }
+        }
+        cache_.erase(oldest);
     }
 }
 

--- a/src/image_loader.h
+++ b/src/image_loader.h
@@ -45,6 +45,7 @@ public:
     void CancelPending();
 
     void ClearCache() noexcept { cache_.clear(); }
+    void RemoveCached(const std::wstring& abs_path) { cache_.erase(abs_path); }
 
     // 保留中のリクエストをキャンセルする（CancelPendingと同等）。
     void Shutdown();
@@ -54,6 +55,7 @@ private:
         Microsoft::WRL::ComPtr<ID2D1Bitmap> bitmap;
         float width = 0.0f;
         float height = 0.0f;
+        mutable uint64_t last_access = 0;
     };
 
     struct DecodeResult {
@@ -67,10 +69,14 @@ private:
     };
 
     void GetDpiScale(float& scale_x, float& scale_y) const;
+    void EvictLruIfNeeded();
+
+    static constexpr size_t kMaxCacheEntries = 16;
 
     Microsoft::WRL::ComPtr<IWICImagingFactory> wic_factory_;
     ID2D1RenderTarget* render_target_ = nullptr;
     std::unordered_map<std::wstring, CachedImage> cache_;
+    mutable uint64_t access_counter_ = 0;
 
     // 非同期読み込み
     HWND hwnd_ = nullptr;

--- a/src/image_loader.h
+++ b/src/image_loader.h
@@ -46,6 +46,10 @@ public:
 
     void ClearCache() noexcept { cache_.clear(); }
     void RemoveCached(const std::wstring& abs_path) { cache_.erase(abs_path); }
+    size_t CacheSize() const noexcept { return cache_.size(); }
+
+    // テスト用: ビットマップなしのダミーエントリをキャッシュに挿入する。
+    void InsertCacheEntry(const std::wstring& path, float width, float height);
 
     // 保留中のリクエストをキャンセルする（CancelPendingと同等）。
     void Shutdown();

--- a/src/image_loader.h
+++ b/src/image_loader.h
@@ -71,7 +71,7 @@ private:
     void GetDpiScale(float& scale_x, float& scale_y) const;
     void EvictLruIfNeeded();
 
-    static constexpr size_t kMaxCacheEntries = 16;
+    static constexpr size_t kMaxCacheEntries = 128;
 
     Microsoft::WRL::ComPtr<IWICImagingFactory> wic_factory_;
     ID2D1RenderTarget* render_target_ = nullptr;
@@ -82,7 +82,7 @@ private:
     HWND hwnd_ = nullptr;
     UINT msg_id_ = 0;
     TaskScheduler* scheduler_ = nullptr;
-    std::atomic<uint32_t> cancel_gen_{0};
+    std::atomic<uint32_t> cancel_gen_{ 0 };
     std::mutex pending_mutex_;
     std::unordered_set<std::wstring> pending_paths_;
 

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -345,7 +345,7 @@ bool LayoutEngine::EnsureVisibleLayout(std::pmr::vector<Node>& nodes, LayoutCach
 
 bool LayoutEngine::ProcessDirtyBatch(std::pmr::vector<Node>& nodes, LayoutCache& cache,
     float viewport_width, int batch_size, int time_budget_us,
-    float viewport_top, float viewport_height)
+    float viewport_top, float viewport_height, float buffer_screens)
 {
     const float content_width = theme_->ContentWidth(viewport_width);
     int processed = 0;
@@ -353,8 +353,8 @@ bool LayoutEngine::ProcessDirtyBatch(std::pmr::vector<Node>& nodes, LayoutCache&
     size_t last_processed = 0;
 
     const bool has_viewport_limit = (viewport_top >= 0.0f && viewport_height > 0.0f);
-    const float limit_top = has_viewport_limit ? viewport_top - viewport_height * 5.0f : 0.0f;
-    const float limit_bottom = has_viewport_limit ? viewport_top + viewport_height + viewport_height * 5.0f : 0.0f;
+    const float limit_top = has_viewport_limit ? viewport_top - viewport_height * buffer_screens : 0.0f;
+    const float limit_bottom = has_viewport_limit ? viewport_top + viewport_height + viewport_height * buffer_screens : 0.0f;
 
     const bool has_budget = (time_budget_us > 0);
     const auto start = has_budget ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -344,19 +344,32 @@ bool LayoutEngine::EnsureVisibleLayout(std::pmr::vector<Node>& nodes, LayoutCach
 }
 
 bool LayoutEngine::ProcessDirtyBatch(std::pmr::vector<Node>& nodes, LayoutCache& cache,
-    float viewport_width, int batch_size, int time_budget_us)
+    float viewport_width, int batch_size, int time_budget_us,
+    float viewport_top, float viewport_height)
 {
     const float content_width = theme_->ContentWidth(viewport_width);
     int processed = 0;
     size_t first_dirty = nodes.size();
     size_t last_processed = 0;
 
+    const bool has_viewport_limit = (viewport_top >= 0.0f && viewport_height > 0.0f);
+    const float limit_top = has_viewport_limit ? viewport_top - viewport_height * 5.0f : 0.0f;
+    const float limit_bottom = has_viewport_limit ? viewport_top + viewport_height + viewport_height * 5.0f : 0.0f;
+
     const bool has_budget = (time_budget_us > 0);
     const auto start = has_budget ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
+
+    // メインループ中にビューポート付近にスキップされたダーティノードがあるか追跡する。
+    // 二重 O(n) スキャンを回避するため。
+    bool any_nearby_dirty_skipped = false;
 
     for (size_t i = 0; i < nodes.size(); i++) {
         auto& entry = cache[i];
         if (!entry.layout_dirty) {
+            continue;
+        }
+
+        if (has_viewport_limit && IsOffscreen(entry.y_position, entry.height, limit_top, limit_bottom)) {
             continue;
         }
 
@@ -365,6 +378,7 @@ bool LayoutEngine::ProcessDirtyBatch(std::pmr::vector<Node>& nodes, LayoutCache&
         if (has_budget && processed > 0) {
             const auto elapsed = std::chrono::steady_clock::now() - start;
             if (std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count() >= time_budget_us) {
+                any_nearby_dirty_skipped = true;
                 break;
             }
         }
@@ -377,6 +391,7 @@ bool LayoutEngine::ProcessDirtyBatch(std::pmr::vector<Node>& nodes, LayoutCache&
         last_processed = i;
 
         if (++processed >= batch_size) {
+            any_nearby_dirty_skipped = true;
             break;
         }
     }
@@ -390,6 +405,12 @@ bool LayoutEngine::ProcessDirtyBatch(std::pmr::vector<Node>& nodes, LayoutCache&
     const auto result = RecomputeYPositions(nodes, cache, *theme_, first_dirty, false, last_processed);
     total_height_ = result.total_height;
     has_dirty_nodes_ = result.has_dirty_nodes;
+
+    // ビューポート制限時: 付近のダーティノードが全て処理済みなら完了とみなす。
+    // 遠方のダーティノードはスクロール時に EnsureVisibleLayout で処理される。
+    if (has_viewport_limit && has_dirty_nodes_ && !any_nearby_dirty_skipped) {
+        has_dirty_nodes_ = false;
+    }
 
     // すべてのダーティノードが処理されたら last_viewport_width_ を更新する
     if (!has_dirty_nodes_) {

--- a/src/layout.h
+++ b/src/layout.h
@@ -41,7 +41,8 @@ public:
     void LayoutNodes(std::pmr::vector<Node>& nodes, LayoutCache& cache, float viewport_width);
     bool ProcessDirtyBatch(std::pmr::vector<Node>& nodes, LayoutCache& cache,
         float viewport_width, int batch_size, int time_budget_us = 0,
-        float viewport_top = -1.0f, float viewport_height = -1.0f);
+        float viewport_top = -1.0f, float viewport_height = -1.0f,
+        float buffer_screens = 5.0f);
     bool EnsureVisibleLayout(std::pmr::vector<Node>& nodes, LayoutCache& cache, float viewport_width,
         float viewport_top, float viewport_bottom);
     constexpr bool HasDirtyNodes() const noexcept { return has_dirty_nodes_; }

--- a/src/layout.h
+++ b/src/layout.h
@@ -40,7 +40,8 @@ public:
         float viewport_top = -1.0f, float viewport_bottom = -1.0f);
     void LayoutNodes(std::pmr::vector<Node>& nodes, LayoutCache& cache, float viewport_width);
     bool ProcessDirtyBatch(std::pmr::vector<Node>& nodes, LayoutCache& cache,
-        float viewport_width, int batch_size, int time_budget_us = 0);
+        float viewport_width, int batch_size, int time_budget_us = 0,
+        float viewport_top = -1.0f, float viewport_height = -1.0f);
     bool EnsureVisibleLayout(std::pmr::vector<Node>& nodes, LayoutCache& cache, float viewport_width,
         float viewport_top, float viewport_bottom);
     constexpr bool HasDirtyNodes() const noexcept { return has_dirty_nodes_; }

--- a/src/layout_cache.h
+++ b/src/layout_cache.h
@@ -126,6 +126,13 @@ constexpr float ComputeTotalContentHeight(const LayoutCache& cache, size_t node_
     return cache[last].y_position + cache[last].height + margin_top;
 }
 
+// ノードの Y 範囲 [y, y+h) が [range_top, range_bottom] と重ならない場合 true を返す。
+// ビューポート外判定の共通ヘルパー。
+constexpr bool IsOffscreen(float y, float h, float range_top, float range_bottom) noexcept
+{
+    return y + h < range_top || y > range_bottom;
+}
+
 // 下端が viewport_top 以上の最初のノードを二分探索で見つける。
 // 最初の可視候補ノードのインデックスを返す。該当なしの場合は node_count を返す。
 constexpr int FindFirstVisibleNodeIndex(const LayoutCache& cache, size_t node_count, float viewport_top) noexcept

--- a/src/layout_cache.h
+++ b/src/layout_cache.h
@@ -126,8 +126,8 @@ constexpr float ComputeTotalContentHeight(const LayoutCache& cache, size_t node_
     return cache[last].y_position + cache[last].height + margin_top;
 }
 
-// ノードの Y 範囲 [y, y+h) が [range_top, range_bottom] と重ならない場合 true を返す。
-// ビューポート外判定の共通ヘルパー。
+// ノードの Y 範囲 [y, y+h] が [range_top, range_bottom] と重ならない場合 true を返す。
+// 端が接している場合（y+h == range_top 等）は重なり扱い（false）。
 constexpr bool IsOffscreen(float y, float h, float range_top, float range_bottom) noexcept
 {
     return y + h < range_top || y > range_bottom;

--- a/src/layout_service.cpp
+++ b/src/layout_service.cpp
@@ -7,8 +7,13 @@ void LayoutService::ViewportLayout(Document& doc, LayoutCache& cache, float widt
     engine_.ComputeLayout(doc.GetNodesMut(), cache, width, viewport_top, viewport_bottom);
 }
 
-bool LayoutService::ProcessDirtyBatch(Document& doc, LayoutCache& cache, float width, int batch_size, int time_budget_us)
+bool LayoutService::ProcessDirtyBatch(Document& doc, LayoutCache& cache, float width, int batch_size, int time_budget_us,
+    float viewport_height)
 {
+    if (viewport_height > 0.0f) {
+        const float vp_top = viewport_.GetScrollY();
+        return engine_.ProcessDirtyBatch(doc.GetNodesMut(), cache, width, batch_size, time_budget_us, vp_top, viewport_height);
+    }
     return engine_.ProcessDirtyBatch(doc.GetNodesMut(), cache, width, batch_size, time_budget_us);
 }
 

--- a/src/layout_service.cpp
+++ b/src/layout_service.cpp
@@ -8,11 +8,11 @@ void LayoutService::ViewportLayout(Document& doc, LayoutCache& cache, float widt
 }
 
 bool LayoutService::ProcessDirtyBatch(Document& doc, LayoutCache& cache, float width, int batch_size, int time_budget_us,
-    float viewport_height)
+    float viewport_height, float buffer_screens)
 {
     if (viewport_height > 0.0f) {
         const float vp_top = viewport_.GetScrollY();
-        return engine_.ProcessDirtyBatch(doc.GetNodesMut(), cache, width, batch_size, time_budget_us, vp_top, viewport_height);
+        return engine_.ProcessDirtyBatch(doc.GetNodesMut(), cache, width, batch_size, time_budget_us, vp_top, viewport_height, buffer_screens);
     }
     return engine_.ProcessDirtyBatch(doc.GetNodesMut(), cache, width, batch_size, time_budget_us);
 }

--- a/src/layout_service.h
+++ b/src/layout_service.h
@@ -15,7 +15,9 @@ public:
     void ViewportLayout(Document& doc, LayoutCache& cache, float width, float height);
 
     // ダーティバッチ処理（遅延レイアウト）
-    bool ProcessDirtyBatch(Document& doc, LayoutCache& cache, float width, int batch_size, int time_budget_us = 0);
+    // viewport_height > 0 の場合、ビューポート付近のダーティノードのみ処理する。
+    bool ProcessDirtyBatch(Document& doc, LayoutCache& cache, float width, int batch_size, int time_budget_us = 0,
+        float viewport_height = -1.0f);
 
     // 可視領域のレイアウト保証（OnPaint 時）
     bool EnsureVisibleLayout(Document& doc, LayoutCache& cache, float width, float height);

--- a/src/layout_service.h
+++ b/src/layout_service.h
@@ -17,7 +17,7 @@ public:
     // ダーティバッチ処理（遅延レイアウト）
     // viewport_height > 0 の場合、ビューポート付近のダーティノードのみ処理する。
     bool ProcessDirtyBatch(Document& doc, LayoutCache& cache, float width, int batch_size, int time_budget_us = 0,
-        float viewport_height = -1.0f);
+        float viewport_height = -1.0f, float buffer_screens = 5.0f);
 
     // 可視領域のレイアウト保証（OnPaint 時）
     bool EnsureVisibleLayout(Document& doc, LayoutCache& cache, float width, float height);

--- a/src/mermaid.cpp
+++ b/src/mermaid.cpp
@@ -12,7 +12,7 @@
 #pragma comment(lib, "windowscodecs.lib")
 #pragma comment(lib, "shlwapi.lib")
 
-static constexpr size_t MAX_CACHE_ENTRIES = 4096;
+static constexpr size_t MAX_CACHE_ENTRIES = 64;
 
 static std::span<const std::byte> LoadMermaidJsGzFromResource()
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(mendo_tests
     test_help.cpp
     test_search_state.cpp
     test_locale.cpp
+    test_memory_eviction.cpp
 )
 
 target_link_libraries(mendo_tests PRIVATE

--- a/tests/test_memory_eviction.cpp
+++ b/tests/test_memory_eviction.cpp
@@ -1,0 +1,263 @@
+#include <gtest/gtest.h>
+#include <memory_resource>
+#include "image_loader.h"
+#include "layout_cache.h"
+#include "layout.h"
+#include "parser.h"
+#include "mock_text_measurer.h"
+
+// ============================================================
+// ImageLoader LRU キャッシュテスト
+// ============================================================
+
+class ImageLoaderLruTest : public ::testing::Test {
+protected:
+    ImageLoader loader_;
+
+    void SetUp() override
+    {
+        // キャッシュの LRU 動作テストでは GetCachedImage / RemoveCached のみ使用。
+        // レンダーターゲットや WIC は不要。
+        loader_.Init(nullptr);
+    }
+};
+
+TEST_F(ImageLoaderLruTest, GetCachedImageReturnsFalseForUnknownPath)
+{
+    DiagramEntry out;
+    EXPECT_FALSE(loader_.GetCachedImage(L"nonexistent.png", out));
+}
+
+TEST_F(ImageLoaderLruTest, ClearCacheRemovesAllEntries)
+{
+    // キャッシュをクリアしてもクラッシュしないこと
+    loader_.ClearCache();
+    DiagramEntry out;
+    EXPECT_FALSE(loader_.GetCachedImage(L"any.png", out));
+}
+
+TEST_F(ImageLoaderLruTest, RemoveCachedDoesNotCrashOnMissingKey)
+{
+    // 存在しないキーの削除でクラッシュしないこと
+    loader_.RemoveCached(L"nonexistent.png");
+}
+
+// ============================================================
+// LayoutCache ビューポート外 eviction テスト
+// ============================================================
+
+TEST(LayoutCacheEviction, EvictedEntriesPreservePositionAndHeight)
+{
+    // eviction 後も y_position と height が保持されることを確認
+    LayoutCache cache;
+    cache.Resize(5);
+
+    for (size_t i = 0; i < 5; i++) {
+        cache[i].y_position = static_cast<float>(i * 200);
+        cache[i].height = 100.0f;
+        cache[i].layout_dirty = false;
+        cache[i].effects_applied = true;
+    }
+
+    // ノード 0, 1 を eviction 対象としてシミュレート
+    cache[0].text_layout.Reset();
+    cache[0].layout_dirty = true;
+    cache[0].effects_applied = false;
+    cache[1].text_layout.Reset();
+    cache[1].layout_dirty = true;
+    cache[1].effects_applied = false;
+
+    // y_position と height は保持される
+    EXPECT_FLOAT_EQ(cache[0].y_position, 0.0f);
+    EXPECT_FLOAT_EQ(cache[0].height, 100.0f);
+    EXPECT_FLOAT_EQ(cache[1].y_position, 200.0f);
+    EXPECT_FLOAT_EQ(cache[1].height, 100.0f);
+
+    // layout_dirty が設定される
+    EXPECT_TRUE(cache[0].layout_dirty);
+    EXPECT_TRUE(cache[1].layout_dirty);
+    EXPECT_FALSE(cache[0].effects_applied);
+
+    // 非 eviction ノードは影響を受けない
+    EXPECT_FALSE(cache[2].layout_dirty);
+    EXPECT_TRUE(cache[2].effects_applied);
+}
+
+TEST(LayoutCacheEviction, DiagramEvictionPreservesWidthHeight)
+{
+    // DiagramEntry のビットマップを解放しても width/height が保持されることを確認
+    LayoutCache cache;
+    cache.Resize(3);
+
+    cache.GetDiagram(0).width = 400.0f;
+    cache.GetDiagram(0).height = 300.0f;
+    cache.GetDiagram(1).width = 800.0f;
+    cache.GetDiagram(1).height = 600.0f;
+
+    // ビットマップのみ解放
+    cache.GetDiagram(0).bitmap.Reset();
+    cache.GetDiagram(1).bitmap.Reset();
+
+    EXPECT_FLOAT_EQ(cache.GetDiagram(0).width, 400.0f);
+    EXPECT_FLOAT_EQ(cache.GetDiagram(0).height, 300.0f);
+    EXPECT_FLOAT_EQ(cache.GetDiagram(1).width, 800.0f);
+    EXPECT_FLOAT_EQ(cache.GetDiagram(1).height, 600.0f);
+    EXPECT_EQ(cache.GetDiagram(0).bitmap.Get(), nullptr);
+}
+
+// ============================================================
+// ProcessDirtyBatch ビューポート制限テスト
+// ============================================================
+
+class ProcessDirtyBatchViewportTest : public ::testing::Test {
+protected:
+    MockTextMeasurer mock_;
+    LayoutEngine engine_;
+    Theme theme_;
+
+    void SetUp() override
+    {
+        theme_ = GetLightTheme();
+        ASSERT_TRUE(engine_.Init(&mock_, theme_));
+    }
+};
+
+TEST_F(ProcessDirtyBatchViewportTest, SkipsFarOffscreenNodes)
+{
+    // 100 ノードのドキュメントを作成
+    std::string md;
+    for (int i = 0; i < 100; i++) {
+        md += "paragraph " + std::to_string(i) + "\n\n";
+    }
+    auto nodes = ParseMarkdown(md);
+    ASSERT_GT(nodes.size(), 50u);
+
+    LayoutCache cache;
+    cache.Resize(nodes.size());
+
+    // 初回レイアウトで Y 位置を確定
+    engine_.ComputeLayout(nodes, cache, 800.0f);
+
+    // 全ノードの layout_dirty を true に設定（eviction をシミュレート）
+    for (size_t i = 0; i < nodes.size(); i++) {
+        cache[i].layout_dirty = true;
+        cache[i].text_layout.Reset();
+    }
+
+    // ビューポートを先頭に設定（top=0, height=200）
+    // バッファ: ±5画面 = ±1000px → [−1000, 1200] が処理範囲
+    const float viewport_top = 0.0f;
+    const float viewport_height = 200.0f;
+
+    // ビューポート制限付きで ProcessDirtyBatch を実行
+    engine_.ProcessDirtyBatch(nodes, cache, 800.0f, 10000, 0,
+        viewport_top, viewport_height);
+
+    // ビューポート付近のノードはダーティでなくなっているはず
+    EXPECT_FALSE(cache[0].layout_dirty) << "ビューポート内のノードは処理されるべき";
+
+    // ビューポートから遠いノード（y > 1200）はダーティのまま
+    bool found_far_dirty = false;
+    for (size_t i = 0; i < nodes.size(); i++) {
+        if (cache[i].y_position > 1200.0f && cache[i].layout_dirty) {
+            found_far_dirty = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found_far_dirty) << "ビューポート遠方のノードは未処理のままであるべき";
+}
+
+TEST_F(ProcessDirtyBatchViewportTest, WithoutViewportLimitProcessesAll)
+{
+    std::string md;
+    for (int i = 0; i < 50; i++) {
+        md += "paragraph " + std::to_string(i) + "\n\n";
+    }
+    auto nodes = ParseMarkdown(md);
+
+    LayoutCache cache;
+    cache.Resize(nodes.size());
+    engine_.ComputeLayout(nodes, cache, 800.0f);
+
+    for (size_t i = 0; i < nodes.size(); i++) {
+        cache[i].layout_dirty = true;
+        cache[i].text_layout.Reset();
+    }
+
+    // ビューポート制限なし（デフォルト: viewport_top=-1, viewport_height=-1）
+    engine_.ProcessDirtyBatch(nodes, cache, 800.0f, 10000, 0);
+
+    // 全ノードが処理されるべき
+    for (size_t i = 0; i < nodes.size(); i++) {
+        EXPECT_FALSE(cache[i].layout_dirty) << "ノード " << i << " は処理されるべき";
+    }
+}
+
+TEST_F(ProcessDirtyBatchViewportTest, HasDirtyNodesFalseAfterNearbyProcessed)
+{
+    std::string md;
+    for (int i = 0; i < 100; i++) {
+        md += "paragraph " + std::to_string(i) + "\n\n";
+    }
+    auto nodes = ParseMarkdown(md);
+
+    LayoutCache cache;
+    cache.Resize(nodes.size());
+    engine_.ComputeLayout(nodes, cache, 800.0f);
+
+    for (size_t i = 0; i < nodes.size(); i++) {
+        cache[i].layout_dirty = true;
+        cache[i].text_layout.Reset();
+    }
+
+    // ビューポート制限付きで全バッチ処理
+    bool more = true;
+    int iterations = 0;
+    while (more && iterations < 100) {
+        more = engine_.ProcessDirtyBatch(nodes, cache, 800.0f, 10000, 0, 0.0f, 200.0f);
+        iterations++;
+    }
+
+    // 付近のダーティノードが処理され、has_dirty_nodes が false になるべき
+    EXPECT_FALSE(engine_.HasDirtyNodes())
+        << "ビューポート付近の全ダーティノードが処理されたら false であるべき";
+}
+
+// ============================================================
+// FindFirstVisibleNodeIndex テスト（eviction の基盤）
+// ============================================================
+
+TEST(FindFirstVisibleNodeIndex, ReturnsZeroForEmptyCache)
+{
+    LayoutCache cache;
+    cache.Resize(0);
+    EXPECT_EQ(FindFirstVisibleNodeIndex(cache, 0, 0.0f), 0);
+}
+
+TEST(FindFirstVisibleNodeIndex, FindsCorrectNodeInMiddle)
+{
+    LayoutCache cache;
+    cache.Resize(10);
+    for (size_t i = 0; i < 10; i++) {
+        cache[i].y_position = static_cast<float>(i * 100);
+        cache[i].height = 80.0f;
+    }
+
+    // viewport_top=450: ノード 4 (y=400, h=80) の下端=480 > 450
+    int idx = FindFirstVisibleNodeIndex(cache, 10, 450.0f);
+    EXPECT_EQ(idx, 4) << "viewport_top=450 の最初の可視ノードはインデックス 4";
+}
+
+TEST(FindFirstVisibleNodeIndex, ReturnsNodeCountWhenAllAbove)
+{
+    LayoutCache cache;
+    cache.Resize(3);
+    for (size_t i = 0; i < 3; i++) {
+        cache[i].y_position = static_cast<float>(i * 100);
+        cache[i].height = 80.0f;
+    }
+
+    // 全ノードがビューポートの上にある場合
+    int idx = FindFirstVisibleNodeIndex(cache, 3, 500.0f);
+    EXPECT_EQ(idx, 3);
+}

--- a/tests/test_memory_eviction.cpp
+++ b/tests/test_memory_eviction.cpp
@@ -42,6 +42,47 @@ TEST_F(ImageLoaderLruTest, RemoveCachedDoesNotCrashOnMissingKey)
     loader_.RemoveCached(L"nonexistent.png");
 }
 
+TEST_F(ImageLoaderLruTest, EvictsOldestWhenExceedingMaxEntries)
+{
+    // kMaxCacheEntries を超えたら最古のエントリが削除される
+    const size_t max_entries = 128; // kMaxCacheEntries
+
+    for (size_t i = 0; i < max_entries; i++) {
+        loader_.InsertCacheEntry(L"img_" + std::to_wstring(i) + L".png", 100.0f, 100.0f);
+    }
+    EXPECT_EQ(loader_.CacheSize(), max_entries);
+
+    // 1つ追加すると最古 (img_0) が削除される
+    loader_.InsertCacheEntry(L"overflow.png", 100.0f, 100.0f);
+    EXPECT_EQ(loader_.CacheSize(), max_entries);
+
+    DiagramEntry out;
+    EXPECT_FALSE(loader_.GetCachedImage(L"img_0.png", out));
+    EXPECT_TRUE(loader_.GetCachedImage(L"overflow.png", out));
+}
+
+TEST_F(ImageLoaderLruTest, RecentlyAccessedEntrysSurvivesEviction)
+{
+    // アクセスしたエントリは LRU エビクションで生き残る
+    const size_t max_entries = 128;
+
+    for (size_t i = 0; i < max_entries; i++) {
+        loader_.InsertCacheEntry(L"img_" + std::to_wstring(i) + L".png", 100.0f, 100.0f);
+    }
+
+    // img_0 にアクセスして最新にする
+    DiagramEntry out;
+    EXPECT_TRUE(loader_.GetCachedImage(L"img_0.png", out));
+
+    // 1つ追加 → img_0 ではなく img_1（最古）が削除される
+    loader_.InsertCacheEntry(L"new.png", 100.0f, 100.0f);
+    EXPECT_EQ(loader_.CacheSize(), max_entries);
+
+    EXPECT_TRUE(loader_.GetCachedImage(L"img_0.png", out));
+    EXPECT_FALSE(loader_.GetCachedImage(L"img_1.png", out));
+    EXPECT_TRUE(loader_.GetCachedImage(L"new.png", out));
+}
+
 // ============================================================
 // LayoutCache ビューポート外 eviction テスト
 // ============================================================


### PR DESCRIPTION
## Summary

- ビューポート外のテキストレイアウト・画像・Mermaid図を遅延解放し、メモリ消費量を削減
- ±3画面の先読みバッファで画像/Mermaid図をビューポート到達前に事前読み込みし、スクロール時のプレースホルダー表示を最小化
- `FlushPendingResources()` ヘルパーで完了済みデコードの反映・キャッシュ適用・Mermaidレンダリングを一括処理に集約
- ImageLoaderキャッシュをLRU管理に委譲し、エビクション後もディスクI/Oなしで即座に再適用可能に

## 主な変更

### メモリ最適化 (`6e097d5`)
- ビューポート±5画面外のテキストレイアウト、画像、Mermaid図を遅延解放
- `EnsureVisibleLayout()` でスクロール時に可視ノードのレイアウトを再作成
- `EvictOffscreenBitmaps()` でD2Dビットマップ参照を解放
- メモリエビクションのユニットテストを追加

### 先読み最適化 (`9cb7f65`)
- `OnPaint` / `ScheduleBitmapManage` でデバウンスを待たず即座にリソースをフラッシュ
- `RequestMermaidRenders` に±3画面の先読みバッファを追加
- `mermaid_batch_loading_` ガードでキャッシュヒット時のコールバックストームを抑制
- 画像エビクション時にImageLoaderキャッシュを残しLRUに管理を委譲

### キャッシュ容量 (`5b72af5`)
- ImageLoaderキャッシュの最大エントリ数を16→128に増加

## Test plan

- [ ] 画像を多数含むMDファイルでスクロール時にプレースホルダーが一瞬表示されないことを確認
- [ ] Mermaid図を含むMDファイルで同様にスクロール時のプレースホルダー表示を確認
- [ ] 大きなMDファイル（数千ノード）でメモリ使用量が増加しすぎないことを確認
- [ ] 高速スクロール後にビューポートに戻った際、画像が即座に表示されることを確認
- [ ] `ctest` で既存テスト（1353件）がすべてパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)