### PR TITLE
リファクタリング: ヒットテスト・描画コマンド生成の引数集約

### DIFF
--- a/src/app/app_mouse.cpp
+++ b/src/app/app_mouse.cpp
@@ -232,16 +232,11 @@ void App::OnXButtonForward()
 App::HitResult App::HitTest(int screen_x, int screen_y) const
 {
     const auto pane_layout = GetPaneLayout();
-    return hit_test_.HitTest(
-        doc_.GetNodes(),
-        layout_cache_,
-        renderer_.GetTheme(),
-        viewport_.GetScrollY(),
-        pane_layout.md_rect.x,
-        cached_dpi_scale_,
-        screen_x,
-        screen_y
-    );
+    return hit_test_.HitTest({
+        doc_.GetNodes(), layout_cache_, renderer_.GetTheme(),
+        viewport_.GetScrollY(), pane_layout.md_rect.x,
+        cached_dpi_scale_, screen_x, screen_y
+    });
 }
 
 std::optional<std::pmr::wstring> App::GetLinkAtHit(const HitResult& hit) const
@@ -424,21 +419,19 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
     }
     // コピーボタンのクリック判定（クリック位置で再判定）
     const float content_width = renderer_.GetTheme().ContentWidth(pane_layout.md_rect.width);
-    const auto copy_node = hit_test_.CopyButtonHitTest(
+    const MdPaneHitContext hit_ctx{
         doc_.GetNodes(), layout_cache_, renderer_.GetTheme(),
         viewport_.GetScrollY(), pane_layout.md_rect.x,
-        content_width, pane_layout.md_rect.height,
-        cached_dpi_scale_, px, py);
+        cached_dpi_scale_, px, py,
+        content_width, pane_layout.md_rect.height
+    };
+    const auto copy_node = hit_test_.CopyButtonHitTest(hit_ctx);
     if (copy_node >= 0) {
         CopyCodeBlockToClipboard(copy_node);
         return;
     }
     // 保存ボタンのクリック判定
