### PR TITLE
リファクタリング: データ構造の最適化によるメモリ効率改善

### DIFF
--- a/src/app/app_mouse.cpp
+++ b/src/app/app_mouse.cpp
@@ -345,7 +345,8 @@ void App::HandleTocPaneClick(float dip_x, float dip_y, const PaneLayout& layout)
     const int idx = doc_.GetToc().HitTest(local_y, theme.pane_item_height);
     if (idx >= 0 && idx < static_cast<int>(doc_.GetToc().GetEntries().size())) {
         PushNavHistory();
-        NavigateToAnchor(doc_.GetToc().GetEntries()[idx].anchor_id);
+        const auto& toc_entry = doc_.GetToc().GetEntries()[idx];
+        NavigateToAnchor(doc_.GetNodes()[toc_entry.node_index].anchor_id());
     }
 }
 
@@ -757,7 +758,7 @@ void App::OnMouseHover(int px, int py)
             [&](bool close_hit, bool, int idx) -> TooltipTarget {
             if (close_hit) { return { TooltipTarget::Zone::TocPaneButton, i18n::S().tooltip_pane_close }; }
             if (idx >= 0 && idx < static_cast<int>(toc_entries.size())) {
-                return { TooltipTarget::Zone::TocPaneItem, toc_entries[idx].text };
+                return { TooltipTarget::Zone::TocPaneItem, std::wstring(doc_.GetNodes()[toc_entries[idx].node_index].GetText()) };
             }
             return {};
         });

--- a/src/app/app_mouse.cpp
+++ b/src/app/app_mouse.cpp
@@ -758,7 +758,7 @@ void App::OnMouseHover(int px, int py)
             [&](bool close_hit, bool, int idx) -> TooltipTarget {
             if (close_hit) { return { TooltipTarget::Zone::TocPaneButton, i18n::S().tooltip_pane_close }; }
             if (idx >= 0 && idx < static_cast<int>(toc_entries.size())) {
-                return { TooltipTarget::Zone::TocPaneItem, std::wstring(doc_.GetNodes()[toc_entries[idx].node_index].GetText()) };
+                return { TooltipTarget::Zone::TocPaneItem, doc_.GetNodes()[toc_entries[idx].node_index].GetText() };
             }
             return {};
         });

