### PR TITLE
リファクタリング: コード重複解消、定数命名統一、std::expected導入

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -1,4 +1,5 @@
 #include "app.h"
+#include "app_constants.h"
 #include "file_loader.h"
 #include "parser.h"
 #include "resource.h"
@@ -160,6 +161,27 @@ void App::HandleScrollbarDrag(float dip_y, const PaneScrollInfo& info,
     scroll.max_scroll = info.max_scroll;
     cache_dirty = true;
     Invalidate();
+}
+
+// ============================================================
+// ファイル読み込み/リロード共通ヘルパー
+// ============================================================
+
+void App::CancelPendingResources()
+{
+    resource_manager_.CancelMermaidBatch();
+    image_loader_.CancelPending();
+    resource_manager_.ClearResolvedPaths();
+}
+
+void App::FinalizeLayout(float md_pane_height)
+{
+    resource_manager_.LoadImages();
+    resource_manager_.RequestMermaidRenders();
+    SyncMaxScroll(md_pane_height);
+    UpdateScrollBar();
+    Invalidate();
+    ScheduleDeferredLayoutIfNeeded();
 }
 
 // ============================================================
@@ -428,10 +450,8 @@ void App::LoadHelpDocument()
     KillTimer(hwnd_, app_timer::LOADING_ANIM);
     file_load_service_.StopLoading();
     viewport_.ClearSelection();
-    resource_manager_.CancelMermaidBatch();
-    image_loader_.CancelPending();
+    CancelPendingResources();
     renderer_.ShrinkBuffers();
-    resource_manager_.ClearResolvedPaths();
     doc_service_.StopWatching();
 
     std::pmr::string utf8(reinterpret_cast<const char*>(rc.data()), rc.size());
@@ -560,18 +580,12 @@ void App::OnParseComplete()
             viewport_.SetScrollY(reload_old_scroll_);
             layout_service_->ViewportLayout(doc_, layout_cache_, md_width, md_height);
 
-            resource_manager_.LoadImages();
-            resource_manager_.RequestMermaidRenders();
-
-            SyncMaxScroll(md_height);
-            UpdateScrollBar();
+            FinalizeLayout(md_height);
 
             if (search_state_.IsVisible() && !search_state_.GetQuery().empty()) {
                 search_bar_ctrl_.RunSearchAndLocate(doc_.GetNodes());
             }
 
-            Invalidate();
-            ScheduleDeferredLayoutIfNeeded();
             doc_service_.ResumeWatching();
             return;
         }
@@ -595,10 +609,8 @@ void App::FinishLoadMarkdownFile()
     search_bar_ctrl_.Reset();
     PostMessage(hwnd_, app_msg::SEARCH_UNFOCUS, app_param::SEARCH_UNFOCUS_FILE_SWITCH, 0);
     active_toc_index_ = -1;
-    resource_manager_.CancelMermaidBatch();
-    image_loader_.CancelPending();
+    CancelPendingResources();
     renderer_.ShrinkBuffers();
-    resource_manager_.ClearResolvedPaths();
 
     const std::pmr::wstring dir = doc_.GetDirectory();
     if (!dir.empty()) {
@@ -676,23 +688,7 @@ void App::FinishLoadMarkdownFile()
         viewport_.AnchorCompensateScroll(anchor.idx, anchor.y_before, layout_cache_);
     }
 
-    // キャッシュ済みリソースを適用（画像/Mermaidの正確な高さを反映）
-    {
-        MENDO_PROFILE("LoadImages");
-        resource_manager_.LoadImages();
-    }
-    {
-        MENDO_PROFILE("RequestMermaidRenders");
-        resource_manager_.RequestMermaidRenders();
-    }
-
-    // キャッシュ適用後にスクロール範囲を確定
-    SyncMaxScroll(md_height);
-    UpdateScrollBar();
-    Invalidate();
-
-    // 残りのダーティノードを遅延レイアウトで処理
-    ScheduleDeferredLayoutIfNeeded();
+    FinalizeLayout(md_height);
 
     UpdateTitleBar();
 
@@ -746,16 +742,18 @@ void App::DoReloadCurrentFile()
 
     const float old_scroll = viewport_.GetScrollY();
 
-    resource_manager_.CancelMermaidBatch();
-    image_loader_.CancelPending();
-    resource_manager_.ClearResolvedPaths();
+    CancelPendingResources();
 
     // ファイルを読み込み、旧コンテンツとの差分位置をコピーなしで計算
-    std::pmr::string new_utf8;
-    {
+    auto load_result = [this]() {
         MENDO_PROFILE("Reload::LoadFile");
-        new_utf8 = FileLoader::LoadFile(doc_.GetFilePath());
+        return FileLoader::LoadFile(doc_.GetFilePath());
+    }();
+    if (!load_result) {
+        doc_service_.ResumeWatching();
+        return;
     }
+    std::pmr::string new_utf8 = std::move(*load_result);
     const std::string_view old_view(doc_.GetRawUtf8());
     const std::string_view new_view(new_utf8);
     const size_t diff_pos = FindFirstDifference(old_view, new_view);
@@ -824,22 +822,12 @@ void App::DoReloadCurrentFile()
         layout_service_->ViewportLayout(doc_, layout_cache_, md_width, md_height);
     }
 