-    const auto save_node = hit_test_.SaveButtonHitTest(
-        doc_.GetNodes(), layout_cache_, renderer_.GetTheme(),
-        viewport_.GetScrollY(), pane_layout.md_rect.x,
-        content_width, pane_layout.md_rect.height,
-        cached_dpi_scale_, px, py);
+    const auto save_node = hit_test_.SaveButtonHitTest(hit_ctx);
     if (save_node >= 0) {
         SaveDiagramAsPng(save_node);
         return;
@@ -868,17 +861,19 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
 
     // コピー/保存ボタンのホバー判定（距離スロットリングで不要な再計算を回避）
     const float content_width = renderer_.GetTheme().ContentWidth(pane_layout.md_rect.width);
+    const MdPaneHitContext hit_ctx{
+        doc_.GetNodes(), layout_cache_, renderer_.GetTheme(),
+        viewport_.GetScrollY(), pane_layout.md_rect.x,
+        cached_dpi_scale_, px, py,
+        content_width, pane_layout.md_rect.height
+    };
     {
         const int cdx = px - hover_throttle_.last_copy_hit_pos.x;
         const int cdy = py - hover_throttle_.last_copy_hit_pos.y;
         if (cdx * cdx + cdy * cdy > HOVER_THROTTLE_DISTANCE_SQ) {
             hover_throttle_.last_copy_hit_pos = { px, py };
             const int old_copy_hover = hovered_copy_node_;
-            hovered_copy_node_ = hit_test_.CopyButtonHitTest(
-                doc_.GetNodes(), layout_cache_, renderer_.GetTheme(),
-                viewport_.GetScrollY(), pane_layout.md_rect.x,
-                content_width, pane_layout.md_rect.height,
-                cached_dpi_scale_, px, py);
+            hovered_copy_node_ = hit_test_.CopyButtonHitTest(hit_ctx);
             if (hovered_copy_node_ != old_copy_hover) {
                 InvalidateMdPane(pane_layout.md_rect);
             }
@@ -896,11 +891,7 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
         if (sdx * sdx + sdy * sdy > HOVER_THROTTLE_DISTANCE_SQ) {
             hover_throttle_.last_save_hit_pos = { px, py };
             const int old_save_hover = hovered_save_node_;
-            hovered_save_node_ = hit_test_.SaveButtonHitTest(
-                doc_.GetNodes(), layout_cache_, renderer_.GetTheme(),
-                viewport_.GetScrollY(), pane_layout.md_rect.x,
-                content_width, pane_layout.md_rect.height,
-                cached_dpi_scale_, px, py);
+            hovered_save_node_ = hit_test_.SaveButtonHitTest(hit_ctx);
             if (hovered_save_node_ != old_save_hover) {
                 InvalidateMdPane(pane_layout.md_rect);
             }

--- a/src/core/toc.cpp
+++ b/src/core/toc.cpp
@@ -15,7 +15,7 @@ void TableOfContents::BuildFromNodes(const std::pmr::vector<Node>& nodes)
 
 void TableOfContents::AddEntry(const Node& node, int node_index)
 {
-    entries_.push_back({ node_index, node.heading_level });
+    entries_.emplace_back(node_index, node.heading_level);
 }
 
 int TableOfContents::HitTest(float local_y, float item_height) const noexcept

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -236,7 +236,7 @@ struct Node {
     // Wideテキストを直接設定
     void SetText(std::wstring_view s)
     {
-        text_.assign(s.data(), s.size());
+        text_.assign(s);
         FinalizeSetText();
     }
 

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -221,6 +221,8 @@ HitTestService::HitResult HitTestService::HitTestTable(
 int HitTestService::CopyButtonHitTest(
     const MdPaneHitContext& ctx) const noexcept
 {
+    assert(ctx.content_width > 0.0f && "content_width must be set for button hit test");
+    assert(ctx.md_pane_height > 0.0f && "md_pane_height must be set for button hit test");
     if (ctx.nodes.empty()) {
         return -1;
     }
@@ -271,6 +273,8 @@ int HitTestService::CopyButtonHitTest(
 int HitTestService::SaveButtonHitTest(
     const MdPaneHitContext& ctx) const noexcept
 {
+    assert(ctx.content_width > 0.0f && "content_width must be set for button hit test");
+    assert(ctx.md_pane_height > 0.0f && "md_pane_height must be set for button hit test");
     if (ctx.nodes.empty()) {
         return -1;
     }

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -1,5 +1,6 @@
 #include "hit_test_service.h"
 #include "ui_constants.h"
+#include <cassert>
 #include <ranges>
 
 namespace {
@@ -69,28 +70,21 @@ static uint32_t ComputeTableFlatOffset(const Node& node, const NodeLayoutEntry& 
 }
 
 HitTestService::HitResult HitTestService::HitTest(
-    const std::pmr::vector<Node>& nodes,
-    const LayoutCache& cache,
-    const Theme& theme,
-    float scroll_y,
-    float md_pane_left,
-    float dpi_scale,
-    int screen_x, int screen_y) const noexcept
+    const MdPaneHitContext& ctx) const noexcept
 {
-
     HitResult result;
-    if (nodes.empty()) {
+    if (ctx.nodes.empty()) {
         return result;
     }
 
-    const auto [dip_x, dip_y] = ScreenToPaneDip(screen_x, screen_y, dpi_scale, md_pane_left, scroll_y);
+    const auto [dip_x, dip_y] = ScreenToPaneDip(ctx.screen_x, ctx.screen_y, ctx.dpi_scale, ctx.md_pane_left, ctx.scroll_y);
 
     // dip_yを含むノードを二分探索で検索
-    int lo = 0, hi = static_cast<int>(nodes.size()) - 1;
+    int lo = 0, hi = static_cast<int>(ctx.nodes.size()) - 1;
     int candidate = -1;
     while (lo <= hi) {
         int mid = (lo + hi) / 2;
-        if (cache[mid].y_position <= dip_y) {
+        if (ctx.cache[mid].y_position <= dip_y) {
             candidate = mid;
             lo = mid + 1;
         }
@@ -99,17 +93,17 @@ HitTestService::HitResult HitTestService::HitTest(
         }
     }
 
-    if (candidate >= 0 && dip_y <= cache[candidate].y_position + cache[candidate].height) {
-        const auto& node = nodes[candidate];
-        const auto& entry = cache[candidate];
+    if (candidate >= 0 && dip_y <= ctx.cache[candidate].y_position + ctx.cache[candidate].height) {
+        const auto& node = ctx.nodes[candidate];
+        const auto& entry = ctx.cache[candidate];
 
         if (node.type == NodeType::Table) {
-            return HitTestTable(node, entry, candidate, theme, dip_x, dip_y);
+            return HitTestTable(node, entry, candidate, ctx.theme, dip_x, dip_y);
         }
 
         if (entry.text_layout) {
-            const float indent = NodeIndent(node, theme);
-            const float local_x = dip_x - theme.margin_left - indent;
+            const float indent = NodeIndent(node, ctx.theme);
+            const float local_x = dip_x - ctx.theme.margin_left - indent;
             const float local_y = dip_y - entry.y_position;
 
             BOOL is_trailing = FALSE;
@@ -125,7 +119,7 @@ HitTestService::HitResult HitTestService::HitTest(
     }
 
     // 全ノードより下をクリック → 最後のノードの末尾を選択
-    for (const auto& [i, node] : nodes | std::views::enumerate | std::views::reverse) {
+    for (const auto& [i, node] : ctx.nodes | std::views::enumerate | std::views::reverse) {
         if (const auto& text = node.GetText(); !text.empty()) {
             result.node_index = static_cast<int>(i);
             result.text_pos = static_cast<uint32_t>(text.size());
@@ -225,40 +219,32 @@ HitTestService::HitResult HitTestService::HitTestTable(
 }
 
 int HitTestService::CopyButtonHitTest(
-    const std::pmr::vector<Node>& nodes,
-    const LayoutCache& cache,
-    const Theme& theme,
-    float scroll_y,
-    float md_pane_left,
-    float content_width,
-    float md_pane_height,
-    float dpi_scale,
-    int screen_x, int screen_y) const noexcept
+    const MdPaneHitContext& ctx) const noexcept
 {
-    if (nodes.empty()) {
+    if (ctx.nodes.empty()) {
         return -1;
     }
 
-    const auto [dip_x, dip_y] = ScreenToPaneDip(screen_x, screen_y, dpi_scale, md_pane_left, scroll_y);
+    const auto [dip_x, dip_y] = ScreenToPaneDip(ctx.screen_x, ctx.screen_y, ctx.dpi_scale, ctx.md_pane_left, ctx.scroll_y);
 
     // コピーボタンはコンテンツ右端にあるため、X座標で大半のマウス位置を早期棄却
-    const float btn_left_bound = theme.margin_left + content_width - COPY_BTN_MARGIN - COPY_BTN_SIZE;
+    const float btn_left_bound = ctx.theme.margin_left + ctx.content_width - COPY_BTN_MARGIN - COPY_BTN_SIZE;
     if (dip_x < btn_left_bound) {
         return -1;
     }
 
-    const float viewport_top = scroll_y;
-    const float viewport_bottom = scroll_y + md_pane_height;
+    const float viewport_top = ctx.scroll_y;
+    const float viewport_bottom = ctx.scroll_y + ctx.md_pane_height;
 
     // 可視範囲のコードブロックを検索
-    const int first = FindFirstVisibleNodeIndex(cache, nodes.size(), viewport_top);
-    const int count = static_cast<int>(nodes.size());
+    const int first = FindFirstVisibleNodeIndex(ctx.cache, ctx.nodes.size(), viewport_top);
+    const int count = static_cast<int>(ctx.nodes.size());
     for (int i = first; i < count; i++) {
-        if (cache[i].y_position - theme.code_block_padding > viewport_bottom) {
+        if (ctx.cache[i].y_position - ctx.theme.code_block_padding > viewport_bottom) {
             break;
         }
 
-        const auto& node = nodes[i];
+        const auto& node = ctx.nodes[i];
         if (node.type != NodeType::CodeBlock) {
             continue;
         }
@@ -266,13 +252,13 @@ int HitTestService::CopyButtonHitTest(
             continue;
         }
 
-        const float indent = NodeIndent(node, theme);
-        const float x = theme.margin_left + indent;
-        const float w = content_width - indent;
-        const float pad = theme.code_block_padding;
+        const float indent = NodeIndent(node, ctx.theme);
+        const float x = ctx.theme.margin_left + indent;
+        const float w = ctx.content_width - indent;
+        const float pad = ctx.theme.code_block_padding;
 
         const float block_right = x + w;
-        const float block_top = cache[i].y_position - pad;
+        const float block_top = ctx.cache[i].y_position - pad;
 
         const D2D1_RECT_F btn = OverlayButtonRect(block_right, block_top);
         if (dip_x >= btn.left && dip_x <= btn.right && dip_y >= btn.top && dip_y <= btn.bottom) {
@@ -283,47 +269,39 @@ int HitTestService::CopyButtonHitTest(
 }
 
 int HitTestService::SaveButtonHitTest(
-    const std::pmr::vector<Node>& nodes,
-    const LayoutCache& cache,
-    const Theme& theme,
-    float scroll_y,
-    float md_pane_left,
-    float content_width,
-    float md_pane_height,
-    float dpi_scale,
-    int screen_x, int screen_y) const noexcept
+    const MdPaneHitContext& ctx) const noexcept
 {
-    if (nodes.empty()) {
+    if (ctx.nodes.empty()) {
         return -1;
     }
 
-    const auto [dip_x, dip_y] = ScreenToPaneDip(screen_x, screen_y, dpi_scale, md_pane_left, scroll_y);
+    const auto [dip_x, dip_y] = ScreenToPaneDip(ctx.screen_x, ctx.screen_y, ctx.dpi_scale, ctx.md_pane_left, ctx.scroll_y);
 
-    const float viewport_top = scroll_y;
-    const float viewport_bottom = scroll_y + md_pane_height;
+    const float viewport_top = ctx.scroll_y;
+    const float viewport_bottom = ctx.scroll_y + ctx.md_pane_height;
 
-    const int first = FindFirstVisibleNodeIndex(cache, nodes.size(), viewport_top);
-    const int count = static_cast<int>(nodes.size());
+    const int first = FindFirstVisibleNodeIndex(ctx.cache, ctx.nodes.size(), viewport_top);
+    const int count = static_cast<int>(ctx.nodes.size());
     for (int i = first; i < count; i++) {
-        if (cache[i].y_position > viewport_bottom) {
+        if (ctx.cache[i].y_position > viewport_bottom) {
             break;
         }
 
-        const auto& node = nodes[i];
+        const auto& node = ctx.nodes[i];
         if (node.type != NodeType::CodeBlock || node.code_language != SyntaxLanguage::Mermaid) {
             continue;
         }
 
-        const auto& diagram = cache.GetDiagram(i);
+        const auto& diagram = ctx.cache.GetDiagram(i);
         if (!diagram.bitmap) {
             continue;
         }
 
-        const float indent = NodeIndent(node, theme);
-        const float x = theme.margin_left + indent;
-        const float cw = content_width - indent;
+        const float indent = NodeIndent(node, ctx.theme);
+        const float x = ctx.theme.margin_left + indent;
+        const float cw = ctx.content_width - indent;
 
-        const auto bmp = MermaidBitmapRect(diagram.width, diagram.height, x, cw, cache[i].y_position);
+        const auto bmp = MermaidBitmapRect(diagram.width, diagram.height, x, cw, ctx.cache[i].y_position);
         const D2D1_RECT_F btn = OverlayButtonRect(bmp.right, bmp.top);
         if (dip_x >= btn.left && dip_x <= btn.right && dip_y >= btn.top && dip_y <= btn.bottom) {
             return i;

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -218,8 +218,7 @@ HitTestService::HitResult HitTestService::HitTestTable(
     return result;
 }
 
-int HitTestService::CopyButtonHitTest(
-    const MdPaneHitContext& ctx) const noexcept
+int HitTestService::CopyButtonHitTest(const MdPaneHitContext& ctx) const noexcept
 {
     assert(ctx.content_width > 0.0f && "content_width must be set for button hit test");
     assert(ctx.md_pane_height > 0.0f && "md_pane_height must be set for button hit test");
@@ -270,8 +269,7 @@ int HitTestService::CopyButtonHitTest(
     return -1;
 }
 
-int HitTestService::SaveButtonHitTest(
-    const MdPaneHitContext& ctx) const noexcept
+int HitTestService::SaveButtonHitTest(const MdPaneHitContext& ctx) const noexcept
 {
     assert(ctx.content_width > 0.0f && "content_width must be set for button hit test");
     assert(ctx.md_pane_height > 0.0f && "md_pane_height must be set for button hit test");

--- a/src/input/hit_test_service.h
+++ b/src/input/hit_test_service.h
@@ -8,6 +8,22 @@
 #include <string>
 #include <memory_resource>
 
+// MDペインのヒットテストに必要なコンテキスト情報。
+// ドキュメントデータ、ビューポート状態、マウス位置をまとめる。
+struct MdPaneHitContext {
+    const std::pmr::vector<Node>& nodes;
+    const LayoutCache& cache;
+    const Theme& theme;
+    float scroll_y;
+    float md_pane_left;
+    float dpi_scale;
+    int screen_x;
+    int screen_y;
+    // ボタンヒットテスト用（HitTestでは未使用）
+    float content_width = 0.0f;
+    float md_pane_height = 0.0f;
+};
+
 class HitTestService {
 public:
     struct HitResult {
@@ -16,13 +32,7 @@ public:
     };
 
     // Md ペイン内のヒットテスト
-    HitResult HitTest(const std::pmr::vector<Node>& nodes,
-        const LayoutCache& cache,
-        const Theme& theme,
-        float scroll_y,
-        float md_pane_left,
-        float dpi_scale,
-        int screen_x, int screen_y) const noexcept;
+    HitResult HitTest(const MdPaneHitContext& ctx) const noexcept;
 
     // テーブルセル内のヒットテスト
     HitResult HitTestTable(const Node& node, const NodeLayoutEntry& entry,
@@ -36,25 +46,9 @@ public:
 
     // コードブロックのコピーボタンのヒットテスト。
     // ヒットしたコードブロックのノードインデックスを返す（-1=なし）。
-    int CopyButtonHitTest(const std::pmr::vector<Node>& nodes,
-        const LayoutCache& cache,
-        const Theme& theme,
-        float scroll_y,
-        float md_pane_left,
-        float content_width,
-        float md_pane_height,
-        float dpi_scale,
-        int screen_x, int screen_y) const noexcept;
+    int CopyButtonHitTest(const MdPaneHitContext& ctx) const noexcept;
 
     // Mermaidダイアグラムの保存ボタンのヒットテスト。
     // ヒットしたダイアグラムのノードインデックスを返す（-1=なし）。
-    int SaveButtonHitTest(const std::pmr::vector<Node>& nodes,
-        const LayoutCache& cache,
-        const Theme& theme,
-        float scroll_y,
-        float md_pane_left,
-        float content_width,
-        float md_pane_height,
-        float dpi_scale,
-        int screen_x, int screen_y) const noexcept;
+    int SaveButtonHitTest(const MdPaneHitContext& ctx) const noexcept;
 };

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -103,11 +103,27 @@ public:
 
     constexpr size_t size() const noexcept { return entries_.size(); }
 
-    constexpr NodeLayoutEntry& operator[](size_t i) noexcept { assert(i < entries_.size()); return entries_[i]; }
-    constexpr const NodeLayoutEntry& operator[](size_t i) const noexcept { assert(i < entries_.size()); return entries_[i]; }
+    constexpr NodeLayoutEntry& operator[](size_t i) noexcept
+    {
+        assert(i < entries_.size());
+        return entries_[i];
+    }
+    constexpr const NodeLayoutEntry& operator[](size_t i) const noexcept
+    {
+        assert(i < entries_.size());
+        return entries_[i];
+    }
 
-    constexpr DiagramEntry& GetDiagram(size_t i) noexcept { assert(i < diagrams_.size()); return diagrams_[i]; }
-    constexpr const DiagramEntry& GetDiagram(size_t i) const noexcept { assert(i < diagrams_.size()); return diagrams_[i]; }
+    constexpr DiagramEntry& GetDiagram(size_t i) noexcept
+    {
+        assert(i < diagrams_.size());
+        return diagrams_[i];
+    }
+    constexpr const DiagramEntry& GetDiagram(size_t i) const noexcept
+    {
+        assert(i < diagrams_.size());
+        return diagrams_[i];
+    }
 
     // すべてのテキストレイアウトとエフェクトを無効化する（テーマ/ズーム変更時）。
     // ダイアグラム/Mermaid キャッシュの処理は呼び出し側で別途行うこと。

--- a/src/render/command_gen_table.cpp
+++ b/src/render/command_gen_table.cpp
@@ -40,8 +40,7 @@ void CommandGenerator::GenTableCellContent(DrawCommandList& cmds, const TableCel
 
 void CommandGenerator::GenTable(DrawCommandList& cmds,
     const Node& node, const NodeLayoutEntry& entry,
-    int node_index, float offset_x, const TextSelection& selection,
-    float viewport_top, float viewport_bottom)
+    int node_index, float offset_x)
 {
     if (node.table_rows().empty() || !entry.has_table_layout() || entry.table_layout->col_widths.empty()) {
         return;
@@ -50,6 +49,9 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
     const float cell_padding = TABLE_CELL_PADDING;
     const float border = TABLE_BORDER_WIDTH;
     const auto& tl = *entry.table_layout;
+    const auto& selection = *frame_selection_;
+    const float viewport_top = frame_viewport_top_;
+    const float viewport_bottom = frame_viewport_bottom_;
 
     const float table_width = std::ranges::fold_left(
         tl.col_widths,

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -46,42 +46,40 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     const float snapped_y = SnapScrollToPixel(scroll_y, dpi_scale);
     cmds.emplace_back(SetTransformCmd{ D2D1::Matrix3x2F::Translation(md_pane_rect.x, -snapped_y) });
 
-    const float viewport_top = scroll_y;
-    const float viewport_bottom = scroll_y + md_pane_rect.height;
-    const float offset_x = theme_->margin_left;
-    const float md_content_width = theme_->ContentWidth(md_pane_rect.width);
+    frame_offset_x_ = theme_->margin_left;
+    frame_viewport_top_ = scroll_y;
+    frame_viewport_bottom_ = scroll_y + md_pane_rect.height;
+    frame_content_width_ = theme_->ContentWidth(md_pane_rect.width);
+    frame_selection_ = &selection;
+    frame_hovered_copy_node_ = hovered_copy_node;
+    frame_hovered_save_node_ = hovered_save_node;
 
     // 最初の可視ノードを二分探索で検索（事前計算済みのインデックスがあればそれを使用）
     const int node_count = static_cast<int>(nodes.size());
     if (first_visible < 0) {
-        first_visible = FindFirstVisibleNodeIndex(cache, nodes.size(), viewport_top);
+        first_visible = FindFirstVisibleNodeIndex(cache, nodes.size(), frame_viewport_top_);
     }
 
     // 同一 blockquote_group のノードをまとめてバー/背景を描画する。
     // ノード単体ごとではなく一括で描画することで、複数行の引用ブロックが連続した見た目になる。
-    GenBlockQuoteGroupDecorations(cmds, nodes, cache, node_count,
-        offset_x, md_content_width, first_visible, viewport_bottom);
+    GenBlockQuoteGroupDecorations(cmds, nodes, cache, node_count, first_visible);
 
     for (int i = first_visible; i < node_count; i++) {
-        if (cache[i].y_position > viewport_bottom) {
+        if (cache[i].y_position > frame_viewport_bottom_) {
             break;
         }
-        GenerateNode(cmds, nodes[i], cache[i], cache.GetDiagram(i),
-            i, offset_x, viewport_top, viewport_bottom,
-            selection, md_content_width, hovered_copy_node, hovered_save_node);
+        GenerateNode(cmds, nodes[i], cache[i], cache.GetDiagram(i), i);
     }
 
     cmds.emplace_back(SetTransformCmd{ D2D1::Matrix3x2F::Identity() });
     cmds.emplace_back(PopClipCmd{});
+    frame_selection_ = nullptr;
     return cmds_;
 }
 
 void CommandGenerator::GenerateNode(DrawCommandList& cmds,
     const Node& node, const NodeLayoutEntry& entry, const DiagramEntry& diagram,
-    int node_index, float offset_x, float viewport_top, float viewport_bottom,
-    const TextSelection& selection, float content_width,
-    int hovered_copy_node,
-    int hovered_save_node)
+    int node_index)
 {
     // ビューポート外のノードをカリング
     // h1/h2は見出し下線がentry.heightの外に描画されるため、カリング境界を拡張する。
@@ -89,13 +87,13 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
     if (node.type == NodeType::Heading && node.heading_level <= 2) {
         node_bottom += theme_->heading_spacing_below * 0.5f + theme_->GetHeadingUnderlineThickness(node.heading_level);
     }
-    if (node_bottom < viewport_top || entry.y_position > viewport_bottom) {
+    if (node_bottom < frame_viewport_top_ || entry.y_position > frame_viewport_bottom_) {
         return;
     }
 
     const float indent = node.indent_level * theme_->indent_width;
-    const float x = offset_x + indent;
-    const float cw = content_width - indent;
+    const float x = frame_offset_x_ + indent;
+    const float cw = frame_content_width_ - indent;
 
     switch (node.type) {
     case NodeType::HorizontalRule:
@@ -119,7 +117,7 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
         return;
 
     case NodeType::Table:
-        GenTable(cmds, node, entry, node_index, x, selection, viewport_top, viewport_bottom);
+        GenTable(cmds, node, entry, node_index, x);
         return;
 
     case NodeType::CodeBlock:
@@ -127,7 +125,7 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
             if (diagram.bitmap) {
                 const auto bmp = MermaidBitmapRect(diagram.width, diagram.height, x, cw, entry.y_position);
                 cmds.emplace_back(DrawBitmapCmd{ diagram.bitmap.Get(), bmp });
-                GenSaveButton(cmds, bmp.right, bmp.top, node_index == hovered_save_node);
+                GenSaveButton(cmds, bmp.right, bmp.top, node_index == frame_hovered_save_node_);
             }
             else {
                 GenDiagramPlaceholder(cmds, x, entry.y_position, cw, entry.height);
@@ -135,7 +133,7 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
             return;
         }
         GenCodeBlockBg(cmds, entry, x, cw);
-        GenCopyButton(cmds, entry, x, cw, node_index == hovered_copy_node);
+        GenCopyButton(cmds, entry, x, cw, node_index == frame_hovered_copy_node_);
         break;
 
     case NodeType::ListItem:
@@ -183,6 +181,7 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
     GenSearchHighlights(cmds, entry.text_layout.Get(), node_index, x, entry.y_position);
 
     // 選択範囲のハイライト
+    const auto& selection = *frame_selection_;
     if (selection.active && node_index >= selection.start_node && node_index <= selection.end_node) {
         uint32_t sel_start = 0;
         uint32_t sel_end = static_cast<uint32_t>(node.GetText().size());
@@ -317,9 +316,11 @@ void CommandGenerator::GenListBullet(DrawCommandList& cmds,
 
 void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds,
     const std::pmr::vector<Node>& nodes, const LayoutCache& cache,
-    int node_count, float offset_x, float content_width,
-    int first_visible, float viewport_bottom)
+    int node_count, int first_visible)
 {
+    const float offset_x = frame_offset_x_;
+    const float content_width = frame_content_width_;
+    const float viewport_bottom = frame_viewport_bottom_;
     static constexpr float BAR_EXTEND = 2.0f;
     static constexpr float ALERT_BG_PAD = 4.0f;
     static constexpr float ALERT_BG_CORNER = 4.0f;

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -95,15 +95,11 @@ public:
 private:
     void GenerateNode(DrawCommandList& cmds,
         const Node& node, const NodeLayoutEntry& entry, const DiagramEntry& diagram,
-        int node_index, float offset_x, float viewport_top, float viewport_bottom,
-        const TextSelection& selection, float content_width,
-        int hovered_copy_node,
-        int hovered_save_node);
+        int node_index);
 
     void GenHorizontalRule(DrawCommandList& cmds, const NodeLayoutEntry& entry, float x, float w);
     void GenTable(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry,
-        int node_index, float x, const TextSelection& selection,
-        float viewport_top, float viewport_bottom);
+        int node_index, float x);
     void GenTableRowBg(DrawCommandList& cmds, bool is_header, bool is_even_row,
         float x, float y, float table_width, float row_h, float border);
     void GenTableCellContent(DrawCommandList& cmds, const TableCell& cell,
@@ -119,8 +115,7 @@ private:
     void GenListBullet(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, float x);
     void GenBlockQuoteGroupDecorations(DrawCommandList& cmds,
         const std::pmr::vector<Node>& nodes, const LayoutCache& cache,
-        int node_count, float offset_x, float content_width,
-        int first_visible, float viewport_bottom);
+        int node_count, int first_visible);
     void GenDiagramPlaceholder(DrawCommandList& cmds, float x, float y, float w, float h);
     void EmitHighlightRects(DrawCommandList& cmds, IDWriteTextLayout* layout,
         uint32_t start, uint32_t length, float origin_x, float origin_y, D2D1_COLOR_F color);
@@ -167,4 +162,14 @@ private:
 
     D2D1_COLOR_F cached_stripe_color_{};
     bool cached_is_dark_ = false;
+
+    // GenerateMdPane のスコープ内で不変のフレーム単位コンテキスト。
+    // GenerateNode 等の private 関数から参照される。
+    float frame_offset_x_ = 0.0f;
+    float frame_viewport_top_ = 0.0f;
+    float frame_viewport_bottom_ = 0.0f;
+    float frame_content_width_ = 0.0f;
+    const TextSelection* frame_selection_ = nullptr;
+    int frame_hovered_copy_node_ = -1;
+    int frame_hovered_save_node_ = -1;
 };

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -383,7 +383,7 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry,
         bool bgs_done = false;
         if (!first_pass && tl.CellIndex(r, 0) < tl.cell_inline_code_bgs.size()) {
             // first_pass でリサイズ済みなのでフラグとして先頭セルの capacity を利用:
-            // first_pass 後に need_bgs=true で走査されたセルは push_back か reserve(0) で
+            // first_pass 後に need_bgs=true で走査されたセルは emplace_back か reserve(0) で
             // 容量が 0 でなくなるが、ここでは簡便にインラインコードランの有無で判定する。
             bgs_done = true;
             const auto cc = row.cells.size();
@@ -424,7 +424,7 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry,
                 if (need_bgs && run.code() && run.length > 0) {
                     const UINT32 count = FetchHitTestMetrics(cell_layout, run.start, run.length, hit_test_buffer_);
                     for (UINT32 hi = 0; hi < count; hi++) {
-                        tl.cell_inline_code_bgs[tl.CellIndex(r, c)].push_back(MakeInlineCodeBg(hit_test_buffer_[hi]));
+                        tl.cell_inline_code_bgs[tl.CellIndex(r, c)].emplace_back(MakeInlineCodeBg(hit_test_buffer_[hi]));
                     }
                 }
             }
@@ -496,7 +496,7 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry,
         if (run.code() && node.type != NodeType::CodeBlock && run.length > 0) {
             const UINT32 count = FetchHitTestMetrics(entry.text_layout.Get(), run.start, run.length, hit_test_buffer_);
             for (UINT32 i = 0; i < count; i++) {
-                entry.inline_code_bgs.push_back(MakeInlineCodeBg(hit_test_buffer_[i]));
+                entry.inline_code_bgs.emplace_back(MakeInlineCodeBg(hit_test_buffer_[i]));
             }
         }
     }

--- a/src/ui/search_state.cpp
+++ b/src/ui/search_state.cpp
@@ -66,7 +66,7 @@ void SearchState::FindMatches(std::wstring_view text, const std::pmr::wstring& l
     if (case_sensitive_) {
         size_t pos = 0;
         while (matches_.size() < MAX_MATCHES && (pos = text.find(query_, pos)) != std::wstring_view::npos) {
-            matches_.push_back({ node_index, static_cast<uint32_t>(pos), query_len, table_row, table_col });
+            matches_.emplace_back(node_index, static_cast<uint32_t>(pos), query_len, table_row, table_col);
             pos += query_len;
         }
     }
@@ -81,7 +81,7 @@ void SearchState::FindMatches(std::wstring_view text, const std::pmr::wstring& l
 
         size_t pos = 0;
         while (matches_.size() < MAX_MATCHES && (pos = lower_text.find(lower_query, pos)) != std::wstring_view::npos) {
-            matches_.push_back({ node_index, static_cast<uint32_t>(pos), query_len, table_row, table_col });
+            matches_.emplace_back(node_index, static_cast<uint32_t>(pos), query_len, table_row, table_col);
             pos += query_len;
         }
     }

--- a/tests/test_copy_button.cpp
+++ b/tests/test_copy_button.cpp
@@ -95,7 +95,7 @@ TEST_F(CopyButtonTest, HitOnCopyButtonReturnsNodeIndex)
     auto [cx, cy] = CopyBtnCenter(pr, code_idx);
     float content_width = 800.0f - theme_.margin_left - theme_.margin_right;
     int result = hit_test_.CopyButtonHitTest(
-        pr.nodes, pr.cache, theme_, 0.0f, 0.0f, content_width, 2000.0f, 1.0f, cx, cy);
+        { pr.nodes, pr.cache, theme_, 0.0f, 0.0f, 1.0f, cx, cy, content_width, 2000.0f });
     EXPECT_EQ(result, code_idx);
 }
 
@@ -105,7 +105,7 @@ TEST_F(CopyButtonTest, HitOutsideCopyButtonReturnsNegative)
     float content_width = 800.0f - theme_.margin_left - theme_.margin_right;
     // 明らかにボタン外の座標（左上端）
     int result = hit_test_.CopyButtonHitTest(
-        pr.nodes, pr.cache, theme_, 0.0f, 0.0f, content_width, 2000.0f, 1.0f, 5, 5);
+        { pr.nodes, pr.cache, theme_, 0.0f, 0.0f, 1.0f, 5, 5, content_width, 2000.0f });
     EXPECT_EQ(result, -1);
 }
 
@@ -115,7 +115,7 @@ TEST_F(CopyButtonTest, NonCodeBlockReturnsNegative)
     float content_width = 800.0f - theme_.margin_left - theme_.margin_right;
     // ドキュメント中央をクリック
     int result = hit_test_.CopyButtonHitTest(
-        pr.nodes, pr.cache, theme_, 0.0f, 0.0f, content_width, 2000.0f, 1.0f, 400, 20);
+        { pr.nodes, pr.cache, theme_, 0.0f, 0.0f, 1.0f, 400, 20, content_width, 2000.0f });
     EXPECT_EQ(result, -1);
 }
 
@@ -131,7 +131,7 @@ TEST_F(CopyButtonTest, MermaidBlockReturnsNegative)
     if (mermaid_idx >= 0) {
         auto [cx, cy] = CopyBtnCenter(pr, mermaid_idx);
         int result = hit_test_.CopyButtonHitTest(
-            pr.nodes, pr.cache, theme_, 0.0f, 0.0f, content_width, 2000.0f, 1.0f, cx, cy);
+            { pr.nodes, pr.cache, theme_, 0.0f, 0.0f, 1.0f, cx, cy, content_width, 2000.0f });
         EXPECT_EQ(result, -1);
     }
 }
@@ -153,13 +153,13 @@ TEST_F(CopyButtonTest, MultipleCodeBlocksHitCorrectOne)
     // 1つ目のコピーボタンをクリック
     auto [cx1, cy1] = CopyBtnCenter(pr, code_indices[0]);
     int r1 = hit_test_.CopyButtonHitTest(
-        pr.nodes, pr.cache, theme_, 0.0f, 0.0f, content_width, 2000.0f, 1.0f, cx1, cy1);
+        { pr.nodes, pr.cache, theme_, 0.0f, 0.0f, 1.0f, cx1, cy1, content_width, 2000.0f });
     EXPECT_EQ(r1, code_indices[0]);
 
     // 2つ目のコピーボタンをクリック
     auto [cx2, cy2] = CopyBtnCenter(pr, code_indices[1]);
     int r2 = hit_test_.CopyButtonHitTest(
-        pr.nodes, pr.cache, theme_, 0.0f, 0.0f, content_width, 2000.0f, 1.0f, cx2, cy2);
+        { pr.nodes, pr.cache, theme_, 0.0f, 0.0f, 1.0f, cx2, cy2, content_width, 2000.0f });
     EXPECT_EQ(r2, code_indices[1]);
 }
 
@@ -168,7 +168,7 @@ TEST_F(CopyButtonTest, EmptyDocumentReturnsNegative)
     auto pr = Parse("");
     float content_width = 800.0f - theme_.margin_left - theme_.margin_right;
     int result = hit_test_.CopyButtonHitTest(
-        pr.nodes, pr.cache, theme_, 0.0f, 0.0f, content_width, 2000.0f, 1.0f, 400, 400);
+        { pr.nodes, pr.cache, theme_, 0.0f, 0.0f, 1.0f, 400, 400, content_width, 2000.0f });
     EXPECT_EQ(result, -1);
 }
 
@@ -204,6 +204,6 @@ TEST_F(CopyButtonTest, ScrolledViewportHitTest)
     int sy = static_cast<int>((btn.top + btn.bottom) * 0.5f - scroll_y);
 
     int result = hit_test_.CopyButtonHitTest(
-        pr.nodes, pr.cache, theme_, scroll_y, 0.0f, content_width, 600.0f, 1.0f, sx, sy);
+        { pr.nodes, pr.cache, theme_, scroll_y, 0.0f, 1.0f, sx, sy, content_width, 600.0f });
     EXPECT_EQ(result, code_idx);
 }


### PR DESCRIPTION
## Summary
- `HitTestService` の `HitTest` / `CopyButtonHitTest` / `SaveButtonHitTest` に個別に渡していた8〜10個の引数を `MdPaneHitContext` 構造体にまとめ、呼び出し側の可読性を改善
- `CommandGenerator` の `GenerateNode` / `GenTable` / `GenBlockQuoteGroupDecorations` に渡していたフレーム単位のコンテキスト（viewport範囲、offset、content_width、selection、hovered node等）をメンバ変数（`frame_*`）に集約し、引数を削減
- `push_back` → `emplace_back`、`text_.assign(s.data(), s.size())` → `text_.assign(s)` 等の小改善

## Test plan
- [x] Release ビルド成功
- [x] 全1463テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)