### PR TITLE
タイトルバーにファイルを開くボタンを追加し、左側レイアウトに再配置

### DIFF
--- a/src/app/app_mouse.cpp
+++ b/src/app/app_mouse.cpp
@@ -1,5 +1,6 @@
 #include "app.h"
 #include "app_constants.h"
+#include "app_events.h"
 #include "i18n.h"
 #include "pane_layout.h"
 #include "document_utils.h"
@@ -25,6 +26,7 @@ TooltipTarget BuildTitleBarTooltip(TitleBarHitZone zone, bool is_maximized) noex
 {
     const auto& ls = i18n::S();
     switch (zone) {
+    case TitleBarHitZone::OpenFile:    return { TooltipTarget::Zone::TitleBarButton, ls.tooltip_open_file };
     case TitleBarHitZone::Help:        return { TooltipTarget::Zone::TitleBarButton, ls.tooltip_help };
     case TitleBarHitZone::ThemeToggle: return { TooltipTarget::Zone::TitleBarButton, ls.tooltip_theme_toggle };
     case TitleBarHitZone::Search:      return { TooltipTarget::Zone::TitleBarButton, ls.tooltip_search };
@@ -354,30 +356,15 @@ bool App::HandleTitleBarClick(float dip_x, float dip_y)
     }
 
     const auto tb_zone = titlebar_.HitTest(dip_x, dip_y);
-    if (tb_zone == TitleBarHitZone::Help) {
-        if (!doc_.GetFilePath().empty() && !IsHelpPath(doc_.GetFilePath())) {
-            PushNavHistory();
-        }
-        LoadHelpDocument();
-        return true;
-    }
-    if (tb_zone == TitleBarHitZone::Search) {
-        OnSearchOpen();
-        return true;
-    }
-    if (tb_zone == TitleBarHitZone::ThemeToggle) {
-        ToggleDarkMode();
-        return true;
-    }
-    if (tb_zone == TitleBarHitZone::FileToggle || tb_zone == TitleBarHitZone::TocToggle) {
-        if (tb_zone == TitleBarHitZone::FileToggle) {
-            panes_.ToggleFilePane();
-        }
-        else {
-            panes_.ToggleTocPane();
-        }
-        RefreshPaneLayout();
-        return true;
+    // アクションシステム経由でディスパッチ（Ctrl+Oなどのキーボード操作と同じパスを通す）
+    switch (tb_zone) {
+    case TitleBarHitZone::OpenFile:    ExecuteActions({{OpenFileAction{}}}); return true;
+    case TitleBarHitZone::Help:        ExecuteActions({{ShowHelpAction{}}}); return true;
+    case TitleBarHitZone::Search:      ExecuteActions({{OpenSearchBarAction{}}}); return true;
+    case TitleBarHitZone::ThemeToggle: ExecuteActions({{ToggleDarkModeAction{}}}); return true;
+    case TitleBarHitZone::FileToggle:  ExecuteActions({{TogglePaneAction{true}}}); return true;
+    case TitleBarHitZone::TocToggle:   ExecuteActions({{TogglePaneAction{false}}}); return true;
+    default: break;
     }
     if (tb_zone == TitleBarHitZone::Minimize) {
         ShowWindow(hwnd_, SW_MINIMIZE);

--- a/src/app/app_render_state.cpp
+++ b/src/app/app_render_state.cpp
@@ -35,6 +35,8 @@ TitleBarRenderState App::BuildTitleBarRenderState(float window_width) const
     TitleBarRenderState tb;
     tb.height = titlebar_.GetHeight();
     tb.window_width = window_width;
+    tb.open_file_btn_rect = titlebar_.GetOpenFileButton().rect;
+    tb.open_file_btn_hovered = titlebar_.GetOpenFileButton().hovered;
     tb.help_btn_rect = titlebar_.GetHelpButton().rect;
     tb.help_btn_hovered = titlebar_.GetHelpButton().hovered;
     tb.theme_btn_rect = titlebar_.GetThemeToggleButton().rect;

--- a/src/render/renderer.h
+++ b/src/render/renderer.h
@@ -57,6 +57,7 @@ struct TitleBarRenderState {
     // --- 8バイトアライメント ---
     std::wstring_view title_text;
     // --- 4バイトアライメント (D2D1_RECT_F = 4×float) ---
+    D2D1_RECT_F open_file_btn_rect{};
     D2D1_RECT_F help_btn_rect{};
     D2D1_RECT_F theme_btn_rect{};
     D2D1_RECT_F search_btn_rect{};
@@ -70,6 +71,7 @@ struct TitleBarRenderState {
     float height = 0.0f;
     float window_width = 0.0f;
     // --- 1バイトアライメント ---
+    bool open_file_btn_hovered = false;
     bool help_btn_hovered = false;
     bool theme_btn_hovered = false;
     bool is_dark_mode = false;

--- a/src/render/renderer_titlebar.cpp
+++ b/src/render/renderer_titlebar.cpp
@@ -27,6 +27,15 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
         }
     };
 
+    // ファイルを開くボタン
+    drawButton(
+        tb.open_file_btn_rect,
+        L"\uE838",
+        tb.open_file_btn_hovered,
+        BrushId::TitleBarButtonHover,
+        BrushId::TitleBarText,
+        text_alpha
+    );
     // ヘルプボタン
     drawButton(
         tb.help_btn_rect,

--- a/src/ui/i18n.h
+++ b/src/ui/i18n.h
@@ -9,6 +9,7 @@ enum class Lang : uint8_t { Ja, En };
 
 struct Strings {
     // タイトルバー tooltip
+    std::wstring_view tooltip_open_file;
     std::wstring_view tooltip_help;
     std::wstring_view tooltip_theme_toggle;
     std::wstring_view tooltip_search;
@@ -67,6 +68,7 @@ struct Strings {
 
 inline constexpr Strings kJa = {
     // タイトルバー tooltip
+    L"ファイルを開く (Ctrl+O)",
     L"ヘルプ (F1)",
     L"ダーク/ライトモード切替",
     L"検索 (Ctrl+F)",
@@ -114,6 +116,7 @@ inline constexpr Strings kJa = {
 
 inline constexpr Strings kEn = {
     // タイトルバー tooltip
+    L"Open File (Ctrl+O)",
     L"Help (F1)",
     L"Toggle Dark/Light Mode",
     L"Search (Ctrl+F)",

--- a/src/ui/titlebar.h
+++ b/src/ui/titlebar.h
@@ -7,6 +7,7 @@ enum class TitleBarHitZone {
     None,        // タイトルバー外
     Caption,     // ドラッグ可能領域
     Icon,        // アプリアイコン（システムメニュー）
+    OpenFile,    // ファイルを開くボタン
     Help,        // ヘルプボタン
     ThemeToggle, // ダークモード切替ボタン
     Search,      // 検索ボタン
@@ -41,7 +42,23 @@ public:
     // ウィンドウ幅からボタン位置を計算
     void UpdateLayout(float window_width_dip) noexcept
     {
-        // キャプションボタン（右端から配置、全高を使用）
+        // ── 左側ボタン群（アイコンの右から配置）──
+        // アイコン位置（タイトルバー左端、垂直中央）
+        const float icon_top = (BASE_HEIGHT - ICON_SIZE) / 2.0f;
+        icon_rect_ = D2D1::RectF(ICON_LEFT_MARGIN, icon_top,
+            ICON_LEFT_MARGIN + ICON_SIZE, icon_top + ICON_SIZE);
+
+        float left = ICON_LEFT_MARGIN + ICON_SIZE + ICON_RIGHT_GAP;
+        open_file_.rect = D2D1::RectF(left, 0.0f, left + BUTTON_WIDTH, BASE_HEIGHT);
+        left += BUTTON_WIDTH;
+        search_.rect = D2D1::RectF(left, 0.0f, left + BUTTON_WIDTH, BASE_HEIGHT);
+        left += BUTTON_WIDTH;
+        theme_toggle_.rect = D2D1::RectF(left, 0.0f, left + BUTTON_WIDTH, BASE_HEIGHT);
+        left += BUTTON_WIDTH;
+        help_.rect = D2D1::RectF(left, 0.0f, left + BUTTON_WIDTH, BASE_HEIGHT);
+        left += BUTTON_WIDTH;
+
+        // ── 右側ボタン群（右端から配置）──
         float right = window_width_dip;
         close_.rect = D2D1::RectF(right - CAPTION_BTN_WIDTH, 0.0f, right, BASE_HEIGHT);
         right -= CAPTION_BTN_WIDTH;
@@ -50,32 +67,14 @@ public:
         minimize_.rect = D2D1::RectF(right - CAPTION_BTN_WIDTH, 0.0f, right, BASE_HEIGHT);
         right -= CAPTION_BTN_WIDTH;
 
-        // ヘルプボタン（最小化ボタンの左隣に配置）
-        help_.rect = D2D1::RectF(right - BUTTON_WIDTH, 0.0f, right, BASE_HEIGHT);
-        right -= BUTTON_WIDTH;
-
-        // ダークモード切替ボタン（ヘルプボタンの左隣に配置）
-        theme_toggle_.rect = D2D1::RectF(right - BUTTON_WIDTH, 0.0f, right, BASE_HEIGHT);
-        right -= BUTTON_WIDTH;
-
-        // 検索ボタン（ダークモード切替ボタンの左隣に配置）
-        search_.rect = D2D1::RectF(right - BUTTON_WIDTH, 0.0f, right, BASE_HEIGHT);
-        right -= BUTTON_WIDTH;
-
-        // ペイン切替ボタン（検索ボタンの左隣に配置）
+        // ペイン切替ボタン（最小化ボタンの左隣から配置）
         toc_toggle_.rect = D2D1::RectF(right - BUTTON_WIDTH, 0.0f, right, BASE_HEIGHT);
         right -= BUTTON_WIDTH;
         file_toggle_.rect = D2D1::RectF(right - BUTTON_WIDTH, 0.0f, right, BASE_HEIGHT);
 
-        // アイコン位置（タイトルバー左端、垂直中央）
-        const float icon_top = (BASE_HEIGHT - ICON_SIZE) / 2.0f;
-        icon_rect_ = D2D1::RectF(ICON_LEFT_MARGIN, icon_top,
-            ICON_LEFT_MARGIN + ICON_SIZE, icon_top + ICON_SIZE);
-
-        // タイトルテキスト領域（アイコンの右からファイル切替ボタンの左まで）
-        const float title_left = ICON_LEFT_MARGIN + ICON_SIZE + ICON_RIGHT_GAP;
+        // タイトルテキスト領域（左側ボタンの右からファイル切替ボタンの左まで）
         const float title_right = file_toggle_.rect.left;
-        title_text_rect_ = D2D1::RectF(title_left, 0.0f, (title_right > title_left) ? title_right : title_left, BASE_HEIGHT);
+        title_text_rect_ = D2D1::RectF(left, 0.0f, (title_right > left) ? title_right : left, BASE_HEIGHT);
     }
 
     // DIP座標でヒットテスト
@@ -93,11 +92,9 @@ public:
         if (PointInRect(dip_x, dip_y, minimize_.rect)) {
             return TitleBarHitZone::Minimize;
         }
-        if (PointInRect(dip_x, dip_y, file_toggle_.rect)) {
-            return TitleBarHitZone::FileToggle;
-        }
-        if (PointInRect(dip_x, dip_y, toc_toggle_.rect)) {
-            return TitleBarHitZone::TocToggle;
+        // 左側ボタン群
+        if (PointInRect(dip_x, dip_y, open_file_.rect)) {
+            return TitleBarHitZone::OpenFile;
         }
         if (PointInRect(dip_x, dip_y, search_.rect)) {
             return TitleBarHitZone::Search;
@@ -107,6 +104,13 @@ public:
         }
         if (PointInRect(dip_x, dip_y, help_.rect)) {
             return TitleBarHitZone::Help;
+        }
+        // 右側ボタン群
+        if (PointInRect(dip_x, dip_y, file_toggle_.rect)) {
+            return TitleBarHitZone::FileToggle;
+        }
+        if (PointInRect(dip_x, dip_y, toc_toggle_.rect)) {
+            return TitleBarHitZone::TocToggle;
         }
         // アイコン領域（クリックしやすいようアイコン右のギャップまで含む）
         if (dip_x < icon_rect_.right + ICON_RIGHT_GAP) {
@@ -122,6 +126,7 @@ public:
             return false;
         }
         hovered_ = zone;
+        open_file_.hovered = (zone == TitleBarHitZone::OpenFile);
         help_.hovered = (zone == TitleBarHitZone::Help);
         theme_toggle_.hovered = (zone == TitleBarHitZone::ThemeToggle);
         search_.hovered = (zone == TitleBarHitZone::Search);
@@ -134,6 +139,7 @@ public:
     }
 
     constexpr TitleBarHitZone GetHovered() const noexcept { return hovered_; }
+    constexpr const TitleBarButton& GetOpenFileButton() const noexcept { return open_file_; }
     constexpr const TitleBarButton& GetHelpButton() const noexcept { return help_; }
     constexpr const TitleBarButton& GetThemeToggleButton() const noexcept { return theme_toggle_; }
     constexpr const TitleBarButton& GetSearchButton() const noexcept { return search_; }
@@ -146,6 +152,7 @@ public:
     constexpr const D2D1_RECT_F& GetTitleTextRect() const noexcept { return title_text_rect_; }
 
 private:
+    TitleBarButton open_file_;
     TitleBarButton help_;
     TitleBarButton theme_toggle_;
     TitleBarButton search_;

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -258,6 +258,7 @@ LRESULT Win32Window::OnNcHitTest(LPARAM lParam)
         switch (zone) {
         case TitleBarHitZone::Icon:
             return HTSYSMENU;  // システムメニュー表示（ダブルクリックで閉じる）
+        case TitleBarHitZone::OpenFile:
         case TitleBarHitZone::Help:
         case TitleBarHitZone::ThemeToggle:
         case TitleBarHitZone::Search:

--- a/tests/test_titlebar.cpp
+++ b/tests/test_titlebar.cpp
@@ -47,32 +47,43 @@ TEST_F(TitleBarTest, MinimizeButtonIsLeftOfMaximize)
     EXPECT_FLOAT_EQ(minimize.rect.right, maximize.rect.left);
 }
 
-TEST_F(TitleBarTest, HelpButtonIsLeftOfMinimize)
+// 左側ボタン群: Icon | OpenFile | Search | ThemeToggle | Help
+
+TEST_F(TitleBarTest, OpenFileIsRightOfIcon)
+{
+    auto& open_file = tb_.GetOpenFileButton();
+    float expected_left = TitleBar::ICON_LEFT_MARGIN + TitleBar::ICON_SIZE + TitleBar::ICON_RIGHT_GAP;
+    EXPECT_FLOAT_EQ(open_file.rect.left, expected_left);
+}
+
+TEST_F(TitleBarTest, SearchIsRightOfOpenFile)
+{
+    auto& open_file = tb_.GetOpenFileButton();
+    auto& search = tb_.GetSearchButton();
+    EXPECT_FLOAT_EQ(search.rect.left, open_file.rect.right);
+}
+
+TEST_F(TitleBarTest, ThemeToggleIsRightOfSearch)
+{
+    auto& search = tb_.GetSearchButton();
+    auto& theme = tb_.GetThemeToggleButton();
+    EXPECT_FLOAT_EQ(theme.rect.left, search.rect.right);
+}
+
+TEST_F(TitleBarTest, HelpIsRightOfThemeToggle)
+{
+    auto& theme = tb_.GetThemeToggleButton();
+    auto& help = tb_.GetHelpButton();
+    EXPECT_FLOAT_EQ(help.rect.left, theme.rect.right);
+}
+
+// 右側ボタン群: FileToggle | TocToggle | Minimize | Maximize | Close
+
+TEST_F(TitleBarTest, TocToggleIsLeftOfMinimize)
 {
     auto& minimize = tb_.GetMinimizeButton();
-    auto& help = tb_.GetHelpButton();
-    EXPECT_FLOAT_EQ(help.rect.right, minimize.rect.left);
-}
-
-TEST_F(TitleBarTest, ThemeToggleIsLeftOfHelp)
-{
-    auto& help = tb_.GetHelpButton();
-    auto& theme = tb_.GetThemeToggleButton();
-    EXPECT_FLOAT_EQ(theme.rect.right, help.rect.left);
-}
-
-TEST_F(TitleBarTest, SearchIsLeftOfThemeToggle)
-{
-    auto& theme = tb_.GetThemeToggleButton();
-    auto& search = tb_.GetSearchButton();
-    EXPECT_FLOAT_EQ(search.rect.right, theme.rect.left);
-}
-
-TEST_F(TitleBarTest, TocToggleIsLeftOfSearch)
-{
-    auto& search = tb_.GetSearchButton();
     auto& toc = tb_.GetTocToggleButton();
-    EXPECT_FLOAT_EQ(toc.rect.right, search.rect.left);
+    EXPECT_FLOAT_EQ(toc.rect.right, minimize.rect.left);
 }
 
 TEST_F(TitleBarTest, FileToggleIsLeftOfTocToggle)
@@ -88,6 +99,7 @@ TEST_F(TitleBarTest, AllButtonsUseFullHeight)
         EXPECT_FLOAT_EQ(btn.rect.top, 0.0f);
         EXPECT_FLOAT_EQ(btn.rect.bottom, TitleBar::BASE_HEIGHT);
     };
+    check(tb_.GetOpenFileButton());
     check(tb_.GetHelpButton());
     check(tb_.GetThemeToggleButton());
     check(tb_.GetSearchButton());
@@ -113,6 +125,7 @@ TEST_F(TitleBarTest, PaneToggleButtonWidth)
     auto check = [](const TitleBarButton& btn) static {
         EXPECT_FLOAT_EQ(btn.rect.right - btn.rect.left, TitleBar::BUTTON_WIDTH);
     };
+    check(tb_.GetOpenFileButton());
     check(tb_.GetHelpButton());
     check(tb_.GetThemeToggleButton());
     check(tb_.GetSearchButton());
@@ -120,11 +133,11 @@ TEST_F(TitleBarTest, PaneToggleButtonWidth)
     check(tb_.GetTocToggleButton());
 }
 
-TEST_F(TitleBarTest, TitleTextRectStartsAfterIcon)
+TEST_F(TitleBarTest, TitleTextRectStartsAfterLeftButtons)
 {
     auto& rect = tb_.GetTitleTextRect();
-    float expected = TitleBar::ICON_LEFT_MARGIN + TitleBar::ICON_SIZE + TitleBar::ICON_RIGHT_GAP;
-    EXPECT_FLOAT_EQ(rect.left, expected);
+    auto& help = tb_.GetHelpButton();
+    EXPECT_FLOAT_EQ(rect.left, help.rect.right);
 }
 
 TEST_F(TitleBarTest, TitleTextRectEndsAtFileToggleButton)
@@ -279,6 +292,7 @@ TEST_F(TitleBarTest, SetHoveredNoneClearsAll)
 {
     tb_.SetHovered(TitleBarHitZone::FileToggle);
     tb_.SetHovered(TitleBarHitZone::None);
+    EXPECT_FALSE(tb_.GetOpenFileButton().hovered);
     EXPECT_FALSE(tb_.GetHelpButton().hovered);
     EXPECT_FALSE(tb_.GetThemeToggleButton().hovered);
     EXPECT_FALSE(tb_.GetSearchButton().hovered);
@@ -293,6 +307,7 @@ TEST_F(TitleBarTest, SetHoveredSetsExactlyOneButton)
 {
     auto countHovered = [&]() {
         int count = 0;
+        if (tb_.GetOpenFileButton().hovered) { ++count; }
         if (tb_.GetHelpButton().hovered) { ++count; }
         if (tb_.GetThemeToggleButton().hovered) { ++count; }
         if (tb_.GetSearchButton().hovered) { ++count; }
@@ -305,6 +320,7 @@ TEST_F(TitleBarTest, SetHoveredSetsExactlyOneButton)
     };
 
     TitleBarHitZone zones[] = {
+        TitleBarHitZone::OpenFile,
         TitleBarHitZone::Help, TitleBarHitZone::ThemeToggle,
         TitleBarHitZone::Search,
         TitleBarHitZone::FileToggle, TitleBarHitZone::TocToggle,
@@ -326,6 +342,7 @@ TEST_F(TitleBarTest, ButtonsDoNotOverlap)
     // 全ボタンの矩形を収集して、左端でソートし隣接確認
     struct Rect { float left; float right; };
     Rect rects[] = {
+        { tb_.GetOpenFileButton().rect.left,      tb_.GetOpenFileButton().rect.right },
         { tb_.GetHelpButton().rect.left,          tb_.GetHelpButton().rect.right },
         { tb_.GetThemeToggleButton().rect.left,   tb_.GetThemeToggleButton().rect.right },
         { tb_.GetSearchButton().rect.left,        tb_.GetSearchButton().rect.right },
@@ -348,9 +365,10 @@ TEST_F(TitleBarTest, ButtonsDoNotOverlap)
 TEST_F(TitleBarTest, TitleTextDoesNotOverlapButtons)
 {
     auto& title = tb_.GetTitleTextRect();
+    auto& help = tb_.GetHelpButton().rect;
     auto& file = tb_.GetFileToggleButton().rect;
+    EXPECT_GE(title.left, help.right);
     EXPECT_LE(title.right, file.left);
-    EXPECT_GE(title.left, 0.0f);
 }
 
 // ═══════════════════════════════════════════════

--- a/tests/test_titlebar.cpp
+++ b/tests/test_titlebar.cpp
@@ -189,6 +189,24 @@ TEST_F(TitleBarTest, HitTestMinimizeButton)
     EXPECT_EQ(tb_.HitTest(cx, cy), TitleBarHitZone::Minimize);
 }
 
+TEST_F(TitleBarTest, HitTestOpenFileButton)
+{
+    auto& btn = tb_.GetOpenFileButton();
+    float cx = (btn.rect.left + btn.rect.right) / 2.0f;
+    float cy = (btn.rect.top + btn.rect.bottom) / 2.0f;
+    EXPECT_EQ(tb_.HitTest(cx, cy), TitleBarHitZone::OpenFile);
+}
+
+TEST_F(TitleBarTest, HitTestOpenFileButtonBoundary)
+{
+    auto& btn = tb_.GetOpenFileButton();
+    float cy = (btn.rect.top + btn.rect.bottom) / 2.0f;
+    // 左端ちょうどはボタン内
+    EXPECT_EQ(tb_.HitTest(btn.rect.left, cy), TitleBarHitZone::OpenFile);
+    // 右端の直前はボタン内
+    EXPECT_EQ(tb_.HitTest(btn.rect.right - 0.01f, cy), TitleBarHitZone::OpenFile);
+}
+
 TEST_F(TitleBarTest, HitTestFileToggle)
 {
     auto& btn = tb_.GetFileToggleButton();


### PR DESCRIPTION
## Summary
- タイトルバーにファイルを開くボタン（フォルダアイコン）を追加
- OpenFile, Search, ThemeToggle, Help ボタンをタイトルバーの左側（アイコンの右）に移動し、FileToggle, TocToggle, キャプションボタンは右側に残す左右2グループレイアウトに変更
- タイトルバーボタンのクリック処理を `ExecuteActions` 経由のアクションディスパッチに統一し、キーボードショートカット（Ctrl+O等）と同じコードパスを通すようリファクタリング

## Test plan
- [x] 全1459テスト通過
- [ ] アプリ起動し、タイトルバー左側にOpenFile/Search/ThemeToggle/Helpボタンが表示されることを確認
- [ ] OpenFileボタンクリックでファイルダイアログが開き、ファイルを選択して表示できることを確認
- [ ] 各ボタンのホバー表示・ツールチップが正常に動作することを確認
- [ ] ウィンドウリサイズ時にレイアウトが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)