-    // キャッシュ済み画像/Mermaidを適用してY位置を正確にする
-    resource_manager_.LoadImages();
-    resource_manager_.RequestMermaidRenders();
-
-    SyncMaxScroll(md_height);
-    UpdateScrollBar();
+    FinalizeLayout(md_height);
 
     // 検索バー表示中なら再検索
     if (search_state_.IsVisible() && !search_state_.GetQuery().empty()) {
         search_bar_ctrl_.RunSearchAndLocate(doc_.GetNodes());
     }
-
-    Invalidate();
-
-    // 残りのダーティノードを遅延レイアウトで処理
-    ScheduleDeferredLayoutIfNeeded();
 
     // リロード完了まで一時停止していたファイル監視を再開する
     doc_service_.ResumeWatching();
@@ -1231,17 +1219,21 @@ void App::OnDestroy()
     SavePaneState();
     SaveScrollPosition();
     config_.SaveWString("General", "Language", i18n::GetLangKey());
-    KillTimer(hwnd_, app_timer::DEFERRED_LAYOUT);
-    KillTimer(hwnd_, app_timer::LOADING_ANIM);
-    KillTimer(hwnd_, app_timer::SWIPE_OVERLAY);
-    KillTimer(hwnd_, app_timer::TOAST);
-    KillTimer(hwnd_, app_timer::SEARCH_CARET);
-    KillTimer(hwnd_, app_timer::SEARCH_DEBOUNCE);
-    KillTimer(hwnd_, app_timer::TOOLTIP);
-    KillTimer(hwnd_, app_timer::BITMAP_MANAGE);
-    KillTimer(hwnd_, app_timer::MERMAID_BATCH);
-    KillTimer(hwnd_, app_timer::MERMAID_INIT_RETRY);
-    KillTimer(hwnd_, app_timer::FILE_RELOAD_DEBOUNCE);
+    for (UINT_PTR id : {
+        app_timer::DEFERRED_LAYOUT,
+        app_timer::LOADING_ANIM,
+        app_timer::SWIPE_OVERLAY,
+        app_timer::TOAST,
+        app_timer::SEARCH_CARET,
+        app_timer::SEARCH_DEBOUNCE,
+        app_timer::TOOLTIP,
+        app_timer::BITMAP_MANAGE,
+        app_timer::MERMAID_BATCH,
+        app_timer::MERMAID_INIT_RETRY,
+        app_timer::FILE_RELOAD_DEBOUNCE,
+    }) {
+        KillTimer(hwnd_, id);
+    }
 }
 
 RECT App::GetSearchEditRect() const

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "app_constants.h"
 #include "renderer.h"
 #include "task_scheduler.h"
 #include "mermaid_file_cache.h"
@@ -9,12 +8,12 @@
 #include "file_explorer.h"
 #include "document.h"
 #include "document_service.h"
+#include "document_utils.h"
 #include "hit_test_service.h"
 #include "pane.h"
 #include "pane_layout.h"
 #include "pane_controller.h"
 #include "titlebar.h"
-#include "document_utils.h"
 #include "layout_cache.h"
 #include "layout_service.h"
 #include "viewport_manager.h"
@@ -235,6 +234,10 @@ private:
     void ApplyMermaidCacheHeights(float md_width);
     bool ShouldDeferForTruncateRewrite(bool is_prefix_only, size_t old_size, size_t new_size);
     void UpdateTitleBar();
+
+    // ファイル読み込み/リロード共通ヘルパー
+    void CancelPendingResources();
+    void FinalizeLayout(float md_pane_height);
     void SaveLastFilePath();
     void SavePaneState();
     void LoadPaneState();

--- a/src/app/app_mouse.cpp
+++ b/src/app/app_mouse.cpp
@@ -1,4 +1,5 @@
 #include "app.h"
+#include "app_constants.h"
 #include "i18n.h"
 #include "pane_layout.h"
 #include "document_utils.h"

--- a/src/app/app_scroll.cpp
+++ b/src/app/app_scroll.cpp
@@ -1,4 +1,5 @@
 #include "app.h"
+#include "app_constants.h"
 #include "pane_layout.h"
 #include "profiler.h"
 #include <windows.h>

