### PR TITLE
パフォーマンス最適化とRAIIハンドルラッパー導入

### DIFF
--- a/src/app/app_clipboard.cpp
+++ b/src/app/app_clipboard.cpp
@@ -3,6 +3,7 @@
 #include "pane_layout.h"
 #include "mermaid_util.h"
 #include "mermaid_file_cache.h"
+#include "win_handle.h"
 #include "i18n.h"
 #include <commdlg.h>
 
@@ -64,19 +65,16 @@ void App::SetClipboardText(std::wstring_view text) const
     EmptyClipboard();
 
     const size_t bytes = (text.size() + 1) * sizeof(wchar_t);
-    const HGLOBAL hMem = GlobalAlloc(GMEM_MOVEABLE, bytes);
+    UniqueGlobalMem hMem{ GlobalAlloc(GMEM_MOVEABLE, bytes) };
     if (hMem) {
-        void* ptr = GlobalLock(hMem);
+        void* ptr = GlobalLock(hMem.get());
         if (ptr) {
             memcpy(ptr, text.data(), text.size() * sizeof(wchar_t));
             static_cast<wchar_t*>(ptr)[text.size()] = L'\0';
-            GlobalUnlock(hMem);
-            if (!SetClipboardData(CF_UNICODETEXT, hMem)) {
-                GlobalFree(hMem);
+            GlobalUnlock(hMem.get());
+            if (SetClipboardData(CF_UNICODETEXT, hMem.get())) {
+                hMem.release(); // クリップボードに所有権移譲
             }
-        }
-        else {
-            GlobalFree(hMem);
         }
     }
     CloseClipboard();
@@ -138,15 +136,15 @@ void App::SaveDiagramAsPng(int node_index)
     }
 
     // PNGデータをファイルに書き出す
