### PR TITLE
リファクタリング: ファイルI/OをWin32 APIベースのユーティリティに統一

### DIFF
--- a/src/app/app_clipboard.cpp
+++ b/src/app/app_clipboard.cpp
@@ -4,6 +4,7 @@
 #include "mermaid_util.h"
 #include "mermaid_file_cache.h"
 #include "win_handle.h"
+#include "file_io.h"
 #include "i18n.h"
 #include <commdlg.h>
 
@@ -115,8 +116,8 @@ void App::SaveDiagramAsPng(int node_index)
     const uint64_t key = mermaid_util::HashCode(node.text_utf8, md_width, dark);
 
     MermaidFileCache::CacheEntry entry;
-    std::vector<uint8_t> png_data;
-    if (!file_cache_.Lookup(key, entry, png_data) || png_data.empty()) {
+    MermaidFileCache::PngBlob png;
+    if (!file_cache_.Lookup(key, entry, png) || png.size == 0) {
         return;
     }
 
@@ -136,20 +137,9 @@ void App::SaveDiagramAsPng(int node_index)
     }
 
     // PNGデータをファイルに書き出す
-    UniqueHandle hFile{ CreateFileW(filename, GENERIC_WRITE, 0, nullptr,
-        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr) };
-    if (!hFile) {
-        return;
-    }
-    DWORD written = 0;
-    const DWORD size = static_cast<DWORD>(png_data.size());
-    const BOOL ok = WriteFile(hFile.get(), png_data.data(), size, &written, nullptr);
-    hFile.reset(); // DeleteFileW の前にファイルを閉じる
-
-    if (ok && written == size) {
+    if (WriteAllBytes(filename, png.data.get(), png.size)) {
         ShowToast(i18n::S().toast_image_saved);
-    }
-    else {
+    } else {
         DeleteFileW(filename);
     }
 }

--- a/src/io/config_store.cpp
+++ b/src/io/config_store.cpp
@@ -1,9 +1,9 @@
 #include "config_store.h"
 #include "ini_parser.h"
 #include "string_convert.h"
+#include "file_io.h"
 #include <algorithm>
 #include <charconv>
-#include <fstream>
 #include <shlobj.h>
 
 #pragma comment(lib, "shell32.lib")
@@ -69,11 +69,11 @@ void Load()
     }
 
     const auto ini_path = dir / L"settings.ini";
-    std::ifstream ifs(ini_path, std::ios::binary);
-    if (ifs) {
-        const std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
-        g_data = ini::Parse(content);
+    auto [buf, size] = ReadAllBytes(ini_path);
+    if (!buf) {
+        return;
     }
+    g_data = ini::Parse(std::string_view(reinterpret_cast<const char*>(buf.get()), size));
 }
 
 void Save()
@@ -88,15 +88,8 @@ void Save()
     const auto tmp_path = dir / L"settings.ini.tmp";
 
     const std::string content = ini::Serialize(g_data);
-    {
-        std::ofstream ofs(tmp_path, std::ios::binary);
-        if (!ofs) {
-            return;
-        }
-        ofs.write(content.data(), static_cast<std::streamsize>(content.size()));
-        if (!ofs) {
-            return;
-        }
+    if (!WriteAllBytes(tmp_path, content.data(), content.size())) {
+        return;
     }
 
     std::error_code ec;
@@ -104,10 +97,7 @@ void Save()
     if (ec) {
         // renameが失敗した場合（クロスボリューム等）、直接書き込み
         std::filesystem::remove(tmp_path, ec);
-        std::ofstream ofs(ini_path, std::ios::binary);
-        if (ofs) {
-            ofs.write(content.data(), static_cast<std::streamsize>(content.size()));
-        }
+        WriteAllBytes(ini_path, content.data(), content.size());
     }
 }
 

--- a/src/io/config_store.cpp
+++ b/src/io/config_store.cpp
@@ -92,11 +92,9 @@ void Save()
         return;
     }
 