--- a/src/core/document_service.cpp
+++ b/src/core/document_service.cpp
@@ -4,27 +4,18 @@
 
 bool DocumentService::LoadFile(const std::pmr::wstring& path, Document& doc)
 {
-    std::pmr::string content;
+    std::expected<std::pmr::string, FileLoadError> result;
     {
         MENDO_PROFILE("FileLoader::LoadFile");
-        content = FileLoader::LoadFile(path);
+        result = FileLoader::LoadFile(path);
     }
-    if (content.empty() && GetFileAttributesW(path.c_str()) == INVALID_FILE_ATTRIBUTES) {
+    if (!result) {
         return false;
     }
     {
         MENDO_PROFILE("Document::FromMarkdown");
-        doc = Document::FromMarkdown(std::move(content), path);
+        doc = Document::FromMarkdown(std::move(*result), path);
     }
-    return true;
-}
-
-bool DocumentService::ReloadFile(Document& doc)
-{
-    if (doc.GetFilePath().empty()) {
-        return false;
-    }
-    doc.ReplaceFromMarkdown(FileLoader::LoadFile(doc.GetFilePath()));
     return true;
 }
 

--- a/src/core/document_service.h
+++ b/src/core/document_service.h
@@ -9,9 +9,6 @@ public:
     // ファイルを読み込み、Document を構築。成功時 true。
     bool LoadFile(const std::pmr::wstring& path, Document& doc);
 
-    // 現在のファイルを再読み込み
-    bool ReloadFile(Document& doc);
-
     // ファイル監視
     void StartWatching(const std::pmr::wstring& path, FileWatcher::ChangeCallback cb);
     void StopWatching() noexcept;

--- a/src/io/file_load_service.cpp
+++ b/src/io/file_load_service.cpp
@@ -48,8 +48,8 @@ void FileLoadService::StartAsyncLoad(TaskScheduler& scheduler, HWND hwnd, UINT m
             return;
         }
 
-        std::pmr::string content = FileLoader::LoadFile(path);
-        if (content.empty() && GetFileAttributesW(path.c_str()) == INVALID_FILE_ATTRIBUTES) {
+        auto load_result = FileLoader::LoadFile(path);
+        if (!load_result) {
             if (async_gen_.load(std::memory_order_relaxed) == gen) {
                 PostMessage(hwnd, msg_id, 0, 0);
             }
@@ -60,7 +60,7 @@ void FileLoadService::StartAsyncLoad(TaskScheduler& scheduler, HWND hwnd, UINT m
             return;
         }
 
-        Document doc = Document::FromMarkdown(std::move(content), path);
+        Document doc = Document::FromMarkdown(std::move(*load_result), path);
 
         if (async_gen_.load(std::memory_order_relaxed) != gen) {
             return;

--- a/src/io/file_load_service.h
+++ b/src/io/file_load_service.h
@@ -48,8 +48,8 @@ public:
 
     // ---- パスアクセス ----
 
-    constexpr std::wstring_view GetLoadingPath() const noexcept { return loading_path_; }
-    constexpr void SetLoadingPath(std::wstring_view path) { loading_path_ = path; }
+    std::wstring_view GetLoadingPath() const noexcept { return loading_path_; }
+    void SetLoadingPath(std::wstring_view path) { loading_path_ = path; }
 
 private:
     DocumentService& doc_service_;

--- a/src/io/file_loader.cpp
+++ b/src/io/file_loader.cpp
@@ -5,25 +5,30 @@
 #pragma comment(lib, "shlwapi.lib")
 #pragma comment(lib, "comdlg32.lib")
 
-std::pmr::string FileLoader::LoadFile(const std::pmr::wstring& path)
+std::expected<std::pmr::string, FileLoadError> FileLoader::LoadFile(const std::pmr::wstring& path)
 {
     // エディタがファイルを開いている間も読み取れるよう FILE_SHARE_READ | FILE_SHARE_WRITE を指定
     const HANDLE hFile = CreateFileW(path.c_str(), GENERIC_READ,
         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
         nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (hFile == INVALID_HANDLE_VALUE) {
-        return {};
+        return std::unexpected(FileLoadError::NotFound);
     }
 
     LARGE_INTEGER size;
-    if (!GetFileSizeEx(hFile, &size) || size.QuadPart == 0) {
+    if (!GetFileSizeEx(hFile, &size)) {
         CloseHandle(hFile);
-        return {};
+        return std::unexpected(FileLoadError::ReadFailed);
+    }
+
+    if (size.QuadPart == 0) {
+        CloseHandle(hFile);
+        return std::pmr::string{};
     }
 
     if (size.QuadPart > MAX_FILE_SIZE) {
         CloseHandle(hFile);
-        return {};
+        return std::unexpected(FileLoadError::TooLarge);
     }
 
     // UTF-8 BOMを先に検出し、全内容の memmove を回避する
@@ -52,7 +57,7 @@ std::pmr::string FileLoader::LoadFile(const std::pmr::wstring& path)
     CloseHandle(hFile);
 
     if (!ok) {
-        return {};
+        return std::unexpected(FileLoadError::ReadFailed);
     }
 
     return content;

--- a/src/io/file_loader.h
+++ b/src/io/file_loader.h
@@ -1,14 +1,22 @@
 #pragma once
 #include <string>
 #include <memory_resource>
+#include <expected>
 #include <windows.h>
 
 // ファイル読み込みの最大サイズ（256MB）。FileLoader / ImageLoader で共有。
 inline constexpr LONGLONG MAX_FILE_SIZE = 256LL * 1024 * 1024;
 
+// FileLoader::LoadFile のエラー型。
+enum class FileLoadError {
+    NotFound,    // ファイルが見つからない、またはアクセス拒否
+    TooLarge,    // ファイルサイズが MAX_FILE_SIZE を超過
+    ReadFailed,  // 読み込み中のI/Oエラー
+};
+
 // ファイル読み込みユーティリティ（静的メソッドのみ）。
 class FileLoader {
 public:
-    static std::pmr::string LoadFile(const std::pmr::wstring& path);
+    static std::expected<std::pmr::string, FileLoadError> LoadFile(const std::pmr::wstring& path);
     static std::pmr::wstring OpenFileDialog(HWND owner);
 };

--- a/src/io/image_loader.h
+++ b/src/io/image_loader.h
@@ -72,11 +72,11 @@ private:
 
     void GetDpiScale(float& scale_x, float& scale_y) const;
 
-    static constexpr size_t kMaxCacheEntries = 128;
+    static constexpr size_t MAX_CACHE_ENTRIES = 128;
 
     Microsoft::WRL::ComPtr<IWICImagingFactory> wic_factory_;
     ID2D1RenderTarget* render_target_ = nullptr;
-    LruCache<std::wstring, CachedImage> cache_{ kMaxCacheEntries };
+    LruCache<std::wstring, CachedImage> cache_{ MAX_CACHE_ENTRIES };
 
     // 非同期読み込み
     HWND hwnd_ = nullptr;

--- a/src/io/session_service.cpp
+++ b/src/io/session_service.cpp
@@ -44,19 +44,19 @@ void SessionService::LoadPaneState(PaneController& panes, float client_width)
     panes.SetFilePaneVisible(config_.LoadBool("Pane", "ShowFile", true));
     panes.SetTocPaneVisible(config_.LoadBool("Pane", "ShowToc", true));
 
-    constexpr int kDefaultWidth = static_cast<int>(PaneController::PANE_DEFAULT_WIDTH);
-    constexpr int kMinWidth = static_cast<int>(PaneController::PANE_MIN_WIDTH);
+    constexpr int DEFAULT_WIDTH = static_cast<int>(PaneController::PANE_DEFAULT_WIDTH);
+    constexpr int MIN_WIDTH = static_cast<int>(PaneController::PANE_MIN_WIDTH);
 
     // クライアント幅に基づいて有効な最大ペイン幅を計算する
-    int dynamic_max = kDefaultWidth;
+    int dynamic_max = DEFAULT_WIDTH;
     if (client_width > 0.0f) {
-        dynamic_max = std::max(kMinWidth, static_cast<int>(client_width) - kMinWidth);
+        dynamic_max = std::max(MIN_WIDTH, static_cast<int>(client_width) - MIN_WIDTH);
     }
 
     panes.SetFilePaneWidth(static_cast<float>(
-        config_.LoadInt("Pane", "FileWidth", kDefaultWidth, kMinWidth, dynamic_max)));
+        config_.LoadInt("Pane", "FileWidth", DEFAULT_WIDTH, MIN_WIDTH, dynamic_max)));
     panes.SetTocPaneWidth(static_cast<float>(
-        config_.LoadInt("Pane", "TocWidth", kDefaultWidth, kMinWidth, dynamic_max)));
+        config_.LoadInt("Pane", "TocWidth", DEFAULT_WIDTH, MIN_WIDTH, dynamic_max)));
 }
 
 void SessionService::SaveScrollPosition(int node, float scroll_y, float node_y)

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -20,7 +20,7 @@ static std::span<const std::byte> LoadMermaidJsGzFromResource()
 // 仮想ホスト経由で配信される小さなHTMLテンプレート。mermaid.jsは別の
 // <script src>として読み込まれるため、HTMLは2MBのNavigateToString制限を
 // 十分に下回る。両リソースはWebResourceRequestedによりインプロセスで配信される。
-static const char kMermaidHtml[] = R"HTML(<!DOCTYPE html>
+static const char MERMAID_HTML[] = R"HTML(<!DOCTYPE html>
 <html>
 <head>
 <meta charset="utf-8">
@@ -168,10 +168,10 @@ static std::pmr::wstring GetWebView2UserDataFolder()
 }
 
 // オフスクリーンWebView2ホストのウィンドウクラス名
-static const wchar_t* kMermaidHostClass = L"mendo_MermaidHost";
+static const wchar_t* MERMAID_HOST_CLASS = L"mendo_MermaidHost";
 
 // 仮想ホストURL
-static constexpr wchar_t kAppLocalIndexUrl[] = L"https://app.local/index.html";
+static constexpr wchar_t APP_LOCAL_INDEX_URL[] = L"https://app.local/index.html";
 
 // ---- MermaidRendererの実装 ----
 
@@ -243,7 +243,7 @@ void MermaidRenderer::EnsureInitialized()
         wc.cbSize = sizeof(wc);
         wc.lpfnWndProc = DefWindowProcW;
         wc.hInstance = GetModuleHandleW(nullptr);
-        wc.lpszClassName = kMermaidHostClass;
+        wc.lpszClassName = MERMAID_HOST_CLASS;
         RegisterClassExW(&wc);
         class_registered = true;
     }