-    HANDLE hFile = CreateFileW(filename, GENERIC_WRITE, 0, nullptr,
-        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (hFile == INVALID_HANDLE_VALUE) {
+    UniqueHandle hFile{ CreateFileW(filename, GENERIC_WRITE, 0, nullptr,
+        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr) };
+    if (!hFile) {
         return;
     }
     DWORD written = 0;
     const DWORD size = static_cast<DWORD>(png_data.size());
-    const BOOL ok = WriteFile(hFile, png_data.data(), size, &written, nullptr);
-    CloseHandle(hFile);
+    const BOOL ok = WriteFile(hFile.get(), png_data.data(), size, &written, nullptr);
+    hFile.reset(); // DeleteFileW の前にファイルを閉じる
 
     if (ok && written == size) {
         ShowToast(i18n::S().toast_image_saved);

--- a/src/core/document_utils.cpp
+++ b/src/core/document_utils.cpp
@@ -97,10 +97,12 @@ std::optional<std::pmr::wstring> FindLinkAtPosition(const Node& node, uint32_t t
 std::pmr::wstring ToLowerAscii(std::wstring_view text)
 {
     std::pmr::wstring result;
-    result.reserve(text.size());
-    std::ranges::transform(text, std::back_inserter(result),
-        [](wchar_t c) static noexcept -> wchar_t {
-        return (c >= L'A' && c <= L'Z') ? static_cast<wchar_t>(c - L'A' + L'a') : c;
+    result.resize_and_overwrite(text.size(), [&text](wchar_t* buf, size_t count) noexcept -> size_t {
+        for (size_t i = 0; i < count; ++i) {
+            const wchar_t c = text[i];
+            buf[i] = (c >= L'A' && c <= L'Z') ? static_cast<wchar_t>(c - L'A' + L'a') : c;
+        }
+        return count;
     });
     return result;
 }

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -294,8 +294,7 @@ int OnEnterBlock(MD_BLOCKTYPE type, void* detail, void* userdata)
         ctx->BeginNode(NodeType::CodeBlock);
         auto* const code_detail = static_cast<MD_BLOCK_CODE_DETAIL*>(detail);
         if (code_detail && code_detail->lang.text && code_detail->lang.size > 0) {
-            const std::pmr::wstring lang_str = Utf8ToWide(std::string_view{ code_detail->lang.text, static_cast<size_t>(code_detail->lang.size) });
-            ctx->current_node->code_language = DetectLanguage(lang_str);
+            ctx->current_node->code_language = DetectLanguage(std::string_view{ code_detail->lang.text, static_cast<size_t>(code_detail->lang.size) });
         }
         break;
     }
@@ -530,7 +529,7 @@ int OnLeaveSpan(MD_SPANTYPE type, void* /*detail*/, void* userdata)
     if (type == MD_SPAN_IMG) {
         if (auto* cn = ctx->current_node; cn && !ctx->pending_image_src.empty()) {
             cn->ensure_image();
-            cn->image_data->src = ctx->pending_image_src;
+            cn->image_data->src = std::move(ctx->pending_image_src);
         }
         ctx->pending_image_src.clear();
     }
@@ -786,7 +785,7 @@ void TransformAlertNode(Node& node, AlertType type, size_t marker_end)
         new_runs.emplace_back(adjusted);
     }
 
-    node.SetText(new_text);
+    node.SetText(std::move(new_text));
     node.runs = std::move(new_runs);
     node.alert_type = type;
     node.alert_label_length = static_cast<uint32_t>(full_label_len);
@@ -827,6 +826,7 @@ ParseResult ParseMarkdown(std::string_view markdown_text)
     ParseContext ctx;
     ctx.markdown_base = markdown_text.data();
     ctx.utf8_accum.reserve(4096);
+    ctx.nodes.reserve(std::max<size_t>(64, markdown_text.size() / 64));
 
     MD_PARSER parser{};
     parser.abi_version = 0;

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -826,7 +826,7 @@ ParseResult ParseMarkdown(std::string_view markdown_text)
     ParseContext ctx;
     ctx.markdown_base = markdown_text.data();
     ctx.utf8_accum.reserve(4096);
-    ctx.nodes.reserve(std::max<size_t>(64, markdown_text.size() / 64));
+    ctx.nodes.reserve(std::clamp(markdown_text.size() / 64, size_t{ 64 }, size_t{ 8192 }));
 
     MD_PARSER parser{};
     parser.abi_version = 0;

--- a/src/core/syntax.cpp
+++ b/src/core/syntax.cpp
@@ -781,54 +781,79 @@ static_assert(std::size(LANGUAGE_DEFS) == static_cast<size_t>(SyntaxLanguage::Cm
 
 // ---- 公開API ----
 
-SyntaxLanguage DetectLanguage(std::wstring_view info_string)
+SyntaxLanguage DetectLanguage(std::string_view info_string)
 {
     if (info_string.empty()) {
         return SyntaxLanguage::None;
     }
 
-    // 最初の単語を抽出して小文字に変換
-    std::wstring lang;
-    for (wchar_t c : info_string) {
-        if (c == L' ' || c == L'\t') {
+    // 最初の単語を抽出してASCII小文字に変換（スタックバッファで割り当て回避）
+    char lang_buf[32];
+    size_t lang_len = 0;
+    for (char c : info_string) {
+        if (c == ' ' || c == '\t') {
             break;
         }
-        lang += (c >= L'A' && c <= L'Z') ? static_cast<wchar_t>(c - L'A' + L'a') : c;
+        if (lang_len >= sizeof(lang_buf) - 1) {
+            break;
+        }
+        lang_buf[lang_len++] = (c >= 'A' && c <= 'Z') ? static_cast<char>(c - 'A' + 'a') : c;
     }
+    const std::string_view lang(lang_buf, lang_len);
 
-    if (lang == L"c" || lang == L"cpp" || lang == L"c++" || lang == L"cxx" ||
-        lang == L"h" || lang == L"hpp" || lang == L"cc" || lang == L"hxx") {
+    if (lang == "c" || lang == "cpp" || lang == "c++" || lang == "cxx" ||
+        lang == "h" || lang == "hpp" || lang == "cc" || lang == "hxx") {
         return SyntaxLanguage::Cpp;
     }
-    if (lang == L"python" || lang == L"py") {
+    if (lang == "python" || lang == "py") {
         return SyntaxLanguage::Python;
     }
-    if (lang == L"javascript" || lang == L"js" || lang == L"jsx") {
+    if (lang == "javascript" || lang == "js" || lang == "jsx") {
         return SyntaxLanguage::JavaScript;
     }
-    if (lang == L"typescript" || lang == L"ts" || lang == L"tsx") {
+    if (lang == "typescript" || lang == "ts" || lang == "tsx") {
         return SyntaxLanguage::TypeScript;
     }
-    if (lang == L"mermaid") {
+    if (lang == "mermaid") {
         return SyntaxLanguage::Mermaid;
     }
-    if (lang == L"go" || lang == L"golang") {
+    if (lang == "go" || lang == "golang") {
         return SyntaxLanguage::Go;
     }
-    if (lang == L"rust" || lang == L"rs") {
+    if (lang == "rust" || lang == "rs") {
         return SyntaxLanguage::Rust;
     }
-    if (lang == L"bash" || lang == L"sh" || lang == L"zsh" || lang == L"shell") {
+    if (lang == "bash" || lang == "sh" || lang == "zsh" || lang == "shell") {
         return SyntaxLanguage::Bash;
     }
-    if (lang == L"powershell" || lang == L"pwsh" || lang == L"ps1") {
+    if (lang == "powershell" || lang == "pwsh" || lang == "ps1") {
         return SyntaxLanguage::PowerShell;
     }
-    if (lang == L"cmd" || lang == L"bat" || lang == L"batch" || lang == L"dosbatch") {
+    if (lang == "cmd" || lang == "bat" || lang == "batch" || lang == "dosbatch") {
         return SyntaxLanguage::Cmd;
     }
 
     return SyntaxLanguage::None;
+}
+
+SyntaxLanguage DetectLanguage(std::wstring_view info_string)
+{
+    if (info_string.empty()) {
+        return SyntaxLanguage::None;
+    }
+    // 言語名は全てASCIIなのでnarrowに変換してstring_view版に委譲
+    char buf[32];
+    size_t len = 0;
+    for (wchar_t c : info_string) {
+        if (c == L' ' || c == L'\t') {
+            break;
+        }
+        if (len >= sizeof(buf) - 1 || c > 0x7F) {
+            break;
+        }
+        buf[len++] = static_cast<char>(c);
+    }
+    return DetectLanguage(std::string_view(buf, len));
 }
 
 std::pmr::vector<SyntaxToken> Tokenize(std::wstring_view text, SyntaxLanguage language)

--- a/src/core/syntax.h
+++ b/src/core/syntax.h
@@ -37,5 +37,6 @@ struct SyntaxToken {
 };
 
 SyntaxLanguage DetectLanguage(std::wstring_view info_string);
+SyntaxLanguage DetectLanguage(std::string_view info_string);
 
 std::pmr::vector<SyntaxToken> Tokenize(std::wstring_view text, SyntaxLanguage language);

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <memory>
 #include <memory_resource>
+#include <algorithm>
 #include "syntax.h"
 #include "string_convert.h"
 
@@ -170,18 +171,21 @@ struct Node {
         return text_;
     }
 
+    // const wchar_t* からの呼び出し（リテラル文字列等）をオーバーロード解決で曖昧にしないための委譲
+    void SetText(const wchar_t* s) { SetText(std::wstring_view{ s }); }
+
     // Wideテキストを直接設定
     void SetText(std::wstring_view s)
     {
         text_.assign(s.data(), s.size());
-        text_valid_ = true;
-        text_utf8.clear();
-        line_count = 0;
-        for (wchar_t ch : s) {
-            if (ch == L'\n') {
-                ++line_count;
-            }
-        }
+        FinalizeSetText();
+    }
+
+    // Wideテキストをムーブで設定（コピー回避）
+    void SetText(std::pmr::wstring&& s) noexcept
+    {
+        text_ = std::move(s);
+        FinalizeSetText();
     }
 
     // テーブル行への便利アクセサ
@@ -205,6 +209,13 @@ struct Node {
     bool has_image() const noexcept { return image_data != nullptr; }
 
 private:
+    void FinalizeSetText() noexcept
+    {
+        text_valid_ = true;
+        text_utf8.clear();
+        line_count = static_cast<int>(std::count(text_.begin(), text_.end(), L'\n'));
+    }
+
     mutable std::pmr::wstring text_;    // Wideキャッシュ（GetText()で遅延変換）
     mutable bool text_valid_ = false;   // text_ が最新ならtrue
 };

--- a/src/io/file_explorer.cpp
+++ b/src/io/file_explorer.cpp
@@ -1,5 +1,6 @@
 #include "file_explorer.h"
 #include "document_utils.h"
+#include "win_handle.h"
 #include <algorithm>
 #include <filesystem>
 
@@ -42,8 +43,8 @@ void FileExplorer::Refresh()
     const std::filesystem::path dir_base{ directory_ };
     const auto pattern = dir_base / L"*";
     WIN32_FIND_DATAW fd;
-    const HANDLE hFind = FindFirstFileW(pattern.c_str(), &fd);
-    if (hFind == INVALID_HANDLE_VALUE) {
+    UniqueFindHandle hFind{ FindFirstFileW(pattern.c_str(), &fd) };
+    if (!hFind) {
         return;
     }
 
@@ -78,9 +79,7 @@ void FileExplorer::Refresh()
             entry.full_path.assign((dir_base / fd.cFileName).native());
             files.emplace_back(std::move(entry));
         }
-    } while (FindNextFileW(hFind, &fd));
-
-    FindClose(hFind);
+    } while (FindNextFileW(hFind.get(), &fd));
 
     // ディレクトリとファイルをそれぞれ大文字小文字無視でソート
     std::ranges::sort(dirs, [](const FileEntry& a, const FileEntry& b) static noexcept {

--- a/src/io/file_loader.cpp
+++ b/src/io/file_loader.cpp
@@ -1,4 +1,5 @@
 #include "file_loader.h"
+#include "win_handle.h"
 #include <shlwapi.h>
 #include <commdlg.h>
 
@@ -8,26 +9,23 @@
 std::expected<std::pmr::string, FileLoadError> FileLoader::LoadFile(const std::pmr::wstring& path)
 {
     // エディタがファイルを開いている間も読み取れるよう FILE_SHARE_READ | FILE_SHARE_WRITE を指定
-    const HANDLE hFile = CreateFileW(path.c_str(), GENERIC_READ,
+    UniqueHandle hFile{ CreateFileW(path.c_str(), GENERIC_READ,
         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-        nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (hFile == INVALID_HANDLE_VALUE) {
+        nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr) };
+    if (!hFile) {
         return std::unexpected(FileLoadError::NotFound);
     }
 
     LARGE_INTEGER size;
-    if (!GetFileSizeEx(hFile, &size)) {
-        CloseHandle(hFile);
+    if (!GetFileSizeEx(hFile.get(), &size)) {
         return std::unexpected(FileLoadError::ReadFailed);
     }
 
     if (size.QuadPart == 0) {
-        CloseHandle(hFile);
         return std::pmr::string{};
     }
 
     if (size.QuadPart > MAX_FILE_SIZE) {
-        CloseHandle(hFile);
         return std::unexpected(FileLoadError::TooLarge);
     }
 
@@ -37,13 +35,13 @@ std::expected<std::pmr::string, FileLoadError> FileLoader::LoadFile(const std::p
     if (file_size >= 3) {
         unsigned char bom[3]{};
         DWORD bom_read = 0;
-        if (ReadFile(hFile, bom, 3, &bom_read, nullptr) && bom_read == 3 &&
+        if (ReadFile(hFile.get(), bom, 3, &bom_read, nullptr) && bom_read == 3 &&
             bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF) {
             bom_skip = 3;
         }
         else {
             // BOMなし: ファイル先頭に巻き戻す
-            SetFilePointer(hFile, 0, nullptr, FILE_BEGIN);
+            SetFilePointer(hFile.get(), 0, nullptr, FILE_BEGIN);
         }
     }
 
@@ -51,10 +49,9 @@ std::expected<std::pmr::string, FileLoadError> FileLoader::LoadFile(const std::p
     DWORD bytesRead = 0;
     BOOL ok = FALSE;
     content.resize_and_overwrite(file_size - bom_skip, [&](char* buf, size_t count) -> size_t {
-        ok = ReadFile(hFile, buf, static_cast<DWORD>(count), &bytesRead, nullptr);
+        ok = ReadFile(hFile.get(), buf, static_cast<DWORD>(count), &bytesRead, nullptr);
         return ok ? bytesRead : 0;
     });
-    CloseHandle(hFile);
 
     if (!ok) {
         return std::unexpected(FileLoadError::ReadFailed);

--- a/src/io/file_watcher.cpp
+++ b/src/io/file_watcher.cpp
@@ -19,26 +19,27 @@ void FileWatcher::StartWatching(const std::pmr::wstring& file_path, ChangeCallba
         return;
     }
 
-    dir_handle_ = CreateFileW(
+    dir_handle_.reset(CreateFileW(
         dir.c_str(),
         FILE_LIST_DIRECTORY,
         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
         nullptr,
         OPEN_EXISTING,
         FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
-        nullptr);
+        nullptr));
 
-    if (dir_handle_ == INVALID_HANDLE_VALUE) {
+    if (!dir_handle_) {
+        return;
+    }
+
+    event_.reset(CreateEventW(nullptr, TRUE, FALSE, nullptr));
+    if (!event_) {
+        dir_handle_.reset();
         return;
     }
 
     overlapped_ = {};
-    overlapped_.hEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
-    if (!overlapped_.hEvent) {
-        CloseHandle(dir_handle_);
-        dir_handle_ = INVALID_HANDLE_VALUE;
-        return;
-    }
+    overlapped_.hEvent = event_.get();
 
     watching_ = true;
     BeginRead();
@@ -46,13 +47,13 @@ void FileWatcher::StartWatching(const std::pmr::wstring& file_path, ChangeCallba
 
 void FileWatcher::BeginRead()
 {
-    if (dir_handle_ == INVALID_HANDLE_VALUE) {
+    if (!dir_handle_) {
         return;
     }
 
     ResetEvent(overlapped_.hEvent);
     read_pending_ = ReadDirectoryChangesW(
-        dir_handle_,
+        dir_handle_.get(),
         change_buf_,
         sizeof(change_buf_),
         FALSE,
@@ -68,18 +69,13 @@ void FileWatcher::BeginRead()
 
 void FileWatcher::StopWatching() noexcept
 {
-    if (read_pending_ && dir_handle_ != INVALID_HANDLE_VALUE) {
-        CancelIo(dir_handle_);
+    if (read_pending_ && dir_handle_) {
+        CancelIo(dir_handle_.get());
         read_pending_ = false;
     }
-    if (overlapped_.hEvent) {
-        CloseHandle(overlapped_.hEvent);
-        overlapped_ = {};
-    }
-    if (dir_handle_ != INVALID_HANDLE_VALUE) {
-        CloseHandle(dir_handle_);
-        dir_handle_ = INVALID_HANDLE_VALUE;
-    }
+    event_.reset();
+    overlapped_ = {};
+    dir_handle_.reset();
     watching_ = false;
     paused_ = false;
     pending_change_ = false;
@@ -88,12 +84,12 @@ void FileWatcher::StopWatching() noexcept
 
 void FileWatcher::CheckForChanges()
 {
-    if (!watching_ || !read_pending_ || dir_handle_ == INVALID_HANDLE_VALUE) {
+    if (!watching_ || !read_pending_ || !dir_handle_) {
         return;
     }
 
     DWORD bytes_returned = 0;
-    if (!GetOverlappedResult(dir_handle_, &overlapped_, &bytes_returned, FALSE)) {
+    if (!GetOverlappedResult(dir_handle_.get(), &overlapped_, &bytes_returned, FALSE)) {
         if (GetLastError() != ERROR_IO_INCOMPLETE) {
             read_pending_ = false;
             StopWatching();

--- a/src/io/file_watcher.h
+++ b/src/io/file_watcher.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <memory_resource>
 #include <windows.h>
+#include "win_handle.h"
 
 // ReadDirectoryChangesW によるファイル変更監視。
 // 指定ファイルの親ディレクトリを監視し、対象ファイルの変更を検出してコールバックを呼ぶ。
@@ -36,7 +37,8 @@ private:
     ChangeCallback on_change_;
     bool watching_ = false;
 
-    HANDLE dir_handle_ = INVALID_HANDLE_VALUE;
+    UniqueHandle dir_handle_;
+    UniqueEventHandle event_;          // overlapped_.hEvent のオーナー（StartWatching で同期）
     OVERLAPPED overlapped_{};
     alignas(DWORD) char change_buf_[4096]{};
     bool read_pending_ = false;

--- a/src/io/image_loader.cpp
+++ b/src/io/image_loader.cpp
@@ -2,8 +2,8 @@
 #include "file_loader.h"
 #include "task_scheduler.h"
 #include "ui_constants.h"
+#include "win_handle.h"
 #include <shlwapi.h>
-#include <vector>
 
 #pragma comment(lib, "shlwapi.lib")
 
@@ -12,30 +12,38 @@
 // 外部エディタ等がファイルを更新できなくなる問題を回避する。
 static Microsoft::WRL::ComPtr<IStream> ReadFileToStream(const std::wstring& path)
 {
-    const HANDLE hFile = CreateFileW(path.c_str(), GENERIC_READ,
+    UniqueHandle hFile{ CreateFileW(path.c_str(), GENERIC_READ,
         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-        nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (hFile == INVALID_HANDLE_VALUE) {
+        nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr) };
+    if (!hFile) {
         return nullptr;
     }
 
     LARGE_INTEGER size;
-    if (!GetFileSizeEx(hFile, &size) || size.QuadPart == 0 || size.QuadPart > MAX_FILE_SIZE) {
-        CloseHandle(hFile);
+    if (!GetFileSizeEx(hFile.get(), &size) || size.QuadPart == 0 || size.QuadPart > MAX_FILE_SIZE) {
         return nullptr;
     }
 
-    std::vector<BYTE> buf(static_cast<size_t>(size.QuadPart));
-    DWORD bytesRead = 0;
-    const BOOL ok = ReadFile(hFile, buf.data(), static_cast<DWORD>(buf.size()), &bytesRead, nullptr);
-    CloseHandle(hFile);
+    const auto alloc_size = static_cast<SIZE_T>(size.QuadPart);
+    UniqueGlobalMem hMem{ GlobalAlloc(GMEM_MOVEABLE, alloc_size) };
+    if (!hMem) {
+        return nullptr;
+    }
 
-    if (!ok || bytesRead != buf.size()) {
+    void* ptr = GlobalLock(hMem.get());
+    DWORD bytesRead = 0;
+    const BOOL ok = ReadFile(hFile.get(), ptr, static_cast<DWORD>(alloc_size), &bytesRead, nullptr);
+    GlobalUnlock(hMem.get());
+
+    if (!ok || bytesRead != alloc_size) {
         return nullptr;
     }
 
     Microsoft::WRL::ComPtr<IStream> stream;
-    stream.Attach(SHCreateMemStream(buf.data(), static_cast<UINT>(buf.size())));
+    if (FAILED(CreateStreamOnHGlobal(hMem.get(), TRUE, &stream))) {
+        return nullptr;
+    }
+    hMem.release(); // CreateStreamOnHGlobal(TRUE) が所有権を取得
     return stream;
 }
 

--- a/src/io/image_loader.cpp
+++ b/src/io/image_loader.cpp
@@ -31,6 +31,9 @@ static Microsoft::WRL::ComPtr<IStream> ReadFileToStream(const std::wstring& path
     }
 
     void* ptr = GlobalLock(hMem.get());
+    if (!ptr) {
+        return nullptr;
+    }
     DWORD bytesRead = 0;
     const BOOL ok = ReadFile(hFile.get(), ptr, static_cast<DWORD>(alloc_size), &bytesRead, nullptr);
     GlobalUnlock(hMem.get());

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -383,9 +383,9 @@ void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float 
         MeasureTableCells(node, entry, natural_widths);
 
         // 自然幅をキャッシュ（リサイズ高速パス用）
-        tl.natural_col_widths = natural_widths;
+        tl.natural_col_widths = std::move(natural_widths);
 
         // 第2パス: 列幅を設定し、行の高さを計測
-        FinalizeTableLayout(node, entry, max_width, col_count, natural_widths);
+        FinalizeTableLayout(node, entry, max_width, col_count, tl.natural_col_widths);
     }
 }

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -219,10 +219,12 @@ void LayoutEngine::ComputeLayout(std::pmr::vector<Node>& nodes, LayoutCache& cac
     const auto node_count = nodes.size();
     cache.Resize(node_count);
 
-    const bool width_changed = (viewport_width != last_viewport_width_);
+    const bool width_changed = std::abs(viewport_width - last_viewport_width_) > 0.5f;
     const bool partial = (viewport_top >= 0.0f);
 
-    last_viewport_width_ = viewport_width;
+    if (width_changed) {
+        last_viewport_width_ = viewport_width;
+    }
 
     const float content_width = theme_->ContentWidth(viewport_width);
     float y = theme_->margin_top;

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -108,7 +108,9 @@ public:
             e.effects_applied = false;
             e.inline_code_bgs.clear();
             if (e.table_layout) {
+                e.table_layout->cell_layouts.clear();
                 e.table_layout->cell_inline_code_bgs.clear();
+                e.table_layout->natural_col_widths.clear();
             }
         }
         effects_generation_++;
@@ -133,6 +135,10 @@ public:
         for (auto& e : entries_) {
             e.layout_dirty = true;
             e.text_layout.Reset();
+            if (e.table_layout) {
+                e.table_layout->cell_layouts.clear();
+                e.table_layout->natural_col_widths.clear();
+            }
         }
         effects_generation_++;
     }

--- a/src/layout/layout_service.cpp
+++ b/src/layout/layout_service.cpp
@@ -2,9 +2,8 @@
 
 void LayoutService::ViewportLayout(Document& doc, LayoutCache& cache, float width, float height)
 {
-    const float viewport_top = viewport_.GetScrollY();
-    const float viewport_bottom = viewport_.GetScrollY() + height;
-    engine_.ComputeLayout(doc.GetNodesMut(), cache, width, viewport_top, viewport_bottom);
+    const float scroll_y = viewport_.GetScrollY();
+    engine_.ComputeLayout(doc.GetNodesMut(), cache, width, scroll_y, scroll_y + height);
 }
 
 bool LayoutService::ProcessDirtyBatch(Document& doc, LayoutCache& cache, float width, int batch_size, int time_budget_us,
@@ -19,9 +18,8 @@ bool LayoutService::ProcessDirtyBatch(Document& doc, LayoutCache& cache, float w
 
 bool LayoutService::EnsureVisibleLayout(Document& doc, LayoutCache& cache, float width, float height)
 {
-    const float viewport_top = viewport_.GetScrollY();
-    const float viewport_bottom = viewport_.GetScrollY() + height;
-    return engine_.EnsureVisibleLayout(doc.GetNodesMut(), cache, width, viewport_top, viewport_bottom);
+    const float scroll_y = viewport_.GetScrollY();
+    return engine_.EnsureVisibleLayout(doc.GetNodesMut(), cache, width, scroll_y, scroll_y + height);
 }
 
 void LayoutService::RecomputeAfterDiagram(Document& doc, LayoutCache& cache, const Theme& theme) noexcept

--- a/src/nav/nav_history.cpp
+++ b/src/nav/nav_history.cpp
@@ -21,7 +21,7 @@ bool NavHistory::GoBack(const NavEntry& current, NavEntry& out)
     if (forward_stack_.size() > MAX_HISTORY) {
         forward_stack_.pop_front();
     }
-    out = back_stack_.back();
+    out = std::move(back_stack_.back());
     back_stack_.pop_back();
     return true;
 }
@@ -33,7 +33,7 @@ bool NavHistory::GoForward(const NavEntry& current, NavEntry& out)
     }
 
     back_stack_.emplace_back(current);
-    out = forward_stack_.back();
+    out = std::move(forward_stack_.back());
     forward_stack_.pop_back();
     return true;
 }

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -570,7 +570,7 @@ void Renderer::Render(const RenderParams& p)
     // 描画前パス: 可視ノードに描画エフェクト（シンタックスハイライト、リンク色）を適用。
     // レイアウト世代と可視範囲が前回と同一ならスキップする（静止時の不要な走査を回避）。
     const uint32_t effects_gen = p.cache.GetEffectsGeneration();
-    if (effects_gen != last_effects_gen_ || first_visible != last_effects_first_ || viewport_bottom != last_effects_bottom_) {
+    if (effects_gen != last_effects_gen_ || first_visible != last_effects_first_ || std::abs(viewport_bottom - last_effects_bottom_) > 0.5f) {
         MENDO_PROFILE("ApplyVisibleEffects");
         ApplyVisibleEffects(p.nodes, p.cache, first_visible, viewport_top, viewport_bottom);
         last_effects_gen_ = effects_gen;

--- a/src/util/lru_cache.h
+++ b/src/util/lru_cache.h
@@ -66,7 +66,7 @@ public:
         }
 
         order_.push_front({ key, std::move(value) });
-        map_[key] = order_.begin();
+        map_.emplace(key, order_.begin());
     }
 
     void Clear()

--- a/src/util/win_handle.h
+++ b/src/util/win_handle.h
@@ -1,0 +1,79 @@
+#pragma once
+#include <windows.h>
+
+// ポリシーベースの汎用 RAII リソースラッパー。
+// Traits は type, invalid(), close(type) を定義する。
+template<typename Traits>
+class UniqueResource {
+    using handle_t = typename Traits::type;
+
+public:
+    UniqueResource() noexcept = default;
+    explicit UniqueResource(handle_t h) noexcept : handle_(h) {}
+    ~UniqueResource() { reset(); }
+
+    UniqueResource(const UniqueResource&) = delete;
+    UniqueResource& operator=(const UniqueResource&) = delete;
+    UniqueResource(UniqueResource&& other) noexcept : handle_(other.release()) {}
+    UniqueResource& operator=(UniqueResource&& other) noexcept
+    {
+        if (this != &other) {
+            reset(other.release());
+        }
+        return *this;
+    }
+
+    explicit operator bool() const noexcept { return handle_ != Traits::invalid(); }
+    handle_t get() const noexcept { return handle_; }
+
+    handle_t release() noexcept
+    {
+        handle_t h = handle_;
+        handle_ = Traits::invalid();
+        return h;
+    }
+
+    void reset(handle_t h = Traits::invalid()) noexcept
+    {
+        if (handle_ != Traits::invalid()) {
+            Traits::close(handle_);
+        }
+        handle_ = h;
+    }
+
+private:
+    handle_t handle_ = Traits::invalid();
+};
+
+// CloseHandle で解放、無効値 INVALID_HANDLE_VALUE（CreateFileW 等）
+struct HandleTraits {
+    using type = HANDLE;
+    static type invalid() noexcept { return INVALID_HANDLE_VALUE; }
+    static void close(type h) noexcept { CloseHandle(h); }
+};
+using UniqueHandle = UniqueResource<HandleTraits>;
+
+// CloseHandle で解放、無効値 nullptr（CreateEventW 等）
+struct EventHandleTraits {
+    using type = HANDLE;
+    static type invalid() noexcept { return nullptr; }
+    static void close(type h) noexcept { CloseHandle(h); }
+};
+using UniqueEventHandle = UniqueResource<EventHandleTraits>;
+
+// FindClose で解放（FindFirstFileW）
+struct FindHandleTraits {
+    using type = HANDLE;
+    static type invalid() noexcept { return INVALID_HANDLE_VALUE; }
+    static void close(type h) noexcept { FindClose(h); }
+};
+using UniqueFindHandle = UniqueResource<FindHandleTraits>;
+
+// GlobalFree で解放（GlobalAlloc）。
+// SetClipboardData / CreateStreamOnHGlobal への所有権移譲時は release() を使う。
+struct GlobalMemTraits {
+    using type = HGLOBAL;
+    static type invalid() noexcept { return nullptr; }
+    static void close(type h) noexcept { GlobalFree(h); }
+};
+using UniqueGlobalMem = UniqueResource<GlobalMemTraits>;

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -67,6 +67,7 @@ bool Win32Window::Create(HINSTANCE hInstance, int nCmdShow)
 
     InitSystemMenu();
     UpdateDwmFrame();
+    UpdateDpiMetricsCache();
 
     if (!RestoreWindowPlacement(nCmdShow)) {
         ShowWindow(hwnd_, nCmdShow);
@@ -74,6 +75,19 @@ bool Win32Window::Create(HINSTANCE hInstance, int nCmdShow)
     UpdateWindow(hwnd_);
 
     return true;
+}
+
+void Win32Window::UpdateDpiMetricsCache()
+{
+    if (!hwnd_) {
+        return;
+    }
+    const UINT dpi = GetDpiForWindow(hwnd_);
+    cached_nchit_border_ = MulDiv(4, dpi, 96);
+    cached_nchit_frame_y_ = GetSystemMetricsForDpi(SM_CYFRAME, dpi)
+        + GetSystemMetricsForDpi(SM_CXPADDEDBORDER, dpi);
+    cached_nchit_right_border_ = GetSystemMetricsForDpi(SM_CXFRAME, dpi)
+        + GetSystemMetricsForDpi(SM_CXPADDEDBORDER, dpi);
 }
 
 void Win32Window::UpdateDwmFrame()
@@ -193,14 +207,9 @@ LRESULT Win32Window::OnNcHitTest(LPARAM lParam)
 
     // 非最大化時のリサイズ枠判定（細めの枠でスクロールバーと干渉しないようにする）
     if (!IsZoomed(hwnd_)) {
-        const UINT dpi = GetDpiForWindow(hwnd_);
-        const int border = MulDiv(4, dpi, 96);
-        // 上端はタイトルバーがないため標準のフレーム厚を使う
-        const int frame_y = GetSystemMetricsForDpi(SM_CYFRAME, dpi)
-            + GetSystemMetricsForDpi(SM_CXPADDEDBORDER, dpi);
-        // 右辺はシステム標準幅で広めに確保（スクロールバーとの共存）
-        const int right_border = GetSystemMetricsForDpi(SM_CXFRAME, dpi)
-            + GetSystemMetricsForDpi(SM_CXPADDEDBORDER, dpi);
+        const int border = cached_nchit_border_;
+        const int frame_y = cached_nchit_frame_y_;
+        const int right_border = cached_nchit_right_border_;
 
         RECT rc;
         GetClientRect(hwnd_, &rc);
@@ -475,6 +484,7 @@ LRESULT Win32Window::HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam)
         const auto* suggested = reinterpret_cast<const RECT*>(lParam);
         app_.OnDpiChanged(dpi, suggested);
         UpdateDwmFrame();
+        UpdateDpiMetricsCache();
         return 0;
     }
 

--- a/src/window/window.h
+++ b/src/window/window.h
@@ -32,9 +32,17 @@ private:
     void RepositionSearchEdit();
     void SyncSearchCaretFromEdit();
 
+    void UpdateDpiMetricsCache();
+
     HWND hwnd_ = nullptr;
     HWND search_edit_ = nullptr;
     bool in_sys_menu_ = false;   // システムメニューのモーダルループ中フラグ
     bool tracking_mouse_ = false; // TrackMouseEvent によるマウス追跡中フラグ
+
+    // WM_NCHITTEST用DPIメトリクスキャッシュ（WM_DPICHANGED時に更新）
+    int cached_nchit_border_ = 4;
+    int cached_nchit_frame_y_ = 8;
+    int cached_nchit_right_border_ = 8;
+
     App app_;
 };


### PR DESCRIPTION
## Summary

- プロジェクト全体のパフォーマンスレビューに基づく最適化を実施（20ファイル、+260/-118行）
- ポリシーベースの汎用RAIIハンドルラッパー `UniqueResource<Traits>` を導入し、手動リソース管理を全箇所で排除
- テーブルのズーム/テーマ変更時にセルレイアウトが無効化されないバグと、ビューポート幅のサブピクセルドリフトバグを修正

### パフォーマンス改善
- `DetectLanguage` に `string_view` 版を追加し、コードブロックごとのUTF-8→Wide変換を排除
- `ToLowerAscii` を `resize_and_overwrite` で最適化
- パース時の `nodes` vector に `reserve` を追加
- `pending_image_src` / `SetText` / `natural_col_widths` / `NavHistory` で `std::move` 活用
- `WM_NCHITTEST` のDPIメトリクスをキャッシュ化（マウス移動ごとのOS API呼び出しを排除）
- `LruCache::Insert` で `emplace` 使用によりハッシュ二重計算を回避
- `GetScrollY()` の二重呼び出しを排除
- ビューポート幅変更とエフェクト適用のスキップ判定にイプシロンを追加

### バグ修正
- `InvalidateAllLayouts` / `MarkAllDirty` でテーブルの `cell_layouts` をクリアし、ズーム変更後に古いフォントサイズのセルレイアウトが再利用される問題を修正
- `last_viewport_width_` を `width_changed` 時のみ更新し、0.5f未満の累積変化で再レイアウトが漏れる問題を修正

### RAII導入
- `UniqueResource<Traits>` テンプレート + 4種のTraits構造体で型エイリアスを定義
- `file_loader` / `image_loader` / `file_watcher` / `file_explorer` / `app_clipboard` の全手動リソース管理をRAIIに移行
- 画像読み込みを `SHCreateMemStream` から `CreateStreamOnHGlobal` に変更し二重バッファコピーを排除

## Test plan

- [x] `cmake --build build --config Release` でビルド成功
- [x] `ctest` で全1455テスト合格
- [ ] アプリを起動し、Markdownファイルを開いてスクロール・ズーム・テーマ切替が正常に動作することを確認
- [ ] テーブルを含むドキュメントでズーム変更後にセルのフォントサイズが正しく更新されることを確認
- [ ] 画像を含むドキュメントの表示が正常であることを確認
- [ ] ファイル変更監視（エディタで保存後の自動リロード）が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)