### PR TITLE
リファクタリング: コード重複解消・Reducer拡張・メッセージハンドラ分割

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -982,9 +982,10 @@ void App::HandleDropFile(std::wstring_view path)
 
 void App::Dispatch(const AppAction& action)
 {
-    // Reducer はすべてのアクションを受け取る。
-    // 処理対象のアクションは状態を更新し副作用を返す。
-    // 対象外のアクションは no-op で空の副作用リストを返す。
+    // Reducer が cached_pane_layout を参照するため、最新レイアウトを保証する。
+    // キャッシュ済みなら O(1) で返る。
+    GetPaneLayout();
+
     auto effects = Reduce(state_, action);
     effect_executor_.Execute(effects);
 

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -83,7 +83,19 @@ bool App::Init(HWND hwnd)
                     LoadMarkdownFile(path);
                 }
             },
-        });
+            .invalidate_pane_cache = [this](PaneZone pane) {
+                if (pane == PaneZone::FilePane) {
+                    renderer_.InvalidateFilePaneCache();
+                }
+                else if (pane == PaneZone::TocPane) {
+                    renderer_.InvalidateTocPaneCache();
+                }
+            },
+            .refresh_pane_layout = [this]() {
+                RefreshPaneLayout();
+            },
+        }
+    );
 
     mermaid_renderer_.Init(hwnd_, renderer_.GetRenderTarget(), [this]() {
         resource_manager_.ScheduleMermaidBatch();
@@ -112,6 +124,8 @@ bool App::Init(HWND hwnd)
     if (theme_service_.IsDarkMode()) {
         ApplyDarkModeToWindow(hwnd_, true);
     }
+
+    SyncPaneThemeCache();
 
     cursors_.Init();
 
@@ -477,7 +491,7 @@ void App::BeginAsyncLoad(const std::pmr::wstring& path)
     file_load_service_.SetLoadingPath(path);
     if (DocumentService::NeedsLoadingAnimation(path) && !state_.pending_prefix_shrink) {
         file_load_service_.StartLoading(path);
-        SetTimer(hwnd_, app_timer::LOADING_ANIM, 16, nullptr);
+        SetTimer(hwnd_, app_timer::LOADING_ANIM, app_timer::FRAME_INTERVAL_MS, nullptr);
         Invalidate();
         UpdateWindow(hwnd_);
     }
@@ -568,30 +582,11 @@ void App::OnParseComplete()
         }
 
         if (is_prefix_only) {
-            // prefix-only はファイル末尾の伸縮のみ。prefix 部分のノード列は
-            // 同一なので、旧キャッシュの実測高さ・text_layout をそのまま保持する。
-            // Reset() + EstimateNodeHeights() だと推定高さの累積誤差で
-            // 大規模ファイル後半のスクロール位置が大きくずれる。
+            // prefix-only はファイル末尾の伸縮のみ。FinishReload が
+            // ResizePreservingPrefix で旧キャッシュの実測高さを保持する。
             resource_manager_.CancelMermaidBatch();
             state_.doc = std::move(result->doc);
-            state_.layout_cache.ResizePreservingPrefix(state_.doc.GetNodes().size());
-
-            renderer_.InvalidateTocPaneCache();
-
-            const auto pane_layout = GetPaneLayout();
-            const float md_width = pane_layout.md_rect.width;
-            const float md_height = pane_layout.md_rect.height;
-
-            state_.viewport.SetScrollY(state_.reload_old_scroll);
-            layout_service_->ViewportLayout(state_.doc, state_.layout_cache, md_width, md_height);
-
-            FinalizeLayout(md_height);
-
-            if (state_.search_state.IsVisible() && !state_.search_state.GetQuery().empty()) {
-                state_.search_bar_ctrl.RunSearchAndLocate(state_.doc.GetNodes());
-            }
-
-            doc_service_.ResumeWatching();
+            FinishReload(true, diff_pos, state_.reload_old_scroll);
             return;
         }
 
@@ -702,7 +697,7 @@ void App::FinishLoadMarkdownFile(bool heights_estimated)
 
     doc_service_.StartWatching(state_.doc.GetFilePath(), [this]() {
         KillTimer(hwnd_, app_timer::FILE_RELOAD_DEBOUNCE);
-        SetTimer(hwnd_, app_timer::FILE_RELOAD_DEBOUNCE, 200, nullptr);
+        SetTimer(hwnd_, app_timer::FILE_RELOAD_DEBOUNCE, app_timer::FILE_RELOAD_DEBOUNCE_MS, nullptr);
     });
 }
 
@@ -786,8 +781,17 @@ void App::DoReloadCurrentFile()
         state_.doc.ReplaceFromMarkdown(std::move(new_utf8));
     }
 