@@ -252,7 +252,7 @@ void MermaidRenderer::EnsureInitialized()
     for (int i = 0; i < worker_count_; i++) {
         workers_[i].hwnd = CreateWindowExW(
             WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
-            kMermaidHostClass,
+            MERMAID_HOST_CLASS,
             L"",
             WS_POPUP,
             -32000, -32000,     // 画面外の遠い位置
@@ -291,7 +291,7 @@ void MermaidRenderer::CreateWebView2Environment()
         if (FAILED(result) || !env) {
             // 前回プロセスがユーザーデータフォルダをまだ解放していない場合など
             // に失敗する。タイマーで遅延リトライする。
-            if (env_retry_count_ < kMaxEnvRetries && hwnd_) {
+            if (env_retry_count_ < MAX_ENV_RETRIES && hwnd_) {
                 ++env_retry_count_;
                 SetTimer(hwnd_, TIMER_INIT_RETRY, 500, nullptr);
             }
@@ -396,9 +396,9 @@ void MermaidRenderer::SetupWorker(int index)
                 }
                 else if (wcscmp(msg, L"mermaid-failed") == 0) {
                     // mermaid.jsの読み込みに失敗した場合、ページを再読み込みして再試行する
-                    if (w.init_retries < kMaxWorkerRetries && w.webview) {
+                    if (w.init_retries < MAX_WORKER_RETRIES && w.webview) {
                         ++w.init_retries;
-                        w.webview->Navigate(kAppLocalIndexUrl);
+                        w.webview->Navigate(APP_LOCAL_INDEX_URL);
                     }
                 }
                 CoTaskMemFree(msg);
@@ -471,7 +471,7 @@ void MermaidRenderer::SetupWorker(int index)
             }
             else {
                 // その他のパスにはHTMLテンプレートを配信する
-                stream = CreateMemoryStream(kMermaidHtml, sizeof(kMermaidHtml) - 1);
+                stream = CreateMemoryStream(MERMAID_HTML, sizeof(MERMAID_HTML) - 1);
                 headers = L"Content-Type: text/html; charset=utf-8";
             }
 
@@ -486,7 +486,7 @@ void MermaidRenderer::SetupWorker(int index)
 
         // 仮想ホストにナビゲートする（HTML + JSは上記ハンドラにより
         // メモリから配信される）。
-        w.webview->Navigate(kAppLocalIndexUrl);
+        w.webview->Navigate(APP_LOCAL_INDEX_URL);
 
         return S_OK;
     }).Get());