--- a/src/app/app_render_state.cpp
+++ b/src/app/app_render_state.cpp
@@ -23,7 +23,7 @@ SidePaneState App::BuildSidePaneState(const ::PaneLayout& layout) const
 {
     return { layout.file_rect, layout.toc_rect,
              file_explorer_.GetEntries(), panes_.FileScroll(),
-             doc_.GetToc().GetEntries(), panes_.TocScroll(),
+             doc_.GetToc().GetEntries(), doc_.GetNodes(), panes_.TocScroll(),
              panes_.GetHoveredFileIndex(), panes_.GetHoveredTocIndex(), active_toc_index_,
              panes_.IsFilePaneVisible(), panes_.IsTocPaneVisible(),
              panes_.IsFileCloseHovered(), panes_.IsFileRefreshHovered(),

--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -62,8 +62,8 @@ void Document::BuildHeadingIndices(const std::pmr::vector<size_t>& heading_indic
     for (size_t i : heading_indices) {
         const auto& node = nodes_[i];
         toc_.AddEntry(node, static_cast<int>(i));
-        if (!node.anchor_id.empty()) {
-            anchor_index_.emplace(node.anchor_id, static_cast<int>(i));
+        if (!node.anchor_id().empty()) {
+            anchor_index_.emplace(std::pmr::wstring(node.anchor_id()), static_cast<int>(i));
         }
     }
 }

--- a/src/core/document_utils.cpp
+++ b/src/core/document_utils.cpp
@@ -117,7 +117,7 @@ int FindAnchorNodeIndex(const std::pmr::vector<Node>& nodes, std::wstring_view a
     const std::pmr::wstring target = ToLowerAscii(anchor);
 
     for (const auto& [i, node] : nodes | std::views::enumerate) {
-        if (node.type == NodeType::Heading && node.anchor_id == target) {
+        if (node.type == NodeType::Heading && node.anchor_id() == target) {
             return static_cast<int>(i);
         }
     }

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -142,10 +142,10 @@ struct ParseContext {
         TextRun run;
         run.start = start;
         run.length = length;
-        run.bold = current_span.bold;
-        run.italic = current_span.italic;
-        run.code = current_span.code;
-        run.strikethrough = current_span.strikethrough;
+        run.set_bold(current_span.bold);
+        run.set_italic(current_span.italic);
+        run.set_code(current_span.code);
+        run.set_strikethrough(current_span.strikethrough);
         if (current_span.link_url_index >= 0 && current_node) {
             const auto& url = link_urls[static_cast<size_t>(current_span.link_url_index)];
             // ノードのURLプール内で重複を検索し、なければ追加
@@ -450,9 +450,10 @@ int OnLeaveBlock(MD_BLOCKTYPE type, void* /*detail*/, void* userdata)
             std::pmr::wstring base_id = GenerateAnchorId(cn->GetText());
             auto [it, inserted] = ctx->anchor_counts.try_emplace(std::move(base_id), 0);
             const int count = it->second++;
-            cn->anchor_id.assign(it->first.data(), it->first.size());
+            cn->ensure_heading();
+            cn->heading_data->anchor_id.assign(it->first.data(), it->first.size());
             if (count > 0) {
-                std::format_to(std::back_inserter(cn->anchor_id), L"-{}", count);
+                std::format_to(std::back_inserter(cn->heading_data->anchor_id), L"-{}", count);
             }
             ctx->heading_indices.emplace_back(ctx->current_node_index);
         }
@@ -766,7 +767,7 @@ void TransformAlertNode(Node& node, AlertType type, size_t marker_end)
     TextRun label_run;
     label_run.start = 0;
     label_run.length = static_cast<uint32_t>(full_label_len);
-    label_run.bold = true;
+    label_run.set_bold(true);
     new_runs.emplace_back(label_run);
 
     // 元のランを調整（マーカー部分を除外）

--- a/src/core/toc.cpp
+++ b/src/core/toc.cpp
@@ -15,12 +15,7 @@ void TableOfContents::BuildFromNodes(const std::pmr::vector<Node>& nodes)
 
 void TableOfContents::AddEntry(const Node& node, int node_index)
 {
-    TocEntry entry;
-    entry.text = node.GetText();
-    entry.anchor_id = node.anchor_id;
-    entry.heading_level = node.heading_level;
-    entry.node_index = node_index;
-    entries_.emplace_back(std::move(entry));
+    entries_.push_back({ node_index, node.heading_level });
 }
 
 int TableOfContents::HitTest(float local_y, float item_height) const noexcept

--- a/src/core/toc.h
+++ b/src/core/toc.h
@@ -7,10 +7,8 @@
 #include <ranges>
 
 struct TocEntry {
-    std::pmr::wstring text;
-    std::pmr::wstring anchor_id;
-    int heading_level = 1;
     int node_index = -1;
+    int heading_level = 1;
 };
 
 class TableOfContents {

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -47,13 +47,58 @@ constexpr size_t AlertColorIndex(AlertType t) noexcept
 struct TextRun {
     uint32_t start = 0;
     uint32_t length = 0;
-    bool bold = false;
-    bool italic = false;
-    bool code = false;
-    bool strikethrough = false;
     int16_t link_url_index = -1; // -1 = リンクなし, >= 0 = Node::link_urls へのインデックス
 
+    constexpr bool bold() const noexcept { return flags & BOLD; }
+    constexpr bool italic() const noexcept { return flags & ITALIC; }
+    constexpr bool code() const noexcept { return flags & CODE; }
+    constexpr bool strikethrough() const noexcept { return flags & STRIKETHROUGH; }
     constexpr bool has_link() const noexcept { return link_url_index >= 0; }
+
+    constexpr void set_bold(bool v) noexcept
+    {
+        if (v) {
+            flags |= BOLD;
+        }
+        else {
+            flags &= ~BOLD;
+        }
+    }
+    constexpr void set_italic(bool v) noexcept
+    {
+        if (v) {
+            flags |= ITALIC;
+        }
+        else {
+            flags &= ~ITALIC;
+        }
+    }
+    constexpr void set_code(bool v) noexcept
+    {
+        if (v) {
+            flags |= CODE;
+        }
+        else {
+            flags &= ~CODE;
+        }
+    }
+    constexpr void set_strikethrough(bool v) noexcept
+    {
+        if (v) {
+            flags |= STRIKETHROUGH;
+        }
+        else {
+            flags &= ~STRIKETHROUGH;
+        }
+    }
+
+private:
+    static constexpr uint8_t BOLD = 0x01;
+    static constexpr uint8_t ITALIC = 0x02;
+    static constexpr uint8_t CODE = 0x04;
+    static constexpr uint8_t STRIKETHROUGH = 0x08;
+
+    uint8_t flags = 0;
 };
 
 // テキスト選択: 位置は (node_index, char_offset) のペアで表す。
@@ -110,6 +155,16 @@ struct NodeTableData {
     std::pmr::vector<TableRow> rows;
 };
 
+// 見出し専用データ（Headingノードのみ確保してメモリを節約）
+struct NodeHeadingData {
+    std::pmr::wstring anchor_id; // 内部リンク向けGitHubスタイルのスラグ
+};
+
+// コードブロック専用データ（CodeBlockノードのみ確保してメモリを節約）
+struct NodeCodeData {
+    std::pmr::vector<SyntaxToken> syntax_tokens;
+};
+
 // 画像専用データ（Imageノードのみ確保）
 struct NodeImageData {
     std::pmr::wstring src;     // 画像ソースパス（Markdown内の記述）
@@ -120,8 +175,6 @@ struct NodeImageData {
 struct Node {
     mutable std::pmr::string text_utf8; // テキスト主記憶（UTF-8、パーサーが設定。GetText()後に解放される場合あり）
     std::pmr::vector<TextRun> runs;
-    std::pmr::wstring anchor_id;   // 見出し用: 内部リンク向けGitHubスタイルのスラグ
-    std::pmr::vector<SyntaxToken> syntax_tokens;
 
     // runs および table_data->rows 内の TextRun::link_url_index が参照するリンクURLプール
     std::pmr::vector<std::pmr::wstring> link_urls;
@@ -131,6 +184,12 @@ struct Node {
 
     // 画像データ（type == Image の場合のみ確保、それ以外は nullptr）
     std::unique_ptr<NodeImageData> image_data;
+
+    // 見出しデータ（type == Heading の場合のみ確保、それ以外は nullptr）
+    std::unique_ptr<NodeHeadingData> heading_data;
+
+    // コードブロックデータ（type == CodeBlock の場合のみ確保、それ以外は nullptr）
+    std::unique_ptr<NodeCodeData> code_data;
 
     int heading_level = 0;
     int indent_level = 0;
@@ -207,6 +266,45 @@ struct Node {
         }
     }
     bool has_image() const noexcept { return image_data != nullptr; }
+
+    // 見出しへの便利アクセサ
+    void ensure_heading()
+    {
+        if (!heading_data) {
+            heading_data = std::make_unique<NodeHeadingData>();
+        }
+    }
+    bool has_heading() const noexcept { return heading_data != nullptr; }
+    // アンカーIDへの安全アクセス。Headingでなければ空文字列を返す。
+    // 注: 戻り値は heading_data のライフタイムに依存する。
+    std::wstring_view anchor_id() const noexcept
+    {
+        return heading_data ? std::wstring_view(heading_data->anchor_id) : std::wstring_view{};
+    }
+
+    // コードブロックへの便利アクセサ
+    void ensure_code()
+    {
+        if (!code_data) {
+            code_data = std::make_unique<NodeCodeData>();
+        }
+    }
+    bool has_code() const noexcept { return code_data != nullptr; }
+    const std::pmr::vector<SyntaxToken>& syntax_tokens() const noexcept
+    {
+        // code_data が nullptr の場合のみ呼ばれる想定だが、安全のためガード
+        if (code_data) {
+            return code_data->syntax_tokens;
+        }
+        // 空のベクターを返す（CodeBlock以外では syntax_tokens() は呼ばれない設計）
+        static const std::pmr::vector<SyntaxToken> empty;
+        return empty;
+    }
+    std::pmr::vector<SyntaxToken>& syntax_tokens_mut()
+    {
+        ensure_code();
+        return code_data->syntax_tokens;
+    }
 
 private:
     void FinalizeSetText() noexcept

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -195,10 +195,7 @@ HitTestService::HitResult HitTestService::HitTestTable(
     // セルのテキストレイアウト内でヒットテスト
     const size_t r = static_cast<size_t>(hit_row);
     const size_t c = static_cast<size_t>(hit_col);
-    IDWriteTextLayout* cell_layout = nullptr;
-    if (r < tl.cell_layouts.size() && c < tl.cell_layouts[r].size()) {
-        cell_layout = tl.cell_layouts[r][c].Get();
-    }
+    IDWriteTextLayout* cell_layout = tl.GetCellLayout(r, c);
     if (cell_layout) {
         float cell_x = base_x + border;
         for (size_t cc = 0; cc < c; cc++) {

--- a/src/io/file_explorer.cpp
+++ b/src/io/file_explorer.cpp
@@ -31,7 +31,6 @@ void FileExplorer::Refresh()
         const auto parent = dir_path.parent_path();
         if (parent != dir_path) {
             FileEntry pe;
-            pe.filename = L"..";
             pe.full_path.assign(parent.native());
             pe.is_directory = true;
             pe.is_parent = true;
@@ -68,14 +67,12 @@ void FileExplorer::Refresh()
 
         if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
             FileEntry entry;
-            entry.filename = fd.cFileName;
             entry.full_path.assign((dir_base / fd.cFileName).native());
             entry.is_directory = true;
             dirs.emplace_back(std::move(entry));
         }
         else if (IsMarkdownFile(fd.cFileName)) {
             FileEntry entry;
-            entry.filename = fd.cFileName;
             entry.full_path.assign((dir_base / fd.cFileName).native());
             files.emplace_back(std::move(entry));
         }
@@ -83,10 +80,10 @@ void FileExplorer::Refresh()
 
     // ディレクトリとファイルをそれぞれ大文字小文字無視でソート
     std::ranges::sort(dirs, [](const FileEntry& a, const FileEntry& b) static noexcept {
-        return _wcsicmp(a.filename.c_str(), b.filename.c_str()) < 0;
+        return _wcsicmp(a.GetDisplayName(), b.GetDisplayName()) < 0;
     });
     std::ranges::sort(files, [](const FileEntry& a, const FileEntry& b) static noexcept {
-        return _wcsicmp(a.filename.c_str(), b.filename.c_str()) < 0;
+        return _wcsicmp(a.GetDisplayName(), b.GetDisplayName()) < 0;
     });
 
     // 追加: ディレクトリを先に、次にファイル

--- a/src/io/file_explorer.h
+++ b/src/io/file_explorer.h
@@ -6,11 +6,21 @@
 #include <memory_resource>
 
 struct FileEntry {
-    std::pmr::wstring filename;
     std::pmr::wstring full_path;
     bool is_current = false;
     bool is_directory = false;
     bool is_parent = false;  // ".." エントリ
+
+    // 表示名を返す（full_pathの末尾ファイル名、".."エントリは"..") 。
+    // 戻り値はfull_pathの内部バッファまたはリテラルを指すためnull終端。
+    const wchar_t* GetDisplayName() const noexcept
+    {
+        if (is_parent) {
+            return L"..";
+        }
+        const auto pos = full_path.find_last_of(L"\\/");
+        return (pos != full_path.npos) ? full_path.c_str() + pos + 1 : full_path.c_str();
+    }
 };
 
 class FileExplorer {

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -88,17 +88,17 @@ void DWriteTextMeasurer::ApplyCellRunFormatting(IDWriteTextLayout* layout,
 {
     for (const auto& run : runs) {
         const DWRITE_TEXT_RANGE range{ run.start, run.length };
-        if (run.bold) {
+        if (run.bold()) {
             layout->SetFontWeight(DWRITE_FONT_WEIGHT_EXTRA_BOLD, range);
         }
-        if (run.italic) {
+        if (run.italic()) {
             layout->SetFontStyle(DWRITE_FONT_STYLE_ITALIC, range);
         }
-        if (run.code) {
+        if (run.code()) {
             layout->SetFontFamilyName(theme_->monospace_font.c_str(), range);
             layout->SetFontSize(theme_->font_size_code, range);
         }
-        if (run.strikethrough) {
+        if (run.strikethrough()) {
             layout->SetStrikethrough(TRUE, range);
         }
         if (run.has_link()) {
@@ -175,19 +175,19 @@ void DWriteTextMeasurer::MeasureNode(Node& node, NodeLayoutEntry& entry, float m
     // ラン単位のフォーマットを適用
     for (const auto& run : node.runs) {
         const DWRITE_TEXT_RANGE range{ run.start, run.length };
-        if (run.bold) {
+        if (run.bold()) {
             layout->SetFontWeight(DWRITE_FONT_WEIGHT_EXTRA_BOLD, range);
         }
-        if (run.italic) {
+        if (run.italic()) {
             layout->SetFontStyle(DWRITE_FONT_STYLE_ITALIC, range);
         }
-        if (run.code && node.type != NodeType::CodeBlock) {
+        if (run.code() && node.type != NodeType::CodeBlock) {
             layout->SetFontFamilyName(theme_->monospace_font.c_str(), range);
             if (node.type != NodeType::Heading) {
                 layout->SetFontSize(theme_->font_size_code, range);
             }
         }
-        if (run.strikethrough) {
+        if (run.strikethrough()) {
             layout->SetStrikethrough(TRUE, range);
         }
     }
@@ -205,10 +205,10 @@ void DWriteTextMeasurer::MeasureNode(Node& node, NodeLayoutEntry& entry, float m
 
     // コードブロックのシンタックストークン化をレイアウトパスで事前実行する。
     // 描画パス（ApplyNodeEffects）での遅延トークン化を排除し、フレーム落ちを防止する。
-    if (node.type == NodeType::CodeBlock && node.syntax_tokens.empty() &&
+    if (node.type == NodeType::CodeBlock && node.syntax_tokens().empty() &&
         node.code_language != SyntaxLanguage::None &&
         node.code_language != SyntaxLanguage::Mermaid) {
-        node.syntax_tokens = Tokenize(text, node.code_language);
+        node.syntax_tokens_mut() = Tokenize(text, node.code_language);
     }
 
     entry.text_layout = std::move(layout);
@@ -237,15 +237,16 @@ void DWriteTextMeasurer::MeasureTableCells(Node& node, NodeLayoutEntry& entry,
             }
 
             IDWriteTextFormat* const cell_fmt = cell.is_header ? fmt_bold : fmt;
+            const size_t ci = tl.CellIndex(r, c);
             dwrite_->CreateTextLayout(
                 cell.text.c_str(), static_cast<UINT32>(cell.text.size()),
                 cell_fmt, CODE_BLOCK_NO_WRAP_WIDTH, LAYOUT_MAX_HEIGHT,
-                &tl.cell_layouts[r][c]);
+                &tl.cell_layouts[ci]);
 
-            if (tl.cell_layouts[r][c]) {
-                ApplyCellRunFormatting(tl.cell_layouts[r][c].Get(), cell.runs);
+            if (tl.cell_layouts[ci]) {
+                ApplyCellRunFormatting(tl.cell_layouts[ci].Get(), cell.runs);
                 DWRITE_TEXT_METRICS metrics{};
-                tl.cell_layouts[r][c]->GetMetrics(&metrics);
+                tl.cell_layouts[ci]->GetMetrics(&metrics);
                 natural_widths[c] = std::max(natural_widths[c], metrics.width);
             }
         }
@@ -274,17 +275,18 @@ void DWriteTextMeasurer::FinalizeTableLayout(Node& node, NodeLayoutEntry& entry,
             auto& cell = row.cells[c];
             const float cw = (c < tl.col_widths.size()) ? tl.col_widths[c] : DEFAULT_COLUMN_WIDTH;
 
-            if (tl.cell_layouts[r][c]) {
-                tl.cell_layouts[r][c]->SetMaxWidth(cw);
+            const size_t ci = tl.CellIndex(r, c);
+            if (tl.cell_layouts[ci]) {
+                tl.cell_layouts[ci]->SetMaxWidth(cw);
                 if (cell.align == 1) {
-                    tl.cell_layouts[r][c]->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+                    tl.cell_layouts[ci]->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
                 }
                 else if (cell.align == 2) {
-                    tl.cell_layouts[r][c]->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_TRAILING);
+                    tl.cell_layouts[ci]->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_TRAILING);
                 }
 
                 DWRITE_TEXT_METRICS metrics{};
-                tl.cell_layouts[r][c]->GetMetrics(&metrics);
+                tl.cell_layouts[ci]->GetMetrics(&metrics);
                 row_height = std::max(row_height, metrics.height + cell_padding * 2.0f);
             }
         }
@@ -347,7 +349,7 @@ void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float 
 
     // セルレイアウトが既に存在する場合は第1パス（テキストレイアウト作成）をスキップし、
     // 列幅の再計算のみ行う（リサイズ時の高速パス）。
-    const bool has_existing_layouts = !tl.cell_layouts.empty() && (tl.cell_layouts.size() == row_count);
+    const bool has_existing_layouts = !tl.cell_layouts.empty() && (tl.cell_layouts.size() == row_count * col_count);
     if (has_existing_layouts) {
         // キャッシュ済み自然幅を使用し、DirectWrite呼び出しを回避
         if (tl.natural_col_widths.size() == col_count) {
@@ -358,12 +360,12 @@ void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float 
             std::pmr::vector<float> natural_widths(col_count, 0.0f);
             for (size_t r = 0; r < row_count; r++) {
                 const auto cell_count = rows[r].cells.size();
-                const auto cell_layout_count = tl.cell_layouts[r].size();
-                for (size_t c = 0; c < cell_count && c < cell_layout_count; c++) {
-                    if (tl.cell_layouts[r][c]) {
-                        tl.cell_layouts[r][c]->SetMaxWidth(CODE_BLOCK_NO_WRAP_WIDTH);
+                for (size_t c = 0; c < cell_count && c < col_count; c++) {
+                    const size_t ci = tl.CellIndex(r, c);
+                    if (tl.cell_layouts[ci]) {
+                        tl.cell_layouts[ci]->SetMaxWidth(CODE_BLOCK_NO_WRAP_WIDTH);
                         DWRITE_TEXT_METRICS metrics{};
-                        tl.cell_layouts[r][c]->GetMetrics(&metrics);
+                        tl.cell_layouts[ci]->GetMetrics(&metrics);
                         natural_widths[c] = std::max(natural_widths[c], metrics.width);
                     }
                 }
@@ -373,10 +375,8 @@ void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float 
         }
     }
     else {
-        tl.cell_layouts.resize(row_count);
-        for (size_t r = 0; r < row_count; r++) {
-            tl.cell_layouts[r].resize(rows[r].cells.size());
-        }
+        tl.col_count = col_count;
+        tl.cell_layouts.resize(row_count * col_count);
 
         // 第1パス: テキストレイアウトを作成し、自然な幅を計測
         std::pmr::vector<float> natural_widths(col_count, 0.0f);

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -8,18 +8,28 @@
 #include <cassert>
 
 
-struct InlineCodeBg {
-    float left, top, width, height;
-};
+// インラインコードの背景矩形（レイアウト原点からの相対座標、パディング適用済み）
+using InlineCodeBg = D2D1_RECT_F;
 
 // テーブル専用のレイアウトデータ（テーブルノードのみ確保してメモリを節約）
 struct TableLayoutData {
-    std::pmr::vector<std::pmr::vector<Microsoft::WRL::ComPtr<IDWriteTextLayout>>> cell_layouts; // [行][列]
-    std::pmr::vector<std::pmr::vector<std::pmr::vector<InlineCodeBg>>> cell_inline_code_bgs; // [行][列][]
+    std::pmr::vector<Microsoft::WRL::ComPtr<IDWriteTextLayout>> cell_layouts; // フラット配列 [行 * col_count + 列]
+    std::pmr::vector<std::pmr::vector<InlineCodeBg>> cell_inline_code_bgs; // フラット配列 [行 * col_count + 列][]
+    size_t col_count = 0; // cell_layoutsのストライド
     std::pmr::vector<float> col_widths;
     std::pmr::vector<float> row_heights;
     std::pmr::vector<float> natural_col_widths; // リサイズ高速パス用キャッシュ
     std::pmr::vector<uint32_t> row_flat_offsets; // 各行の線形化テキスト先頭オフセット（ヒットテスト高速化用）
+
+    // フラットインデックスへの変換
+    constexpr size_t CellIndex(size_t row, size_t col) const noexcept { return row * col_count + col; }
+
+    // セルレイアウトの安全アクセス
+    IDWriteTextLayout* GetCellLayout(size_t row, size_t col) const noexcept
+    {
+        const size_t idx = CellIndex(row, col);
+        return (idx < cell_layouts.size()) ? cell_layouts[idx].Get() : nullptr;
+    }
 };
 
 struct NodeLayoutEntry {
@@ -111,6 +121,7 @@ public:
                 e.table_layout->cell_layouts.clear();
                 e.table_layout->cell_inline_code_bgs.clear();
                 e.table_layout->natural_col_widths.clear();
+                e.table_layout->col_count = 0;
             }
         }
         effects_generation_++;
@@ -138,6 +149,7 @@ public:
             if (e.table_layout) {
                 e.table_layout->cell_layouts.clear();
                 e.table_layout->natural_col_widths.clear();
+                e.table_layout->col_count = 0;
             }
         }
         effects_generation_++;

--- a/src/nav/nav_history.cpp
+++ b/src/nav/nav_history.cpp
@@ -1,21 +1,12 @@
 #include "nav_history.h"
 
-uint16_t NavHistory::InternPath(std::wstring_view path)
+uint32_t NavHistory::InternPath(std::wstring_view path)
 {
-    const auto pool_size = path_pool_.size();
-    for (size_t i = 0; i < pool_size; ++i) {
-        if (path_pool_[i] == path) {
-            return static_cast<uint16_t>(i);
-        }
-    }
-    // プールが上限に達した場合、全履歴をリセットして再インターンする
-    if (pool_size >= MAX_PATH_POOL) {
-        back_stack_.clear();
-        forward_stack_.clear();
-        path_pool_.clear();
+    if (const auto iter = std::ranges::find(path_pool_, path); iter != path_pool_.end()) {
+        return static_cast<uint32_t>(std::ranges::distance(path_pool_.begin(), iter));
     }
     path_pool_.emplace_back(path);
-    return static_cast<uint16_t>(path_pool_.size() - 1);
+    return static_cast<uint32_t>(path_pool_.size() - 1);
 }
 
 NavEntry NavHistory::ToExternal(const InternalEntry& e) const

--- a/src/nav/nav_history.cpp
+++ b/src/nav/nav_history.cpp
@@ -1,8 +1,24 @@
 #include "nav_history.h"
 
+uint16_t NavHistory::InternPath(std::wstring_view path)
+{
+    for (uint16_t i = 0; i < path_pool_.size(); ++i) {
+        if (path_pool_[i] == path) {
+            return i;
+        }
+    }
+    path_pool_.emplace_back(path);
+    return static_cast<uint16_t>(path_pool_.size() - 1);
+}
+
+NavEntry NavHistory::ToExternal(const InternalEntry& e) const
+{
+    return NavEntry(path_pool_[e.path_index], e.scroll_y);
+}
+
 void NavHistory::Push(const NavEntry& current)
 {
-    back_stack_.emplace_back(current);
+    back_stack_.emplace_back(ToInternal(current));
     forward_stack_.clear();
 
     // 履歴サイズを制限（dequeなのでpop_frontはO(1)）
@@ -17,11 +33,11 @@ bool NavHistory::GoBack(const NavEntry& current, NavEntry& out)
         return false;
     }
 
-    forward_stack_.emplace_back(current);
+    forward_stack_.emplace_back(ToInternal(current));
     if (forward_stack_.size() > MAX_HISTORY) {
         forward_stack_.pop_front();
     }
-    out = std::move(back_stack_.back());
+    out = ToExternal(back_stack_.back());
     back_stack_.pop_back();
     return true;
 }
@@ -32,8 +48,8 @@ bool NavHistory::GoForward(const NavEntry& current, NavEntry& out)
         return false;
     }
 
-    back_stack_.emplace_back(current);
-    out = std::move(forward_stack_.back());
+    back_stack_.emplace_back(ToInternal(current));
+    out = ToExternal(forward_stack_.back());
     forward_stack_.pop_back();
     return true;
 }
@@ -42,4 +58,5 @@ void NavHistory::Clear() noexcept
 {
     back_stack_.clear();
     forward_stack_.clear();
+    path_pool_.clear();
 }

--- a/src/nav/nav_history.cpp
+++ b/src/nav/nav_history.cpp
@@ -2,10 +2,17 @@
 
 uint16_t NavHistory::InternPath(std::wstring_view path)
 {
-    for (uint16_t i = 0; i < path_pool_.size(); ++i) {
+    const auto pool_size = path_pool_.size();
+    for (size_t i = 0; i < pool_size; ++i) {
         if (path_pool_[i] == path) {
-            return i;
+            return static_cast<uint16_t>(i);
         }
+    }
+    // プールが上限に達した場合、全履歴をリセットして再インターンする
+    if (pool_size >= MAX_PATH_POOL) {
+        back_stack_.clear();
+        forward_stack_.clear();
+        path_pool_.clear();
     }
     path_pool_.emplace_back(path);
     return static_cast<uint16_t>(path_pool_.size() - 1);

--- a/src/nav/nav_history.h
+++ b/src/nav/nav_history.h
@@ -18,6 +18,7 @@ struct NavEntry {
 
 // ブラウザスタイルの戻る/進むナビゲーション履歴。
 // 純粋なロジックのみ、Win32依存なし — 完全にテスト可能。
+// 内部ではパスをインターン化し、同一パスの重複保持を回避する。
 class NavHistory {
 public:
     // ナビゲーション前の現在の状態を記録する。
@@ -43,6 +44,20 @@ public:
     static constexpr size_t MAX_HISTORY = 1024;
 
 private:
-    std::pmr::deque<NavEntry> back_stack_;
-    std::pmr::deque<NavEntry> forward_stack_;
+    // 内部エントリ: パスインデックス + スクロール位置（8バイト）
+    struct InternalEntry {
+        uint16_t path_index = 0;
+        float scroll_y = 0.0f;
+    };
+
+    // パスをインターン化し、インデックスを返す
+    uint16_t InternPath(std::wstring_view path);
+
+    // NavEntry ↔ InternalEntry 変換
+    InternalEntry ToInternal(const NavEntry& e) { return { InternPath(e.file_path), e.scroll_y }; }
+    NavEntry ToExternal(const InternalEntry& e) const;
+
+    std::pmr::vector<std::pmr::wstring> path_pool_;
+    std::pmr::deque<InternalEntry> back_stack_;
+    std::pmr::deque<InternalEntry> forward_stack_;
 };

--- a/src/nav/nav_history.h
+++ b/src/nav/nav_history.h
@@ -42,6 +42,7 @@ public:
     void Clear() noexcept;
 
     static constexpr size_t MAX_HISTORY = 1024;
+    static constexpr size_t MAX_PATH_POOL = UINT16_MAX; // path_index が uint16_t のため
 
 private:
     // 内部エントリ: パスインデックス + スクロール位置（8バイト）

--- a/src/nav/nav_history.h
+++ b/src/nav/nav_history.h
@@ -42,17 +42,17 @@ public:
     void Clear() noexcept;
 
     static constexpr size_t MAX_HISTORY = 1024;
-    static constexpr size_t MAX_PATH_POOL = UINT16_MAX; // path_index が uint16_t のため
+    static constexpr size_t MAX_PATH_POOL = UINT32_MAX; // path_index が uint32_t のため
 
 private:
     // 内部エントリ: パスインデックス + スクロール位置（8バイト）
     struct InternalEntry {
-        uint16_t path_index = 0;
+        uint32_t path_index = 0;
         float scroll_y = 0.0f;
     };
 
     // パスをインターン化し、インデックスを返す
-    uint16_t InternPath(std::wstring_view path);
+    uint32_t InternPath(std::wstring_view path);
 
     // NavEntry ↔ InternalEntry 変換
     InternalEntry ToInternal(const NavEntry& e) { return { InternPath(e.file_path), e.scroll_y }; }

--- a/src/render/command_gen_table.cpp
+++ b/src/render/command_gen_table.cpp
@@ -121,14 +121,11 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
             const float text_x = cx + cell_padding;
             const float text_y = y + cell_padding;
 
-            IDWriteTextLayout* cell_layout = nullptr;
-            if (r < tl.cell_layouts.size() && c < tl.cell_layouts[r].size()) {
-                cell_layout = tl.cell_layouts[r][c].Get();
-            }
+            IDWriteTextLayout* cell_layout = tl.GetCellLayout(r, c);
 
             // セルのインラインコード背景
-            if (r < tl.cell_inline_code_bgs.size() && c < tl.cell_inline_code_bgs[r].size()) {
-                GenInlineCodeBgs(cmds, tl.cell_inline_code_bgs[r][c], text_x, text_y, theme_->code_bg_color);
+            if (const size_t ci = tl.CellIndex(r, c); ci < tl.cell_inline_code_bgs.size()) {
+                GenInlineCodeBgs(cmds, tl.cell_inline_code_bgs[ci], text_x, text_y, theme_->code_bg_color);
             }
 
             // 検索マッチのハイライト（テーブルセル）

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -28,16 +28,17 @@ inline UINT32 FetchHitTestMetrics(IDWriteTextLayout* layout, UINT32 start, UINT3
 }
 
 // インラインコードの背景矩形を描画する。
+// bgsにはパディング適用済みのレイアウト原点相対矩形が格納されている。
 inline void GenInlineCodeBgs(DrawCommandList& cmds,
     const std::pmr::vector<InlineCodeBg>& bgs,
     float origin_x, float origin_y, D2D1_COLOR_F color)
 {
     for (const auto& bg : bgs) {
         const D2D1_RECT_F rect = D2D1::RectF(
-            origin_x + bg.left - INLINE_CODE_PAD_X,
-            origin_y + bg.top - INLINE_CODE_PAD_Y,
-            origin_x + bg.left + bg.width + INLINE_CODE_PAD_X,
-            origin_y + bg.top + bg.height + INLINE_CODE_PAD_Y
+            origin_x + bg.left,
+            origin_y + bg.top,
+            origin_x + bg.right,
+            origin_y + bg.bottom
         );
         cmds.emplace_back(FillRoundedRectCmd{ rect, INLINE_CODE_CORNER, INLINE_CODE_CORNER, color });
     }
@@ -74,7 +75,7 @@ public:
             : D2D1::ColorF(0.0f, 0.0f, 0.0f, a);
     }
     constexpr void SetFormats(const Formats& fmts) noexcept { formats_ = fmts; }
-    void SetSearchMatches(const std::vector<SearchMatch>* matches, int current_index) noexcept
+    void SetSearchMatches(const std::pmr::vector<SearchMatch>* matches, int current_index) noexcept
     {
         search_matches_ = matches;
         current_match_index_ = current_index;
@@ -136,7 +137,7 @@ private:
     MonotonicResource frame_resource_{ 128 * 1024 };
     DrawCommandList cmds_{ frame_resource_.resource() };
 
-    const std::vector<SearchMatch>* search_matches_ = nullptr;
+    const std::pmr::vector<SearchMatch>* search_matches_ = nullptr;
     int current_match_index_ = -1;
 
     std::pmr::vector<DWRITE_HIT_TEST_METRICS>* shared_hit_test_buffer_ = nullptr;

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -334,6 +334,17 @@ ID2D1SolidColorBrush* Renderer::GetSyntaxBrush(SyntaxTokenType type) const noexc
     return Brush(SYNTAX_MAP[idx]);
 }
 
+// DWRITE_HIT_TEST_METRICS からパディング適用済みの InlineCodeBg を生成する。
+static InlineCodeBg MakeInlineCodeBg(const DWRITE_HIT_TEST_METRICS& m) noexcept
+{
+    return D2D1::RectF(
+        m.left - INLINE_CODE_PAD_X,
+        m.top - INLINE_CODE_PAD_Y,
+        m.left + m.width + INLINE_CODE_PAD_X,
+        m.top + m.height + INLINE_CODE_PAD_Y
+    );
+}
+
 void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry,
     float viewport_top, float viewport_bottom)
 {
@@ -348,7 +359,7 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry,
     auto& tl = *entry.table_layout;
     if (first_pass) {
         entry.effects_applied = true;
-        tl.cell_inline_code_bgs.resize(row_count);
+        tl.cell_inline_code_bgs.resize(row_count * tl.col_count);
     }
 
     const float border = TABLE_BORDER_WIDTH;
@@ -362,8 +373,28 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry,
 
         const bool row_visible = (viewport_top < 0.0f)
             || (row_bottom >= viewport_top && row_y <= viewport_bottom);
-        const bool bgs_done = (r < tl.cell_inline_code_bgs.size())
-            && (tl.cell_inline_code_bgs[r].size() == row.cells.size());
+        // 行の全セルを走査済みかを判定: 行のフラット範囲が確保されており、
+        // いずれかのセルに背景があるか、全セルが空(インラインコードなし)なら完了とみなす。
+        bool bgs_done = false;
+        if (!first_pass && tl.CellIndex(r, 0) < tl.cell_inline_code_bgs.size()) {
+            // first_pass でリサイズ済みなのでフラグとして先頭セルの capacity を利用:
+            // first_pass 後に need_bgs=true で走査されたセルは push_back か reserve(0) で
+            // 容量が 0 でなくなるが、ここでは簡便にインラインコードランの有無で判定する。
+            bgs_done = true;
+            const auto cc = row.cells.size();
+            for (size_t c = 0; c < cc; c++) {
+                // インラインコードランを持つセルに背景がなければ未処理
+                for (const auto& run : row.cells[c].runs) {
+                    if (run.code() && run.length > 0 && tl.cell_inline_code_bgs[tl.CellIndex(r, c)].empty()) {
+                        bgs_done = false;
+                        break;
+                    }
+                }
+                if (!bgs_done) {
+                    break;
+                }
+            }
+        }
         const bool need_bgs = row_visible && !bgs_done;
 
         // 2回目以降: インラインコード背景の計算が不要な行はスキップ
@@ -372,17 +403,9 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry,
             continue;
         }
 
-        // この行のインラインコード背景を計算する場合のみ内側ベクターを確保
-        if (need_bgs && r < tl.cell_inline_code_bgs.size()) {
-            tl.cell_inline_code_bgs[r].resize(row.cells.size());
-        }
-
         const auto col_count = row.cells.size();
         for (size_t c = 0; c < col_count; c++) {
-            IDWriteTextLayout* cell_layout = nullptr;
-            if (r < tl.cell_layouts.size() && c < tl.cell_layouts[r].size()) {
-                cell_layout = tl.cell_layouts[r][c].Get();
-            }
+            IDWriteTextLayout* cell_layout = tl.GetCellLayout(r, c);
             if (!cell_layout) {
                 continue;
             }
@@ -393,15 +416,10 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry,
                     cell_layout->SetDrawingEffect(Brush(BrushId::Link), range);
                 }
                 // インラインコード背景: 可視かつ未計算の行のみ
-                if (need_bgs && run.code && run.length > 0) {
+                if (need_bgs && run.code() && run.length > 0) {
                     const UINT32 count = FetchHitTestMetrics(cell_layout, run.start, run.length, hit_test_buffer_);
                     for (UINT32 hi = 0; hi < count; hi++) {
-                        tl.cell_inline_code_bgs[r][c].emplace_back(
-                            hit_test_buffer_[hi].left,
-                            hit_test_buffer_[hi].top,
-                            hit_test_buffer_[hi].width,
-                            hit_test_buffer_[hi].height
-                        );
+                        tl.cell_inline_code_bgs[tl.CellIndex(r, c)].push_back(MakeInlineCodeBg(hit_test_buffer_[hi]));
                     }
                 }
             }
@@ -437,7 +455,7 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry,
     // コードブロックにシンタックスハイライトを適用
     // トークン化はMeasureNode（レイアウトパス）で事前実行済み
     if (node.type == NodeType::CodeBlock) {
-        for (const auto& token : node.syntax_tokens) {
+        for (const auto& token : node.syntax_tokens()) {
             if (token.type == SyntaxTokenType::Plain) {
                 continue;
             }
@@ -470,15 +488,10 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry,
             entry.text_layout->SetUnderline(TRUE, range);
             entry.text_layout->SetDrawingEffect(Brush(BrushId::Link), range);
         }
-        if (run.code && node.type != NodeType::CodeBlock && run.length > 0) {
+        if (run.code() && node.type != NodeType::CodeBlock && run.length > 0) {
             const UINT32 count = FetchHitTestMetrics(entry.text_layout.Get(), run.start, run.length, hit_test_buffer_);
             for (UINT32 i = 0; i < count; i++) {
-                entry.inline_code_bgs.emplace_back(
-                    hit_test_buffer_[i].left,
-                    hit_test_buffer_[i].top,
-                    hit_test_buffer_[i].width,
-                    hit_test_buffer_[i].height
-                );
+                entry.inline_code_bgs.push_back(MakeInlineCodeBg(hit_test_buffer_[i]));
             }
         }
     }
@@ -493,7 +506,7 @@ void Renderer::DrawSidePanes(const SidePaneState& sp)
         DrawSplitter(sp.file_pane_rect.x + sp.file_pane_rect.width, sp.file_pane_rect.y, sp.file_pane_rect.y + sp.file_pane_rect.height);
     }
     if (sp.show_toc_pane) {
-        DrawToc(sp.toc_entries, sp.toc_pane_rect, sp.toc_scroll, sp.hovered_toc_index, sp.toc_close_hovered, sp.active_toc_index);
+        DrawToc(sp.toc_entries, sp.nodes, sp.toc_pane_rect, sp.toc_scroll, sp.hovered_toc_index, sp.toc_close_hovered, sp.active_toc_index);
         DrawSplitter(sp.toc_pane_rect.x + sp.toc_pane_rect.width, sp.toc_pane_rect.y, sp.toc_pane_rect.y + sp.toc_pane_rect.height);
     }
 }

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -373,6 +373,11 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry,
 
         const bool row_visible = (viewport_top < 0.0f)
             || (row_bottom >= viewport_top && row_y <= viewport_bottom);
+        // 2回目以降のパスではオフスクリーン行の背景走査をスキップ
+        if (!first_pass && !row_visible) {
+            row_y = row_bottom;
+            continue;
+        }
         // 行の全セルを走査済みかを判定: 行のフラット範囲が確保されており、
         // いずれかのセルに背景があるか、全セルが空(インラインコードなし)なら完了とみなす。
         bool bgs_done = false;

--- a/src/render/renderer.h
+++ b/src/render/renderer.h
@@ -96,6 +96,7 @@ struct SidePaneState {
     const std::pmr::vector<FileEntry>& file_entries;
     const ScrollState& file_scroll;
     const std::pmr::vector<TocEntry>& toc_entries;
+    const std::pmr::vector<Node>& nodes; // TocEntryからのテキスト参照用
     const ScrollState& toc_scroll;
     // --- 4バイトアライメント ---
     int hovered_file_index;
@@ -203,7 +204,7 @@ public:
     void SetDeviceLostCallback(std::function<void(ID2D1RenderTarget*)> cb) { on_device_lost_ = std::move(cb); }
 
     int HitTestSearchInput(std::wstring_view query, float local_x, float max_width) const;
-    void SetSearchMatches(const std::vector<SearchMatch>* matches, int current_index) noexcept
+    void SetSearchMatches(const std::pmr::vector<SearchMatch>* matches, int current_index) noexcept
     {
         cmd_generator_.SetSearchMatches(matches, current_index);
     }
@@ -223,7 +224,7 @@ private:
     void DrawTitleBar(const TitleBarRenderState& tb);
     void DrawMdScrollbar(const PaneRect& md_pane_rect, float scroll_y, float total_content_height, bool has_dirty_nodes);
     void DrawFileExplorer(const std::pmr::vector<FileEntry>& entries, const PaneRect& rect, const ScrollState& scroll, int hovered_index, bool close_hovered, bool refresh_hovered);
-    void DrawToc(const std::pmr::vector<TocEntry>& entries, const PaneRect& rect, const ScrollState& scroll, int hovered_index, bool close_hovered, int active_index);
+    void DrawToc(const std::pmr::vector<TocEntry>& entries, const std::pmr::vector<Node>& nodes, const PaneRect& rect, const ScrollState& scroll, int hovered_index, bool close_hovered, int active_index);
     void DrawSplitter(float x, float top, float bottom);
     void DrawNavOverlay(const PaneRect& md_pane_rect, bool can_back, bool can_forward, int hovered);  // 0=なし, 1=戻る, 2=進む
     void DrawGestureTrail(const std::pmr::deque<GesturePoint>& points);

--- a/src/render/renderer_pane.cpp
+++ b/src/render/renderer_pane.cpp
@@ -198,9 +198,10 @@ void Renderer::DrawFileExplorer(const std::pmr::vector<FileEntry>& entries, cons
 
         if (fmt_.pane_item) {
             const D2D1_RECT_F text_rect = D2D1::RectF(4.0f + icon_col_width, item_y, width - 4.0f, item_y + theme_.pane_item_height);
+            const wchar_t* name = entry.GetDisplayName();
             rt->DrawText(
-                entry.filename.c_str(),
-                static_cast<UINT32>(entry.filename.size()),
+                name,
+                static_cast<UINT32>(wcslen(name)),
                 fmt_.pane_item.Get(),
                 text_rect,
                 Brush(BrushId::Text),
@@ -229,8 +230,8 @@ void Renderer::DrawFileExplorer(const std::pmr::vector<FileEntry>& entries, cons
     );
 }
 
-void Renderer::DrawToc(const std::pmr::vector<TocEntry>& entries, const PaneRect& rect,
-    const ScrollState& scroll, int hovered_index, bool close_hovered, int active_index)
+void Renderer::DrawToc(const std::pmr::vector<TocEntry>& entries, const std::pmr::vector<Node>& nodes,
+    const PaneRect& rect, const ScrollState& scroll, int hovered_index, bool close_hovered, int active_index)
 {
     auto draw_item = [&](ID2D1RenderTarget* rt, int i, float item_y, float width) {
         const auto& entry = entries[i];
@@ -245,7 +246,8 @@ void Renderer::DrawToc(const std::pmr::vector<TocEntry>& entries, const PaneRect
         if (fmt_.pane_item) {
             const D2D1_RECT_F text_rect = D2D1::RectF(
                 8.0f + indent, item_y, width - 4.0f, item_y + theme_.pane_item_height);
-            rt->DrawText(entry.text.c_str(), static_cast<UINT32>(entry.text.size()),
+            const auto& text = nodes[entry.node_index].GetText();
+            rt->DrawText(text.c_str(), static_cast<UINT32>(text.size()),
                 fmt_.pane_item.Get(), text_rect, Brush(BrushId::Text),
                 D2D1_DRAW_TEXT_OPTIONS_CLIP);
         }

--- a/src/ui/search_state.cpp
+++ b/src/ui/search_state.cpp
@@ -19,7 +19,7 @@ void SearchState::ExecuteSearch(const std::pmr::vector<Node>& nodes)
     }
 
     // 大文字小文字無視の場合、クエリの小文字変換をループ外で1回だけ行う
-    std::wstring lower_query;
+    std::pmr::wstring lower_query;
     if (!case_sensitive_) {
         lower_query.reserve(query_.size());
         std::ranges::transform(
@@ -56,7 +56,7 @@ void SearchState::ExecuteSearch(const std::pmr::vector<Node>& nodes)
     matches_truncated_ = (matches_.size() >= MAX_MATCHES);
 }
 
-void SearchState::FindMatches(std::wstring_view text, const std::wstring& lower_query, int node_index, int table_row, int table_col)
+void SearchState::FindMatches(std::wstring_view text, const std::pmr::wstring& lower_query, int node_index, int table_row, int table_col)
 {
     if (matches_.size() >= MAX_MATCHES) {
         return;

--- a/src/ui/search_state.h
+++ b/src/ui/search_state.h
@@ -36,8 +36,8 @@ public:
         lower_text_buf_ = {};
     }
 
-    const std::wstring& GetQuery() const noexcept { return query_; }
-    const std::vector<SearchMatch>& GetMatches() const noexcept { return matches_; }
+    const std::pmr::wstring& GetQuery() const noexcept { return query_; }
+    const std::pmr::vector<SearchMatch>& GetMatches() const noexcept { return matches_; }
     int GetCurrentMatchIndex() const noexcept { return current_match_; }
     int GetMatchCount() const noexcept { return static_cast<int>(matches_.size()); }
     // 大文字小文字の区別
@@ -59,13 +59,13 @@ public:
     void SetCurrentMatchNear(float scroll_y, const LayoutCache& cache) noexcept;
 
 private:
-    void FindMatches(std::wstring_view text, const std::wstring& lower_query, int node_index, int table_row = -1, int table_col = -1);
+    void FindMatches(std::wstring_view text, const std::pmr::wstring& lower_query, int node_index, int table_row = -1, int table_col = -1);
 
     static constexpr size_t MAX_MATCHES = 10000;
 
-    std::wstring query_;
-    std::vector<SearchMatch> matches_;
-    std::wstring lower_text_buf_; // 大文字小文字無視検索用の再利用可能バッファ
+    std::pmr::wstring query_;
+    std::pmr::vector<SearchMatch> matches_;
+    std::pmr::wstring lower_text_buf_; // 大文字小文字無視検索用の再利用可能バッファ
     int current_match_ = -1;
     bool visible_ = false;
     bool case_sensitive_ = false;

--- a/tests/mock_text_measurer.h
+++ b/tests/mock_text_measurer.h
@@ -94,10 +94,8 @@ public:
         auto& tl = entry.ensure_table_layout();
         tl.col_widths.assign(col_count, max_width / static_cast<float>(col_count));
         tl.row_heights.assign(node.table_rows().size(), table_row_height);
-        tl.cell_layouts.resize(node.table_rows().size());
-        for (size_t r = 0; r < node.table_rows().size(); r++) {
-            tl.cell_layouts[r].resize(node.table_rows()[r].cells.size());
-        }
+        tl.col_count = col_count;
+        tl.cell_layouts.resize(node.table_rows().size() * col_count);
 
         float total = table_border;
         for (size_t r = 0; r < node.table_rows().size(); r++) {

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -18,7 +18,7 @@ TEST(DocumentTest, FromMarkdownBasic)
     EXPECT_GE(doc.GetNodes().size(), 2u);
     // TOCに見出しが含まれるべき
     EXPECT_FALSE(doc.GetToc().GetEntries().empty());
-    EXPECT_EQ(doc.GetToc().GetEntries()[0].text, L"Hello");
+    EXPECT_EQ(doc.GetNodes()[doc.GetToc().GetEntries()[0].node_index].GetText(), L"Hello");
 }
 
 TEST(DocumentTest, FromMarkdownEmpty)
@@ -63,14 +63,14 @@ TEST(DocumentTest, ReplaceContent)
 {
     auto doc = Document::FromMarkdown("# First", L"C:\\test.md");
     EXPECT_FALSE(doc.GetToc().GetEntries().empty());
-    EXPECT_EQ(doc.GetToc().GetEntries()[0].text, L"First");
+    EXPECT_EQ(doc.GetNodes()[doc.GetToc().GetEntries()[0].node_index].GetText(), L"First");
 
     // 新しいコンテンツで置き換え
     doc.ReplaceContent(ParseMarkdown("# Second\n## Sub"));
 
     // TOCが再構築されるべき
     EXPECT_GE(doc.GetToc().GetEntries().size(), 2u);
-    EXPECT_EQ(doc.GetToc().GetEntries()[0].text, L"Second");
+    EXPECT_EQ(doc.GetNodes()[doc.GetToc().GetEntries()[0].node_index].GetText(), L"Second");
     // ファイルパスは変更されないべき
     EXPECT_EQ(doc.GetFilePath(), L"C:\\test.md");
 }
@@ -195,7 +195,8 @@ TEST(DocumentTest, BuildIndicesTocAndAnchorConsistent)
     ASSERT_EQ(toc.size(), 3u);
     // TOCエントリのnode_indexがアンカーインデックスと一致
     for (const auto& entry : toc) {
-        const int anchor_idx = doc.FindAnchorIndex(entry.anchor_id);
+        const auto& anchor = doc.GetNodes()[entry.node_index].anchor_id();
+        const int anchor_idx = doc.FindAnchorIndex(anchor);
         EXPECT_EQ(anchor_idx, entry.node_index);
     }
 }

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -607,12 +607,14 @@ TEST(FindAnchorNodeIndex, DuplicateAnchors)
 
     Node h1;
     h1.type = NodeType::Heading;
-    h1.anchor_id = L"title";
+    h1.ensure_heading();
+    h1.heading_data->anchor_id = L"title";
     nodes.emplace_back(std::move(h1));
 
     Node h2;
     h2.type = NodeType::Heading;
-    h2.anchor_id = L"title-1";
+    h2.ensure_heading();
+    h2.heading_data->anchor_id = L"title-1";
     nodes.emplace_back(std::move(h2));
 
     // 最初のマッチが優先される

--- a/tests/test_file_explorer.cpp
+++ b/tests/test_file_explorer.cpp
@@ -54,7 +54,7 @@ TEST_F(FileExplorerTest, EmptyDirectoryHasParentOnly)
     auto& entries = explorer.GetEntries();
     ASSERT_EQ(entries.size(), 1u);
     EXPECT_TRUE(entries[0].is_parent);
-    EXPECT_EQ(entries[0].filename, L"..");
+    EXPECT_EQ(std::wstring_view(entries[0].GetDisplayName()), L"..");
 }
 
 // ---- Bug #23: パスの正規化（末尾のバックスラッシュ） ----
@@ -89,7 +89,7 @@ TEST_F(FileExplorerTest, TrailingSlashDoesNotCreateDoubleBackslash)
     // .mdファイルが問題なく見つかること
     bool found_md = false;
     for (const auto& entry : explorer.GetEntries()) {
-        if (entry.filename == L"hello.md") {
+        if (std::wstring_view(entry.GetDisplayName()) == L"hello.md") {
             found_md = true;
             // full_pathに二重バックスラッシュが含まれないこと
             EXPECT_EQ(entry.full_path.find(L"\\\\"), std::wstring::npos)
@@ -123,7 +123,7 @@ TEST_F(FileExplorerTest, ShowsMarkdownExtension)
 
     // ".." + markdownファイル1つ
     EXPECT_EQ(entries.size(), 2u);
-    EXPECT_EQ(entries[1].filename, L"doc.markdown");
+    EXPECT_EQ(std::wstring_view(entries[1].GetDisplayName()), L"doc.markdown");
 }
 
 TEST_F(FileExplorerTest, ShowsMkdExtension)
@@ -135,7 +135,7 @@ TEST_F(FileExplorerTest, ShowsMkdExtension)
     auto& entries = explorer.GetEntries();
 
     EXPECT_EQ(entries.size(), 2u);
-    EXPECT_EQ(entries[1].filename, L"doc.mkd");
+    EXPECT_EQ(std::wstring_view(entries[1].GetDisplayName()), L"doc.mkd");
 }
 
 TEST_F(FileExplorerTest, HidesNonMarkdownFiles)
@@ -194,9 +194,9 @@ TEST_F(FileExplorerTest, EntriesSortedCaseInsensitive)
 
     // ".."エントリをスキップ
     ASSERT_GE(entries.size(), 4u);
-    EXPECT_EQ(entries[1].filename, L"aaa.md");
-    EXPECT_EQ(entries[2].filename, L"Bbb.md");
-    EXPECT_EQ(entries[3].filename, L"ccc.md");
+    EXPECT_EQ(std::wstring_view(entries[1].GetDisplayName()), L"aaa.md");
+    EXPECT_EQ(std::wstring_view(entries[2].GetDisplayName()), L"Bbb.md");
+    EXPECT_EQ(std::wstring_view(entries[3].GetDisplayName()), L"ccc.md");
 }
 
 TEST_F(FileExplorerTest, CaseInsensitiveMdExtension)
@@ -225,7 +225,7 @@ TEST_F(FileExplorerTest, SetCurrentFileMarksEntry)
     auto& entries = explorer.GetEntries();
     bool found = false;
     for (const auto& e : entries) {
-        if (e.filename == L"b.md") {
+        if (std::wstring_view(e.GetDisplayName()) == L"b.md") {
             EXPECT_TRUE(e.is_current);
             found = true;
         }
@@ -337,11 +337,11 @@ TEST_F(FileExplorerTest, SetDirectoryThenSetDirectoryAgainSwitches)
     // 新しいディレクトリの内容が表示されること
     bool found_other = false;
     for (const auto& e : explorer.GetEntries()) {
-        if (e.filename == L"other.md") {
+        if (std::wstring_view(e.GetDisplayName()) == L"other.md") {
             found_other = true;
         }
         // 前のディレクトリのファイルがないこと
-        EXPECT_NE(e.filename, L"test.md");
+        EXPECT_NE(std::wstring_view(e.GetDisplayName()), L"test.md");
     }
     EXPECT_TRUE(found_other);
 }
@@ -382,7 +382,7 @@ TEST_F(FileExplorerTest, FullPathIsCorrect)
 
     bool found = false;
     for (const auto& e : explorer.GetEntries()) {
-        if (e.filename == L"test.md") {
+        if (std::wstring_view(e.GetDisplayName()) == L"test.md") {
             std::wstring expected = temp_dir_.wstring() + L"\\" + L"test.md";
             EXPECT_EQ(std::wstring_view{ e.full_path }, std::wstring_view{ expected });
             found = true;

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -191,11 +191,12 @@ TEST_F(LayoutTest, TableCellLayoutsCreated)
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
     ASSERT_TRUE(cache[0].has_table_layout());
-    const auto& cell_layouts = cache[0].table_layout->cell_layouts;
-    for (size_t r = 0; r < cell_layouts.size(); r++) {
-        for (size_t c = 0; c < cell_layouts[r].size(); c++) {
-            if (!nodes[0].table_rows()[r].cells[c].text.empty()) {
-                EXPECT_NE(cell_layouts[r][c].Get(), nullptr);
+    const auto& tl = *cache[0].table_layout;
+    const auto& rows = nodes[0].table_rows();
+    for (size_t r = 0; r < rows.size(); r++) {
+        for (size_t c = 0; c < rows[r].cells.size(); c++) {
+            if (!rows[r].cells[c].text.empty()) {
+                EXPECT_NE(tl.GetCellLayout(r, c), nullptr);
             }
         }
     }
@@ -217,8 +218,8 @@ TEST_F(LayoutTest, TableCellLinkHasUnderline)
     // データ行の2番目のセルにはリンクランがあり、下線が適用されていること
     const auto& cell = nodes[0].table_rows()[1].cells[1];
     ASSERT_TRUE(cache[0].has_table_layout());
-    auto& cell_layout = cache[0].table_layout->cell_layouts[1][1];
-    ASSERT_NE(cell_layout.Get(), nullptr);
+    IDWriteTextLayout* cell_layout = cache[0].table_layout->GetCellLayout(1, 1);
+    ASSERT_NE(cell_layout, nullptr);
 
     // セル内にリンクランが存在することを確認
     bool has_link_run = false;
@@ -1169,7 +1170,7 @@ TEST_F(LayoutTest, InlineCodeInHeadingAllLevels)
 
         bool found_code_run = false;
         for (const auto& run : nodes[0].runs) {
-            if (run.code) {
+            if (run.code()) {
                 found_code_run = true;
                 float code_font_size = 0.0f;
                 DWRITE_TEXT_RANGE range{};
@@ -1196,7 +1197,7 @@ TEST_F(LayoutTest, InlineCodeInParagraphUsesCodeFontSize)
     ASSERT_NE(cache[0].text_layout.Get(), nullptr);
 
     for (const auto& run : nodes[0].runs) {
-        if (run.code) {
+        if (run.code()) {
             float code_font_size = 0.0f;
             DWRITE_TEXT_RANGE range{};
             cache[0].text_layout->GetFontSize(run.start, &code_font_size, &range);
@@ -1218,7 +1219,7 @@ TEST_F(LayoutTest, InlineCodeInHeadingUsesMonospaceFont)
     ASSERT_NE(cache[0].text_layout.Get(), nullptr);
 
     for (const auto& run : nodes[0].runs) {
-        if (run.code) {
+        if (run.code()) {
             WCHAR font_name[256] = {};
             DWRITE_TEXT_RANGE range{};
             HRESULT hr = cache[0].text_layout->GetFontFamilyName(

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -68,14 +68,14 @@ TEST(Parser, HeadingAnchorId)
 {
     auto nodes = ParseMarkdown("# Hello World").nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].anchor_id, L"hello-world");
+    EXPECT_EQ(nodes[0].anchor_id(), L"hello-world");
 }
 
 TEST(Parser, HeadingAnchorIdCjk)
 {
     auto nodes = ParseMarkdown("## コードブロック").nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].anchor_id, L"コードブロック");
+    EXPECT_EQ(nodes[0].anchor_id(), L"コードブロック");
 }
 
 // ---- インライン書式 ----
@@ -86,8 +86,8 @@ TEST(Parser, BoldText)
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"bold");
     ASSERT_GE(nodes[0].runs.size(), 1u);
-    EXPECT_TRUE(nodes[0].runs[0].bold);
-    EXPECT_FALSE(nodes[0].runs[0].italic);
+    EXPECT_TRUE(nodes[0].runs[0].bold());
+    EXPECT_FALSE(nodes[0].runs[0].italic());
 }
 
 TEST(Parser, ItalicText)
@@ -96,8 +96,8 @@ TEST(Parser, ItalicText)
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"italic");
     ASSERT_GE(nodes[0].runs.size(), 1u);
-    EXPECT_TRUE(nodes[0].runs[0].italic);
-    EXPECT_FALSE(nodes[0].runs[0].bold);
+    EXPECT_TRUE(nodes[0].runs[0].italic());
+    EXPECT_FALSE(nodes[0].runs[0].bold());
 }
 
 TEST(Parser, BoldItalicText)
@@ -105,8 +105,8 @@ TEST(Parser, BoldItalicText)
     auto nodes = ParseMarkdown("***bolditalic***").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_GE(nodes[0].runs.size(), 1u);
-    EXPECT_TRUE(nodes[0].runs[0].bold);
-    EXPECT_TRUE(nodes[0].runs[0].italic);
+    EXPECT_TRUE(nodes[0].runs[0].bold());
+    EXPECT_TRUE(nodes[0].runs[0].italic());
 }
 
 TEST(Parser, InlineCode)
@@ -115,7 +115,7 @@ TEST(Parser, InlineCode)
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"code");
     ASSERT_GE(nodes[0].runs.size(), 1u);
-    EXPECT_TRUE(nodes[0].runs[0].code);
+    EXPECT_TRUE(nodes[0].runs[0].code());
 }
 
 TEST(Parser, StrikethroughText)
@@ -123,7 +123,7 @@ TEST(Parser, StrikethroughText)
     auto nodes = ParseMarkdown("~~deleted~~").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_GE(nodes[0].runs.size(), 1u);
-    EXPECT_TRUE(nodes[0].runs[0].strikethrough);
+    EXPECT_TRUE(nodes[0].runs[0].strikethrough());
 }
 
 TEST(Parser, MixedFormattingPreservesOrder)
@@ -132,9 +132,9 @@ TEST(Parser, MixedFormattingPreservesOrder)
     ASSERT_EQ(nodes.size(), 1u);
     // 少なくとも3つのランを持つべき: "normal ", "bold", " normal"
     ASSERT_GE(nodes[0].runs.size(), 3u);
-    EXPECT_FALSE(nodes[0].runs[0].bold);
-    EXPECT_TRUE(nodes[0].runs[1].bold);
-    EXPECT_FALSE(nodes[0].runs[2].bold);
+    EXPECT_FALSE(nodes[0].runs[0].bold());
+    EXPECT_TRUE(nodes[0].runs[1].bold());
+    EXPECT_FALSE(nodes[0].runs[2].bold());
 }
 
 // ---- リンク ----
@@ -614,7 +614,7 @@ TEST(Parser, TableCellWithBold)
     // 2番目のヘッダーセルは太字ランを持つべき
     bool has_bold = false;
     for (const auto& run : header.cells[1].runs) {
-        if (run.bold) has_bold = true;
+        if (run.bold()) has_bold = true;
     }
     EXPECT_TRUE(has_bold);
 }
@@ -697,7 +697,7 @@ TEST(Parser, TableCellWithBoldLink)
 
     bool has_bold_link = false;
     for (const auto& run : cell.runs) {
-        if (run.bold && run.has_link()) {
+        if (run.bold() && run.has_link()) {
             has_bold_link = true;
         }
     }
@@ -759,7 +759,7 @@ TEST(Parser, MultipleHeadingsHaveAnchors)
     auto nodes = ParseMarkdown("# A\n\n## B\n\n### C").nodes;
     for (const auto& node : nodes) {
         if (node.type == NodeType::Heading) {
-            EXPECT_FALSE(node.anchor_id.empty())
+            EXPECT_FALSE(node.anchor_id().empty())
                 << "見出しにアンカーがない";
         }
     }
@@ -773,7 +773,7 @@ TEST(Parser, BoldLink)
     ASSERT_EQ(nodes.size(), 1u);
     bool has_bold_link = false;
     for (const auto& run : nodes[0].runs) {
-        if (run.bold && run.has_link()) {
+        if (run.bold() && run.has_link()) {
             has_bold_link = true;
         }
     }
@@ -786,18 +786,18 @@ TEST(Parser, DuplicateHeadingAnchorsAreUnique)
 {
     auto nodes = ParseMarkdown("# Title\n\n## Title\n\n### Title").nodes;
     ASSERT_EQ(nodes.size(), 3u);
-    EXPECT_EQ(nodes[0].anchor_id, L"title");
-    EXPECT_EQ(nodes[1].anchor_id, L"title-1");
-    EXPECT_EQ(nodes[2].anchor_id, L"title-2");
+    EXPECT_EQ(nodes[0].anchor_id(), L"title");
+    EXPECT_EQ(nodes[1].anchor_id(), L"title-1");
+    EXPECT_EQ(nodes[2].anchor_id(), L"title-2");
 }
 
 TEST(Parser, DuplicateAnchorsWithDifferentText)
 {
     auto nodes = ParseMarkdown("# A\n\n## B\n\n### A").nodes;
     ASSERT_EQ(nodes.size(), 3u);
-    EXPECT_EQ(nodes[0].anchor_id, L"a");
-    EXPECT_EQ(nodes[1].anchor_id, L"b");
-    EXPECT_EQ(nodes[2].anchor_id, L"a-1");
+    EXPECT_EQ(nodes[0].anchor_id(), L"a");
+    EXPECT_EQ(nodes[1].anchor_id(), L"b");
+    EXPECT_EQ(nodes[2].anchor_id(), L"a-1");
 }
 
 // ---- 数値HTMLエンティティ ----
@@ -972,7 +972,7 @@ TEST(Parser, AlertLabelIsBold)
     ASSERT_GE(nodes.size(), 1u);
     ASSERT_GE(nodes[0].runs.size(), 1u);
     // 最初のランはラベル部分で太字であるべき
-    EXPECT_TRUE(nodes[0].runs[0].bold);
+    EXPECT_TRUE(nodes[0].runs[0].bold());
     EXPECT_EQ(nodes[0].runs[0].start, 0u);
     EXPECT_EQ(nodes[0].runs[0].length, nodes[0].alert_label_length);
 }
@@ -1097,8 +1097,8 @@ TEST(Parser, AlertWithInlineFormatting)
     // フォーマット用のランがあるべき
     bool has_bold = false, has_code = false;
     for (const auto& run : nodes[0].runs) {
-        if (run.bold && run.start > 0) has_bold = true; // ラベル以外の太字
-        if (run.code) has_code = true;
+        if (run.bold() && run.start > 0) has_bold = true; // ラベル以外の太字
+        if (run.code()) has_code = true;
     }
     EXPECT_TRUE(has_bold);
     EXPECT_TRUE(has_code);
@@ -1364,7 +1364,7 @@ TEST(Parser, SyntaxTokensEmptyAfterParse)
     EXPECT_EQ(nodes[0].type, NodeType::CodeBlock);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Cpp);
     // パース時にはトークン化されないことを確認（レンダラーで遅延実行）
-    EXPECT_TRUE(nodes[0].syntax_tokens.empty());
+    EXPECT_TRUE(nodes[0].syntax_tokens().empty());
 }
 
 TEST(Parser, SyntaxTokensEmptyForMermaid)
@@ -1372,7 +1372,7 @@ TEST(Parser, SyntaxTokensEmptyForMermaid)
     auto nodes = ParseMarkdown("```mermaid\ngraph TD\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Mermaid);
-    EXPECT_TRUE(nodes[0].syntax_tokens.empty());
+    EXPECT_TRUE(nodes[0].syntax_tokens().empty());
 }
 
 // ---- UTF-8バッチ変換 ----
@@ -1390,9 +1390,9 @@ TEST(Parser, Utf8BatchWithSpanBoundary)
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"before bold after");
     ASSERT_GE(nodes[0].runs.size(), 3u);
-    EXPECT_FALSE(nodes[0].runs[0].bold);
-    EXPECT_TRUE(nodes[0].runs[1].bold);
-    EXPECT_FALSE(nodes[0].runs[2].bold);
+    EXPECT_FALSE(nodes[0].runs[0].bold());
+    EXPECT_TRUE(nodes[0].runs[1].bold());
+    EXPECT_FALSE(nodes[0].runs[2].bold());
 }
 
 TEST(Parser, Utf8BatchWithEntity)
@@ -1430,7 +1430,7 @@ TEST(Parser, Utf8BatchMixedAsciiAndMultibyte)
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"Hello 世界 test");
     ASSERT_GE(nodes[0].runs.size(), 3u);
-    EXPECT_TRUE(nodes[0].runs[1].bold);
+    EXPECT_TRUE(nodes[0].runs[1].bold());
 }
 
 TEST(Parser, Utf8BatchCodeBlockContent)
@@ -1454,8 +1454,8 @@ TEST(Parser, Utf8BatchNestedFormatting)
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"bold and italic");
     ASSERT_GE(nodes[0].runs.size(), 1u);
-    EXPECT_TRUE(nodes[0].runs[0].bold);
-    EXPECT_TRUE(nodes[0].runs[0].italic);
+    EXPECT_TRUE(nodes[0].runs[0].bold());
+    EXPECT_TRUE(nodes[0].runs[0].italic());
 }
 
 TEST(Parser, Utf8BatchLinkText)

--- a/tests/test_toc.cpp
+++ b/tests/test_toc.cpp
@@ -25,9 +25,9 @@ TEST(Toc, SingleHeading)
     TableOfContents toc;
     toc.BuildFromNodes(nodes);
     ASSERT_EQ(toc.GetEntries().size(), 1u);
-    EXPECT_EQ(toc.GetEntries()[0].text, L"Title");
+    EXPECT_EQ(nodes[toc.GetEntries()[0].node_index].GetText(), L"Title");
     EXPECT_EQ(toc.GetEntries()[0].heading_level, 1);
-    EXPECT_EQ(toc.GetEntries()[0].anchor_id, L"title");
+    EXPECT_EQ(nodes[toc.GetEntries()[0].node_index].anchor_id(), L"title");
 }
 
 TEST(Toc, MultipleHeadings)
@@ -50,7 +50,7 @@ TEST(Toc, HeadingTextPreserved)
     TableOfContents toc;
     toc.BuildFromNodes(nodes);
     ASSERT_EQ(toc.GetEntries().size(), 1u);
-    EXPECT_EQ(toc.GetEntries()[0].text, L"Hello World");
+    EXPECT_EQ(nodes[toc.GetEntries()[0].node_index].GetText(), L"Hello World");
 }
 
 TEST(Toc, AnchorIdPreserved)
@@ -59,7 +59,7 @@ TEST(Toc, AnchorIdPreserved)
     TableOfContents toc;
     toc.BuildFromNodes(nodes);
     ASSERT_EQ(toc.GetEntries().size(), 1u);
-    EXPECT_EQ(toc.GetEntries()[0].anchor_id, L"コードブロック");
+    EXPECT_EQ(nodes[toc.GetEntries()[0].node_index].anchor_id(), L"コードブロック");
 }
 
 TEST(Toc, RebuildClearsPrevious)
@@ -73,7 +73,7 @@ TEST(Toc, RebuildClearsPrevious)
 
     toc.BuildFromNodes(nodes2);
     EXPECT_EQ(toc.GetEntries().size(), 1u);
-    EXPECT_EQ(toc.GetEntries()[0].text, L"X");
+    EXPECT_EQ(nodes2[toc.GetEntries()[0].node_index].GetText(), L"X");
 }
 
 // ---- HitTest ----
@@ -123,10 +123,11 @@ TEST(Toc, DuplicateHeadingText)
     ASSERT_EQ(toc.GetEntries().size(), 3u);
     // すべて同じテキストを持つべき
     for (const auto& entry : toc.GetEntries()) {
-        EXPECT_EQ(entry.text, L"Title");
+        EXPECT_EQ(nodes[entry.node_index].GetText(), L"Title");
     }
     // ただしanchor_idは一意であるべき（パーサーリファクタリング後）
-    EXPECT_NE(toc.GetEntries()[0].anchor_id, toc.GetEntries()[1].anchor_id);
+    EXPECT_NE(nodes[toc.GetEntries()[0].node_index].anchor_id(),
+              nodes[toc.GetEntries()[1].node_index].anchor_id());
 }
 
 TEST(Toc, ManyHeadings)

--- a/tests/test_types.cpp
+++ b/tests/test_types.cpp
@@ -127,7 +127,7 @@ TEST(NodeTest, DefaultState)
     EXPECT_FALSE(node.task_checked);
     EXPECT_TRUE(node.GetText().empty());
     EXPECT_TRUE(node.runs.empty());
-    EXPECT_TRUE(node.anchor_id.empty());
+    EXPECT_TRUE(node.anchor_id().empty());
     EXPECT_EQ(node.code_language, SyntaxLanguage::None);
     EXPECT_FALSE(node.has_table());
 }
@@ -139,9 +139,9 @@ TEST(TextRun, DefaultState)
     TextRun run;
     EXPECT_EQ(run.start, 0u);
     EXPECT_EQ(run.length, 0u);
-    EXPECT_FALSE(run.bold);
-    EXPECT_FALSE(run.italic);
-    EXPECT_FALSE(run.code);
-    EXPECT_FALSE(run.strikethrough);
+    EXPECT_FALSE(run.bold());
+    EXPECT_FALSE(run.italic());
+    EXPECT_FALSE(run.code());
+    EXPECT_FALSE(run.strikethrough());
     EXPECT_FALSE(run.has_link());
 }


### PR DESCRIPTION
## Summary

- **TextRun**: 4つのboolを`uint8_t`ビットフラグに変更（16→12バイト/Run）
- **Node**: `anchor_id`と`syntax_tokens`を専用サブ構造体（`NodeHeadingData`/`NodeCodeData`）に分離し、非対象ノードあたり~48バイト削減
- **TocEntry**: `text`/`anchor_id`の重複コピーを除去し、`node_index`経由でNodeを参照する設計に変更（~64バイト/見出し削減）
- **TableLayoutData**: `vector<vector<T>>`をフラット配列+`col_count`ストライドに変更（ヒープ割り当てをrows×cols回→1回に削減）
- **InlineCodeBg**: `D2D1_RECT_F`エイリアスに変更し、パディングをレイアウト時に事前計算（描画時の算術を省略）
- **FileEntry**: `filename`フィールドを除去し`full_path`から`GetDisplayName()`で導出（~32バイト/エントリ削減）
- **NavHistory**: 内部パスインターン化（`InternalEntry` 8バイト + `path_pool_`）でパス文字列の重複保持を回避
- **SearchState**: `std::vector`/`std::wstring`を`std::pmr`版に統一し`synchronized_pool_resource`を活用

## Test plan

- [x] 全1463テスト合格を確認
- [x] 大規模Markdownファイル（1000+ノード）での動作確認
- [x] テーブルを多く含む文書での描画確認
- [x] ファイルペイン・目次ペインの表示確認
- [x] ナビゲーション（戻る/進む）の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)