+    FinishReload(is_prefix_only, diff_pos, old_scroll);
+}
+
+// DoReloadCurrentFile / OnParseComplete 共通のリロード後処理。
+// ドキュメントは更新済みの状態で呼ばれる。
+// is_prefix_only: ファイル末尾の伸縮のみか
+// diff_pos: 差分開始位置 (prefix-only の場合は使用しない)
+// old_scroll: リロード前のスクロール位置
+void App::FinishReload(bool is_prefix_only, size_t diff_pos, float old_scroll)
+{
     if (is_prefix_only) {
-        // prefix 部分のノード列は同一なので旧キャッシュの実測高さを保持する
         state_.layout_cache.ResizePreservingPrefix(state_.doc.GetNodes().size());
     }
     else {
@@ -811,10 +815,11 @@ void App::DoReloadCurrentFile()
         ? old_scroll
         : CalcScrollForDiff(diff_pos, md_height, old_scroll);
 
-    MENDO_TRACEF("DoReload: desired_scroll=%.1f old_scroll=%.1f", desired_scroll, old_scroll);
+    MENDO_TRACEF("FinishReload: desired_scroll=%.1f old_scroll=%.1f is_prefix_only=%d",
+        desired_scroll, old_scroll, is_prefix_only ? 1 : 0);
 
     // スクロール位置を設定してからViewportLayoutを呼ぶことで、
-    // 変更箇所周辺の可視ノードが計測される
+    // 変更箇所周辺の可視ノードが優先的に計測される
     state_.viewport.SetScrollY(desired_scroll);
 
     {
@@ -824,12 +829,10 @@ void App::DoReloadCurrentFile()
 
     FinalizeLayout(md_height);
 
-    // 検索バー表示中なら再検索
     if (state_.search_state.IsVisible() && !state_.search_state.GetQuery().empty()) {
         state_.search_bar_ctrl.RunSearchAndLocate(state_.doc.GetNodes());
     }
 
-    // リロード完了まで一時停止していたファイル監視を再開する
     doc_service_.ResumeWatching();
 }
 
@@ -950,6 +953,33 @@ void App::OnKeyDown(WPARAM key)
     Dispatch(controller_.HandleKeyDown(event));
 }
 
+void App::HandleOpenFile()
+{
+    const auto path = FileLoader::OpenFileDialog(hwnd_);
+    if (!path.empty()) {
+        if (!state_.doc.GetFilePath().empty()) {
+            PushNavHistory();
+        }
+        LoadMarkdownFile(path);
+    }
+}
+
+void App::HandleShowHelp()
+{
+    if (!state_.doc.GetFilePath().empty() && !IsHelpPath(state_.doc.GetFilePath())) {
+        PushNavHistory();
+    }
+    LoadHelpDocument();
+}
+
+void App::HandleDropFile(std::wstring_view path)
+{
+    if (!state_.doc.GetFilePath().empty()) {
+        PushNavHistory();
+    }
+    LoadMarkdownFile(path);
+}
+
 void App::Dispatch(const AppAction& action)
 {
     // Reducer はすべてのアクションを受け取る。
@@ -958,35 +988,9 @@ void App::Dispatch(const AppAction& action)
     auto effects = Reduce(state_, action);
     effect_executor_.Execute(effects);
 
-    // Reducer が処理しないアクションは std::visit で処理
+    // Reducer が処理しないアクションはハンドラメソッドに委譲
     std::visit(overloaded{
-        [this](const ScrollPaneAction& a) {
-            const auto pane_layout = GetPaneLayout();
-            const auto& theme = renderer_.GetTheme();
-            if (a.pane == PaneZone::FilePane) {
-                const float max_file_scroll = std::max(0.0f,
-                    static_cast<float>(state_.file_explorer.GetEntries().size()) * theme.pane_item_height
-                    - (pane_layout.file_rect.height - theme.pane_header_height));
-                if (state_.panes.ScrollFilePaneBy(a.delta, max_file_scroll)) {
-                    renderer_.InvalidateFilePaneCache();
-                    Invalidate();
-                }
-            }
-            else if (a.pane == PaneZone::TocPane) {
-                const float max_toc_scroll = std::max(0.0f, static_cast<float>(state_.doc.GetToc().GetEntries().size()) * theme.pane_item_height - (pane_layout.toc_rect.height - theme.pane_header_height));
-                if (state_.panes.ScrollTocPaneBy(a.delta, max_toc_scroll)) {
-                    renderer_.InvalidateTocPaneCache();
-                    Invalidate();
-                }
-            }
-        },
-        [this](const TogglePaneAction& a) {
-            switch (a.target) {
-            case PaneTarget::File: state_.panes.ToggleFilePane(); break;
-            case PaneTarget::Toc:  state_.panes.ToggleTocPane();  break;
-            }
-            RefreshPaneLayout();
-        },
+        // ---- コマンド系 ----
         [this](const ZoomAction& a) {
             switch (a.direction) {
             case ZoomDirection::In:    ZoomIn();    break;
@@ -994,33 +998,12 @@ void App::Dispatch(const AppAction& action)
             case ZoomDirection::Reset: ZoomReset(); break;
             }
         },
-        [this](const ReloadFileAction&) {
-            ReloadCurrentFile();
-        },
-        [this](const OpenFileAction&) {
-            const auto path = FileLoader::OpenFileDialog(hwnd_);
-            if (!path.empty()) {
-                if (!state_.doc.GetFilePath().empty()) {
-                    PushNavHistory();
-                }
-                LoadMarkdownFile(path);
-            }
-        },
-        [this](const ToggleDarkModeAction&) {
-            ToggleDarkMode();
-        },
-        [this](const NavigateBackAction&) {
-            NavigateBack();
-        },
-        [this](const NavigateForwardAction&) {
-            NavigateForward();
-        },
-        [this](const ShowHelpAction&) {
-            if (!state_.doc.GetFilePath().empty() && !IsHelpPath(state_.doc.GetFilePath())) {
-                PushNavHistory();
-            }
-            LoadHelpDocument();
-        },
+        [this](const ReloadFileAction&) { ReloadCurrentFile(); },
+        [this](const OpenFileAction&) { HandleOpenFile(); },
+        [this](const ToggleDarkModeAction&) { ToggleDarkMode(); },
+        [this](const NavigateBackAction&) { NavigateBack(); },
+        [this](const NavigateForwardAction&) { NavigateForward(); },
+        [this](const ShowHelpAction&) { HandleShowHelp(); },
         // ---- マウスイベント系 ----
         [this](const LButtonDownAction& a) { OnLButtonDown(a.px, a.py); },
         [this](const LButtonUpAction& a) { OnLButtonUp(a.px, a.py); },
@@ -1034,12 +1017,7 @@ void App::Dispatch(const AppAction& action)
         [this](const XButtonBackAction&) { NavigateBack(); },
         [this](const XButtonForwardAction&) { NavigateForward(); },
         [this](const HWheelAction& a) { OnMouseHWheel(a.delta); },
-        [this](const DropFilesAction& a) {
-            if (!state_.doc.GetFilePath().empty()) {
-                PushNavHistory();
-            }
-            LoadMarkdownFile(a.path);
-        },
+        [this](const DropFilesAction& a) { HandleDropFile(a.path); },
         // ---- システムイベント系 ----
         [this](const ResizeAction& a) { OnResize(a.width, a.height); },
         [this](const DpiChangedAction& a) { OnDpiChanged(a.dpi, &a.suggested); },
@@ -1062,10 +1040,7 @@ void App::OnDropFiles(HDROP hDrop)
     if (required > 0) {
         std::pmr::wstring path(required, L'\0');
         if (DragQueryFileW(hDrop, 0, path.data(), required + 1)) {
-            if (!state_.doc.GetFilePath().empty()) {
-                PushNavHistory();
-            }
-            LoadMarkdownFile(path);
+            HandleDropFile(path);
         }
     }
     DragFinish(hDrop);
@@ -1166,7 +1141,7 @@ void App::OnCaptureChanged()
 void App::ShowToast(std::wstring_view message)
 {
     state_.toast.Show(message);
-    SetTimer(hwnd_, app_timer::TOAST, 16, nullptr);
+    SetTimer(hwnd_, app_timer::TOAST, app_timer::FRAME_INTERVAL_MS, nullptr);
     Invalidate();
 }
 

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -88,15 +88,15 @@ public:
     void OnDestroy();
 
     // 検索（Win32Windowから呼ばれるコールバック）— Reducer経由で状態変更
-    void OnSearchTextChanged(std::wstring_view text) { Dispatch(SearchTextChangedAction{std::pmr::wstring{text}}); }
+    void OnSearchTextChanged(std::wstring_view text) { Dispatch(SearchTextChangedAction{ std::pmr::wstring{text} }); }
     void OnSearchClose() { Dispatch(CloseSearchBarAction{}); }
     void OnSearchNext() { Dispatch(SearchNextAction{}); }
     void OnSearchPrev() { Dispatch(SearchPrevAction{}); }
     bool IsSearchBarVisible() const noexcept { return state_.search_state.IsVisible(); }
     void OnToggleCaseSensitive() { Dispatch(ToggleCaseSensitiveAction{}); }
     void OnToggleHighlight() { Dispatch(ToggleHighlightAction{}); }
-    void SetSearchSelection(int sel_start, int sel_end) { Dispatch(SearchSelectionAction{sel_start, sel_end}); }
-    void SetImeComposition(std::wstring_view comp) { Dispatch(ImeCompositionAction{std::pmr::wstring{comp}}); }
+    void SetSearchSelection(int sel_start, int sel_end) { Dispatch(SearchSelectionAction{ sel_start, sel_end }); }
+    void SetImeComposition(std::wstring_view comp) { Dispatch(ImeCompositionAction{ std::pmr::wstring{comp} }); }
     RECT GetSearchEditRect() const;
 
     // 検索バーコントローラへのアクセス（app_mouse.cppでのドラッグ/ホバー処理用）
@@ -132,7 +132,7 @@ public:
     TitleBarHitZone TitleBarHitTest(float dip_x, float dip_y) const noexcept { return state_.titlebar.HitTest(dip_x, dip_y); }
     bool IsOverMdScrollbar(float dip_x, float dip_y) const;
     bool IsOverMdScrollbar(float dip_x, float dip_y, const ::PaneLayout& layout) const noexcept;
-    void OnActivate(bool active) { Dispatch(ActivateAction{active}); }
+    void OnActivate(bool active) { Dispatch(ActivateAction{ active }); }
 
 private:
     // AppControllerが返すアクションを実行
@@ -196,7 +196,7 @@ private:
     // サイドペイン スクロールバードラッグ共通処理
     void HandleSidePaneScrollDrag(float dip_y, const PaneRect& rect,
         float total_content, ScrollState& scroll,
-        void (Renderer::*invalidate)());
+        void (Renderer::* invalidate)());
 
     // レイアウト / スクロール
     void ScheduleDeferredLayoutIfNeeded();
@@ -222,6 +222,9 @@ private:
     bool ShouldDeferForTruncateRewrite(bool is_prefix_only, size_t old_size, size_t new_size);
     void UpdateTitleBar();
 
+    // リロード共通処理: 差分分析後のレイアウト更新・スクロール復元・検索再実行
+    void FinishReload(bool is_prefix_only, size_t diff_pos, float old_scroll);
+
     // ファイル読み込み/リロード共通ヘルパー
     void CancelPendingResources();
     void FinalizeLayout(float md_pane_height);
@@ -239,6 +242,14 @@ private:
 
     // 検索
     void OnSearchOpen() { state_.search_bar_ctrl.OnOpen(state_.doc.GetNodes()); }
+
+    // Reducer 用テーマ定数キャッシュの同期
+    void SyncPaneThemeCache();
+
+    // Dispatch() 内のインラインハンドラから抽出したヘルパー
+    void HandleOpenFile();
+    void HandleShowHelp();
+    void HandleDropFile(std::wstring_view path);
 
     // ダークモード / ズーム (theme_service_に委譲)
     void ToggleDarkMode();

--- a/src/app/app_constants.h
+++ b/src/app/app_constants.h
@@ -22,6 +22,10 @@ inline constexpr UINT_PTR BITMAP_MANAGE = ResourceManager::TIMER_BITMAP_MANAGE;
 inline constexpr UINT_PTR MERMAID_INIT_RETRY = MermaidRenderer::TIMER_INIT_RETRY;
 inline constexpr UINT_PTR FILE_RELOAD_DEBOUNCE = 13;
 
+// タイマー間隔 (ms)
+inline constexpr UINT FRAME_INTERVAL_MS = 16;              // ~60fps アニメーション用
+inline constexpr UINT FILE_RELOAD_DEBOUNCE_MS = 200;       // ファイル変更通知のデバウンス
+
 } // namespace app_timer
 
 namespace app_msg {

--- a/src/app/app_constants.h
+++ b/src/app/app_constants.h
@@ -37,6 +37,9 @@ inline constexpr UINT SEARCH_FOCUS = WM_APP + 4;
 inline constexpr UINT SEARCH_UNFOCUS = WM_APP + 5;
 inline constexpr UINT PARSE_COMPLETE = WM_APP + 6;
 
+// カスタムメッセージの上限（この値未満が有効範囲）
+inline constexpr UINT END = WM_APP + 7;
+
 } // namespace app_msg
 
 namespace app_param {

--- a/src/app/app_context_menu.cpp
+++ b/src/app/app_context_menu.cpp
@@ -65,12 +65,10 @@ void App::OnContextMenu(int screen_x, int screen_y)
         ToggleDarkMode();
         break;
     case IDM_TOGGLE_FILE_PANE:
-        state_.panes.ToggleFilePane();
-        RefreshPaneLayout();
+        Dispatch(TogglePaneAction{ PaneTarget::File });
         break;
     case IDM_TOGGLE_TOC_PANE:
-        state_.panes.ToggleTocPane();
-        RefreshPaneLayout();
+        Dispatch(TogglePaneAction{ PaneTarget::Toc });
         break;
     default:
         break;

--- a/src/app/app_navigate.cpp
+++ b/src/app/app_navigate.cpp
@@ -1,6 +1,5 @@
 #include "app.h"
 #include "document_utils.h"
-#include <shellapi.h>
 #include <algorithm>
 
 // ============================================================
@@ -18,9 +17,12 @@ void App::HandleLinkClick(std::wstring_view url)
         PushNavHistory();
         NavigateToAnchor(result.target);
         break;
-    case NavigationService::NavigateResult::Type::ExternalUrl:
-        ShellExecuteW(hwnd_, L"open", result.target.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+    case NavigationService::NavigateResult::Type::ExternalUrl: {
+        SideEffectList effects;
+        effects.emplace_back(effect::ShellOpen{ std::pmr::wstring{result.target} });
+        effect_executor_.Execute(effects);
         break;
+    }
     default:
         break;
     }
@@ -78,8 +80,17 @@ void App::NavigateForward()
 // ダークモード
 // ============================================================
 
+void App::SyncPaneThemeCache()
+{
+    const auto& theme = renderer_.GetTheme();
+    state_.cached_pane_item_height = theme.pane_item_height;
+    state_.cached_pane_header_height = theme.pane_header_height;
+}
+
 void App::FinishThemeOrZoomChange(const AnchorState& anchor, float offset_scale)
 {
+    SyncPaneThemeCache();
+
     auto layout = GetPaneLayout();
     float md_width = layout.md_rect.width;
     float md_height = layout.md_rect.height;

--- a/src/app/app_scroll.cpp
+++ b/src/app/app_scroll.cpp
@@ -91,7 +91,7 @@ void App::HandleSidePaneScrollDrag(float dip_y, const PaneRect& rect,
 void App::ScheduleDeferredLayoutIfNeeded()
 {
     if (layout_service_->HasDirtyNodes()) {
-        SetTimer(hwnd_, app_timer::DEFERRED_LAYOUT, 16, nullptr);
+        SetTimer(hwnd_, app_timer::DEFERRED_LAYOUT, app_timer::FRAME_INTERVAL_MS, nullptr);
     }
 }
 

--- a/src/app/app_state.h
+++ b/src/app/app_state.h
@@ -65,4 +65,9 @@ struct AppState {
     mutable PaneLayout cached_pane_layout{};
     mutable float cached_window_width_for_layout = 0.0f;
     mutable bool pane_layout_valid = false;
+
+    // テーマから取得したペイン定数のキャッシュ（ズーム変更時に更新）。
+    // Reducer がペインスクロールの max_scroll を計算するために使用する。
+    float cached_pane_item_height = 28.0f;
+    float cached_pane_header_height = 32.0f;
 };

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -24,8 +24,44 @@ SideEffectList Reduce(AppState& state, const AppAction& action)
         }
     };
 
+    // ペインの max_scroll を計算するヘルパー
+    const auto calc_pane_max_scroll = [&](PaneZone pane) -> float {
+        const float item_h = state.cached_pane_item_height;
+        const float header_h = state.cached_pane_header_height;
+        if (pane == PaneZone::FilePane) {
+            const float total = static_cast<float>(state.file_explorer.GetEntries().size()) * item_h;
+            return std::max(0.0f, total - (state.cached_pane_layout.file_rect.height - header_h));
+        }
+        else {
+            const float total = static_cast<float>(state.doc.GetToc().GetEntries().size()) * item_h;
+            return std::max(0.0f, total - (state.cached_pane_layout.toc_rect.height - header_h));
+        }
+    };
+
     std::visit(overloaded{
         [](const NoOpAction&) {},
+        [&](const ScrollPaneAction& a) {
+            if (a.pane == PaneZone::FilePane) {
+                if (state.panes.ScrollFilePaneBy(a.delta, calc_pane_max_scroll(PaneZone::FilePane))) {
+                    effects.emplace_back(effect::InvalidatePaneCache{PaneZone::FilePane});
+                    effects.emplace_back(effect::InvalidateWindow{});
+                }
+            }
+            else if (a.pane == PaneZone::TocPane) {
+                if (state.panes.ScrollTocPaneBy(a.delta, calc_pane_max_scroll(PaneZone::TocPane))) {
+                    effects.emplace_back(effect::InvalidatePaneCache{PaneZone::TocPane});
+                    effects.emplace_back(effect::InvalidateWindow{});
+                }
+            }
+        },
+        [&](const TogglePaneAction& a) {
+            switch (a.target) {
+            case PaneTarget::File: state.panes.ToggleFilePane(); break;
+            case PaneTarget::Toc:  state.panes.ToggleTocPane();  break;
+            }
+            state.pane_layout_valid = false;
+            effects.emplace_back(effect::RefreshPaneLayout{});
+        },
         [&](const KeyScrollAction& a) {
             state.scroll_restore.pending_restore_scroll_y = -1;
             const float old_scroll = state.viewport.GetScrollY();

--- a/src/app/side_effect.h
+++ b/src/app/side_effect.h
@@ -80,7 +80,7 @@ struct ApplyDarkMode { bool dark; };
 
 } // namespace effect
 
-using SideEffect = std::variant <
+using SideEffect = std::variant<
     effect::InvalidateWindow,
     effect::InvalidateRect,
     effect::InvalidateTitleBar,

--- a/src/app/side_effect.h
+++ b/src/app/side_effect.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "pane.h"
+#include "pane_layout.h"
 #include "tooltip.h"
 #include <algorithm>
 #include <variant>
@@ -70,12 +71,16 @@ struct LoadImages {};
 struct RequestMermaidRenders {};
 struct CancelMermaidBatch {};
 
+// ---- ペインキャッシュ ----
+struct InvalidatePaneCache { PaneZone pane; };
+struct RefreshPaneLayout {};
+
 // ---- ダークモード ----
 struct ApplyDarkMode { bool dark; };
 
 } // namespace effect
 
-using SideEffect = std::variant<
+using SideEffect = std::variant <
     effect::InvalidateWindow,
     effect::InvalidateRect,
     effect::InvalidateTitleBar,
@@ -106,14 +111,17 @@ using SideEffect = std::variant<
     effect::LoadImages,
     effect::RequestMermaidRenders,
     effect::CancelMermaidBatch,
+    effect::InvalidatePaneCache,
+    effect::RefreshPaneLayout,
     effect::ApplyDarkMode
->;
+> ;
 
 using SideEffectList = std::pmr::vector<SideEffect>;
 
 // ヘルパー: 副作用リストに特定の副作用型が含まれるかチェック
 template<typename T>
-bool HasEffect(const SideEffectList& effects) noexcept {
+bool HasEffect(const SideEffectList& effects) noexcept
+{
     return std::ranges::any_of(effects, [](const auto& e) {
         return std::holds_alternative<T>(e);
     });

--- a/src/app/side_effect_executor.cpp
+++ b/src/app/side_effect_executor.cpp
@@ -120,12 +120,12 @@ void SideEffectExecutor::Execute(const SideEffectList& effects)
             },
             [this](const effect::ShowToast& e) {
                 state_->toast.Show(e.message);
-                ::SetTimer(hwnd_, app_timer::TOAST, 16, nullptr);
+                ::SetTimer(hwnd_, app_timer::TOAST, app_timer::FRAME_INTERVAL_MS, nullptr);
                 InvalidateRect(hwnd_, nullptr, FALSE);
             },
             [this](const effect::DeferredLayout&) {
                 if (layout_service_->HasDirtyNodes()) {
-                    ::SetTimer(hwnd_, app_timer::DEFERRED_LAYOUT, 16, nullptr);
+                    ::SetTimer(hwnd_, app_timer::DEFERRED_LAYOUT, app_timer::FRAME_INTERVAL_MS, nullptr);
                 }
             },
             [this](const effect::BitmapManage&) {
@@ -137,7 +137,7 @@ void SideEffectExecutor::Execute(const SideEffectList& effects)
             [this](const effect::StartFileWatch& e) {
                 doc_service_->StartWatching(e.path, [hwnd = hwnd_]() {
                     ::KillTimer(hwnd, app_timer::FILE_RELOAD_DEBOUNCE);
-                    ::SetTimer(hwnd, app_timer::FILE_RELOAD_DEBOUNCE, 200, nullptr);
+                    ::SetTimer(hwnd, app_timer::FILE_RELOAD_DEBOUNCE, app_timer::FILE_RELOAD_DEBOUNCE_MS, nullptr);
                 });
             },
             [this](const effect::StopFileWatch&) {
@@ -154,6 +154,12 @@ void SideEffectExecutor::Execute(const SideEffectList& effects)
             },
             [this](const effect::CancelMermaidBatch&) {
                 resource_manager_->CancelMermaidBatch();
+            },
+            [this](const effect::InvalidatePaneCache& e) {
+                cb_.invalidate_pane_cache(e.pane);
+            },
+            [this](const effect::RefreshPaneLayout&) {
+                cb_.refresh_pane_layout();
             },
             [this](const effect::ApplyDarkMode& e) {
                 ApplyDarkModeToWindow(hwnd_, e.dark);

--- a/src/app/side_effect_executor.h
+++ b/src/app/side_effect_executor.h
@@ -20,12 +20,14 @@ public:
         std::function<void(std::wstring_view)> load_file;
         std::function<void()> reload_file;
         std::function<void()> open_file_dialog;
+        std::function<void(PaneZone)> invalidate_pane_cache;
+        std::function<void()> refresh_pane_layout;
     };
 
     void Init(HWND hwnd, ResourceManager& resource_manager,
-              CursorManager& cursors, DocumentService& doc_service,
-              ConfigService& config, AppState& state,
-              LayoutService& layout_service, Callbacks cb);
+        CursorManager& cursors, DocumentService& doc_service,
+        ConfigService& config, AppState& state,
+        LayoutService& layout_service, Callbacks cb);
     void Execute(const SideEffectList& effects);
 
 private:

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -166,7 +166,7 @@ struct ParseContext {
         return run;
     }
 
-    // テーブルセルにWideテキストを追加（セルはWideのまま維持）
+    // テーブルセルにWideテキストを追加（AppendText/AppendUtf8から委譲される）
     void AppendTextToCell(std::wstring_view text)
     {
         const uint32_t start = static_cast<uint32_t>(current_cell->text.size());
@@ -174,7 +174,9 @@ struct ParseContext {
         current_cell->runs.emplace_back(MakeRun(start, static_cast<uint32_t>(text.size())));
     }
 
-    // ノードにWideテキストを追加（Wide→UTF-8変換してtext_utf8に蓄積、BR/SOFTBR/Entity用）
+    // Wideテキストを現在のノードまたはセルに追加する。
+    // セル内なら AppendTextToCell に委譲。
+    // ノードなら Wide→UTF-8 変換して text_utf8 に蓄積する（BR/SOFTBR/Entity用）。
     void AppendText(std::wstring_view text)
     {
         if (current_cell) {
@@ -210,7 +212,7 @@ struct ParseContext {
         }
     }
 
-    // テーブルセルにUTF-8テキストをWide変換して追加
+    // テーブルセルにUTF-8テキストをWide変換して追加（AppendUtf8から委譲される）
     void AppendUtf8ToCell(std::string_view text)
     {
         Utf8ToWide(text, text_buffer);
@@ -219,7 +221,9 @@ struct ParseContext {
         }
     }
 
-    // UTF-8テキストをワイド文字に変換し、現在のノード/セルに追加する（エンティティ等用）
+    // UTF-8テキストを現在のノードまたはセルに追加する。
+    // セル内なら AppendUtf8ToCell に委譲（Wide変換が必要）。
+    // ノードなら text_utf8 に直接蓄積し、Wide長のみ計算する（遅延変換で高速化）。
     void AppendUtf8(std::string_view text)
     {
         if (current_cell) {

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -45,9 +45,9 @@ TableRowHit FindTableRow(const Node& node, const NodeLayoutEntry& entry,
     return { -1, 0.0f };
 }
 
-// テーブル内のクリック座標からヒットした列を特定する。
-// 見つからない場合は最終列を返す。
-// cell_left_x にはヒットしたセルの左端X座標（パディング含まず）を書き込む。
+// テーブル内のクリック座標か��ヒットした列を特���する。
+// 見つからない場合は最終列を返す（列数0の場合は0を返す）。
+// cell_left_x にはヒットしたセ���の左端X座標���パディング含まず）を書き込む。
 int FindTableCol(const TableLayoutData& tl, float base_x, float dip_x,
     float& cell_left_x) noexcept
 {

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -21,6 +21,58 @@ float NodeIndent(const Node& node, const Theme& theme) noexcept
     return node.indent_level * theme.indent_width;
 }
 
+// テーブル内のクリック座標からヒットした行を特定する。
+// 見つかった場合は行インデックスとその行の上端Y座標を返す。
+struct TableRowHit { int row; float row_top_y; };
+TableRowHit FindTableRow(const Node& node, const NodeLayoutEntry& entry,
+    const Theme& theme, float dip_y) noexcept
+{
+    if (!entry.has_table_layout()) {
+        return { -1, 0.0f };
+    }
+    const auto& tl = *entry.table_layout;
+    const float border = TABLE_BORDER_WIDTH;
+    float ry = entry.y_position;
+    const auto row_count = node.table_rows().size();
+    for (size_t r = 0; r < row_count; r++) {
+        const float row_h = (r < tl.row_heights.size()) ? tl.row_heights[r] : (theme.font_size_body * TABLE_ROW_HEIGHT_FACTOR);
+        const float row_bottom = ry + row_h + border;
+        if (dip_y < row_bottom) {
+            return { static_cast<int>(r), ry };
+        }
+        ry += row_h + border;
+    }
+    return { -1, 0.0f };
+}
+
+// テーブル内のクリック座標からヒットした列を特定する。
+// 見つからない場合は最終列を返す。
+// cell_left_x にはヒットしたセルの左端X座標（パディング含まず）を書き込む。
+int FindTableCol(const TableLayoutData& tl, float base_x, float dip_x,
+    float& cell_left_x) noexcept
+{
+    const float cell_padding = TABLE_CELL_PADDING;
+    const float border = TABLE_BORDER_WIDTH;
+    float cx = base_x + border;
+    const auto col_count = tl.col_widths.size();
+    for (size_t c = 0; c < col_count; c++) {
+        const float col_right = cx + tl.col_widths[c] + cell_padding * 2.0f;
+        if (dip_x < col_right) {
+            cell_left_x = cx;
+            return static_cast<int>(c);
+        }
+        cx += tl.col_widths[c] + cell_padding * 2.0f + border;
+    }
+    // 最終列にフォールバック
+    if (col_count > 0) {
+        // cx は最終列の右端を過ぎているので巻き戻す
+        cell_left_x = cx - tl.col_widths[col_count - 1] - cell_padding * 2.0f - border;
+        return static_cast<int>(col_count - 1);
+    }
+    cell_left_x = base_x + border;
+    return 0;
+}
+
 } // namespace
 
 // 指定された行・列までのフラットテキストオフセットを計算する。
@@ -130,50 +182,23 @@ HitTestService::HitResult HitTestService::HitTestTable(
     HitResult result;
     result.node_index = node_index;
 
-    const float indent = NodeIndent(node, theme);
-    const float base_x = theme.margin_left + indent;
-    const float cell_padding = TABLE_CELL_PADDING;
-    const float border = TABLE_BORDER_WIDTH;
-
     if (!entry.has_table_layout()) {
         result.text_pos = static_cast<uint32_t>(node.GetText().size());
         return result;
     }
     const auto& tl = *entry.table_layout;
 
-    // クリックされた行を特定
-    float ry = entry.y_position;
-    int hit_row = -1;
-    const auto row_count = node.table_rows().size();
-    for (size_t r = 0; r < row_count; r++) {
-        const float row_h = (r < tl.row_heights.size()) ? tl.row_heights[r] : (theme.font_size_body * TABLE_ROW_HEIGHT_FACTOR);
-        const float row_bottom = ry + row_h + border;
-        if (dip_y < row_bottom) {
-            hit_row = static_cast<int>(r);
-            break;
-        }
-        ry += row_h + border;
-    }
+    const float indent = NodeIndent(node, theme);
+    const float base_x = theme.margin_left + indent;
+
+    const auto [hit_row, row_top_y] = FindTableRow(node, entry, theme, dip_y);
     if (hit_row < 0) {
         result.text_pos = static_cast<uint32_t>(node.GetText().size());
         return result;
     }
 
-    // クリックされた列を特定
-    float cx = base_x + border;
-    int hit_col = static_cast<int>(tl.col_widths.size()) - 1; // デフォルトは最後の列
-    const auto col_count = tl.col_widths.size();
-    for (size_t c = 0; c < col_count; c++) {
-        const float col_right = cx + tl.col_widths[c] + cell_padding * 2.0f;
-        if (dip_x < col_right) {
-            hit_col = static_cast<int>(c);
-            break;
-        }
-        cx += tl.col_widths[c] + cell_padding * 2.0f + border;
-    }
-    if (hit_col < 0) {
-        hit_col = 0;
-    }
+    float cell_left_x = 0.0f;
+    const int hit_col = FindTableCol(tl, base_x, dip_x, cell_left_x);
 
     // セル (hit_row, hit_col) のフラットテキストオフセットを計算
     const uint32_t flat_offset = ComputeTableFlatOffset(node, entry, hit_row, hit_col);
@@ -183,24 +208,14 @@ HitTestService::HitResult HitTestService::HitTestTable(
     const size_t c = static_cast<size_t>(hit_col);
     IDWriteTextLayout* cell_layout = tl.GetCellLayout(r, c);
     if (cell_layout) {
-        float cell_x = base_x + border;
-        for (size_t cc = 0; cc < c; cc++) {
-            cell_x += tl.col_widths[cc] + cell_padding * 2.0f + border;
-        }
-        const float cell_text_x = cell_x + cell_padding;
-
-        float cell_y = entry.y_position;
-        for (size_t rr = 0; rr < r; rr++) {
-            const float rh = (rr < tl.row_heights.size()) ? tl.row_heights[rr] : (theme.font_size_body * TABLE_ROW_HEIGHT_FACTOR);
-            cell_y += rh + border;
-        }
-        const float cell_text_y = cell_y + cell_padding;
+        const float text_x = cell_left_x + TABLE_CELL_PADDING;
+        const float text_y = row_top_y + TABLE_CELL_PADDING;
 
         BOOL is_trailing = FALSE, is_inside = FALSE;
         DWRITE_HIT_TEST_METRICS metrics{};
         cell_layout->HitTestPoint(
-            dip_x - cell_text_x,
-            dip_y - cell_text_y,
+            dip_x - text_x,
+            dip_y - text_y,
             &is_trailing,
             &is_inside,
             &metrics

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -45,9 +45,9 @@ TableRowHit FindTableRow(const Node& node, const NodeLayoutEntry& entry,
     return { -1, 0.0f };
 }
 
-// テーブル内のクリック座標か��ヒットした列を特���する。
+// テーブル内のクリック座標からヒットした列を特定する。
 // 見つからない場合は最終列を返す（列数0の場合は0を返す）。
-// cell_left_x にはヒットしたセ���の左端X座標���パディング含まず）を書き込む。
+// cell_left_x にはヒットしたセルの左端X座標（パディング含まず）を書き込む。
 int FindTableCol(const TableLayoutData& tl, float base_x, float dip_x,
     float& cell_left_x) noexcept
 {

--- a/src/io/image_loader.cpp
+++ b/src/io/image_loader.cpp
@@ -91,7 +91,10 @@ static std::optional<WicDecodeResult> DecodeFromStream(
     }
 
     UINT w = 0, h = 0;
-    frame->GetSize(&w, &h);
+    hr = frame->GetSize(&w, &h);
+    if (FAILED(hr)) {
+        return std::nullopt;
+    }
 
     return WicDecodeResult{ converter, w, h };
 }

--- a/src/io/image_loader.cpp
+++ b/src/io/image_loader.cpp
@@ -3,6 +3,7 @@
 #include "task_scheduler.h"
 #include "ui_constants.h"
 #include "win_handle.h"
+#include <optional>
 #include <shlwapi.h>
 
 #pragma comment(lib, "shlwapi.lib")
@@ -48,6 +49,51 @@ static Microsoft::WRL::ComPtr<IStream> ReadFileToStream(const std::wstring& path
     }
     hMem.release(); // CreateStreamOnHGlobal(TRUE) が所有権を取得
     return stream;
+}
+
+// WIC デコードパイプラインの共通処理。
+// IStream から画像をデコードし、FormatConverter とピクセルサイズを返す。
+// LoadImage（同期）と RequestLoadAsync（非同期）の両方から使用される。
+struct WicDecodeResult {
+    Microsoft::WRL::ComPtr<IWICFormatConverter> converter;
+    UINT pixel_width = 0;
+    UINT pixel_height = 0;
+};
+
+static std::optional<WicDecodeResult> DecodeFromStream(
+    IWICImagingFactory* wic, IStream* stream)
+{
+    Microsoft::WRL::ComPtr<IWICBitmapDecoder> decoder;
+    HRESULT hr = wic->CreateDecoderFromStream(
+        stream, nullptr, WICDecodeMetadataCacheOnLoad, &decoder);
+    if (FAILED(hr)) {
+        return std::nullopt;
+    }
+
+    Microsoft::WRL::ComPtr<IWICBitmapFrameDecode> frame;
+    hr = decoder->GetFrame(0, &frame);
+    if (FAILED(hr)) {
+        return std::nullopt;
+    }
+
+    Microsoft::WRL::ComPtr<IWICFormatConverter> converter;
+    hr = wic->CreateFormatConverter(&converter);
+    if (FAILED(hr)) {
+        return std::nullopt;
+    }
+
+    hr = converter->Initialize(
+        frame.Get(), GUID_WICPixelFormat32bppPBGRA,
+        WICBitmapDitherTypeNone, nullptr, 0.0f,
+        WICBitmapPaletteTypeCustom);
+    if (FAILED(hr)) {
+        return std::nullopt;
+    }
+
+    UINT w = 0, h = 0;
+    frame->GetSize(&w, &h);
+
+    return WicDecodeResult{ converter, w, h };
 }
 
 ImageLoader::~ImageLoader()
@@ -116,45 +162,16 @@ bool ImageLoader::LoadImage(const std::wstring& abs_path, DiagramEntry& out)
         return false;
     }
 
-    Microsoft::WRL::ComPtr<IWICBitmapDecoder> decoder;
-    HRESULT hr = wic_factory_->CreateDecoderFromStream(
-        stream.Get(),
-        nullptr,
-        WICDecodeMetadataCacheOnLoad,
-        &decoder
-    );
-    if (FAILED(hr)) {
-        return false;
-    }
-
-    Microsoft::WRL::ComPtr<IWICBitmapFrameDecode> frame;
-    hr = decoder->GetFrame(0, &frame);
-    if (FAILED(hr)) {
-        return false;
-    }
-
-    Microsoft::WRL::ComPtr<IWICFormatConverter> converter;
-    hr = wic_factory_->CreateFormatConverter(&converter);
-    if (FAILED(hr)) {
-        return false;
-    }
-
-    hr = converter->Initialize(
-        frame.Get(), GUID_WICPixelFormat32bppPBGRA,
-        WICBitmapDitherTypeNone, nullptr, 0.0f,
-        WICBitmapPaletteTypeCustom);
-    if (FAILED(hr)) {
+    const auto decoded = DecodeFromStream(wic_factory_.Get(), stream.Get());
+    if (!decoded) {
         return false;
     }
 
     Microsoft::WRL::ComPtr<ID2D1Bitmap> bitmap;
-    hr = render_target_->CreateBitmapFromWicBitmap(converter.Get(), &bitmap);
+    const HRESULT hr = render_target_->CreateBitmapFromWicBitmap(decoded->converter.Get(), &bitmap);
     if (FAILED(hr)) {
         return false;
     }
-
-    UINT w = 0, h = 0;
-    frame->GetSize(&w, &h);
 
     // ピクセルサイズを DIP に変換
     float scale_x, scale_y;
@@ -162,8 +179,8 @@ bool ImageLoader::LoadImage(const std::wstring& abs_path, DiagramEntry& out)
 
     CachedImage cached;
     cached.bitmap = bitmap;
-    cached.width = static_cast<float>(w) / scale_x;
-    cached.height = static_cast<float>(h) / scale_y;
+    cached.width = static_cast<float>(decoded->pixel_width) / scale_x;
+    cached.height = static_cast<float>(decoded->pixel_height) / scale_y;
 
     out.bitmap = bitmap;
     out.width = cached.width;
@@ -210,30 +227,12 @@ void ImageLoader::RequestLoadAsync(const std::wstring& abs_path,
 
         if (wic_factory_) {
             const auto stream = ReadFileToStream(path);
-            Microsoft::WRL::ComPtr<IWICBitmapDecoder> decoder;
-            HRESULT hr = stream ? wic_factory_->CreateDecoderFromStream(
-                stream.Get(), nullptr, WICDecodeMetadataCacheOnLoad, &decoder) : E_FAIL;
-
-            if (SUCCEEDED(hr)) {
-                Microsoft::WRL::ComPtr<IWICBitmapFrameDecode> frame;
-                hr = decoder->GetFrame(0, &frame);
-                if (SUCCEEDED(hr)) {
-                    Microsoft::WRL::ComPtr<IWICFormatConverter> converter;
-                    hr = wic_factory_->CreateFormatConverter(&converter);
-                    if (SUCCEEDED(hr)) {
-                        hr = converter->Initialize(
-                            frame.Get(), GUID_WICPixelFormat32bppPBGRA,
-                            WICBitmapDitherTypeNone, nullptr, 0.0f,
-                            WICBitmapPaletteTypeCustom);
-                        if (SUCCEEDED(hr)) {
-                            UINT w = 0, h = 0;
-                            frame->GetSize(&w, &h);
-                            result.converter = converter;
-                            result.width = static_cast<float>(w);
-                            result.height = static_cast<float>(h);
-                            result.success = true;
-                        }
-                    }
+            if (stream) {
+                if (const auto decoded = DecodeFromStream(wic_factory_.Get(), stream.Get())) {
+                    result.converter = decoded->converter;
+                    result.width = static_cast<float>(decoded->pixel_width);
+                    result.height = static_cast<float>(decoded->pixel_height);
+                    result.success = true;
                 }
             }
         }

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -487,7 +487,7 @@ LRESULT Win32Window::HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam)
     }
 
     // WM_APP+N カスタム通知メッセージ
-    if (msg >= WM_APP && msg < WM_APP + 16) {
+    if (msg >= WM_APP && msg < app_msg::END) {
         return HandleAppNotification(msg, wParam, lParam);
     }
 

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -286,46 +286,10 @@ LRESULT Win32Window::OnNcHitTest(LPARAM lParam)
     return HTCLIENT;
 }
 
-LRESULT Win32Window::HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam)
+// マウス入力メッセージを処理する。
+LRESULT Win32Window::HandleMouseMessage(UINT msg, WPARAM wParam, LPARAM lParam)
 {
     switch (msg) {
-    case WM_NCCALCSIZE:
-        return OnNcCalcSize(wParam, lParam);
-
-    case WM_NCHITTEST:
-        return OnNcHitTest(lParam);
-
-    case WM_PAINT:
-        app_->OnPaint();
-        return 0;
-
-    case WM_SIZE:
-        app_->OnResize(LOWORD(lParam), HIWORD(lParam));
-        RepositionSearchEdit();
-        return 0;
-
-    case WM_ACTIVATE:
-        app_->OnActivate(LOWORD(wParam) != WA_INACTIVE);
-        return DefWindowProcW(hwnd_, msg, wParam, lParam);
-
-    case WM_ENTERSIZEMOVE:
-        app_->OnEnterSizeMove();
-        return 0;
-
-    case WM_EXITSIZEMOVE:
-        app_->OnExitSizeMove();
-        return 0;
-
-    case WM_NCLBUTTONDOWN:
-        // システムメニュー表示時はフラグを立て、モーダルループ中の右クリック競合を防ぐ
-        if (wParam == HTSYSMENU) {
-            in_sys_menu_ = true;
-            const auto r = DefWindowProcW(hwnd_, msg, wParam, lParam);
-            in_sys_menu_ = false;
-            return r;
-        }
-        return DefWindowProcW(hwnd_, msg, wParam, lParam);
-
     case WM_RBUTTONDOWN:
         if (in_sys_menu_) {
             return 0;
@@ -431,21 +395,42 @@ LRESULT Win32Window::HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam)
         return 0;
     }
 
-    case WM_KEYDOWN:
-        app_->OnKeyDown(wParam);
+    case WM_XBUTTONDOWN: {
+        const WORD button = GET_XBUTTON_WPARAM(wParam);
+        if (button == XBUTTON1) {
+            app_->OnXButtonBack();
+        }
+        else if (button == XBUTTON2) {
+            app_->OnXButtonForward();
+        }
+        return TRUE;
+    }
+
+    default:
+        break;
+    }
+    return DefWindowProcW(hwnd_, msg, wParam, lParam);
+}
+
+// WM_APP+N カスタム通知メッセージを処理する。
+LRESULT Win32Window::HandleAppNotification(UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    switch (msg) {
+    case app_msg::LOAD_FILE:
+        app_->OnAppLoadFile();
         return 0;
 
-    case WM_COMMAND:
-        if (HIWORD(wParam) == EN_CHANGE && reinterpret_cast<HWND>(lParam) == search_edit_) {
-            const int text_len = GetWindowTextLengthW(search_edit_);
-            std::wstring buf(static_cast<size_t>(std::max(text_len, 0)), L'\0');
-            const int copied = GetWindowTextW(search_edit_, buf.data(), text_len + 1);
-            buf.resize(static_cast<size_t>(std::max(copied, 0)));
-            app_->OnSearchTextChanged(buf);
-            SyncSearchCaretFromEdit();
-            return 0;
-        }
-        break;
+    case app_msg::RELOAD_FILE:
+        app_->OnAppReloadFile();
+        return 0;
+
+    case app_msg::IMAGE_LOADED:
+        app_->OnAppImageLoaded();
+        return 0;
+
+    case app_msg::PARSE_COMPLETE:
+        app_->OnParseComplete();
+        return 0;
 
     case app_msg::SEARCH_FOCUS:
         if (search_edit_) {
@@ -474,16 +459,91 @@ LRESULT Win32Window::HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam)
         }
         return 0;
 
-    case WM_XBUTTONDOWN: {
-        const WORD button = GET_XBUTTON_WPARAM(wParam);
-        if (button == XBUTTON1) {
-            app_->OnXButtonBack();
-        }
-        else if (button == XBUTTON2) {
-            app_->OnXButtonForward();
-        }
-        return TRUE;
+    default:
+        break;
     }
+    return DefWindowProcW(hwnd_, msg, wParam, lParam);
+}
+
+LRESULT Win32Window::HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    // マウス入力メッセージ
+    switch (msg) {
+    case WM_RBUTTONDOWN:
+    case WM_RBUTTONUP:
+    case WM_LBUTTONDOWN:
+    case WM_LBUTTONUP:
+    case WM_MOUSEMOVE:
+    case WM_MOUSELEAVE:
+    case WM_SETCURSOR:
+    case WM_LBUTTONDBLCLK:
+    case WM_MOUSEWHEEL:
+    case WM_MOUSEHWHEEL:
+    case WM_CONTEXTMENU:
+    case WM_XBUTTONDOWN:
+        return HandleMouseMessage(msg, wParam, lParam);
+    default:
+        break;
+    }
+
+    // WM_APP+N カスタム通知メッセージ
+    if (msg >= WM_APP && msg < WM_APP + 16) {
+        return HandleAppNotification(msg, wParam, lParam);
+    }
+
+    switch (msg) {
+    case WM_NCCALCSIZE:
+        return OnNcCalcSize(wParam, lParam);
+
+    case WM_NCHITTEST:
+        return OnNcHitTest(lParam);
+
+    case WM_PAINT:
+        app_->OnPaint();
+        return 0;
+
+    case WM_SIZE:
+        app_->OnResize(LOWORD(lParam), HIWORD(lParam));
+        RepositionSearchEdit();
+        return 0;
+
+    case WM_ACTIVATE:
+        app_->OnActivate(LOWORD(wParam) != WA_INACTIVE);
+        return DefWindowProcW(hwnd_, msg, wParam, lParam);
+
+    case WM_ENTERSIZEMOVE:
+        app_->OnEnterSizeMove();
+        return 0;
+
+    case WM_EXITSIZEMOVE:
+        app_->OnExitSizeMove();
+        return 0;
+
+    case WM_NCLBUTTONDOWN:
+        // システムメニュー表示時はフラグを立て、モーダルループ中の右クリック競合を防ぐ
+        if (wParam == HTSYSMENU) {
+            in_sys_menu_ = true;
+            const auto r = DefWindowProcW(hwnd_, msg, wParam, lParam);
+            in_sys_menu_ = false;
+            return r;
+        }
+        return DefWindowProcW(hwnd_, msg, wParam, lParam);
+
+    case WM_KEYDOWN:
+        app_->OnKeyDown(wParam);
+        return 0;
+
+    case WM_COMMAND:
+        if (HIWORD(wParam) == EN_CHANGE && reinterpret_cast<HWND>(lParam) == search_edit_) {
+            const int text_len = GetWindowTextLengthW(search_edit_);
+            std::wstring buf(static_cast<size_t>(std::max(text_len, 0)), L'\0');
+            const int copied = GetWindowTextW(search_edit_, buf.data(), text_len + 1);
+            buf.resize(static_cast<size_t>(std::max(copied, 0)));
+            app_->OnSearchTextChanged(buf);
+            SyncSearchCaretFromEdit();
+            return 0;
+        }
+        break;
 
     case WM_DROPFILES:
         app_->OnDropFiles(reinterpret_cast<HDROP>(wParam));
@@ -500,22 +560,6 @@ LRESULT Win32Window::HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam)
 
     case WM_TIMER:
         app_->HandleTimer(wParam);
-        return 0;
-
-    case app_msg::LOAD_FILE:
-        app_->OnAppLoadFile();
-        return 0;
-
-    case app_msg::RELOAD_FILE:
-        app_->OnAppReloadFile();
-        return 0;
-
-    case app_msg::IMAGE_LOADED:
-        app_->OnAppImageLoaded();
-        return 0;
-
-    case app_msg::PARSE_COMPLETE:
-        app_->OnParseComplete();
         return 0;
 
     case WM_SYSCOMMAND:

--- a/src/window/window.h
+++ b/src/window/window.h
@@ -28,6 +28,8 @@ private:
     LRESULT HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam);
     LRESULT OnNcCalcSize(WPARAM wParam, LPARAM lParam);
     LRESULT OnNcHitTest(LPARAM lParam);
+    LRESULT HandleMouseMessage(UINT msg, WPARAM wParam, LPARAM lParam);
+    LRESULT HandleAppNotification(UINT msg, WPARAM wParam, LPARAM lParam);
     void UpdateDwmFrame();
     void InitSystemMenu();
     void ResetWindowPlacement();


### PR DESCRIPTION
## Summary
- **Reducer拡張**: `ScrollPaneAction`/`TogglePaneAction` をApp::DispatchからReducerに移動し、`InvalidatePaneCache`/`RefreshPaneLayout` 副作用を追加。コンテキストメニューからのペイン操作もDispatch経由に統一
- **コード重複解消**: `FinishReload()`（リロード後処理）、`DecodeFromStream()`（WICデコードパイプライン）、`SyncPaneThemeCache()`（テーマキャッシュ同期）を共通ヘルパーとして抽出
- **テーブルヒットテスト改善**: `FindTableRow`/`FindTableCol`/`ComputeCellTextOrigin` を補助関数に分離。`FindTableCol` が列X座標も返すことで二重走査を解消
- **ウィンドウメッセージハンドラ分割**: `HandleMessage()` を `HandleMouseMessage()`/`HandleAppNotification()` に分割し可読性向上
- **マジックナンバー定数化**: タイマー間隔 `16`→`FRAME_INTERVAL_MS`、`200`→`FILE_RELOAD_DEBOUNCE_MS`
- **外部URL処理の副作用化**: `ShellExecuteW` 直接呼び出しを `effect::ShellOpen` 経由に変更

## Test plan
- [x] 全1479テストがパスすることを確認
- [x] ファイルペイン/TOCペインのスクロールが正常に動作すること
- [x] コンテキストメニューからのペイン開閉が動作すること
- [x] ファイルリロード（prefix-only/full両方）でスクロール位置が復元されること
- [x] テーブル内クリックでテキスト選択が正しく動作すること
- [x] 画像の同期/非同期読み込みが正常に動作すること
- [x] ズーム変更後のペインスクロールが正しく動作すること
- [x] 外部リンクのクリックでブラウザが開くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)