--- a/src/mermaid/mermaid.h
+++ b/src/mermaid/mermaid.h
@@ -95,7 +95,7 @@ private:
         unsigned int request_id = 0; // リクエスト固有のID（JS側のpostMessageと照合）
     };
 
-    static constexpr int kMaxWorkers = 4;
+    static constexpr int MAX_WORKERS = 4;
 
     // WebView2ワーカー: 各ワーカーが独立したWebView2インスタンスを持ち、
     // 1つのダイアグラムを非同期レンダリングできる。
@@ -130,7 +130,7 @@ private:
     Microsoft::WRL::ComPtr<ICoreWebView2Environment> webview_env_;
     std::span<const std::byte> cached_mermaid_gz_; // Win32リソースから直接参照するgzip圧縮済みmermaid.js
 
-    Worker workers_[kMaxWorkers];
+    Worker workers_[MAX_WORKERS];
     int worker_count_ = 0;
     bool initialized_ = false;
     bool ready_ = false;
@@ -145,13 +145,13 @@ private:
         float width = 0.0f;
         float height = 0.0f;
     };
-    static constexpr size_t kMaxCacheEntries = 64;
-    LruCache<uint64_t, CachedBitmap> cache_{ kMaxCacheEntries };
+    static constexpr size_t MAX_CACHE_ENTRIES = 64;
+    LruCache<uint64_t, CachedBitmap> cache_{ MAX_CACHE_ENTRIES };
 
     MermaidFileCache* file_cache_ = nullptr;
 
     // WebView2環境生成リトライ
-    static constexpr int kMaxEnvRetries = 3;
-    static constexpr int kMaxWorkerRetries = 3;
+    static constexpr int MAX_ENV_RETRIES = 3;
+    static constexpr int MAX_WORKER_RETRIES = 3;
     int env_retry_count_ = 0;
 };

--- a/src/mermaid/mermaid_file_cache.cpp
+++ b/src/mermaid/mermaid_file_cache.cpp
@@ -119,11 +119,11 @@ void MermaidFileCache::LoadIndex()
     ifs.read(reinterpret_cast<char*>(&dpr), 4);
     ifs.read(reinterpret_cast<char*>(&count), 4);
 