-    std::error_code ec;
-    std::filesystem::rename(tmp_path, ini_path, ec);
-    if (ec) {
+    if (!MoveFileExW(tmp_path.c_str(), ini_path.c_str(), MOVEFILE_REPLACE_EXISTING)) {
         // renameが失敗した場合（クロスボリューム等）、直接書き込み
-        std::filesystem::remove(tmp_path, ec);
+        DeleteFileW(tmp_path.c_str());
         WriteAllBytes(ini_path, content.data(), content.size());
     }
 }

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -556,9 +556,9 @@ void MermaidRenderer::RequestRender(Node& node, NodeLayoutEntry& layout_entry,
     // ファイルキャッシュを確認
     if (file_cache_) {
         MermaidFileCache::CacheEntry fentry;
-        std::vector<uint8_t> png_data;
-        if (file_cache_->Lookup(hash, fentry, png_data)) {
-            auto stream = CreateMemoryStream(png_data.data(), png_data.size());
+        MermaidFileCache::PngBlob png;
+        if (file_cache_->Lookup(hash, fentry, png)) {
+            auto stream = CreateMemoryStream(png.data.get(), png.size);
             if (stream) {
                 Microsoft::WRL::ComPtr<ID2D1Bitmap> bitmap;
                 float bw = 0, bh = 0;

--- a/src/mermaid/mermaid_file_cache.cpp
+++ b/src/mermaid/mermaid_file_cache.cpp
@@ -1,10 +1,36 @@
 #include "mermaid_file_cache.h"
 #include "task_scheduler.h"
 #include "config_store.h"
-#include <fstream>
+#include "file_io.h"
 #include <algorithm>
+#include <cstring>
+#include <memory>
 #include <chrono>
 #include <cmath>
+
+namespace {
+
+#pragma pack(push, 1)
+struct IndexHeader {
+    uint32_t magic;
+    uint32_t version;
+    float dpr;
+    uint32_t count;
+};
+
+struct IndexRecord {
+    uint64_t key;
+    float css_width;
+    float css_height;
+    uint32_t png_size;
+    int64_t last_used;
+};
+#pragma pack(pop)
+
+static_assert(sizeof(IndexHeader) == 16);
+static_assert(sizeof(IndexRecord) == 28);
+
+} // namespace
 
 MermaidFileCache::~MermaidFileCache()
 {
@@ -34,15 +60,20 @@ std::filesystem::path MermaidFileCache::GetCacheDir() const
     return base / L"MermaidCache";
 }
 
+std::filesystem::path MermaidFileCache::GetPngPath(const std::filesystem::path& dir, uint64_t key) const
+{
+    wchar_t name[24];
+    swprintf_s(name, L"%016llx.png", key);
+    return dir / name;
+}
+
 std::filesystem::path MermaidFileCache::GetPngPath(uint64_t key) const
 {
     const auto dir = GetCacheDir();
     if (dir.empty()) {
         return {};
     }
-    wchar_t name[24];
-    swprintf_s(name, L"%016llx.png", key);
-    return dir / name;
+    return GetPngPath(dir, key);
 }
 
 std::filesystem::path MermaidFileCache::GetIndexPath() const
@@ -106,51 +137,49 @@ void MermaidFileCache::LoadIndex()
         return;
     }
 
-    std::ifstream ifs(path, std::ios::binary);
-    if (!ifs) {
+    auto [buf, buf_size] = ReadAllBytes(path);
+    if (!buf || buf_size < 16) {
         return;
     }
 
     // ヘッダー読み込み
-    uint32_t magic = 0, version = 0, count = 0;
-    float dpr = 0.0f;
-    ifs.read(reinterpret_cast<char*>(&magic), 4);
-    ifs.read(reinterpret_cast<char*>(&version), 4);
-    ifs.read(reinterpret_cast<char*>(&dpr), 4);
-    ifs.read(reinterpret_cast<char*>(&count), 4);
+    const uint8_t* p = buf.get();
+    IndexHeader header;
+    std::memcpy(&header, p, sizeof(header));
+    p += sizeof(header);
 
-    if (!ifs || magic != MAGIC || version != VERSION) {
+    if (header.magic != MAGIC || header.version != VERSION) {
         return;
     }
     // 異常なエントリ数を拒否
-    if (count > DEFAULT_MAX_ENTRIES * 2) {
+    if (header.count > DEFAULT_MAX_ENTRIES * 2) {
         return;
     }
 
-    stored_dpr_ = dpr;
+    stored_dpr_ = header.dpr;
+    index_.reserve(header.count);
 
-    for (uint32_t i = 0; i < count; ++i) {
-        uint64_t key = 0;
-        IndexEntry entry;
-        ifs.read(reinterpret_cast<char*>(&key), 8);
-        ifs.read(reinterpret_cast<char*>(&entry.css_width), 4);
-        ifs.read(reinterpret_cast<char*>(&entry.css_height), 4);
-        ifs.read(reinterpret_cast<char*>(&entry.png_size), 4);
-        ifs.read(reinterpret_cast<char*>(&entry.last_used), 8);
-        if (!ifs) {
+    for (uint32_t i = 0; i < header.count; ++i) {
+        if (static_cast<size_t>(p - buf.get()) + sizeof(IndexRecord) > buf_size) {
             break;
         }
 
+        IndexRecord record;
+        std::memcpy(&record, p, sizeof(record));
+        p += sizeof(record);
+
         // 壊れたエントリを無視する
-        if (entry.css_width <= 0.0f || entry.css_height <= 0.0f ||
-            !std::isfinite(entry.css_width) || !std::isfinite(entry.css_height) ||
-            entry.png_size == 0) {
+        if (record.css_width <= 0.0f || record.css_height <= 0.0f ||
+            !std::isfinite(record.css_width) || !std::isfinite(record.css_height) ||
+            record.png_size == 0) {
             continue;
         }
 
-        index_[key] = entry;
-        lru_order_.emplace(entry.last_used, key);
-        total_size_ += entry.png_size;
+        index_[record.key] = IndexEntry{
+            record.css_width, record.css_height, record.png_size, record.last_used
+        };
+        lru_order_.emplace(record.last_used, record.key);
+        total_size_ += record.png_size;
     }
 }
 
@@ -161,34 +190,39 @@ void MermaidFileCache::SaveIndex()
         return;
     }
 
-    const auto dir = GetCacheDir();
     std::error_code ec;
-    std::filesystem::create_directories(dir, ec);
+    std::filesystem::create_directories(path.parent_path(), ec);
 
-    std::ofstream ofs(path, std::ios::binary);
-    if (!ofs) {
+    const uint32_t count = static_cast<uint32_t>(index_.size());
+
+    const size_t buf_size = sizeof(IndexHeader) + count * sizeof(IndexRecord);
+    auto buf = std::make_unique_for_overwrite<uint8_t[]>(buf_size);
+    uint8_t* p = buf.get();
+
+    IndexHeader header{ MAGIC, VERSION, current_dpr_, count };
+    std::memcpy(p, &header, sizeof(header));
+    p += sizeof(header);
+
+    for (const auto& [key, entry] : index_) {
+        IndexRecord record{ key, entry.css_width, entry.css_height, entry.png_size, entry.last_used };
+        std::memcpy(p, &record, sizeof(record));
+        p += sizeof(record);
+    }
+
+    const auto tmp_path = path.parent_path() / L"index.bin.tmp";
+    if (!WriteAllBytes(tmp_path, buf.get(), buf_size)) {
         return;
     }
 
-    const uint32_t magic = MAGIC;
-    const uint32_t version = VERSION;
-    const uint32_t count = static_cast<uint32_t>(index_.size());
-
-    ofs.write(reinterpret_cast<const char*>(&magic), 4);
-    ofs.write(reinterpret_cast<const char*>(&version), 4);
-    ofs.write(reinterpret_cast<const char*>(&current_dpr_), 4);
-    ofs.write(reinterpret_cast<const char*>(&count), 4);
-
-    for (const auto& [key, entry] : index_) {
-        ofs.write(reinterpret_cast<const char*>(&key), 8);
-        ofs.write(reinterpret_cast<const char*>(&entry.css_width), 4);
-        ofs.write(reinterpret_cast<const char*>(&entry.css_height), 4);
-        ofs.write(reinterpret_cast<const char*>(&entry.png_size), 4);
-        ofs.write(reinterpret_cast<const char*>(&entry.last_used), 8);
+    std::filesystem::rename(tmp_path, path, ec);
+    if (ec) {
+        // renameが失敗した場合、直接書き込み
+        std::filesystem::remove(tmp_path, ec);
+        WriteAllBytes(path, buf.get(), buf_size);
     }
 }
 
-bool MermaidFileCache::Lookup(uint64_t key, CacheEntry& entry, std::vector<uint8_t>& png_data)
+bool MermaidFileCache::Lookup(uint64_t key, CacheEntry& entry, PngBlob& png)
 {
     auto it = index_.find(key);
     if (it == index_.end()) {
@@ -200,9 +234,9 @@ bool MermaidFileCache::Lookup(uint64_t key, CacheEntry& entry, std::vector<uint8
         return false;
     }
 
-    std::ifstream ifs(path, std::ios::binary | std::ios::ate);
-    if (!ifs) {
-        // ファイルが存在しない（書き込み前 or 削除済み）→ 古いインデックスエントリを除去
+    auto [data, data_size] = ReadAllBytes(path);
+    if (!data) {
+        // ファイルが存在しない or 読み取り失敗 → 古いインデックスエントリを除去
         if (total_size_ >= it->second.png_size) {
             total_size_ -= it->second.png_size;
         }
@@ -213,20 +247,8 @@ bool MermaidFileCache::Lookup(uint64_t key, CacheEntry& entry, std::vector<uint8
         index_.erase(it);
         return false;
     }
-
-    const auto size = ifs.tellg();
-    if (size <= 0) {
-        RemoveLruEntry(it->second.last_used, key);
-        index_.erase(it);
-        return false;
-    }
-
-    ifs.seekg(0);
-    png_data.resize(static_cast<size_t>(size));
-    ifs.read(reinterpret_cast<char*>(png_data.data()), size);
-    if (!ifs) {
-        return false;
-    }
+    png.data = std::move(data);
+    png.size = data_size;
 
     entry.css_width = it->second.css_width;
     entry.css_height = it->second.css_height;
@@ -296,18 +318,14 @@ void MermaidFileCache::StoreAsync(uint64_t key, float css_width, float css_heigh
         std::error_code ec;
         std::filesystem::create_directories(path.parent_path(), ec);
 
-        std::ofstream ofs(path, std::ios::binary);
-        if (ofs) {
-            ofs.write(
-                reinterpret_cast<const char*>(data.data()),
-                static_cast<std::streamsize>(data.size())
-            );
-        }
+        WriteAllBytes(path, data.data(), data.size());
     });
 }
 
 void MermaidFileCache::EvictIfNeeded(uint32_t new_png_size)
 {
+    const auto dir = GetCacheDir();
+
     while ((index_.size() >= max_entries_ ||
         total_size_ + new_png_size > max_total_size_) &&
         !lru_order_.empty()) {
@@ -322,10 +340,9 @@ void MermaidFileCache::EvictIfNeeded(uint32_t new_png_size)
         }
 
         // PNGファイルを削除
-        const auto path = GetPngPath(evict_key);
-        if (!path.empty()) {
+        if (!dir.empty()) {
             std::error_code ec;
-            std::filesystem::remove(path, ec);
+            std::filesystem::remove(GetPngPath(dir, evict_key), ec);
         }
 
         if (total_size_ >= it->second.png_size) {
@@ -348,9 +365,9 @@ void MermaidFileCache::ClearAll()
     if (!dir.empty()) {
         std::error_code ec;
         for (const auto& [key, _] : index_) {
-            std::filesystem::remove(GetPngPath(key), ec);
+            std::filesystem::remove(GetPngPath(dir, key), ec);
         }
-        std::filesystem::remove(GetIndexPath(), ec);
+        std::filesystem::remove(dir / L"index.bin", ec);
     }
 
     index_.clear();

--- a/src/mermaid/mermaid_file_cache.cpp
+++ b/src/mermaid/mermaid_file_cache.cpp
@@ -214,10 +214,9 @@ void MermaidFileCache::SaveIndex()
         return;
     }
 
-    std::filesystem::rename(tmp_path, path, ec);
-    if (ec) {
+    if (!MoveFileExW(tmp_path.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING)) {
         // renameが失敗した場合、直接書き込み
-        std::filesystem::remove(tmp_path, ec);
+        DeleteFileW(tmp_path.c_str());
         WriteAllBytes(path, buf.get(), buf_size);
     }
 }
@@ -234,17 +233,20 @@ bool MermaidFileCache::Lookup(uint64_t key, CacheEntry& entry, PngBlob& png)
         return false;
     }
 
-    auto [data, data_size] = ReadAllBytes(path);
+    DWORD read_error = 0;
+    auto [data, data_size] = ReadAllBytes(path, &read_error);
     if (!data) {
-        // ファイルが存在しない or 読み取り失敗 → 古いインデックスエントリを除去
-        if (total_size_ >= it->second.png_size) {
-            total_size_ -= it->second.png_size;
+        // ファイルが確実に存在しない場合のみインデックスエントリを除去する。
+        // 共有違反など一時的なエラーではエントリを保持する。
+        if (read_error == ERROR_FILE_NOT_FOUND || read_error == ERROR_PATH_NOT_FOUND) {
+            if (total_size_ >= it->second.png_size) {
+                total_size_ -= it->second.png_size;
+            } else {
+                total_size_ = 0;
+            }
+            RemoveLruEntry(it->second.last_used, key);
+            index_.erase(it);
         }
-        else {
-            total_size_ = 0;
-        }
-        RemoveLruEntry(it->second.last_used, key);
-        index_.erase(it);
         return false;
     }
     png.data = std::move(data);

--- a/src/mermaid/mermaid_file_cache.h
+++ b/src/mermaid/mermaid_file_cache.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <memory>
 #include <vector>
 #include <filesystem>
 #include <unordered_map>
@@ -28,13 +29,19 @@ public:
         float css_height = 0.0f;
     };
 
+    // サイズ付きバイトバッファ
+    struct PngBlob {
+        std::unique_ptr<uint8_t[]> data;
+        size_t size = 0;
+    };
+
     // キャッシュを初期化し、インデックスをディスクから読み込む。
     // current_dprが保存済みDPRと異なる場合、キャッシュを全削除する。
     void Init(float current_dpr, TaskScheduler& scheduler);
 
     // キャッシュされたPNGを検索する。見つかった場合trueを返す。
     // last_usedタイムスタンプも更新される。
-    bool Lookup(uint64_t key, CacheEntry& entry, std::vector<uint8_t>& png_data);
+    bool Lookup(uint64_t key, CacheEntry& entry, PngBlob& png);
 
     // インデックスからCSSサイズのみを取得する（ディスクI/O無し）。
     // スクロール位置復元時の高さ推定に使用する。
@@ -42,8 +49,7 @@ public:
 
     // PNGファイルをバックグラウンドスレッドで非同期に書き出す。
     // インデックスエントリは即座に追加される。
-    void StoreAsync(uint64_t key, float css_width, float css_height,
-        std::vector<uint8_t> png_data);
+    void StoreAsync(uint64_t key, float css_width, float css_height, std::vector<uint8_t> png_data);
 
     // インデックスをディスクに保存する（アプリ終了時に呼び出す）。
     void SaveIndex();
@@ -77,6 +83,7 @@ private:
     };
 
     std::filesystem::path GetCacheDir() const;
+    std::filesystem::path GetPngPath(const std::filesystem::path& dir, uint64_t key) const;
     std::filesystem::path GetPngPath(uint64_t key) const;
     std::filesystem::path GetIndexPath() const;
     void LoadIndex();
@@ -99,5 +106,5 @@ private:
 
     // バックグラウンド書き込み
     TaskScheduler* scheduler_ = nullptr;
-    std::atomic<uint32_t> write_gen_{0};
+    std::atomic<uint32_t> write_gen_{ 0 };
 };

--- a/src/util/file_io.h
+++ b/src/util/file_io.h
@@ -1,15 +1,24 @@
 #pragma once
 #include "win_handle.h"
+#include <cstdint>
 #include <filesystem>
 #include <memory>
 #include <utility>
 
 // ファイルを全て読み込む。失敗時は{nullptr, 0}を返す。
-inline std::pair<std::unique_ptr<uint8_t[]>, size_t> ReadAllBytes(const std::filesystem::path& path)
+// out_errorが非nullの場合、CreateFileW失敗時のGetLastError()を格納する。
+inline std::pair<std::unique_ptr<uint8_t[]>, size_t> ReadAllBytes(
+    const std::filesystem::path& path, DWORD* out_error = nullptr)
 {
+    if (out_error) {
+        *out_error = 0;
+    }
     UniqueHandle hFile(CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
         OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
     if (!hFile) {
+        if (out_error) {
+            *out_error = GetLastError();
+        }
         return {};
     }
     LARGE_INTEGER file_size;

--- a/src/util/file_io.h
+++ b/src/util/file_io.h
@@ -1,0 +1,49 @@
+#pragma once
+#include "win_handle.h"
+#include <filesystem>
+#include <memory>
+#include <utility>
+
+// ファイルを全て読み込む。失敗時は{nullptr, 0}を返す。
+inline std::pair<std::unique_ptr<uint8_t[]>, size_t> ReadAllBytes(const std::filesystem::path& path)
+{
+    UniqueHandle hFile(CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
+        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+    if (!hFile) {
+        return {};
+    }
+    LARGE_INTEGER file_size;
+    if (!GetFileSizeEx(hFile.get(), &file_size) || file_size.QuadPart <= 0) {
+        return {};
+    }
+    const auto size = static_cast<size_t>(file_size.QuadPart);
+    if (size > UINT32_MAX) {
+        return {};
+    }
+    auto buf = std::make_unique_for_overwrite<uint8_t[]>(size);
+    DWORD bytes_read = 0;
+    if (!ReadFile(hFile.get(), buf.get(), static_cast<DWORD>(size), &bytes_read, nullptr) ||
+        bytes_read != static_cast<DWORD>(size)) {
+        return {};
+    }
+    return {std::move(buf), size};
+}
+
+// ファイルに全て書き込む。成功時はtrueを返す。
+inline bool WriteAllBytes(const std::filesystem::path& path, const void* data, size_t size)
+{
+    if (size > UINT32_MAX) {
+        return false;
+    }
+    UniqueHandle hFile(CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr,
+        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
+    if (!hFile) {
+        return false;
+    }
+    DWORD bytes_written = 0;
+    if (!WriteFile(hFile.get(), data, static_cast<DWORD>(size), &bytes_written, nullptr) ||
+        bytes_written != static_cast<DWORD>(size)) {
+        return false;
+    }
+    return true;
+}

--- a/tests/test_document_service.cpp
+++ b/tests/test_document_service.cpp
@@ -10,7 +10,9 @@ class DocumentServiceTest : public ::testing::Test {
 protected:
     void SetUp() override
     {
-        test_dir_ = std::filesystem::temp_directory_path() / "mendo_doc_service_test";
+        auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+        test_dir_ = std::filesystem::temp_directory_path()
+            / ("mendo_doc_service_test_" + std::string(info->name()));
         std::filesystem::create_directories(test_dir_);
     }
     void TearDown() override

--- a/tests/test_mermaid_file_cache.cpp
+++ b/tests/test_mermaid_file_cache.cpp
@@ -4,6 +4,7 @@
 #include "mermaid_util.h"
 #include <filesystem>
 #include <fstream>
+#include <cstring>
 #include <memory>
 #include <thread>
 #include <chrono>
@@ -84,11 +85,12 @@ TEST_F(MermaidFileCacheTest, StoreAndLookupRoundTrip)
     FlushAndReopen();
 
     MermaidFileCache::CacheEntry entry;
-    std::vector<uint8_t> out;
+    MermaidFileCache::PngBlob out;
     EXPECT_TRUE(cache_.Lookup(key, entry, out));
     EXPECT_EQ(entry.css_width, 400.0f);
     EXPECT_EQ(entry.css_height, 300.0f);
-    EXPECT_EQ(out, png);
+    ASSERT_EQ(out.size, png.size());
+    EXPECT_EQ(std::memcmp(out.data.get(), png.data(), out.size), 0);
 }
 
 TEST_F(MermaidFileCacheTest, LookupMissReturnsFalse)
@@ -96,7 +98,7 @@ TEST_F(MermaidFileCacheTest, LookupMissReturnsFalse)
     InitCache();
 
     MermaidFileCache::CacheEntry entry;
-    std::vector<uint8_t> out;
+    MermaidFileCache::PngBlob out;
     EXPECT_FALSE(cache_.Lookup(99999, entry, out));
 }
 
@@ -156,7 +158,7 @@ TEST_F(MermaidFileCacheTest, LookupCleansUpStaleIndexEntry)
     std::filesystem::remove(temp_dir_ / name);
 
     MermaidFileCache::CacheEntry entry;
-    std::vector<uint8_t> out;
+    MermaidFileCache::PngBlob out;
     EXPECT_FALSE(cache_.Lookup(42, entry, out));
     // 古いインデックスエントリが削除されていること
     EXPECT_EQ(cache_.EntryCount(), 0u);
@@ -188,7 +190,7 @@ TEST_F(MermaidFileCacheTest, EvictsOldestWhenMaxEntriesExceeded)
     FlushAndReopen();
 
     MermaidFileCache::CacheEntry entry;
-    std::vector<uint8_t> out;
+    MermaidFileCache::PngBlob out;
     EXPECT_FALSE(cache_.Lookup(1, entry, out));
     EXPECT_TRUE(cache_.Lookup(2, entry, out));
     EXPECT_TRUE(cache_.Lookup(3, entry, out));
@@ -277,16 +279,16 @@ TEST_F(MermaidFileCacheTest, SaveAndLoadIndexRoundTrip)
     EXPECT_EQ(fresh->EntryCount(), 2u);
 
     MermaidFileCache::CacheEntry entry;
-    std::vector<uint8_t> out;
+    MermaidFileCache::PngBlob out;
     EXPECT_TRUE(fresh->Lookup(100, entry, out));
     EXPECT_EQ(entry.css_width, 640.0f);
     EXPECT_EQ(entry.css_height, 480.0f);
-    EXPECT_EQ(out.size(), 1024u);
+    EXPECT_EQ(out.size, 1024u);
 
     EXPECT_TRUE(fresh->Lookup(200, entry, out));
     EXPECT_EQ(entry.css_width, 320.0f);
     EXPECT_EQ(entry.css_height, 240.0f);
-    EXPECT_EQ(out.size(), 512u);
+    EXPECT_EQ(out.size, 512u);
 }
 
 TEST_F(MermaidFileCacheTest, LoadIndexWithInvalidMagicIgnoresFile)
@@ -452,7 +454,7 @@ TEST_F(MermaidFileCacheTest, ClearAllRemovesEverything)
 
     // ファイルも削除されていること
     MermaidFileCache::CacheEntry entry;
-    std::vector<uint8_t> out;
+    MermaidFileCache::PngBlob out;
     EXPECT_FALSE(cache_.Lookup(1, entry, out));
     EXPECT_FALSE(cache_.Lookup(2, entry, out));
 }
@@ -491,7 +493,7 @@ TEST_F(MermaidFileCacheTest, OperationsWithoutInitAreNoOp)
     uninit.SetCacheDir(temp_dir_);
 
     MermaidFileCache::CacheEntry entry;
-    std::vector<uint8_t> out;
+    MermaidFileCache::PngBlob out;
     EXPECT_FALSE(uninit.Lookup(1, entry, out));
 
     uninit.SaveIndex();
@@ -526,7 +528,7 @@ TEST_F(MermaidFileCacheTest, LookupRefreshesTimestamp)
 
     // key=1をLookupしてタイムスタンプを更新（key=2より新しくなる）
     MermaidFileCache::CacheEntry entry;
-    std::vector<uint8_t> out;
+    MermaidFileCache::PngBlob out;
     EXPECT_TRUE(cache_.Lookup(1, entry, out));
 
     // key=3を追加 → key=2が最古なのでkey=2が削除される


### PR DESCRIPTION
## Summary
- `ReadAllBytes`/`WriteAllBytes`ユーティリティ(`src/util/file_io.h`)を新規追加し、`std::fstream`による分散したファイルI/O処理をWin32 APIベースに統一
- `MermaidFileCache`のインデックス読み書きをpacked構造体(`IndexHeader`/`IndexRecord`)によるバッチ`memcpy`方式に変更し、`SaveIndex`にアトミックなtmpファイル経由renameを導入
- `Lookup`のPNGデータ返却を`std::vector<uint8_t>`から`PngBlob`(`unique_ptr<uint8_t[]>` + `size_t`)に変更し、不要なコピーを削減

## Test plan
- [x] 全テストがパス（既存の無関係な1件を除く）
- [x] `MermaidFileCache`関連テストがすべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)