-    if (!ifs || magic != kMagic || version != kVersion) {
+    if (!ifs || magic != MAGIC || version != VERSION) {
         return;
     }
     // 異常なエントリ数を拒否
-    if (count > kDefaultMaxEntries * 2) {
+    if (count > DEFAULT_MAX_ENTRIES * 2) {
         return;
     }
 
@@ -170,8 +170,8 @@ void MermaidFileCache::SaveIndex()
         return;
     }
 
-    const uint32_t magic = kMagic;
-    const uint32_t version = kVersion;
+    const uint32_t magic = MAGIC;
+    const uint32_t version = VERSION;
     const uint32_t count = static_cast<uint32_t>(index_.size());
 
     ofs.write(reinterpret_cast<const char*>(&magic), 4);

--- a/src/mermaid/mermaid_file_cache.h
+++ b/src/mermaid/mermaid_file_cache.h
@@ -64,10 +64,10 @@ public:
     uint64_t TotalSize() const noexcept { return total_size_; }
 
 private:
-    static constexpr uint32_t kMagic = 0x4D454D43u;   // "MEMC"
-    static constexpr uint32_t kVersion = 1;
-    static constexpr size_t kDefaultMaxEntries = 4096;
-    static constexpr uint64_t kDefaultMaxTotalSize = 1ULL * 1024 * 1024 * 1024; // 1GB
+    static constexpr uint32_t MAGIC = 0x4D454D43u;   // "MEMC"
+    static constexpr uint32_t VERSION = 1;
+    static constexpr size_t DEFAULT_MAX_ENTRIES = 4096;
+    static constexpr uint64_t DEFAULT_MAX_TOTAL_SIZE = 1ULL * 1024 * 1024 * 1024; // 1GB
 
     struct IndexEntry {
         float css_width = 0.0f;
@@ -94,8 +94,8 @@ private:
     std::multimap<int64_t, uint64_t> lru_order_;
     uint64_t total_size_ = 0;
 
-    size_t max_entries_ = kDefaultMaxEntries;
-    uint64_t max_total_size_ = kDefaultMaxTotalSize;
+    size_t max_entries_ = DEFAULT_MAX_ENTRIES;
+    uint64_t max_total_size_ = DEFAULT_MAX_TOTAL_SIZE;
 
     // バックグラウンド書き込み
     TaskScheduler* scheduler_ = nullptr;

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -275,19 +275,19 @@ void Renderer::RecreatePaneFormats()
     if (fmt_.nav_button) {
         auto* dw = backend_.GetDWriteFactory();
         if (dw) {
-            static const wchar_t kBack[] = L"\x25C0";
-            static const wchar_t kForward[] = L"\x25B6";
-            dw->CreateTextLayout(kBack, 1, fmt_.nav_button.Get(), NAV_BTN_SIZE, NAV_BTN_SIZE, &nav_back_layout_);
-            dw->CreateTextLayout(kForward, 1, fmt_.nav_button.Get(), NAV_BTN_SIZE, NAV_BTN_SIZE, &nav_forward_layout_);
+            static const wchar_t BACK_ICON[] = L"\x25C0";
+            static const wchar_t FORWARD_ICON[] = L"\x25B6";
+            dw->CreateTextLayout(BACK_ICON, 1, fmt_.nav_button.Get(), NAV_BTN_SIZE, NAV_BTN_SIZE, &nav_back_layout_);
+            dw->CreateTextLayout(FORWARD_ICON, 1, fmt_.nav_button.Get(), NAV_BTN_SIZE, NAV_BTN_SIZE, &nav_forward_layout_);
         }
     }
     if (fmt_.gesture_overlay) {
         auto* dw = backend_.GetDWriteFactory();
         if (dw) {
-            static const wchar_t kGestureBack[] = L"\x2190 \x623B\x308B";
-            static const wchar_t kGestureForward[] = L"\x2192 \x9032\x3080";
-            dw->CreateTextLayout(kGestureBack, 4, fmt_.gesture_overlay.Get(), 280.0f, 80.0f, &gesture_back_layout_);
-            dw->CreateTextLayout(kGestureForward, 4, fmt_.gesture_overlay.Get(), 280.0f, 80.0f, &gesture_forward_layout_);
+            static const wchar_t GESTURE_BACK[] = L"\x2190 \x623B\x308B";
+            static const wchar_t GESTURE_FORWARD[] = L"\x2192 \x9032\x3080";
+            dw->CreateTextLayout(GESTURE_BACK, 4, fmt_.gesture_overlay.Get(), 280.0f, 80.0f, &gesture_back_layout_);
+            dw->CreateTextLayout(GESTURE_FORWARD, 4, fmt_.gesture_overlay.Get(), 280.0f, 80.0f, &gesture_forward_layout_);
         }
     }
 

--- a/src/ui/search_state.cpp
+++ b/src/ui/search_state.cpp
@@ -53,19 +53,19 @@ void SearchState::ExecuteSearch(const std::pmr::vector<Node>& nodes)
             FindMatches(std::wstring_view(text.data(), text.size()), lower_query, i);
         }
     }
-    matches_truncated_ = (matches_.size() >= kMaxMatches);
+    matches_truncated_ = (matches_.size() >= MAX_MATCHES);
 }
 
 void SearchState::FindMatches(std::wstring_view text, const std::wstring& lower_query, int node_index, int table_row, int table_col)
 {
-    if (matches_.size() >= kMaxMatches) {
+    if (matches_.size() >= MAX_MATCHES) {
         return;
     }
     const uint32_t query_len = static_cast<uint32_t>(query_.size());
 
     if (case_sensitive_) {
         size_t pos = 0;
-        while (matches_.size() < kMaxMatches && (pos = text.find(query_, pos)) != std::wstring_view::npos) {
+        while (matches_.size() < MAX_MATCHES && (pos = text.find(query_, pos)) != std::wstring_view::npos) {
             matches_.push_back({ node_index, static_cast<uint32_t>(pos), query_len, table_row, table_col });
             pos += query_len;
         }
@@ -78,7 +78,7 @@ void SearchState::FindMatches(std::wstring_view text, const std::wstring& lower_
         const std::wstring_view lower_text(lower_text_buf_.data(), lower_text_buf_.size());
 
         size_t pos = 0;
-        while (matches_.size() < kMaxMatches && (pos = lower_text.find(lower_query, pos)) != std::wstring_view::npos) {
+        while (matches_.size() < MAX_MATCHES && (pos = lower_text.find(lower_query, pos)) != std::wstring_view::npos) {
             matches_.push_back({ node_index, static_cast<uint32_t>(pos), query_len, table_row, table_col });
             pos += query_len;
         }

--- a/src/ui/search_state.h
+++ b/src/ui/search_state.h
@@ -61,7 +61,7 @@ public:
 private:
     void FindMatches(std::wstring_view text, const std::wstring& lower_query, int node_index, int table_row = -1, int table_col = -1);
 
-    static constexpr size_t kMaxMatches = 10000;
+    static constexpr size_t MAX_MATCHES = 10000;
 
     std::wstring query_;
     std::vector<SearchMatch> matches_;

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -1,4 +1,5 @@
 #include "window.h"
+#include "app_constants.h"
 #include "config_store.h"
 #include "i18n.h"
 #include "resource.h"

--- a/tests/test_document_service.cpp
+++ b/tests/test_document_service.cpp
@@ -53,35 +53,6 @@ TEST_F(DocumentServiceTest, LoadFileNotFound)
     EXPECT_TRUE(doc.IsEmpty());
 }
 
-TEST_F(DocumentServiceTest, ReloadFile)
-{
-    auto path = CreateTestFile("reload.md", "# First");
-    DocumentService service(watcher_);
-    Document doc;
-
-    EXPECT_TRUE(service.LoadFile(path, doc));
-    EXPECT_EQ(doc.GetToc().GetEntries()[0].text, L"First");
-
-    // ファイルを変更
-    {
-        std::ofstream ofs(std::filesystem::path(path.c_str()), std::ios::binary);
-        ofs << "# Second\n## Sub";
-    }
-
-    EXPECT_TRUE(service.ReloadFile(doc));
-    EXPECT_EQ(std::wstring_view{ doc.GetFilePath() }, std::wstring_view{ path });
-    EXPECT_GE(doc.GetToc().GetEntries().size(), 2u);
-    EXPECT_EQ(doc.GetToc().GetEntries()[0].text, L"Second");
-}
-
-TEST_F(DocumentServiceTest, ReloadEmptyPathFails)
-{
-    DocumentService service(watcher_);
-    Document doc;
-
-    EXPECT_FALSE(service.ReloadFile(doc));
-}
-
 TEST_F(DocumentServiceTest, NeedsLoadingAnimationSmallFile)
 {
     auto path = CreateTestFile("small.md", "# Small");

--- a/tests/test_file_loader.cpp
+++ b/tests/test_file_loader.cpp
@@ -46,51 +46,58 @@ protected:
 TEST_F(FileLoaderTest, LoadsUtf8File)
 {
     auto path = WriteFile(L"test.md", "Hello, World!");
-    auto content = FileLoader::LoadFile(path.native().c_str());
-    EXPECT_EQ(content, "Hello, World!");
+    auto result = FileLoader::LoadFile(path.native().c_str());
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "Hello, World!");
 }
 
 TEST_F(FileLoaderTest, LoadsMultilineFile)
 {
     auto path = WriteFile(L"multi.md", "line1\nline2\nline3");
-    auto content = FileLoader::LoadFile(path.native().c_str());
-    EXPECT_EQ(content, "line1\nline2\nline3");
+    auto result = FileLoader::LoadFile(path.native().c_str());
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "line1\nline2\nline3");
 }
 
 TEST_F(FileLoaderTest, StripsUtf8Bom)
 {
     std::string bom = "\xEF\xBB\xBF" "Hello";
     auto path = WriteFile(L"bom.md", bom);
-    auto content = FileLoader::LoadFile(path.native().c_str());
-    EXPECT_EQ(content, "Hello");
+    auto result = FileLoader::LoadFile(path.native().c_str());
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "Hello");
 }
 
-TEST_F(FileLoaderTest, NonExistentFileReturnsEmpty)
+TEST_F(FileLoaderTest, NonExistentFileReturnsError)
 {
-    auto content = FileLoader::LoadFile(L"C:\\nonexistent_file_12345.md");
-    EXPECT_TRUE(content.empty());
+    auto result = FileLoader::LoadFile(L"C:\\nonexistent_file_12345.md");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), FileLoadError::NotFound);
 }
 
 TEST_F(FileLoaderTest, EmptyFileReturnsEmpty)
 {
     auto path = WriteFile(L"empty.md", "");
-    auto content = FileLoader::LoadFile(path.native().c_str());
-    EXPECT_TRUE(content.empty());
+    auto result = FileLoader::LoadFile(path.native().c_str());
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result->empty());
 }
 
 TEST_F(FileLoaderTest, LoadsJapaneseUtf8)
 {
     auto path = WriteFile(L"jp.md", "日本語テスト");
-    auto content = FileLoader::LoadFile(path.native().c_str());
-    EXPECT_EQ(content, "日本語テスト");
+    auto result = FileLoader::LoadFile(path.native().c_str());
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "日本語テスト");
 }
 
 TEST_F(FileLoaderTest, BomOnlyFileReturnsEmpty)
 {
     std::string bom_only = "\xEF\xBB\xBF";
     auto path = WriteFile(L"bomonly.md", bom_only);
-    auto content = FileLoader::LoadFile(path.native().c_str());
-    EXPECT_TRUE(content.empty());
+    auto result = FileLoader::LoadFile(path.native().c_str());
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result->empty());
 }
 
 // ---- ファイル監視テスト ----
@@ -152,16 +159,18 @@ TEST_F(FileLoaderTest, LargeFile)
     // 1MBのファイルを作成
     std::string large_content(1024 * 1024, 'A');
     auto path = WriteFile(L"large.md", large_content);
-    auto content = FileLoader::LoadFile(path.native().c_str());
-    EXPECT_EQ(content.size(), large_content.size());
+    auto result = FileLoader::LoadFile(path.native().c_str());
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->size(), large_content.size());
 }
 
 TEST_F(FileLoaderTest, FileWithOnlyBomAndContent)
 {
     std::string bom_content = "\xEF\xBB\xBF# Title\n\nContent";
     auto path = WriteFile(L"bomcontent.md", bom_content);
-    auto content = FileLoader::LoadFile(path.native().c_str());
-    EXPECT_EQ(content, "# Title\n\nContent");
+    auto result = FileLoader::LoadFile(path.native().c_str());
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "# Title\n\nContent");
 }
 
 TEST_F(FileLoaderTest, WatcherRestartOnNewFile)
@@ -209,8 +218,9 @@ TEST_F(FileLoaderTest, WatcherDestructorDoesNotCrash)
 TEST_F(FileLoaderTest, FileWithNewlines)
 {
     auto path = WriteFile(L"newlines.md", "line1\r\nline2\r\nline3");
-    auto content = FileLoader::LoadFile(path.native().c_str());
-    EXPECT_EQ(content, "line1\r\nline2\r\nline3");
+    auto result = FileLoader::LoadFile(path.native().c_str());
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "line1\r\nline2\r\nline3");
 }
 
 // ---- 監視一時停止 / ResumeWatching テスト ----

--- a/tests/test_memory_eviction.cpp
+++ b/tests/test_memory_eviction.cpp
@@ -38,8 +38,8 @@ TEST_F(ImageLoaderLruTest, ClearCacheRemovesAllEntries)
 
 TEST_F(ImageLoaderLruTest, EvictsOldestWhenExceedingMaxEntries)
 {
-    // kMaxCacheEntries を超えたら最古のエントリが削除される
-    const size_t max_entries = 128; // kMaxCacheEntries
+    // MAX_CACHE_ENTRIES を超えたら最古のエントリが削除される
+    const size_t max_entries = 128; // MAX_CACHE_ENTRIES
 
     for (size_t i = 0; i < max_entries; i++) {
         loader_.InsertCacheEntry(L"img_" + std::to_wstring(i) + L".png", 100.0f, 100.0f);


### PR DESCRIPTION
## Summary

- `CancelPendingResources()` / `FinalizeLayout()` ヘルパーを抽出し、ファイル読み込み/リロード処理の重複コード(3箇所)を解消
- `OnDestroy` の11個の `KillTimer` 呼び出しをループに統合
- `kPascalCase` 定数を `UPPER_SNAKE_CASE` に統一（mermaid.h, mermaid_file_cache.h, image_loader.h, search_state.h, session_service.cpp, renderer.cpp）
- `FileLoader::LoadFile` の戻り値を `std::expected<std::pmr::string, FileLoadError>` に変更し、エラー情報を型安全に伝播
- `app.h` から `app_constants.h` を分離し、使用する4つの.cppのみでインクルード
- デッドコード `DocumentService::ReloadFile` を削除
- `file_load_service.h` の不適切な `constexpr` を除去

## Test plan

- [x] `cmake --build build --config Release` でビルド成功
- [x] `ctest` で全1455テストパス
- [x] `/simplify` による3エージェント並列レビュー実施済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)