### PR TITLE
リファクタリング: Reducer移行フェーズ2

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -106,6 +106,12 @@ bool App::Init(HWND hwnd)
             .perform_resize_end = [this]() {
                 OnResizeEnd();
             },
+            .perform_sizing_update = [this]() {
+                const auto& sizing_layout = GetPaneLayout();
+                SyncMaxScroll(sizing_layout.md_rect.height);
+                UpdateScrollBar();
+                Invalidate();
+            },
             .apply_theme_change = [this](const effect::ApplyThemeChange& e) {
                 HandleApplyThemeChange(e);
             },

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -59,13 +59,13 @@ bool App::Init(HWND hwnd)
 
     // PixelToDip用にDPIスケールをキャッシュ (OnDpiChangedで更新)
     const float init_dpi = static_cast<float>(GetDpiForWindow(hwnd_));
-    cached_dpi_scale_ = (init_dpi > 0.0f) ? (init_dpi / DEFAULT_DPI) : 1.0f;
+    state_.cached_dpi_scale = (init_dpi > 0.0f) ? (init_dpi / DEFAULT_DPI) : 1.0f;
 
     // タスクスケジューラを初期化（画像デコード・キャッシュ書き込み共用）
     scheduler_.Init(mermaid_util::ComputeWorkerCount(
         std::thread::hardware_concurrency()));
 
-    file_cache_.Init(cached_dpi_scale_, scheduler_);
+    file_cache_.Init(state_.cached_dpi_scale, scheduler_);
     mermaid_renderer_.SetFileCache(&file_cache_);
 
     resource_manager_.Init(state_.doc, state_.layout_cache, state_.viewport, image_loader_, mermaid_renderer_,
@@ -93,6 +93,57 @@ bool App::Init(HWND hwnd)
             },
             .refresh_pane_layout = [this]() {
                 RefreshPaneLayout();
+            },
+            .renderer_resize = [this](UINT w, UINT h) {
+                renderer_.Resize(w, h);
+            },
+            .renderer_set_dpi = [this](float dpi) {
+                renderer_.SetDpi(dpi);
+            },
+            .clear_file_cache = [this]() {
+                file_cache_.ClearAll();
+            },
+            .perform_resize_end = [this]() {
+                OnResizeEnd();
+            },
+            .apply_theme_change = [this](const effect::ApplyThemeChange& e) {
+                HandleApplyThemeChange(e);
+            },
+            .process_deferred_layout = [this]() {
+                OnDeferredLayout();
+            },
+            .tick_loading_animation = [this]() {
+                file_load_service_.TickLoadingAnimation();
+            },
+            .process_mermaid_batch_timer = [this]() {
+                resource_manager_.ProcessMermaidBatch();
+            },
+            .process_bitmap_manage = [this]() {
+                resource_manager_.OnBitmapManageTimer();
+            },
+            .mermaid_init_retry = [this]() {
+                mermaid_renderer_.OnInitRetryTimer();
+            },
+            .destroy = [this]() {
+                OnDestroy();
+            },
+            .handle_parse_complete = [this]() {
+                OnParseComplete();
+            },
+            .handle_mouse_event = [this](effect::MouseEventType type, int px, int py) {
+                switch (type) {
+                case effect::MouseEventType::LButtonDown:  OnLButtonDown(px, py);  break;
+                case effect::MouseEventType::LButtonUp:    OnLButtonUp(px, py);    break;
+                case effect::MouseEventType::MouseMove:    OnMouseMove(px, py);    break;
+                case effect::MouseEventType::MouseHover:   OnMouseHover(px, py);   break;
+                case effect::MouseEventType::LButtonDblClk: OnLButtonDblClk(px, py); break;
+                case effect::MouseEventType::RButtonDown:  OnRButtonDown(px, py);  break;
+                case effect::MouseEventType::RButtonUp:    OnRButtonUp(px, py);    break;
+                case effect::MouseEventType::RButtonMove:  OnRButtonMove(px, py);  break;
+                }
+            },
+            .handle_context_menu = [this](int sx, int sy) {
+                OnContextMenu(sx, sy);
             },
         }
     );
@@ -155,7 +206,7 @@ bool App::Init(HWND hwnd)
 
 App::DipPoint App::PixelToDip(int px, int py) const noexcept
 {
-    return { px / cached_dpi_scale_, py / cached_dpi_scale_ };
+    return { px / state_.cached_dpi_scale, py / state_.cached_dpi_scale };
 }
 
 PaneScrollInfo App::ComputePaneScrollInfo(
@@ -237,7 +288,7 @@ const PaneLayout& App::GetPaneLayout() const
 
 void App::InvalidatePane(const PaneRect& rect) noexcept
 {
-    const float scale = cached_dpi_scale_;
+    const float scale = state_.cached_dpi_scale;
     RECT rc;
     rc.left = static_cast<LONG>(rect.x * scale);
     rc.top = static_cast<LONG>(rect.y * scale);
@@ -276,10 +327,6 @@ float App::GetMarkdownPaneWidth() const
     const auto layout = GetPaneLayout();
     return layout.md_rect.width;
 }
-
-// ============================================================
-// OnPaint用のレンダーステート構築ヘルパー
-// ============================================================
 
 // ============================================================
 // 描画 / リサイズ
@@ -384,7 +431,7 @@ void App::OnPaint()
                 state_.viewport.GetSelection(), layout.md_rect, sp, tb, gs, ts, sb,
                 state_.viewport.GetScrollY(), layout_service_->GetTotalHeight(),
                 static_cast<int>(state_.nav_hover), state_.hovered_copy_node, state_.hovered_save_node,
-                nav_service_.CanGoBack(), nav_service_.CanGoForward(),
+                state_.nav_history.CanGoBack(), state_.nav_history.CanGoForward(),
                 layout_service_->HasDirtyNodes()
                 });
         }
@@ -395,48 +442,12 @@ void App::OnPaint()
 
 void App::OnResize(UINT width, UINT height)
 {
-    if (width == 0 || height == 0) {
-        return;
-    }
-
-    InvalidatePaneLayoutCache();
-    renderer_.Resize(width, height);
-
-    // タイトルバーボタン位置を再計算
-    {
-        const float window_w_dip = width / cached_dpi_scale_;
-        state_.titlebar.UpdateLayout(window_w_dip);
-    }
-
-    if (state_.is_sizing) {
-        const auto sizing_layout = GetPaneLayout();
-        const float sizing_h = sizing_layout.md_rect.height;
-        SyncMaxScroll(sizing_h);
-        UpdateScrollBar();
-        Invalidate();
-        return;
-    }
-
-    OnResizeEnd();
+    Dispatch(ResizeAction{ width, height });
 }
 
 void App::OnDpiChanged(UINT dpi, const RECT* suggested)
 {
-    cached_dpi_scale_ = static_cast<float>(dpi) / 96.0f;
-    if (cached_dpi_scale_ <= 0.0f) {
-        cached_dpi_scale_ = 1.0f;
-    }
-    renderer_.SetDpi(static_cast<float>(dpi));
-
-    InvalidatePaneLayoutCache();
-    state_.layout_cache.MarkAllDirty();
-    file_cache_.ClearAll();
-
-    SetWindowPos(hwnd_, nullptr,
-        suggested->left, suggested->top,
-        suggested->right - suggested->left,
-        suggested->bottom - suggested->top,
-        SWP_NOZORDER | SWP_NOACTIVATE);
+    Dispatch(DpiChangedAction{ dpi, *suggested });
 }
 
 // ============================================================
@@ -889,7 +900,7 @@ void App::UpdateTitleBar()
 // OnAppImageLoaded / OnAppReloadFile はWM_APPメッセージ経由でresource_manager_に委譲
 void App::OnAppImageLoaded()
 {
-    resource_manager_.OnAppImageLoaded();
+    Dispatch(ImageLoadedAction{});
 }
 
 // ============================================================
@@ -928,18 +939,7 @@ void App::OnMouseWheel(int px, int py, short delta, bool ctrl)
 
 void App::OnMouseHWheel(short delta)
 {
-    const bool had_overlay = state_.swipe_detector.IsOverlayVisible();
-    const int old_direction = state_.swipe_detector.GetOverlayDirection();
-    state_.swipe_detector.OnHWheel(delta, GetTickCount64());
-
-    // 入力のたびにコミットタイマーをリセット。
-    // 指を離して COMMIT_TIMEOUT_MS 経過後に Commit() でナビゲーション判定する。
-    SetTimer(hwnd_, app_timer::SWIPE_OVERLAY, static_cast<UINT>(SwipeDetector::COMMIT_TIMEOUT_MS), nullptr);
-
-    if (had_overlay != state_.swipe_detector.IsOverlayVisible()
-        || old_direction != state_.swipe_detector.GetOverlayDirection()) {
-        Invalidate();
-    }
+    Dispatch(HWheelAction{ delta, GetTickCount64() });
 }
 
 void App::OnKeyDown(WPARAM key)
@@ -953,33 +953,6 @@ void App::OnKeyDown(WPARAM key)
     Dispatch(controller_.HandleKeyDown(event));
 }
 
-void App::HandleOpenFile()
-{
-    const auto path = FileLoader::OpenFileDialog(hwnd_);
-    if (!path.empty()) {
-        if (!state_.doc.GetFilePath().empty()) {
-            PushNavHistory();
-        }
-        LoadMarkdownFile(path);
-    }
-}
-
-void App::HandleShowHelp()
-{
-    if (!state_.doc.GetFilePath().empty() && !IsHelpPath(state_.doc.GetFilePath())) {
-        PushNavHistory();
-    }
-    LoadHelpDocument();
-}
-
-void App::HandleDropFile(std::wstring_view path)
-{
-    if (!state_.doc.GetFilePath().empty()) {
-        PushNavHistory();
-    }
-    LoadMarkdownFile(path);
-}
-
 void App::Dispatch(const AppAction& action)
 {
     // Reducer が cached_pane_layout を参照するため、最新レイアウトを保証する。
@@ -988,51 +961,6 @@ void App::Dispatch(const AppAction& action)
 
     auto effects = Reduce(state_, action);
     effect_executor_.Execute(effects);
-
-    // Reducer が処理しないアクションはハンドラメソッドに委譲
-    std::visit(overloaded{
-        // ---- コマンド系 ----
-        [this](const ZoomAction& a) {
-            switch (a.direction) {
-            case ZoomDirection::In:    ZoomIn();    break;
-            case ZoomDirection::Out:   ZoomOut();   break;
-            case ZoomDirection::Reset: ZoomReset(); break;
-            }
-        },
-        [this](const ReloadFileAction&) { ReloadCurrentFile(); },
-        [this](const OpenFileAction&) { HandleOpenFile(); },
-        [this](const ToggleDarkModeAction&) { ToggleDarkMode(); },
-        [this](const NavigateBackAction&) { NavigateBack(); },
-        [this](const NavigateForwardAction&) { NavigateForward(); },
-        [this](const ShowHelpAction&) { HandleShowHelp(); },
-        // ---- マウスイベント系 ----
-        [this](const LButtonDownAction& a) { OnLButtonDown(a.px, a.py); },
-        [this](const LButtonUpAction& a) { OnLButtonUp(a.px, a.py); },
-        [this](const MouseMoveAction& a) { OnMouseMove(a.px, a.py); },
-        [this](const MouseHoverAction& a) { OnMouseHover(a.px, a.py); },
-        [this](const LButtonDblClkAction& a) { OnLButtonDblClk(a.px, a.py); },
-        [this](const RButtonDownAction& a) { OnRButtonDown(a.px, a.py); },
-        [this](const RButtonUpAction& a) { OnRButtonUp(a.px, a.py); },
-        [this](const RButtonMoveAction& a) { OnRButtonMove(a.px, a.py); },
-        [this](const ContextMenuAction& a) { OnContextMenu(a.screen_x, a.screen_y); },
-        [this](const XButtonBackAction&) { NavigateBack(); },
-        [this](const XButtonForwardAction&) { NavigateForward(); },
-        [this](const HWheelAction& a) { OnMouseHWheel(a.delta); },
-        [this](const DropFilesAction& a) { HandleDropFile(a.path); },
-        // ---- システムイベント系 ----
-        [this](const ResizeAction& a) { OnResize(a.width, a.height); },
-        [this](const DpiChangedAction& a) { OnDpiChanged(a.dpi, &a.suggested); },
-        [this](const ExitSizeMoveAction&) { OnResizeEnd(); },
-        [this](const CaptureChangedAction&) { OnCaptureChanged(); },
-        [this](const DestroyAction&) { OnDestroy(); },
-        // ---- タイマー・非同期系 ----
-        [this](const TimerAction& a) { HandleTimer(a.timer_id); },
-        [this](const FileWatchAction&) { OnFileWatchEvent(); },
-        [this](const ParseCompleteAction&) { OnParseComplete(); },
-        [this](const ImageLoadedAction&) { OnAppImageLoaded(); },
-        // Reducer で処理済みのアクションはここでは何もしない
-        [](const auto&) {},
-        }, action);
 }
 
 void App::OnDropFiles(HDROP hDrop)
@@ -1041,7 +969,7 @@ void App::OnDropFiles(HDROP hDrop)
     if (required > 0) {
         std::pmr::wstring path(required, L'\0');
         if (DragQueryFileW(hDrop, 0, path.data(), required + 1)) {
-            HandleDropFile(path);
+            Dispatch(DropFilesAction{ std::move(path) });
         }
     }
     DragFinish(hDrop);
@@ -1049,75 +977,12 @@ void App::OnDropFiles(HDROP hDrop)
 
 void App::OnFileWatchEvent()
 {
-    MENDO_TRACE("OnFileWatchEvent: file change detected");
-    doc_service_.CheckForChanges();
+    Dispatch(FileWatchAction{});
 }
 
 void App::HandleTimer(UINT_PTR timer_id)
 {
-    MENDO_PROFILE("HandleTimer");
-    switch (timer_id) {
-    case app_timer::DEFERRED_LAYOUT:
-        OnDeferredLayout();
-        break;
-    case app_timer::LOADING_ANIM:
-        file_load_service_.TickLoadingAnimation();
-        Invalidate();
-        break;
-    case app_timer::SWIPE_OVERLAY: {
-        const auto result = state_.swipe_detector.Commit();
-        bool need_redraw = false;
-        switch (result) {
-        case SwipeResult::Back:
-            NavigateBack();
-            need_redraw = true;
-            break;
-        case SwipeResult::Forward:
-            NavigateForward();
-            need_redraw = true;
-            break;
-        default:
-            break;
-        }
-        KillTimer(hwnd_, app_timer::SWIPE_OVERLAY);
-        if (need_redraw) {
-            Invalidate();
-        }
-        break;
-    }
-    case app_timer::TOAST: {
-        if (!state_.toast.Tick()) {
-            KillTimer(hwnd_, app_timer::TOAST);
-        }
-        Invalidate();
-        break;
-    }
-    case app_timer::SEARCH_CARET: {
-        state_.search_bar_ctrl.OnCaretBlinkTimer();
-        break;
-    }
-    case app_timer::TOOLTIP:
-        KillTimer(hwnd_, app_timer::TOOLTIP);
-        state_.tooltip.Show();
-        break;
-    case app_timer::SEARCH_DEBOUNCE:
-        state_.search_bar_ctrl.OnDebounceTimer(state_.doc.GetNodes());
-        break;
-    case app_timer::MERMAID_BATCH:
-        resource_manager_.ProcessMermaidBatch();
-        break;
-    case app_timer::BITMAP_MANAGE:
-        resource_manager_.OnBitmapManageTimer();
-        break;
-    case app_timer::MERMAID_INIT_RETRY:
-        mermaid_renderer_.OnInitRetryTimer();
-        break;
-    case app_timer::FILE_RELOAD_DEBOUNCE:
-        KillTimer(hwnd_, app_timer::FILE_RELOAD_DEBOUNCE);
-        ReloadCurrentFile();
-        break;
-    default: break;
-    }
+    Dispatch(TimerAction{ timer_id });
 }
 
 void App::OnAppLoadFile()
@@ -1132,11 +997,7 @@ void App::OnAppReloadFile()
 
 void App::OnCaptureChanged()
 {
-    state_.search_bar_ctrl.OnCaptureChanged();
-    if (state_.gesture.GetPhase() != GesturePhase::Idle) {
-        state_.gesture.Reset();
-        Invalidate();
-    }
+    Dispatch(CaptureChangedAction{});
 }
 
 void App::ShowToast(std::wstring_view message)
@@ -1188,7 +1049,7 @@ RECT App::GetSearchEditRect() const
     const auto& layout = GetPaneLayout();
     const auto& r = layout.md_rect;
     const auto sbl = ComputeSearchBarLayout(r.x, r.width, r.y + r.height, !state_.search_state.GetQuery().empty());
-    const float s = cached_dpi_scale_;
+    const float s = state_.cached_dpi_scale;
     return {
         static_cast<LONG>(sbl.input_rect.left * s),
         static_cast<LONG>(sbl.input_rect.top * s),

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -13,7 +13,6 @@
 #include "pane.h"
 #include "layout_service.h"
 #include "app_controller.h"
-#include "navigation_service.h"
 #include "config_service.h"
 #include "theme_service.h"
 #include "file_load_service.h"
@@ -73,9 +72,6 @@ public:
 
     // ファイル変更イベント（メッセージループから呼ばれる）
     HANDLE GetFileWatchEvent() const noexcept { return doc_service_.GetFileWatchEvent(); }
-    // state_ への参照アクセサ（app_*.cpp からの移行期に使用）
-    AppState& State() noexcept { return state_; }
-    const AppState& State() const noexcept { return state_; }
     void OnFileWatchEvent();
 
     // タイマーコールバック
@@ -125,7 +121,7 @@ public:
     void InvalidateTitleBar() noexcept;
 
     // Win32Windowのカーソル/再描画用にDPIスケールを公開
-    constexpr float GetDpiScale() const noexcept { return cached_dpi_scale_; }
+    constexpr float GetDpiScale() const noexcept { return state_.cached_dpi_scale; }
 
     // カスタムタイトルバー
     float GetTitleBarHeightDip() const noexcept { return state_.titlebar.GetHeight(); }
@@ -142,12 +138,7 @@ private:
     ResourceManager::Callbacks BuildResourceManagerCallbacks();
     SearchBarController::Callbacks BuildSearchBarCallbacks();
 
-    // アンカーベースのスクロール位置保存/復元
-    struct AnchorState {
-        int idx = -1;
-        float y_before = 0.0f;
-        float offset = 0.0f;
-    };
+    // アンカーベースのスクロール位置保存/復元 (AnchorState は app_state.h で定義)
     AnchorState SaveAnchor() const;
     void RestoreAnchor(const AnchorState& anchor, float md_pane_height);
     void RestoreAnchorWithScale(const AnchorState& anchor, float offset_scale);
@@ -164,9 +155,6 @@ private:
     // リンク・アンカーナビゲーション
     void HandleLinkClick(std::wstring_view url);
     void NavigateToAnchor(std::wstring_view anchor);
-    void ApplyNavigateResult(const NavigationService::NavigateResult& result);
-    void NavigateBack();
-    void NavigateForward();
     void PushNavHistory();
 
     // クリップボード・選択
@@ -239,24 +227,11 @@ private:
     ::PaneZone PaneAtPoint(float dip_x, float dip_y) const;
     float GetMarkdownPaneWidth() const;
 
-
-    // 検索
-    void OnSearchOpen() { state_.search_bar_ctrl.OnOpen(state_.doc.GetNodes()); }
-
     // Reducer 用テーマ定数キャッシュの同期
     void SyncPaneThemeCache();
 
-    // Dispatch() 内のインラインハンドラから抽出したヘルパー
-    void HandleOpenFile();
-    void HandleShowHelp();
-    void HandleDropFile(std::wstring_view path);
-
     // ダークモード / ズーム (theme_service_に委譲)
-    void ToggleDarkMode();
-    void ZoomIn();
-    void ZoomOut();
-    void ZoomReset();
-    void ApplyZoom(float new_zoom);
+    void HandleApplyThemeChange(const effect::ApplyThemeChange& e);
 
     // テーマ/ズーム変更後の共通後処理（ViewportLayout→スクロール復元→再描画）
     void FinishThemeOrZoomChange(const AnchorState& anchor, float offset_scale);
@@ -264,7 +239,6 @@ private:
 private:
     // Win32ハンドル
     HWND hwnd_ = nullptr;
-    float cached_dpi_scale_ = 1.0f;
 
     CursorManager cursors_;
 
@@ -286,7 +260,6 @@ private:
     AppState state_;
 
     // ---- サービス（状態ではなく振る舞い） ----
-    NavigationService nav_service_{ state_.nav_history };
     std::optional<LayoutService> layout_service_;
     ResourceManager resource_manager_;
     SideEffectExecutor effect_executor_;

--- a/src/app/app_constants.h
+++ b/src/app/app_constants.h
@@ -1,32 +1,15 @@
 #pragma once
-#include <windows.h>
-#include <cstdint>
+#include "timer_ids.h"
 #include "search_bar_controller.h"
 #include "resource_manager.h"
 #include "mermaid.h"
 
-// App とWin32Window 間で共有されるタイマーID・カスタムメッセージ定数。
-// 各IDは一意であり、変更する際は全IDの重複がないことを確認すること。
-// サブコンポーネントが定義する定数から導出し、値の二重管理を防ぐ。
-namespace app_timer {
-
-inline constexpr UINT_PTR DEFERRED_LAYOUT = 3;
-inline constexpr UINT_PTR LOADING_ANIM = 4;
-inline constexpr UINT_PTR SWIPE_OVERLAY = 5;
-inline constexpr UINT_PTR TOAST = 6;
-inline constexpr UINT_PTR SEARCH_CARET = SearchBarController::TIMER_CARET;
-inline constexpr UINT_PTR TOOLTIP = 8;
-inline constexpr UINT_PTR SEARCH_DEBOUNCE = SearchBarController::TIMER_DEBOUNCE;
-inline constexpr UINT_PTR MERMAID_BATCH = ResourceManager::TIMER_MERMAID_BATCH;
-inline constexpr UINT_PTR BITMAP_MANAGE = ResourceManager::TIMER_BITMAP_MANAGE;
-inline constexpr UINT_PTR MERMAID_INIT_RETRY = MermaidRenderer::TIMER_INIT_RETRY;
-inline constexpr UINT_PTR FILE_RELOAD_DEBOUNCE = 13;
-
-// タイマー間隔 (ms)
-inline constexpr UINT FRAME_INTERVAL_MS = 16;              // ~60fps アニメーション用
-inline constexpr UINT FILE_RELOAD_DEBOUNCE_MS = 200;       // ファイル変更通知のデバウンス
-
-} // namespace app_timer
+// タイマーIDはtimer_ids.hで定義。コンポーネント定数との一致をコンパイル時検証する。
+static_assert(app_timer::SEARCH_CARET == SearchBarController::TIMER_CARET);
+static_assert(app_timer::SEARCH_DEBOUNCE == SearchBarController::TIMER_DEBOUNCE);
+static_assert(app_timer::MERMAID_BATCH == ResourceManager::TIMER_MERMAID_BATCH);
+static_assert(app_timer::BITMAP_MANAGE == ResourceManager::TIMER_BITMAP_MANAGE);
+static_assert(app_timer::MERMAID_INIT_RETRY == MermaidRenderer::TIMER_INIT_RETRY);
 
 namespace app_msg {
 

--- a/src/app/app_context_menu.cpp
+++ b/src/app/app_context_menu.cpp
@@ -31,7 +31,7 @@ void App::OnContextMenu(int screen_x, int screen_y)
     ContextMenuParams params;
     params.screen_x = screen_x;
     params.screen_y = screen_y;
-    params.dpi_scale = cached_dpi_scale_;
+    params.dpi_scale = state_.cached_dpi_scale;
     params.can_go_back = state_.nav_history.CanGoBack();
     params.can_go_forward = state_.nav_history.CanGoForward();
     params.has_file = !state_.doc.GetFilePath().empty();
@@ -46,10 +46,10 @@ void App::OnContextMenu(int screen_x, int screen_y)
 
     switch (cmd) {
     case IDM_NAV_BACK:
-        NavigateBack();
+        Dispatch(NavigateBackAction{});
         break;
     case IDM_NAV_FORWARD:
-        NavigateForward();
+        Dispatch(NavigateForwardAction{});
         break;
     case IDM_EDIT_FILE: {
         const auto& file_path = state_.doc.GetFilePath();
@@ -62,7 +62,7 @@ void App::OnContextMenu(int screen_x, int screen_y)
         CopySelectionToClipboard();
         break;
     case IDM_TOGGLE_DARK_MODE:
-        ToggleDarkMode();
+        Dispatch(ToggleDarkModeAction{});
         break;
     case IDM_TOGGLE_FILE_PANE:
         Dispatch(TogglePaneAction{ PaneTarget::File });

--- a/src/app/app_events.h
+++ b/src/app/app_events.h
@@ -2,6 +2,7 @@
 #include "pane_layout.h"
 #include <variant>
 #include <string>
+#include <cstdint>
 #include <memory_resource>
 #include <windows.h>
 

--- a/src/app/app_events.h
+++ b/src/app/app_events.h
@@ -22,28 +22,53 @@ struct MouseWheelEvent {
 
 // ──── アクション: コマンド系 (アプリが実行すべき操作) ────
 
-enum class ScrollType { LineUp, LineDown, PageUp, PageDown, Home, End };
+enum class ScrollType {
+    LineUp,
+    LineDown,
+    PageUp,
+    PageDown,
+    Home,
+    End
+};
 
 // キーボード/スクロールバースクロール (Shellがtypeから具体的なdeltaを算出)
-struct KeyScrollAction { ScrollType type; };
+struct KeyScrollAction {
+    ScrollType type;
+};
 
 // ホイール/タッチパッドの直接スクロール (アニメーションなし)
-struct DirectScrollByAction { float delta; };
+struct DirectScrollByAction {
+    float delta;
+};
 
 // ペイン (ファイル/目次) スクロール
-struct ScrollPaneAction { PaneZone pane; float delta; };
+struct ScrollPaneAction {
+    PaneZone pane;
+    float delta;
+};
 
 struct CopyClipboardAction {};
 struct SelectAllAction {};
 struct ClearSelectionAction {};
 
 // サイドペインの切り替え
-enum class PaneTarget { File, Toc };
-struct TogglePaneAction { PaneTarget target; };
+enum class PaneTarget {
+    File,
+    Toc
+};
+struct TogglePaneAction {
+    PaneTarget target;
+};
 
 // ズーム操作
-enum class ZoomDirection { In, Out, Reset };
-struct ZoomAction { ZoomDirection direction; };
+enum class ZoomDirection {
+    In,
+    Out,
+    Reset
+};
+struct ZoomAction {
+    ZoomDirection direction;
+};
 
 struct ReloadFileAction {};
 struct OpenFileAction {};
@@ -59,26 +84,82 @@ struct NoOpAction {};
 
 // ──── アクション: マウスイベント系 ────
 
-struct LButtonDownAction { float dip_x; float dip_y; int px; int py; };
-struct LButtonUpAction { float dip_x; float dip_y; int px; int py; };
-struct MouseMoveAction { float dip_x; float dip_y; int px; int py; };
-struct MouseHoverAction { float dip_x; float dip_y; int px; int py; };
-struct LButtonDblClkAction { float dip_x; float dip_y; int px; int py; };
-struct RButtonDownAction { float dip_x; float dip_y; int px; int py; };
-struct RButtonUpAction { float dip_x; float dip_y; int px; int py; };
-struct RButtonMoveAction { float dip_x; float dip_y; int px; int py; };
-struct ContextMenuAction { int screen_x; int screen_y; };
+struct LButtonDownAction {
+    float dip_x;
+    float dip_y;
+    int px;
+    int py;
+};
+struct LButtonUpAction {
+    float dip_x;
+    float dip_y;
+    int px;
+    int py;
+};
+struct MouseMoveAction {
+    float dip_x;
+    float dip_y;
+    int px;
+    int py;
+};
+struct MouseHoverAction {
+    float dip_x;
+    float dip_y;
+    int px;
+    int py;
+};
+struct LButtonDblClkAction {
+    float dip_x;
+    float dip_y;
+    int px;
+    int py;
+};
+struct RButtonDownAction {
+    float dip_x;
+    float dip_y;
+    int px;
+    int py;
+};
+struct RButtonUpAction {
+    float dip_x;
+    float dip_y;
+    int px;
+    int py;
+};
+struct RButtonMoveAction {
+    float dip_x;
+    float dip_y;
+    int px;
+    int py;
+};
+struct ContextMenuAction {
+    int screen_x;
+    int screen_y;
+};
 struct MouseLeaveAction {};
 struct XButtonBackAction {};
 struct XButtonForwardAction {};
-struct HWheelAction { short delta; };
-struct DropFilesAction { std::pmr::wstring path; };
+struct HWheelAction {
+    short delta;
+    uint64_t tick;
+};
+struct DropFilesAction {
+    std::pmr::wstring path;
+};
 
 // ──── アクション: システムイベント系 ────
 
-struct ResizeAction { UINT width; UINT height; };
-struct DpiChangedAction { UINT dpi; RECT suggested; };
-struct ActivateAction { bool active; };
+struct ResizeAction {
+    UINT width;
+    UINT height;
+};
+struct DpiChangedAction {
+    UINT dpi;
+    RECT suggested;
+};
+struct ActivateAction {
+    bool active;
+};
 struct EnterSizeMoveAction {};
 struct ExitSizeMoveAction {};
 struct CaptureChangedAction {};
@@ -86,18 +167,27 @@ struct DestroyAction {};
 
 // ──── アクション: タイマー・非同期コールバック系 ────
 
-struct TimerAction { UINT_PTR timer_id; };
+struct TimerAction {
+    UINT_PTR timer_id;
+};
 struct FileWatchAction {};
 struct ParseCompleteAction {};
 struct ImageLoadedAction {};
 
 // ──── アクション: 検索系 ────
 
-struct SearchTextChangedAction { std::pmr::wstring text; };
+struct SearchTextChangedAction {
+    std::pmr::wstring text;
+};
 struct ToggleCaseSensitiveAction {};
 struct ToggleHighlightAction {};
-struct SearchSelectionAction { int sel_start; int sel_end; };
-struct ImeCompositionAction { std::pmr::wstring text; };
+struct SearchSelectionAction {
+    int sel_start;
+    int sel_end;
+};
+struct ImeCompositionAction {
+    std::pmr::wstring text;
+};
 
 // ──── AppAction: 全アクションの統一型 ────
 

--- a/src/app/app_mouse.cpp
+++ b/src/app/app_mouse.cpp
@@ -6,7 +6,6 @@
 #include "document_utils.h"
 #include "ui_constants.h"
 #include "resource.h"
-#include <cwctype>
 
 namespace {
 
@@ -184,11 +183,11 @@ bool App::OnRButtonUp(int px, int py)
         break;
     }
     case GestureResult::Back:
-        NavigateBack();
+        Dispatch(NavigateBackAction{});
         Invalidate();
         break;
     case GestureResult::Forward:
-        NavigateForward();
+        Dispatch(NavigateForwardAction{});
         Invalidate();
         break;
     case GestureResult::None:
@@ -213,12 +212,12 @@ void App::OnRButtonMove(int px, int py)
 
 void App::OnXButtonBack()
 {
-    NavigateBack();
+    Dispatch(XButtonBackAction{});
 }
 
 void App::OnXButtonForward()
 {
-    NavigateForward();
+    Dispatch(XButtonForwardAction{});
 }
 
 // ============================================================
@@ -231,7 +230,7 @@ App::HitResult App::HitTest(int screen_x, int screen_y) const
     return state_.hit_test.HitTest({
         state_.doc.GetNodes(), state_.layout_cache, renderer_.GetTheme(),
         state_.viewport.GetScrollY(), pane_layout.md_rect.x,
-        cached_dpi_scale_, screen_x, screen_y
+        state_.cached_dpi_scale, screen_x, screen_y
         });
 }
 
@@ -425,11 +424,11 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
 
     const auto nav_hit = state_.hit_test.NavButtonHitTest(dip_x, dip_y, pane_layout.md_rect);
     if (nav_hit == NavButtonHover::Back) {
-        NavigateBack();
+        Dispatch(NavigateBackAction{});
         return;
     }
     if (nav_hit == NavButtonHover::Forward) {
-        NavigateForward();
+        Dispatch(NavigateForwardAction{});
         return;
     }
     // コピーボタンのクリック判定（クリック位置で再判定）
@@ -437,7 +436,7 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
     const MdPaneHitContext hit_ctx{
         state_.doc.GetNodes(), state_.layout_cache, renderer_.GetTheme(),
         state_.viewport.GetScrollY(), pane_layout.md_rect.x,
-        cached_dpi_scale_, px, py,
+        state_.cached_dpi_scale, px, py,
         content_width, pane_layout.md_rect.height
     };
     const auto copy_node = state_.hit_test.CopyButtonHitTest(hit_ctx);
@@ -900,7 +899,7 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
     const MdPaneHitContext hit_ctx{
         state_.doc.GetNodes(), state_.layout_cache, renderer_.GetTheme(),
         state_.viewport.GetScrollY(), pane_layout.md_rect.x,
-        cached_dpi_scale_, px, py,
+        state_.cached_dpi_scale, px, py,
         content_width, pane_layout.md_rect.height
     };
     {

--- a/src/app/app_mouse.cpp
+++ b/src/app/app_mouse.cpp
@@ -11,14 +11,15 @@
 namespace {
 
 // ペインヘッダー内のボタンがクリックされたか判定する。
-bool HitPaneHeaderButton(float dip_x, float dip_y, const PaneRect& rect, float header_height, D2D1_RECT_F(*button_rect_fn)(float, float) noexcept)
+template <auto ButtonRectFn>
+bool HitPaneHeaderButton(float dip_x, float dip_y, const PaneRect& rect, float header_height)
 {
     const float local_x = dip_x - rect.x;
     const float local_y = dip_y - rect.y;
     if (local_y >= header_height) {
         return false;
     }
-    return PointInRect(local_x, local_y, button_rect_fn(rect.width, header_height));
+    return PointInRect(local_x, local_y, ButtonRectFn(rect.width, header_height));
 }
 
 // タイトルバーボタンに対応するツールチップを返す。
@@ -62,10 +63,10 @@ PaneHoverResult ProcessSidePaneHover(
 {
     PaneHoverResult result;
 
-    const bool close_hit = HitPaneHeaderButton(dip_x, dip_y, rect, header_h, PaneCloseButtonRect);
+    const bool close_hit = HitPaneHeaderButton<PaneCloseButtonRect>(dip_x, dip_y, rect, header_h);
     bool refresh_hit = false;
     if (has_refresh_btn) {
-        refresh_hit = HitPaneHeaderButton(dip_x, dip_y, rect, header_h, PaneRefreshButtonRect);
+        refresh_hit = HitPaneHeaderButton<PaneRefreshButtonRect>(dip_x, dip_y, rect, header_h);
     }
     result.any_button_hit = close_hit || refresh_hit;
 
@@ -97,11 +98,11 @@ bool ProcessSidePaneHeaderClick(
     if (dip_y - rect.y >= header_h) {
         return false;
     }
-    if (HitPaneHeaderButton(dip_x, dip_y, rect, header_h, PaneCloseButtonRect)) {
+    if (HitPaneHeaderButton<PaneCloseButtonRect>(dip_x, dip_y, rect, header_h)) {
         toggle_fn();
         return true;
     }
-    if (has_refresh_btn && HitPaneHeaderButton(dip_x, dip_y, rect, header_h, PaneRefreshButtonRect)) {
+    if (has_refresh_btn && HitPaneHeaderButton<PaneRefreshButtonRect>(dip_x, dip_y, rect, header_h)) {
         refresh_fn();
         return true;
     }

--- a/src/app/app_navigate.cpp
+++ b/src/app/app_navigate.cpp
@@ -1,4 +1,5 @@
 #include "app.h"
+#include "navigation_service.h"
 #include "document_utils.h"
 #include <algorithm>
 
@@ -11,13 +12,13 @@ void App::HandleLinkClick(std::wstring_view url)
     if (url.empty()) {
         return;
     }
-    const auto result = nav_service_.HandleLinkClick(url, state_.doc.GetFilePath());
+    const auto result = ::HandleLinkClick(url);
     switch (result.type) {
-    case NavigationService::NavigateResult::Type::Anchor:
+    case LinkClickResult::Type::Anchor:
         PushNavHistory();
         NavigateToAnchor(result.target);
         break;
-    case NavigationService::NavigateResult::Type::ExternalUrl: {
+    case LinkClickResult::Type::ExternalUrl: {
         SideEffectList effects;
         effects.emplace_back(effect::ShellOpen{ std::pmr::wstring{result.target} });
         effect_executor_.Execute(effects);
@@ -46,34 +47,7 @@ void App::NavigateToAnchor(std::wstring_view anchor)
 
 void App::PushNavHistory()
 {
-    nav_service_.PushHistory(state_.doc.GetFilePath(), state_.viewport.GetScrollY());
-}
-
-void App::ApplyNavigateResult(const NavigationService::NavigateResult& result)
-{
-    if (result.type == NavigationService::NavigateResult::Type::None) {
-        return;
-    }
-    if (result.type == NavigationService::NavigateResult::Type::LoadFile) {
-        state_.scroll_restore.pending_nav_scroll_y = result.scroll_y;
-        LoadMarkdownFile(result.target);
-        return;
-    }
-    ScrollTo(result.scroll_y);
-    const auto layout = GetPaneLayout();
-    UpdateScrollBar();
-    InvalidateMdPane(layout.md_rect);
-    resource_manager_.ScheduleBitmapManage();
-}
-
-void App::NavigateBack()
-{
-    ApplyNavigateResult(nav_service_.GoBack(state_.doc.GetFilePath(), state_.viewport.GetScrollY()));
-}
-
-void App::NavigateForward()
-{
-    ApplyNavigateResult(nav_service_.GoForward(state_.doc.GetFilePath(), state_.viewport.GetScrollY()));
+    state_.nav_history.Push(NavEntry{ state_.doc.GetFilePath(), state_.viewport.GetScrollY() });
 }
 
 // ============================================================
@@ -83,8 +57,15 @@ void App::NavigateForward()
 void App::SyncPaneThemeCache()
 {
     const auto& theme = renderer_.GetTheme();
-    state_.cached_pane_item_height = theme.pane_item_height;
-    state_.cached_pane_header_height = theme.pane_header_height;
+    state_.cached_theme = ThemeConstants{
+        .pane_item_height = theme.pane_item_height,
+        .pane_header_height = theme.pane_header_height,
+        .splitter_width = theme.splitter_width,
+        .margin_left = theme.margin_left,
+        .margin_right = theme.margin_right,
+        .heading_spacing_above = theme.heading_spacing_above,
+        .zoom = theme.zoom,
+    };
 }
 
 void App::FinishThemeOrZoomChange(const AnchorState& anchor, float offset_scale)
@@ -107,71 +88,28 @@ void App::FinishThemeOrZoomChange(const AnchorState& anchor, float offset_scale)
     Invalidate();
 }
 
-void App::ToggleDarkMode()
+void App::HandleApplyThemeChange(const effect::ApplyThemeChange& e)
 {
-    theme_service_.ToggleDarkMode();
-    InvalidatePaneLayoutCache();
+    const AnchorState anchor{ e.anchor_idx, e.anchor_y_before, e.anchor_offset };
 
-    const auto anchor = SaveAnchor();
-
-    renderer_.SetTheme(theme_service_.CreateTheme(state_.viewport.GetZoomIndex()));
-    const bool dark = theme_service_.IsDarkMode();
-    ApplyDarkModeToWindow(hwnd_, dark);
-    state_.tooltip.ApplyDarkMode(dark);
-
-    // 全レイアウトとMermaid図を一括で無効化
-    state_.layout_cache.InvalidateAllWithDiagrams(state_.doc.GetNodes());
-    mermaid_renderer_.CancelPending();
-    mermaid_renderer_.ClearCache();
-
-    FinishThemeOrZoomChange(anchor, 1.0f);
-    theme_service_.SaveDarkMode();
-}
-
-// ============================================================
-// ズーム
-// ============================================================
-
-void App::ZoomIn()
-{
-    const float z = state_.viewport.ZoomIn();
-    if (z > 0.0f) {
-        ApplyZoom(z);
+    if (e.type == effect::ApplyThemeChange::Type::Zoom) {
+        const Theme base = theme_service_.CreateTheme();
+        renderer_.ApplyZoomFromBase(base, e.new_zoom);
+        FinishThemeOrZoomChange(anchor, e.offset_scale);
+        UpdateTitleBar();
+        theme_service_.SaveZoomLevel(e.zoom_index);
+    }
+    else {
+        // DarkMode
+        theme_service_.ToggleDarkMode();
+        renderer_.SetTheme(theme_service_.CreateTheme(state_.viewport.GetZoomIndex()));
+        const bool dark = theme_service_.IsDarkMode();
+        ApplyDarkModeToWindow(hwnd_, dark);
+        state_.tooltip.ApplyDarkMode(dark);
+        mermaid_renderer_.CancelPending();
+        mermaid_renderer_.ClearCache();
+        FinishThemeOrZoomChange(anchor, e.offset_scale);
+        theme_service_.SaveDarkMode();
     }
 }
 
-void App::ZoomOut()
-{
-    const float z = state_.viewport.ZoomOut();
-    if (z > 0.0f) {
-        ApplyZoom(z);
-    }
-}
-
-void App::ZoomReset()
-{
-    const float z = state_.viewport.ZoomReset();
-    if (z > 0.0f) {
-        ApplyZoom(z);
-    }
-}
-
-void App::ApplyZoom(float new_zoom)
-{
-    InvalidatePaneLayoutCache();
-    const auto anchor = SaveAnchor();
-
-    const float old_zoom = renderer_.GetTheme().zoom;
-    const float zoom_ratio = new_zoom / old_zoom;
-
-    state_.panes.ApplyZoom(zoom_ratio);
-
-    const Theme base = theme_service_.CreateTheme();
-    renderer_.ApplyZoomFromBase(base, new_zoom);
-
-    state_.layout_cache.InvalidateAllLayouts();
-
-    FinishThemeOrZoomChange(anchor, zoom_ratio);
-    UpdateTitleBar();
-    theme_service_.SaveZoomLevel(state_.viewport.GetZoomIndex());
-}

--- a/src/app/app_scroll.cpp
+++ b/src/app/app_scroll.cpp
@@ -41,6 +41,7 @@ void App::InvalidateMdPane(const PaneRect& md_rect)
 void App::SyncMaxScroll(float md_pane_height)
 {
     const float total = layout_service_->GetTotalHeight();
+    state_.cached_total_height = total;
     state_.viewport.SyncMaxScroll(total, md_pane_height);
 }
 
@@ -49,13 +50,9 @@ int App::FindFirstVisibleNode() const noexcept
     return state_.viewport.FindFirstVisibleNode(state_.layout_cache, state_.doc.GetNodes().size());
 }
 
-App::AnchorState App::SaveAnchor() const
+AnchorState App::SaveAnchor() const
 {
-    AnchorState a;
-    a.idx = FindFirstVisibleNode();
-    a.y_before = (a.idx >= 0) ? state_.layout_cache[a.idx].y_position : 0.0f;
-    a.offset = state_.viewport.GetScrollY() - a.y_before;
-    return a;
+    return SaveAnchorFromState(state_);
 }
 
 void App::RestoreAnchor(const AnchorState& anchor, float md_pane_height)

--- a/src/app/app_state.h
+++ b/src/app/app_state.h
@@ -21,6 +21,24 @@
 #include <string_view>
 #include <memory_resource>
 
+// スクロール位置のアンカー。レイアウト無効化の前に保存し、復元に使用する。
+struct AnchorState {
+    int idx = -1;
+    float y_before = 0.0f;
+    float offset = 0.0f;
+};
+
+// Reducer がテーマ定数を参照するためのキャッシュ。
+struct ThemeConstants {
+    float pane_item_height = 28.0f;
+    float pane_header_height = 32.0f;
+    float splitter_width = 4.0f;
+    float margin_left = 0.0f;
+    float margin_right = 0.0f;
+    float heading_spacing_above = 0.0f;
+    float zoom = 1.0f;
+};
+
 // アプリケーションの全状態を集約する構造体。
 // Win32ハンドルは含まない。状態に加えて一部のコントローラ
 // (ContextMenu, HitTestService, SearchBarController) を含む。
@@ -66,8 +84,16 @@ struct AppState {
     mutable float cached_window_width_for_layout = 0.0f;
     mutable bool pane_layout_valid = false;
 
-    // テーマから取得したペイン定数のキャッシュ（ズーム変更時に更新）。
-    // Reducer がペインスクロールの max_scroll を計算するために使用する。
-    float cached_pane_item_height = 28.0f;
-    float cached_pane_header_height = 32.0f;
+    // テーマから取得した定数のキャッシュ（ズーム/テーマ変更時に更新）。
+    // Reducer がペインスクロールの max_scroll 計算等に使用する。
+    ThemeConstants cached_theme;
+
+    // DPIスケール（ピクセル→DIP変換用）。OnDpiChanged で更新。
+    float cached_dpi_scale = 1.0f;
+
+    // ドキュメント総高さのキャッシュ。ViewportLayout 後に更新。
+    float cached_total_height = 0.0f;
 };
+
+// 現在のスクロール位置からアンカーを保存する。Reducer と App の共通ヘルパー。
+AnchorState SaveAnchorFromState(const AppState& state) noexcept;

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -311,10 +311,8 @@ SideEffectList Reduce(AppState& state, const AppAction& action)
             const float window_w_dip = a.width / state.cached_dpi_scale;
             state.titlebar.UpdateLayout(window_w_dip);
             if (state.is_sizing) {
-                // sizing中は簡易更新: max_scroll 同期 + 再描画のみ
-                state.viewport.SyncMaxScroll(state.cached_total_height,
-                    state.cached_pane_layout.md_rect.height);
-                effects.emplace_back(effect::InvalidateWindow{});
+                // sizing中は簡易更新: RendererResize 後に PaneLayout 再計算 → max_scroll 同期
+                effects.emplace_back(effect::PerformSizingUpdate{});
             }
             else {
                 effects.emplace_back(effect::PerformResizeEnd{});

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -1,7 +1,55 @@
 #include "reducer.h"
+#include "timer_ids.h"
 #include "document_utils.h"
 #include "ui_constants.h"
 #include "utility.h"
+
+AnchorState SaveAnchorFromState(const AppState& state) noexcept
+{
+    AnchorState a;
+    a.idx = state.viewport.FindFirstVisibleNode(state.layout_cache, state.doc.GetNodes().size());
+    a.y_before = (a.idx >= 0) ? state.layout_cache[a.idx].y_position : 0.0f;
+    a.offset = state.viewport.GetScrollY() - a.y_before;
+    return a;
+}
+
+// ナビゲーション結果を副作用に変換するヘルパー。
+// NavHistory::GoBack/GoForward の結果に応じて LoadFile or 同一ファイル内スクロールを行う。
+static void ApplyNavResult(AppState& state, SideEffectList& effects, NavEntry&& entry)
+{
+    if (entry.file_path != state.doc.GetFilePath() && !entry.file_path.empty()) {
+        // 別ファイルへのナビゲーション
+        state.scroll_restore.pending_nav_scroll_y = entry.scroll_y;
+        effects.emplace_back(effect::LoadFile{ std::move(entry.file_path) });
+    }
+    else {
+        // 同一ファイル内スクロール
+        state.scroll_restore.pending_restore_scroll_y = -1;
+        state.viewport.ScrollTo(entry.scroll_y);
+        state.hover_throttle.Reset();
+        state.tooltip.Hide();
+        state.tooltip.ResetTarget();
+        effects.emplace_back(effect::ClearTooltip{});
+        effects.emplace_back(effect::InvalidateWindow{});
+        effects.emplace_back(effect::BitmapManage{});
+    }
+}
+
+static void ReduceNavigateBack(AppState& state, SideEffectList& effects)
+{
+    NavEntry out;
+    if (state.nav_history.GoBack(NavEntry{ state.doc.GetFilePath(), state.viewport.GetScrollY() }, out)) {
+        ApplyNavResult(state, effects, std::move(out));
+    }
+}
+
+static void ReduceNavigateForward(AppState& state, SideEffectList& effects)
+{
+    NavEntry out;
+    if (state.nav_history.GoForward(NavEntry{ state.doc.GetFilePath(), state.viewport.GetScrollY() }, out)) {
+        ApplyNavResult(state, effects, std::move(out));
+    }
+}
 
 SideEffectList Reduce(AppState& state, const AppAction& action)
 {
@@ -26,8 +74,8 @@ SideEffectList Reduce(AppState& state, const AppAction& action)
 
     // ペインの max_scroll を計算するヘルパー
     const auto calc_pane_max_scroll = [&](PaneZone pane) -> float {
-        const float item_h = state.cached_pane_item_height;
-        const float header_h = state.cached_pane_header_height;
+        const float item_h = state.cached_theme.pane_item_height;
+        const float header_h = state.cached_theme.pane_header_height;
         if (pane == PaneZone::FilePane) {
             const float total = static_cast<float>(state.file_explorer.GetEntries().size()) * item_h;
             return std::max(0.0f, total - (state.cached_pane_layout.file_rect.height - header_h));
@@ -129,6 +177,7 @@ SideEffectList Reduce(AppState& state, const AppAction& action)
         },
         [&](const ExitSizeMoveAction&) {
             state.is_sizing = false;
+            effects.emplace_back(effect::PerformResizeEnd{});
         },
         [&](const MouseLeaveAction&) {
             clear_tooltip();
@@ -163,6 +212,232 @@ SideEffectList Reduce(AppState& state, const AppAction& action)
         },
         [&](const ImeCompositionAction& a) {
             state.search_bar_ctrl.SetImeComposition(a.text);
+        },
+        [&](const CaptureChangedAction&) {
+            state.search_bar_ctrl.OnCaptureChanged();
+            if (state.gesture.GetPhase() != GesturePhase::Idle) {
+                state.gesture.Reset();
+                effects.emplace_back(effect::InvalidateWindow{});
+            }
+        },
+        [&](const DropFilesAction& a) {
+            if (!state.doc.GetFilePath().empty()) {
+                state.nav_history.Push(NavEntry{ state.doc.GetFilePath(), state.viewport.GetScrollY() });
+            }
+            effects.emplace_back(effect::LoadFile{ std::pmr::wstring(a.path) });
+        },
+        [&](const ShowHelpAction&) {
+            if (!state.doc.GetFilePath().empty() && !IsHelpPath(state.doc.GetFilePath())) {
+                state.nav_history.Push(NavEntry{ state.doc.GetFilePath(), state.viewport.GetScrollY() });
+            }
+            effects.emplace_back(effect::LoadFile{ std::pmr::wstring(HELP_PATH) });
+        },
+        [&](const OpenFileAction&) {
+            effects.emplace_back(effect::OpenFileDialog{});
+        },
+        [&](const ReloadFileAction&) {
+            effects.emplace_back(effect::ReloadFile{});
+        },
+        [&](const FileWatchAction&) {
+            effects.emplace_back(effect::CheckFileChanges{});
+        },
+        [&](const ImageLoadedAction&) {
+            effects.emplace_back(effect::NotifyImageLoaded{});
+        },
+        [&](const NavigateBackAction&) {
+            ReduceNavigateBack(state, effects);
+        },
+        [&](const NavigateForwardAction&) {
+            ReduceNavigateForward(state, effects);
+        },
+        [&](const XButtonBackAction&) {
+            ReduceNavigateBack(state, effects);
+        },
+        [&](const XButtonForwardAction&) {
+            ReduceNavigateForward(state, effects);
+        },
+        [&](const ZoomAction& a) {
+            float new_zoom = 0.0f;
+            switch (a.direction) {
+            case ZoomDirection::In:
+                new_zoom = state.viewport.ZoomIn();
+                break;
+            case ZoomDirection::Out:
+                new_zoom = state.viewport.ZoomOut();
+                break;
+            case ZoomDirection::Reset:
+                new_zoom = state.viewport.ZoomReset();
+                break;
+            }
+            if (new_zoom <= 0.0f) {
+                return;
+            }
+            // SaveAnchor はレイアウト無効化の前に実行
+            const auto anchor = SaveAnchorFromState(state);
+            state.pane_layout_valid = false;
+            const float zoom_ratio = new_zoom / state.cached_theme.zoom;
+            state.panes.ApplyZoom(zoom_ratio);
+            state.layout_cache.InvalidateAllLayouts();
+            effects.emplace_back(effect::ApplyThemeChange{
+                .type = effect::ApplyThemeChange::Type::Zoom,
+                .anchor_idx = anchor.idx,
+                .anchor_y_before = anchor.y_before,
+                .anchor_offset = anchor.offset,
+                .offset_scale = zoom_ratio,
+                .new_zoom = new_zoom,
+                .zoom_index = state.viewport.GetZoomIndex(),
+            });
+        },
+        [&](const ToggleDarkModeAction&) {
+            const auto anchor = SaveAnchorFromState(state);
+            state.pane_layout_valid = false;
+            state.layout_cache.InvalidateAllWithDiagrams(state.doc.GetNodes());
+            effects.emplace_back(effect::ApplyThemeChange{
+                .type = effect::ApplyThemeChange::Type::DarkMode,
+                .anchor_idx = anchor.idx,
+                .anchor_y_before = anchor.y_before,
+                .anchor_offset = anchor.offset,
+                .offset_scale = 1.0f,
+                .new_zoom = 0.0f,
+                .zoom_index = state.viewport.GetZoomIndex(),
+            });
+        },
+        [&](const ResizeAction& a) {
+            if (a.width == 0 || a.height == 0) {
+                return;
+            }
+            state.pane_layout_valid = false;
+            effects.emplace_back(effect::RendererResize{ a.width, a.height });
+            const float window_w_dip = a.width / state.cached_dpi_scale;
+            state.titlebar.UpdateLayout(window_w_dip);
+            if (state.is_sizing) {
+                // sizing中は簡易更新: max_scroll 同期 + 再描画のみ
+                state.viewport.SyncMaxScroll(state.cached_total_height,
+                    state.cached_pane_layout.md_rect.height);
+                effects.emplace_back(effect::InvalidateWindow{});
+            }
+            else {
+                effects.emplace_back(effect::PerformResizeEnd{});
+            }
+        },
+        [&](const DpiChangedAction& a) {
+            state.cached_dpi_scale = static_cast<float>(a.dpi) / 96.0f;
+            if (state.cached_dpi_scale <= 0.0f) {
+                state.cached_dpi_scale = 1.0f;
+            }
+            state.pane_layout_valid = false;
+            state.layout_cache.MarkAllDirty();
+            effects.emplace_back(effect::RendererSetDpi{ static_cast<float>(a.dpi) });
+            effects.emplace_back(effect::ClearFileCache{});
+            effects.emplace_back(effect::SetWindowPosition{
+                static_cast<int>(a.suggested.left),
+                static_cast<int>(a.suggested.top),
+                static_cast<int>(a.suggested.right - a.suggested.left),
+                static_cast<int>(a.suggested.bottom - a.suggested.top),
+            });
+        },
+        [&](const HWheelAction& a) {
+            const bool had_overlay = state.swipe_detector.IsOverlayVisible();
+            const int old_direction = state.swipe_detector.GetOverlayDirection();
+            state.swipe_detector.OnHWheel(a.delta, a.tick);
+            effects.emplace_back(effect::SetTimer{ app_timer::SWIPE_OVERLAY,
+                static_cast<UINT>(SwipeDetector::COMMIT_TIMEOUT_MS) });
+            if (had_overlay != state.swipe_detector.IsOverlayVisible()
+                || old_direction != state.swipe_detector.GetOverlayDirection()) {
+                effects.emplace_back(effect::InvalidateWindow{});
+            }
+        },
+        [&](const LButtonDownAction& a) {
+            effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::LButtonDown, a.px, a.py });
+        },
+        [&](const LButtonUpAction& a) {
+            effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::LButtonUp, a.px, a.py });
+        },
+        [&](const MouseMoveAction& a) {
+            effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::MouseMove, a.px, a.py });
+        },
+        [&](const MouseHoverAction& a) {
+            effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::MouseHover, a.px, a.py });
+        },
+        [&](const LButtonDblClkAction& a) {
+            effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::LButtonDblClk, a.px, a.py });
+        },
+        [&](const RButtonDownAction& a) {
+            effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::RButtonDown, a.px, a.py });
+        },
+        [&](const RButtonUpAction& a) {
+            effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::RButtonUp, a.px, a.py });
+        },
+        [&](const RButtonMoveAction& a) {
+            effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::RButtonMove, a.px, a.py });
+        },
+        [&](const ContextMenuAction& a) {
+            effects.emplace_back(effect::HandleContextMenu{ a.screen_x, a.screen_y });
+        },
+        [&](const TimerAction& a) {
+            switch (a.timer_id) {
+            case app_timer::TOAST:
+                if (!state.toast.Tick()) {
+                    effects.emplace_back(effect::KillTimer{ app_timer::TOAST });
+                }
+                effects.emplace_back(effect::InvalidateWindow{});
+                break;
+            case app_timer::SEARCH_CARET:
+                state.search_bar_ctrl.OnCaretBlinkTimer();
+                break;
+            case app_timer::TOOLTIP:
+                effects.emplace_back(effect::KillTimer{ app_timer::TOOLTIP });
+                state.tooltip.Show();
+                break;
+            case app_timer::SEARCH_DEBOUNCE:
+                state.search_bar_ctrl.OnDebounceTimer(state.doc.GetNodes());
+                break;
+            case app_timer::SWIPE_OVERLAY: {
+                const auto result = state.swipe_detector.Commit();
+                effects.emplace_back(effect::KillTimer{ app_timer::SWIPE_OVERLAY });
+                switch (result) {
+                case SwipeResult::Back:
+                    ReduceNavigateBack(state, effects);
+                    effects.emplace_back(effect::InvalidateWindow{});
+                    break;
+                case SwipeResult::Forward:
+                    ReduceNavigateForward(state, effects);
+                    effects.emplace_back(effect::InvalidateWindow{});
+                    break;
+                default:
+                    break;
+                }
+                break;
+            }
+            case app_timer::DEFERRED_LAYOUT:
+                effects.emplace_back(effect::ProcessDeferredLayout{});
+                break;
+            case app_timer::LOADING_ANIM:
+                effects.emplace_back(effect::TickLoadingAnimation{});
+                effects.emplace_back(effect::InvalidateWindow{});
+                break;
+            case app_timer::MERMAID_BATCH:
+                effects.emplace_back(effect::ProcessMermaidBatchTimer{});
+                break;
+            case app_timer::BITMAP_MANAGE:
+                effects.emplace_back(effect::ProcessBitmapManage{});
+                break;
+            case app_timer::MERMAID_INIT_RETRY:
+                effects.emplace_back(effect::MermaidInitRetry{});
+                break;
+            case app_timer::FILE_RELOAD_DEBOUNCE:
+                effects.emplace_back(effect::KillTimer{ app_timer::FILE_RELOAD_DEBOUNCE });
+                effects.emplace_back(effect::ReloadFile{});
+                break;
+            default:
+                break;
+            }
+        },
+        [&](const DestroyAction&) {
+            effects.emplace_back(effect::Destroy{});
+        },
+        [&](const ParseCompleteAction&) {
+            effects.emplace_back(effect::HandleParseComplete{});
         },
         [](const auto&) {},
         }, action);

--- a/src/app/resource_manager.cpp
+++ b/src/app/resource_manager.cpp
@@ -101,9 +101,7 @@ int ResourceManager::ApplyCachedImages()
             ++applied;
         }
         else {
-            image_loader_->RequestLoadAsync(abs_str,
-                [](void* ctx) static { static_cast<ResourceManager*>(ctx)->OnImageLoadComplete(); },
-                this);
+            image_loader_->RequestLoadAsync(abs_str, [this] { OnImageLoadComplete(); });
         }
     }
     return applied;
@@ -183,8 +181,7 @@ int ResourceManager::RequestMermaidRenders()
 
         mermaid_->RequestRender(node, (*cache_)[i], diagram,
             content_width, theme_service_->IsDarkMode(),
-            [](void* ctx) static { static_cast<ResourceManager*>(ctx)->OnMermaidRenderComplete(); },
-            this);
+            [this] { OnMermaidRenderComplete(); });
         if (diagram.bitmap) {
             ++applied;
         }
@@ -250,8 +247,7 @@ void ResourceManager::ProcessMermaidBatch()
         if (!diagram.bitmap) {
             mermaid_->RequestRender(node, (*cache_)[i], diagram,
                 content_width, dark_mode,
-                [](void* ctx) static { static_cast<ResourceManager*>(ctx)->OnMermaidRenderComplete(); },
-                this);
+                [this] { OnMermaidRenderComplete(); });
             if (diagram.bitmap) {
                 any_loaded = true;
             }

--- a/src/app/resource_manager.h
+++ b/src/app/resource_manager.h
@@ -17,14 +17,14 @@ class Renderer;
 class ResourceManager {
 public:
     struct Callbacks {
-        std::function<void()> invalidate;
-        std::function<void(UINT_PTR, UINT)> set_timer;
-        std::function<void(UINT_PTR)> kill_timer;
-        std::function<float()> get_content_width;    // theme.ContentWidth(pane_width)
-        std::function<float()> get_viewport_height;  // pane_layout.md_rect.height
+        std::move_only_function<void()> invalidate;
+        std::move_only_function<void(UINT_PTR, UINT)> set_timer;
+        std::move_only_function<void(UINT_PTR)> kill_timer;
+        std::move_only_function<float()> get_content_width;
+        std::move_only_function<float()> get_viewport_height;
         // レイアウト再計算
-        std::function<void()> recompute_layout;           // RecomputeAfterDiagram
-        std::function<void()> recompute_layout_anchored;  // anchor付き: 保存→再計算→復元→Invalidate
+        std::move_only_function<void()> recompute_layout;           // RecomputeAfterDiagram
+        std::move_only_function<void()> recompute_layout_anchored;  // anchor付き: 保存→再計算→復元→Invalidate
     };
 
     static constexpr UINT_PTR TIMER_MERMAID_BATCH = 10;

--- a/src/app/side_effect.h
+++ b/src/app/side_effect.h
@@ -75,8 +75,55 @@ struct CancelMermaidBatch {};
 struct InvalidatePaneCache { PaneZone pane; };
 struct RefreshPaneLayout {};
 
-// ---- ダークモード ----
+// ---- テーマ・ダークモード ----
 struct ApplyDarkMode { bool dark; };
+
+// テーマ/ズーム変更の複合副作用。
+// Reducer が SaveAnchor + 状態変更を行った後、executor がレンダラー適用 + レイアウトを実行する。
+struct ApplyThemeChange {
+    enum class Type { Zoom, DarkMode };
+    Type type;
+    int anchor_idx;
+    float anchor_y_before;
+    float anchor_offset;
+    float offset_scale;   // Zoom: zoom_ratio, DarkMode: 1.0f
+    float new_zoom;       // Zoom 用: 新しいズーム値
+    int zoom_index;       // Zoom 用: ズームインデックス（設定保存用）
+};
+
+// ---- ファイル監視・リソース ----
+struct CheckFileChanges {};
+struct NotifyImageLoaded {};
+struct ClearFileCache {};
+
+// ---- レンダラー操作 ----
+struct RendererResize { UINT width; UINT height; };
+struct RendererSetDpi { float dpi; };
+
+// ---- ウィンドウ操作（追加） ----
+struct SetWindowPosition { int x; int y; int cx; int cy; };
+
+// ---- リサイズ ----
+struct PerformResizeEnd {};
+
+// ---- タイマー処理委譲 ----
+struct ProcessDeferredLayout {};
+struct TickLoadingAnimation {};
+struct ProcessMermaidBatchTimer {};
+struct ProcessBitmapManage {};
+struct MermaidInitRetry {};
+
+// ---- ライフサイクル ----
+struct Destroy {};
+struct HandleParseComplete {};
+
+// ---- マウスイベント委譲 ----
+enum class MouseEventType {
+    LButtonDown, LButtonUp, MouseMove, MouseHover, LButtonDblClk,
+    RButtonDown, RButtonUp, RButtonMove,
+};
+struct HandleMouseEvent { MouseEventType type; int px; int py; };
+struct HandleContextMenu { int screen_x; int screen_y; };
 
 } // namespace effect
 
@@ -113,8 +160,25 @@ using SideEffect = std::variant<
     effect::CancelMermaidBatch,
     effect::InvalidatePaneCache,
     effect::RefreshPaneLayout,
-    effect::ApplyDarkMode
-> ;
+    effect::ApplyDarkMode,
+    effect::CheckFileChanges,
+    effect::NotifyImageLoaded,
+    effect::RendererResize,
+    effect::RendererSetDpi,
+    effect::SetWindowPosition,
+    effect::ClearFileCache,
+    effect::PerformResizeEnd,
+    effect::ApplyThemeChange,
+    effect::ProcessDeferredLayout,
+    effect::TickLoadingAnimation,
+    effect::ProcessMermaidBatchTimer,
+    effect::ProcessBitmapManage,
+    effect::MermaidInitRetry,
+    effect::Destroy,
+    effect::HandleParseComplete,
+    effect::HandleMouseEvent,
+    effect::HandleContextMenu
+>;
 
 using SideEffectList = std::pmr::vector<SideEffect>;
 

--- a/src/app/side_effect.h
+++ b/src/app/side_effect.h
@@ -105,6 +105,7 @@ struct SetWindowPosition { int x; int y; int cx; int cy; };
 
 // ---- リサイズ ----
 struct PerformResizeEnd {};
+struct PerformSizingUpdate {};
 
 // ---- タイマー処理委譲 ----
 struct ProcessDeferredLayout {};
@@ -168,6 +169,7 @@ using SideEffect = std::variant<
     effect::SetWindowPosition,
     effect::ClearFileCache,
     effect::PerformResizeEnd,
+    effect::PerformSizingUpdate,
     effect::ApplyThemeChange,
     effect::ProcessDeferredLayout,
     effect::TickLoadingAnimation,

--- a/src/app/side_effect_executor.cpp
+++ b/src/app/side_effect_executor.cpp
@@ -185,6 +185,9 @@ void SideEffectExecutor::Execute(const SideEffectList& effects)
             [this](const effect::PerformResizeEnd&) {
                 cb_.perform_resize_end();
             },
+            [this](const effect::PerformSizingUpdate&) {
+                cb_.perform_sizing_update();
+            },
             [this](const effect::ApplyThemeChange& e) {
                 cb_.apply_theme_change(e);
             },

--- a/src/app/side_effect_executor.cpp
+++ b/src/app/side_effect_executor.cpp
@@ -164,6 +164,57 @@ void SideEffectExecutor::Execute(const SideEffectList& effects)
             [this](const effect::ApplyDarkMode& e) {
                 ApplyDarkModeToWindow(hwnd_, e.dark);
             },
+            [this](const effect::CheckFileChanges&) {
+                doc_service_->CheckForChanges();
+            },
+            [this](const effect::NotifyImageLoaded&) {
+                resource_manager_->OnAppImageLoaded();
+            },
+            [this](const effect::RendererResize& e) {
+                cb_.renderer_resize(e.width, e.height);
+            },
+            [this](const effect::RendererSetDpi& e) {
+                cb_.renderer_set_dpi(e.dpi);
+            },
+            [this](const effect::SetWindowPosition& e) {
+                SetWindowPos(hwnd_, nullptr, e.x, e.y, e.cx, e.cy, SWP_NOZORDER | SWP_NOACTIVATE);
+            },
+            [this](const effect::ClearFileCache&) {
+                cb_.clear_file_cache();
+            },
+            [this](const effect::PerformResizeEnd&) {
+                cb_.perform_resize_end();
+            },
+            [this](const effect::ApplyThemeChange& e) {
+                cb_.apply_theme_change(e);
+            },
+            [this](const effect::ProcessDeferredLayout&) {
+                cb_.process_deferred_layout();
+            },
+            [this](const effect::TickLoadingAnimation&) {
+                cb_.tick_loading_animation();
+            },
+            [this](const effect::ProcessMermaidBatchTimer&) {
+                cb_.process_mermaid_batch_timer();
+            },
+            [this](const effect::ProcessBitmapManage&) {
+                cb_.process_bitmap_manage();
+            },
+            [this](const effect::MermaidInitRetry&) {
+                cb_.mermaid_init_retry();
+            },
+            [this](const effect::Destroy&) {
+                cb_.destroy();
+            },
+            [this](const effect::HandleParseComplete&) {
+                cb_.handle_parse_complete();
+            },
+            [this](const effect::HandleMouseEvent& e) {
+                cb_.handle_mouse_event(e.type, e.px, e.py);
+            },
+            [this](const effect::HandleContextMenu& e) {
+                cb_.handle_context_menu(e.screen_x, e.screen_y);
+            },
             }, e);
     }
 }

--- a/src/app/side_effect_executor.h
+++ b/src/app/side_effect_executor.h
@@ -26,6 +26,7 @@ public:
         std::move_only_function<void(float)> renderer_set_dpi;
         std::move_only_function<void()> clear_file_cache;
         std::move_only_function<void()> perform_resize_end;
+        std::move_only_function<void()> perform_sizing_update;
         std::move_only_function<void(const effect::ApplyThemeChange&)> apply_theme_change;
         std::move_only_function<void()> process_deferred_layout;
         std::move_only_function<void()> tick_loading_animation;

--- a/src/app/side_effect_executor.h
+++ b/src/app/side_effect_executor.h
@@ -17,11 +17,11 @@ class SideEffectExecutor {
 public:
     // App のメソッドチェーンに依存する複雑な操作のコールバック
     struct Callbacks {
-        std::function<void(std::wstring_view)> load_file;
-        std::function<void()> reload_file;
-        std::function<void()> open_file_dialog;
-        std::function<void(PaneZone)> invalidate_pane_cache;
-        std::function<void()> refresh_pane_layout;
+        std::move_only_function<void(std::wstring_view)> load_file;
+        std::move_only_function<void()> reload_file;
+        std::move_only_function<void()> open_file_dialog;
+        std::move_only_function<void(PaneZone)> invalidate_pane_cache;
+        std::move_only_function<void()> refresh_pane_layout;
     };
 
     void Init(HWND hwnd, ResourceManager& resource_manager,

--- a/src/app/side_effect_executor.h
+++ b/src/app/side_effect_executor.h
@@ -22,6 +22,20 @@ public:
         std::move_only_function<void()> open_file_dialog;
         std::move_only_function<void(PaneZone)> invalidate_pane_cache;
         std::move_only_function<void()> refresh_pane_layout;
+        std::move_only_function<void(UINT, UINT)> renderer_resize;
+        std::move_only_function<void(float)> renderer_set_dpi;
+        std::move_only_function<void()> clear_file_cache;
+        std::move_only_function<void()> perform_resize_end;
+        std::move_only_function<void(const effect::ApplyThemeChange&)> apply_theme_change;
+        std::move_only_function<void()> process_deferred_layout;
+        std::move_only_function<void()> tick_loading_animation;
+        std::move_only_function<void()> process_mermaid_batch_timer;
+        std::move_only_function<void()> process_bitmap_manage;
+        std::move_only_function<void()> mermaid_init_retry;
+        std::move_only_function<void()> destroy;
+        std::move_only_function<void()> handle_parse_complete;
+        std::move_only_function<void(effect::MouseEventType, int, int)> handle_mouse_event;
+        std::move_only_function<void(int, int)> handle_context_menu;
     };
 
     void Init(HWND hwnd, ResourceManager& resource_manager,

--- a/src/app/timer_ids.h
+++ b/src/app/timer_ids.h
@@ -1,0 +1,25 @@
+#pragma once
+#include <windows.h>
+
+// Reducer と App/Win32Window の両方から参照されるタイマーID定数。
+// レンダラー非依存のヘッダとして分離し、値の二重管理を防ぐ。
+// 各IDは一意であり、変更する際は全IDの重複がないことを確認すること。
+namespace app_timer {
+
+inline constexpr UINT_PTR DEFERRED_LAYOUT = 3;
+inline constexpr UINT_PTR LOADING_ANIM = 4;
+inline constexpr UINT_PTR SWIPE_OVERLAY = 5;
+inline constexpr UINT_PTR TOAST = 6;
+inline constexpr UINT_PTR SEARCH_CARET = 7;
+inline constexpr UINT_PTR TOOLTIP = 8;
+inline constexpr UINT_PTR SEARCH_DEBOUNCE = 9;
+inline constexpr UINT_PTR MERMAID_BATCH = 10;
+inline constexpr UINT_PTR BITMAP_MANAGE = 11;
+inline constexpr UINT_PTR MERMAID_INIT_RETRY = 12;
+inline constexpr UINT_PTR FILE_RELOAD_DEBOUNCE = 13;
+
+// タイマー間隔 (ms)
+inline constexpr UINT FRAME_INTERVAL_MS = 16;              // ~60fps アニメーション用
+inline constexpr UINT FILE_RELOAD_DEBOUNCE_MS = 200;       // ファイル変更通知のデバウンス
+
+} // namespace app_timer

--- a/src/io/file_watcher.h
+++ b/src/io/file_watcher.h
@@ -17,7 +17,7 @@ public:
     FileWatcher& operator=(const FileWatcher&) = delete;
     FileWatcher() = default;
 
-    using ChangeCallback = std::function<void()>;
+    using ChangeCallback = std::move_only_function<void()>;
     void StartWatching(const std::pmr::wstring& file_path, ChangeCallback callback);
     void StopWatching() noexcept;
     void CheckForChanges();

--- a/src/io/image_loader.cpp
+++ b/src/io/image_loader.cpp
@@ -203,8 +203,7 @@ bool ImageLoader::GetCachedImage(const std::wstring& abs_path, DiagramEntry& out
     return false;
 }
 
-void ImageLoader::RequestLoadAsync(const std::wstring& abs_path,
-    Callback on_complete, void* user_data)
+void ImageLoader::RequestLoadAsync(const std::wstring& abs_path, Callback on_complete)
 {
     {
         const std::lock_guard lock(pending_mutex_);
@@ -218,15 +217,14 @@ void ImageLoader::RequestLoadAsync(const std::wstring& abs_path,
     }
 
     const uint32_t gen = cancel_gen_.load();
-    scheduler_->Post([this, path = abs_path, on_complete, user_data, gen] {
+    scheduler_->Post([this, path = abs_path, on_complete = std::move(on_complete), gen]() mutable {
         if (cancel_gen_.load() != gen) {
             return;
         }
 
         DecodeResult result;
         result.path = path;
-        result.on_complete = on_complete;
-        result.user_data = user_data;
+        result.on_complete = std::move(on_complete);
 
         if (wic_factory_) {
             const auto stream = ReadFileToStream(path);
@@ -274,8 +272,7 @@ void ImageLoader::ProcessCompletedDecodes()
         }
     }
 
-    Callback last_cb = nullptr;
-    void* last_data = nullptr;
+    Callback last_cb;
 
     float scale_x, scale_y;
     GetDpiScale(scale_x, scale_y);
@@ -295,12 +292,11 @@ void ImageLoader::ProcessCompletedDecodes()
             }
         }
 
-        last_cb = r.on_complete;
-        last_data = r.user_data;
+        last_cb = std::move(r.on_complete);
     }
 
     if (last_cb) {
-        last_cb(last_data);
+        last_cb();
     }
 }
 

--- a/src/io/image_loader.h
+++ b/src/io/image_loader.h
@@ -10,13 +10,14 @@
 #include <vector>
 #include <mutex>
 #include <atomic>
+#include <functional>
 
 
 class TaskScheduler;
 
 class ImageLoader {
 public:
-    using Callback = void(*)(void*);
+    using Callback = std::move_only_function<void()>;
 
     ~ImageLoader();
 
@@ -33,8 +34,7 @@ public:
     bool GetCachedImage(const std::wstring& abs_path, DiagramEntry& out) const;
 
     // 非同期読み込みをキューに追加する。重複パスは無視される。
-    void RequestLoadAsync(const std::wstring& abs_path,
-        Callback on_complete, void* user_data);
+    void RequestLoadAsync(const std::wstring& abs_path, Callback on_complete);
 
     // UI スレッドから呼び出す: 完了した WIC デコード結果を D2D ビットマップに変換し、
     // キャッシュに格納する。バッチ内の最後の結果のコールバックのみを1回発火する
@@ -65,8 +65,7 @@ private:
         Microsoft::WRL::ComPtr<IWICFormatConverter> converter;
         float width = 0.0f;
         float height = 0.0f;
-        Callback on_complete = nullptr;
-        void* user_data = nullptr;
+        Callback on_complete;
         bool success = false;
     };
 

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -531,7 +531,7 @@ uint64_t MermaidRenderer::HashCode(std::string_view code_utf8, float max_width, 
 void MermaidRenderer::RequestRender(Node& node, NodeLayoutEntry& layout_entry,
     DiagramEntry& diagram_entry,
     float max_width, bool dark_mode,
-    Callback on_complete, void* user_data)
+    Callback on_complete)
 {
     if (node.code_language != SyntaxLanguage::Mermaid) {
         return;
@@ -547,7 +547,7 @@ void MermaidRenderer::RequestRender(Node& node, NodeLayoutEntry& layout_entry,
         layout_entry.height = cached->height;
         layout_entry.layout_dirty = false;
         if (on_complete) {
-            on_complete(user_data);
+            on_complete();
         }
         return;
     }
@@ -572,7 +572,7 @@ void MermaidRenderer::RequestRender(Node& node, NodeLayoutEntry& layout_entry,
                     cache_.Insert(hash, CachedBitmap{ bitmap, fentry.css_width, fentry.css_height });
 
                     if (on_complete) {
-                        on_complete(user_data);
+                        on_complete();
                     }
                     return;
                 }
@@ -595,8 +595,7 @@ void MermaidRenderer::RequestRender(Node& node, NodeLayoutEntry& layout_entry,
     req.diagram_entry = &diagram_entry;
     req.max_width = max_width;
     req.dark_mode = dark_mode;
-    req.on_complete = on_complete;
-    req.on_complete_data = user_data;
+    req.on_complete = std::move(on_complete);
     req.code_hash = hash;
     pending_requests_.push(std::move(req));
 
@@ -622,11 +621,10 @@ void MermaidRenderer::ProcessQueue()
             front.diagram_entry->height = hit->height;
             front.layout_entry->height = hit->height;
             front.layout_entry->layout_dirty = false;
-            const auto cb = front.on_complete;
-            const auto cb_data = front.on_complete_data;
+            auto cb = std::move(front.on_complete);
             pending_requests_.pop();
             if (cb) {
-                cb(cb_data);
+                cb();
             }
             continue;
         }
@@ -655,11 +653,10 @@ void MermaidRenderer::ProcessQueue()
 void MermaidRenderer::FinishWorkerRequest(Worker& worker)
 {
     worker.rendering = false;
-    const auto cb = worker.current_request.on_complete;
-    const auto cb_data = worker.current_request.on_complete_data;
+    auto cb = std::move(worker.current_request.on_complete);
     worker.current_request = {};
     if (cb) {
-        cb(cb_data);
+        cb();
     }
     ProcessQueue();
 }

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -210,8 +210,7 @@ void MermaidRenderer::Shutdown()
     initialized_ = false;
 }
 
-void MermaidRenderer::Init(HWND hwnd, ID2D1RenderTarget* render_target,
-    std::function<void()> on_ready)
+void MermaidRenderer::Init(HWND hwnd, ID2D1RenderTarget* render_target, std::move_only_function<void()> on_ready)
 {
     hwnd_ = hwnd;
     render_target_ = render_target;

--- a/src/mermaid/mermaid.h
+++ b/src/mermaid/mermaid.h
@@ -37,15 +37,14 @@ public:
     // WebView2が初期化済みでレンダリング可能な場合にtrueを返す。
     constexpr bool IsReady() const noexcept { return ready_; }
 
-    // コールバック型: ヒープ割り当てを回避するために関数ポインタ+コンテキストを使用
-    using Callback = void(*)(void*);
+    using Callback = std::move_only_function<void()>;
 
     // Mermaidコードブロックのレンダリングを要求する。
     // 完了時、ダイアグラムエントリのbitmap/width/heightとレイアウトエントリの
     // height/layout_dirtyが設定され、on_completeがUIスレッドで呼び出される。
     void RequestRender(Node& node, NodeLayoutEntry& layout_entry, DiagramEntry& diagram_entry,
         float max_width, bool dark_mode,
-        Callback on_complete, void* user_data);
+        Callback on_complete);
 
     // D2Dレンダーターゲットを更新する（例：リサイズ後）。
     void SetRenderTarget(ID2D1RenderTarget* render_target);
@@ -85,8 +84,7 @@ private:
         DiagramEntry* diagram_entry = nullptr;
         float max_width = 0.0f;
         bool dark_mode = false;
-        Callback on_complete = nullptr;
-        void* on_complete_data = nullptr;
+        Callback on_complete;
         uint64_t code_hash = 0;
         float css_width = 0.0f;   // JSから取得したCSSピクセル寸法（DIP）
         float css_height = 0.0f;

--- a/src/mermaid/mermaid.h
+++ b/src/mermaid/mermaid.h
@@ -32,8 +32,7 @@ public:
     // レンダラーを初期化する。hwndはメインアプリウィンドウ。
     // render_targetはD2Dビットマップの作成に使用する。
     // on_readyはWebView2の初期化完了時にUIスレッドで呼び出される。
-    void Init(HWND hwnd, ID2D1RenderTarget* render_target,
-        std::function<void()> on_ready);
+    void Init(HWND hwnd, ID2D1RenderTarget* render_target, std::move_only_function<void()> on_ready);
 
     // WebView2が初期化済みでレンダリング可能な場合にtrueを返す。
     constexpr bool IsReady() const noexcept { return ready_; }
@@ -135,7 +134,7 @@ private:
     bool initialized_ = false;
     bool ready_ = false;
     unsigned int request_counter_ = 0;
-    std::function<void()> on_all_ready_; // 最初のワーカー準備完了時に1回だけ呼び出す
+    std::move_only_function<void()> on_all_ready_; // 最初のワーカー準備完了時に1回だけ呼び出す
 
     std::queue<RenderRequest, std::pmr::deque<RenderRequest>> pending_requests_;
 

--- a/src/nav/navigation_service.cpp
+++ b/src/nav/navigation_service.cpp
@@ -23,15 +23,15 @@ static bool IsSafeUrlScheme(std::wstring_view url) noexcept
     return starts_with_i(url, L"http://") || starts_with_i(url, L"https://") || starts_with_i(url, L"mailto:");
 }
 
-NavigationService::NavigateResult NavigationService::HandleLinkClick(std::wstring_view url, [[maybe_unused]] std::wstring_view current_file)
+LinkClickResult HandleLinkClick(std::wstring_view url)
 {
-    NavigateResult result;
+    LinkClickResult result;
     if (url.empty()) {
         return result;
     }
     // 内部アンカーリンク: #something
     if (url[0] == L'#') {
-        result.type = NavigateResult::Type::Anchor;
+        result.type = LinkClickResult::Type::Anchor;
         result.target = url.substr(1);
         return result;
     }
@@ -39,45 +39,7 @@ NavigationService::NavigateResult NavigationService::HandleLinkClick(std::wstrin
     if (!IsSafeUrlScheme(url)) {
         return result;
     }
-    result.type = NavigateResult::Type::ExternalUrl;
+    result.type = LinkClickResult::Type::ExternalUrl;
     result.target = url;
     return result;
-}
-
-NavigationService::NavigateResult NavigationService::MakeResultFromEntry(NavEntry&& entry, std::wstring_view current_file)
-{
-    NavigateResult result;
-    if (entry.file_path != current_file && !entry.file_path.empty()) {
-        result.type = NavigateResult::Type::LoadFile;
-        result.target = std::move(entry.file_path);
-        result.scroll_y = entry.scroll_y;
-    }
-    else {
-        result.type = NavigateResult::Type::Anchor;
-        result.scroll_y = entry.scroll_y;
-    }
-    return result;
-}
-
-NavigationService::NavigateResult NavigationService::GoBack(std::wstring_view current_file, float scroll_y)
-{
-    NavEntry out;
-    if (!history_.GoBack(NavEntry{ current_file, scroll_y }, out)) {
-        return {};
-    }
-    return MakeResultFromEntry(std::move(out), current_file);
-}
-
-NavigationService::NavigateResult NavigationService::GoForward(std::wstring_view current_file, float scroll_y)
-{
-    NavEntry out;
-    if (!history_.GoForward(NavEntry{ current_file, scroll_y }, out)) {
-        return {};
-    }
-    return MakeResultFromEntry(std::move(out), current_file);
-}
-
-void NavigationService::PushHistory(std::wstring_view file, float scroll_y)
-{
-    history_.Push(NavEntry{ file, scroll_y });
 }

--- a/src/nav/navigation_service.h
+++ b/src/nav/navigation_service.h
@@ -1,39 +1,15 @@
 #pragma once
-#include "nav_history.h"
-#include "document_utils.h"
 #include <string>
 #include <string_view>
-#include <vector>
 #include <memory_resource>
 
-class NavigationService {
-public:
-    explicit NavigationService(NavHistory& history) noexcept : history_(history) {}
-
-    struct NavigateResult {
-        enum class Type { None, Anchor, ExternalUrl, LoadFile };
-        Type type = Type::None;
-        std::pmr::wstring target;
-        float scroll_y = 0.0f;
-    };
-
-    // リンククリック処理。結果を返すだけで副作用は起こさない。
-    NavigateResult HandleLinkClick(std::wstring_view url,
-        std::wstring_view current_file);
-
-    // 戻る
-    NavigateResult GoBack(std::wstring_view current_file, float scroll_y);
-
-    // 進む
-    NavigateResult GoForward(std::wstring_view current_file, float scroll_y);
-
-    // 履歴にプッシュ
-    void PushHistory(std::wstring_view file, float scroll_y);
-
-    bool CanGoBack() const noexcept { return history_.CanGoBack(); }
-    bool CanGoForward() const noexcept { return history_.CanGoForward(); }
-
-private:
-    NavigateResult MakeResultFromEntry(NavEntry&& entry, std::wstring_view current_file);
-    NavHistory& history_;
+// リンククリックの結果を表す値型。
+// URLスキーム検証とアンカー判定のみを行い、副作用は持たない。
+struct LinkClickResult {
+    enum class Type { None, Anchor, ExternalUrl };
+    Type type = Type::None;
+    std::pmr::wstring target;
 };
+
+// リンククリック処理。URLの種類を判定して結果を返す。副作用は起こさない。
+LinkClickResult HandleLinkClick(std::wstring_view url);

--- a/src/render/renderer.h
+++ b/src/render/renderer.h
@@ -193,7 +193,7 @@ public:
 
     // デバイスロスト後にD2Dレンダーターゲットが再作成された際に呼び出されるコールバックを設定。
     // コールバックには新しいレンダーターゲットのポインタが渡される。
-    void SetDeviceLostCallback(std::function<void(ID2D1RenderTarget*)> cb) { on_device_lost_ = std::move(cb); }
+    void SetDeviceLostCallback(std::move_only_function<void(ID2D1RenderTarget*)> cb) { on_device_lost_ = std::move(cb); }
 
     int HitTestSearchInput(std::wstring_view query, float local_x, float max_width) const;
     void SetSearchMatches(const std::pmr::vector<SearchMatch>* matches, int current_index) noexcept
@@ -294,5 +294,5 @@ private:
     LayoutEngine layout_;
     CommandGenerator cmd_generator_;
     CommandExecutor cmd_executor_;
-    std::function<void(ID2D1RenderTarget*)> on_device_lost_;
+    std::move_only_function<void(ID2D1RenderTarget*)> on_device_lost_;
 };

--- a/src/ui/search_bar_controller.h
+++ b/src/ui/search_bar_controller.h
@@ -22,16 +22,16 @@ public:
 
     // Win32操作をAppから注入するコールバック群
     struct Callbacks {
-        std::function<void()> invalidate;                  // ウィンドウ全体の再描画
-        std::function<void()> invalidate_search_bar;       // 検索バー領域のみ再描画
-        std::function<void(UINT_PTR, UINT)> set_timer;     // SetTimer(id, ms)
-        std::function<void(UINT_PTR)> kill_timer;          // KillTimer(id)
-        std::function<void()> focus_select_all;            // 検索テキスト全選択でフォーカス
-        std::function<void(int)> focus_set_caret;          // キャレット位置指定でフォーカス
-        std::function<void(int, int)> focus_set_selection; // anchor,caret指定でフォーカス
-        std::function<void()> unfocus;                     // フォーカス解除
-        std::function<float()> get_md_pane_height;         // Markdownペイン高さ取得
-        std::function<void(float)> on_scroll_changed;      // スクロール変更後処理(visible_h)
+        std::move_only_function<void()> invalidate;                  // ウィンドウ全体の再描画
+        std::move_only_function<void()> invalidate_search_bar;       // 検索バー領域のみ再描画
+        std::move_only_function<void(UINT_PTR, UINT)> set_timer;     // SetTimer(id, ms)
+        std::move_only_function<void(UINT_PTR)> kill_timer;          // KillTimer(id)
+        std::move_only_function<void()> focus_select_all;            // 検索テキスト全選択でフォーカス
+        std::move_only_function<void(int)> focus_set_caret;          // キャレット位置指定でフォーカス
+        std::move_only_function<void(int, int)> focus_set_selection; // anchor,caret指定でフォーカス
+        std::move_only_function<void()> unfocus;                     // フォーカス解除
+        std::move_only_function<float()> get_md_pane_height;         // Markdownペイン高さ取得
+        std::move_only_function<void(float)> on_scroll_changed;      // スクロール変更後処理(visible_h)
     };
 
     // タイマーID（App::HandleTimerでのルーティング用）

--- a/src/util/task_scheduler.cpp
+++ b/src/util/task_scheduler.cpp
@@ -16,7 +16,7 @@ void TaskScheduler::Init(int thread_count)
     }
 }
 
-void TaskScheduler::Post(std::function<void()> task)
+void TaskScheduler::Post(std::move_only_function<void()> task)
 {
     {
         const std::lock_guard lock(mutex_);
@@ -45,7 +45,7 @@ void TaskScheduler::WorkerLoop()
     CoInitializeEx(nullptr, COINIT_MULTITHREADED);
 
     while (true) {
-        std::function<void()> task;
+        std::move_only_function<void()> task;
         {
             std::unique_lock lock(mutex_);
             cv_.wait(lock, [this] {

--- a/src/util/task_scheduler.h
+++ b/src/util/task_scheduler.h
@@ -23,7 +23,7 @@ public:
     void Init(int thread_count);
 
     // タスクをキューに追加する。任意のワーカースレッドで実行される。
-    void Post(std::function<void()> task);
+    void Post(std::move_only_function<void()> task);
 
     // キューに残っているタスクをすべて処理してからワーカースレッドを終了する。
     void Shutdown();
@@ -32,7 +32,7 @@ private:
     void WorkerLoop();
 
     std::vector<std::thread> workers_;
-    std::queue<std::function<void()>> queue_;
+    std::queue<std::move_only_function<void()>> queue_;
     std::mutex mutex_;
     std::condition_variable cv_;
     std::atomic<bool> shutdown_{false};

--- a/tests/test_help.cpp
+++ b/tests/test_help.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #include "document.h"
 #include "document_utils.h"
-#include "navigation_service.h"
+#include "nav_history.h"
 
 // ═══════════════════════════════════════════════
 // IsHelpPath
@@ -64,44 +64,44 @@ TEST(HelpDocumentTest, HelpPathIsNotMarkdownFile)
 class HelpNavigationTest : public ::testing::Test {
 protected:
     NavHistory history_;
-    NavigationService service_{ history_ };
 };
 
 TEST_F(HelpNavigationTest, GoBackFromHelpToFile)
 {
-    service_.PushHistory(L"C:\\file.md", 50.0f);
+    history_.Push(NavEntry{ L"C:\\file.md", 50.0f });
 
-    auto result = service_.GoBack(HELP_PATH, 0.0f);
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::LoadFile);
-    EXPECT_EQ(result.target, L"C:\\file.md");
-    EXPECT_FLOAT_EQ(result.scroll_y, 50.0f);
+    NavEntry out;
+    ASSERT_TRUE(history_.GoBack(NavEntry{ HELP_PATH, 0.0f }, out));
+    EXPECT_EQ(out.file_path, L"C:\\file.md");
+    EXPECT_FLOAT_EQ(out.scroll_y, 50.0f);
 }
 
 TEST_F(HelpNavigationTest, GoForwardFromFileToHelp)
 {
-    service_.PushHistory(L"C:\\file.md", 50.0f);
+    history_.Push(NavEntry{ L"C:\\file.md", 50.0f });
 
-    service_.GoBack(HELP_PATH, 0.0f);
+    NavEntry back_out;
+    history_.GoBack(NavEntry{ HELP_PATH, 0.0f }, back_out);
 
-    auto result = service_.GoForward(L"C:\\file.md", 50.0f);
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::LoadFile);
-    EXPECT_EQ(std::wstring_view(result.target), HELP_PATH);
-    EXPECT_FLOAT_EQ(result.scroll_y, 0.0f);
+    NavEntry fwd_out;
+    ASSERT_TRUE(history_.GoForward(NavEntry{ L"C:\\file.md", 50.0f }, fwd_out));
+    EXPECT_EQ(std::wstring_view(fwd_out.file_path), HELP_PATH);
+    EXPECT_FLOAT_EQ(fwd_out.scroll_y, 0.0f);
 }
 
 TEST_F(HelpNavigationTest, PushHelpThenGoBack)
 {
-    service_.PushHistory(HELP_PATH, 0.0f);
+    history_.Push(NavEntry{ HELP_PATH, 0.0f });
 
-    auto result = service_.GoBack(L"C:\\file.md", 100.0f);
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::LoadFile);
-    EXPECT_EQ(std::wstring_view(result.target), HELP_PATH);
+    NavEntry out;
+    ASSERT_TRUE(history_.GoBack(NavEntry{ L"C:\\file.md", 100.0f }, out));
+    EXPECT_EQ(std::wstring_view(out.file_path), HELP_PATH);
 }
 
 TEST_F(HelpNavigationTest, HelpPathInHistoryCanGoBack)
 {
-    service_.PushHistory(HELP_PATH, 0.0f);
-    EXPECT_TRUE(service_.CanGoBack());
+    history_.Push(NavEntry{ HELP_PATH, 0.0f });
+    EXPECT_TRUE(history_.CanGoBack());
 }
 
 // ═══════════════════════════════════════════════

--- a/tests/test_image.cpp
+++ b/tests/test_image.cpp
@@ -1067,7 +1067,7 @@ protected:
     // コールバック発火を検知するためのカウンター
     static std::atomic<int> callback_count_;
 
-    static void OnComplete(void* /*ctx*/)
+    static void OnComplete()
     {
         callback_count_.fetch_add(1);
     }
@@ -1113,7 +1113,7 @@ TEST_F(ImageLoaderAsyncTest, AsyncLoadPopulatesCache)
     ASSERT_TRUE(CreateTestImage(L"async.png", GUID_ContainerFormatPng, 120, 90));
     auto path = GetTestImagePath(L"async.png");
 
-    loader_.RequestLoadAsync(path, OnComplete, nullptr);
+    loader_.RequestLoadAsync(path, OnComplete);
     ASSERT_TRUE(WaitForResults(1)) << "非同期読み込みが完了しなかった";
 
     DiagramEntry entry;
@@ -1129,8 +1129,8 @@ TEST_F(ImageLoaderAsyncTest, DuplicateRequestIsIgnored)
     auto path = GetTestImagePath(L"dup.png");
 
     // 同じパスを2回リクエスト — 重複は無視される
-    loader_.RequestLoadAsync(path, OnComplete, nullptr);
-    loader_.RequestLoadAsync(path, OnComplete, nullptr);
+    loader_.RequestLoadAsync(path, OnComplete);
+    loader_.RequestLoadAsync(path, OnComplete);
 
     ASSERT_TRUE(WaitForResults(1));
 
@@ -1145,8 +1145,8 @@ TEST_F(ImageLoaderAsyncTest, MultiplePathsAllCached)
     auto path_a = GetTestImagePath(L"a.png");
     auto path_b = GetTestImagePath(L"b.png");
 
-    loader_.RequestLoadAsync(path_a, OnComplete, nullptr);
-    loader_.RequestLoadAsync(path_b, OnComplete, nullptr);
+    loader_.RequestLoadAsync(path_a, OnComplete);
+    loader_.RequestLoadAsync(path_b, OnComplete);
 
     // 少なくとも1回コールバックが来るのを待つ
     ASSERT_TRUE(WaitForResults(1));
@@ -1163,7 +1163,7 @@ TEST_F(ImageLoaderAsyncTest, FileNotLockedAfterAsyncLoad)
     ASSERT_TRUE(CreateTestImage(L"async_lock.png", GUID_ContainerFormatPng, 80, 60));
     auto path = GetTestImagePath(L"async_lock.png");
 
-    loader_.RequestLoadAsync(path, OnComplete, nullptr);
+    loader_.RequestLoadAsync(path, OnComplete);
     ASSERT_TRUE(WaitForResults(1)) << "非同期読み込みが完了しなかった";
 
     // 非同期読み込み完了後、書き込みモードでファイルを開けること
@@ -1202,7 +1202,7 @@ TEST_F(ImageLoaderAsyncTest, AsyncLoadReturnsDipSizeAt150Percent)
     ASSERT_TRUE(CreateTestImage(L"async_dpi.png", GUID_ContainerFormatPng, 300, 150));
     auto path = GetTestImagePath(L"async_dpi.png");
 
-    loader_.RequestLoadAsync(path, OnComplete, nullptr);
+    loader_.RequestLoadAsync(path, OnComplete);
     ASSERT_TRUE(WaitForResults(1)) << "非同期読み込みが完了しなかった";
 
     DiagramEntry entry;
@@ -1218,7 +1218,7 @@ TEST_F(ImageLoaderAsyncTest, CancelPendingClearsQueue)
     ASSERT_TRUE(CreateTestImage(L"cancel.png", GUID_ContainerFormatPng, 30, 30));
     auto path = GetTestImagePath(L"cancel.png");
 
-    loader_.RequestLoadAsync(path, OnComplete, nullptr);
+    loader_.RequestLoadAsync(path, OnComplete);
     loader_.CancelPending();
 
     // キャンセル後、短時間待ってもコールバックが来ないこと
@@ -1246,7 +1246,7 @@ TEST_F(ImageLoaderAsyncTest, ManyImagesAllCachedCorrectly)
     }
 
     for (auto& p : paths) {
-        loader_.RequestLoadAsync(p, OnComplete, nullptr);
+        loader_.RequestLoadAsync(p, OnComplete);
     }
 
     ASSERT_TRUE(WaitForResults(1)) << "非同期読み込みが完了しなかった";
@@ -1267,7 +1267,7 @@ TEST_F(ImageLoaderAsyncTest, ShutdownDuringHeavyLoad)
     for (int i = 0; i < kImageCount; ++i) {
         auto name = L"heavy_" + std::to_wstring(i) + L".png";
         ASSERT_TRUE(CreateTestImage(name, GUID_ContainerFormatPng, 100, 100));
-        loader_.RequestLoadAsync(GetTestImagePath(name), OnComplete, nullptr);
+        loader_.RequestLoadAsync(GetTestImagePath(name), OnComplete);
     }
 
     // 処理途中で即座にシャットダウン — デッドロックやクラッシュが起きないこと
@@ -1281,7 +1281,7 @@ TEST_F(ImageLoaderAsyncTest, ReinitAfterShutdownWithHeavyLoad)
     for (int i = 0; i < kImageCount; ++i) {
         auto name = L"reinit_a_" + std::to_wstring(i) + L".png";
         ASSERT_TRUE(CreateTestImage(name, GUID_ContainerFormatPng, 40, 40));
-        loader_.RequestLoadAsync(GetTestImagePath(name), OnComplete, nullptr);
+        loader_.RequestLoadAsync(GetTestImagePath(name), OnComplete);
     }
 
     loader_.Shutdown();
@@ -1296,7 +1296,7 @@ TEST_F(ImageLoaderAsyncTest, ReinitAfterShutdownWithHeavyLoad)
     ASSERT_TRUE(CreateTestImage(name, GUID_ContainerFormatPng, 77, 55));
     auto path = GetTestImagePath(name);
 
-    loader_.RequestLoadAsync(path, OnComplete, nullptr);
+    loader_.RequestLoadAsync(path, OnComplete);
     ASSERT_TRUE(WaitForResults(1)) << "再初期化後の非同期読み込みが完了しなかった";
 
     DiagramEntry entry;
@@ -1312,7 +1312,7 @@ TEST_F(ImageLoaderAsyncTest, CancelDuringHeavyLoadThenReload)
     for (int i = 0; i < kImageCount; ++i) {
         auto name = L"cancel_heavy_" + std::to_wstring(i) + L".png";
         ASSERT_TRUE(CreateTestImage(name, GUID_ContainerFormatPng, 50, 50));
-        loader_.RequestLoadAsync(GetTestImagePath(name), OnComplete, nullptr);
+        loader_.RequestLoadAsync(GetTestImagePath(name), OnComplete);
     }
 
     loader_.CancelPending();
@@ -1322,7 +1322,7 @@ TEST_F(ImageLoaderAsyncTest, CancelDuringHeavyLoadThenReload)
     ASSERT_TRUE(CreateTestImage(L"after_cancel.png", GUID_ContainerFormatPng, 88, 66));
     auto path = GetTestImagePath(L"after_cancel.png");
 
-    loader_.RequestLoadAsync(path, OnComplete, nullptr);
+    loader_.RequestLoadAsync(path, OnComplete);
 
     // キャンセル直後は進行中だったワーカーの結果が先に返る可能性があるため、
     // コールバック回数ではなく対象画像がキャッシュされるまで直接ポーリングする

--- a/tests/test_mermaid_renderer.cpp
+++ b/tests/test_mermaid_renderer.cpp
@@ -80,7 +80,7 @@ TEST_F(MermaidRendererTest, NonMermaidNodeDoesNotTriggerInit)
     NodeLayoutEntry layout{};
     DiagramEntry diagram{};
 
-    renderer_->RequestRender(node, layout, diagram, 800.0f, false, nullptr, nullptr);
+    renderer_->RequestRender(node, layout, diagram, 800.0f, false, nullptr);
 
     EXPECT_FALSE(renderer_->IsInitialized());
 }
@@ -97,7 +97,7 @@ TEST_F(MermaidRendererTest, MermaidCacheMissTriggersInit)
     NodeLayoutEntry layout{};
     DiagramEntry diagram{};
 
-    renderer_->RequestRender(node, layout, diagram, 800.0f, false, nullptr, nullptr);
+    renderer_->RequestRender(node, layout, diagram, 800.0f, false, nullptr);
 
     EXPECT_TRUE(renderer_->IsInitialized());
     // WebView2の非同期初期化が完了するまではReadyにはならない
@@ -117,8 +117,8 @@ TEST_F(MermaidRendererTest, MultipleRequestsDoNotReinitialize)
     NodeLayoutEntry layout{};
     DiagramEntry diagram{};
 
-    renderer_->RequestRender(node1, layout, diagram, 800.0f, false, nullptr, nullptr);
-    renderer_->RequestRender(node2, layout, diagram, 800.0f, false, nullptr, nullptr);
+    renderer_->RequestRender(node1, layout, diagram, 800.0f, false, nullptr);
+    renderer_->RequestRender(node2, layout, diagram, 800.0f, false, nullptr);
 
     EXPECT_TRUE(renderer_->IsInitialized());
 }
@@ -133,7 +133,7 @@ TEST_F(MermaidRendererTest, RequestRenderBeforeInitIsSafe)
     NodeLayoutEntry layout{};
     DiagramEntry diagram{};
 
-    renderer_->RequestRender(node, layout, diagram, 800.0f, false, nullptr, nullptr);
+    renderer_->RequestRender(node, layout, diagram, 800.0f, false, nullptr);
 
     EXPECT_FALSE(renderer_->IsReady());
 }

--- a/tests/test_navigation_service.cpp
+++ b/tests/test_navigation_service.cpp
@@ -1,203 +1,65 @@
 #include <gtest/gtest.h>
 #include "navigation_service.h"
 
-class NavigationServiceTest : public ::testing::Test {
-protected:
-    NavHistory history_;
-    NavigationService service_{ history_ };
-};
-
-TEST_F(NavigationServiceTest, HandleAnchorLink)
+// HandleLinkClick は自由関数のため、フィクスチャ不要
+TEST(HandleLinkClickTest, HandleAnchorLink)
 {
-    auto result = service_.HandleLinkClick(L"#section-1", L"C:\\file.md");
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::Anchor);
+    auto result = HandleLinkClick(L"#section-1");
+    EXPECT_EQ(result.type, LinkClickResult::Type::Anchor);
     EXPECT_EQ(result.target, L"section-1");
 }
 
-TEST_F(NavigationServiceTest, HandleExternalLink)
+TEST(HandleLinkClickTest, HandleExternalLink)
 {
-    auto result = service_.HandleLinkClick(L"https://example.com", L"C:\\file.md");
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::ExternalUrl);
+    auto result = HandleLinkClick(L"https://example.com");
+    EXPECT_EQ(result.type, LinkClickResult::Type::ExternalUrl);
     EXPECT_EQ(result.target, L"https://example.com");
 }
 
-TEST_F(NavigationServiceTest, HandleHttpLink)
+TEST(HandleLinkClickTest, HandleHttpLink)
 {
-    auto result = service_.HandleLinkClick(L"http://example.com", L"C:\\file.md");
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::ExternalUrl);
+    auto result = HandleLinkClick(L"http://example.com");
+    EXPECT_EQ(result.type, LinkClickResult::Type::ExternalUrl);
 }
 
-TEST_F(NavigationServiceTest, HandleMailtoLink)
+TEST(HandleLinkClickTest, HandleMailtoLink)
 {
-    auto result = service_.HandleLinkClick(L"mailto:user@example.com", L"C:\\file.md");
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::ExternalUrl);
+    auto result = HandleLinkClick(L"mailto:user@example.com");
+    EXPECT_EQ(result.type, LinkClickResult::Type::ExternalUrl);
 }
 
-TEST_F(NavigationServiceTest, BlockFileScheme)
+TEST(HandleLinkClickTest, BlockFileScheme)
 {
-    auto result = service_.HandleLinkClick(L"file:///C:/Windows/System32/cmd.exe", L"C:\\file.md");
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::None);
+    auto result = HandleLinkClick(L"file:///C:/Windows/System32/cmd.exe");
+    EXPECT_EQ(result.type, LinkClickResult::Type::None);
 }
 
-TEST_F(NavigationServiceTest, BlockJavascriptScheme)
+TEST(HandleLinkClickTest, BlockJavascriptScheme)
 {
-    auto result = service_.HandleLinkClick(L"javascript:alert(1)", L"C:\\file.md");
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::None);
+    auto result = HandleLinkClick(L"javascript:alert(1)");
+    EXPECT_EQ(result.type, LinkClickResult::Type::None);
 }
 
-TEST_F(NavigationServiceTest, BlockUnknownScheme)
+TEST(HandleLinkClickTest, BlockUnknownScheme)
 {
-    auto result = service_.HandleLinkClick(L"ftp://example.com/file", L"C:\\file.md");
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::None);
+    auto result = HandleLinkClick(L"ftp://example.com/file");
+    EXPECT_EQ(result.type, LinkClickResult::Type::None);
 }
 
-TEST_F(NavigationServiceTest, BlockBareRelativePath)
+TEST(HandleLinkClickTest, BlockBareRelativePath)
 {
-    auto result = service_.HandleLinkClick(L"other.md", L"C:\\file.md");
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::None);
+    auto result = HandleLinkClick(L"other.md");
+    EXPECT_EQ(result.type, LinkClickResult::Type::None);
 }
 
-TEST_F(NavigationServiceTest, HttpsCaseInsensitive)
+TEST(HandleLinkClickTest, HttpsCaseInsensitive)
 {
-    auto result = service_.HandleLinkClick(L"HTTPS://EXAMPLE.COM", L"C:\\file.md");
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::ExternalUrl);
+    auto result = HandleLinkClick(L"HTTPS://EXAMPLE.COM");
+    EXPECT_EQ(result.type, LinkClickResult::Type::ExternalUrl);
 }
 
-TEST_F(NavigationServiceTest, HandleEmptyLink)
+TEST(HandleLinkClickTest, HandleEmptyLink)
 {
-    auto result = service_.HandleLinkClick(L"", L"C:\\file.md");
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::None);
-}
-
-TEST_F(NavigationServiceTest, GoBackNoHistory)
-{
-    auto result = service_.GoBack(L"C:\\file.md", 100.0f);
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::None);
-}
-
-TEST_F(NavigationServiceTest, GoBackSameFile)
-{
-    service_.PushHistory(L"C:\\file.md", 50.0f);
-
-    auto result = service_.GoBack(L"C:\\file.md", 200.0f);
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::Anchor);
-    EXPECT_FLOAT_EQ(result.scroll_y, 50.0f);
-}
-
-TEST_F(NavigationServiceTest, GoBackDifferentFile)
-{
-    service_.PushHistory(L"C:\\first.md", 50.0f);
-
-    auto result = service_.GoBack(L"C:\\second.md", 200.0f);
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::LoadFile);
-    EXPECT_EQ(result.target, L"C:\\first.md");
-    EXPECT_FLOAT_EQ(result.scroll_y, 50.0f);
-}
-
-TEST_F(NavigationServiceTest, GoForwardNoHistory)
-{
-    auto result = service_.GoForward(L"C:\\file.md", 100.0f);
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::None);
-}
-
-TEST_F(NavigationServiceTest, GoBackThenForward)
-{
-    service_.PushHistory(L"C:\\first.md", 10.0f);
-
-    // 戻る
-    auto back_result = service_.GoBack(L"C:\\first.md", 100.0f);
-    EXPECT_EQ(back_result.type, NavigationService::NavigateResult::Type::Anchor);
-    EXPECT_FLOAT_EQ(back_result.scroll_y, 10.0f);
-
-    // 進む
-    auto fwd_result = service_.GoForward(L"C:\\first.md", 10.0f);
-    EXPECT_EQ(fwd_result.type, NavigationService::NavigateResult::Type::Anchor);
-    EXPECT_FLOAT_EQ(fwd_result.scroll_y, 100.0f);
-}
-
-TEST_F(NavigationServiceTest, CanGoBackForward)
-{
-    EXPECT_FALSE(service_.CanGoBack());
-    EXPECT_FALSE(service_.CanGoForward());
-
-    service_.PushHistory(L"C:\\file.md", 0.0f);
-    EXPECT_TRUE(service_.CanGoBack());
-    EXPECT_FALSE(service_.CanGoForward());
-}
-
-// ═══════════════════════════════════════════════
-// 異なるファイル間でのスクロール位置保持
-// （戻る/進むでファイルロードが発生するケース）
-// ═══════════════════════════════════════════════
-
-TEST_F(NavigationServiceTest, GoForwardDifferentFileReturnsLoadFile)
-{
-    service_.PushHistory(L"C:\\first.md", 50.0f);
-
-    // first.md → second.md へ移動した後、戻る
-    auto back = service_.GoBack(L"C:\\second.md", 200.0f);
-    ASSERT_EQ(back.type, NavigationService::NavigateResult::Type::LoadFile);
-
-    // first.md から second.md へ進む
-    auto fwd = service_.GoForward(L"C:\\first.md", 50.0f);
-    EXPECT_EQ(fwd.type, NavigationService::NavigateResult::Type::LoadFile);
-    EXPECT_EQ(fwd.target, L"C:\\second.md");
-    EXPECT_FLOAT_EQ(fwd.scroll_y, 200.0f);
-}
-
-TEST_F(NavigationServiceTest, BackForwardCyclePreservesScrollPositions)
-{
-    // A(scroll=100) → B(scroll=300) → C(scroll=500)
-    service_.PushHistory(L"C:\\a.md", 100.0f);
-    service_.PushHistory(L"C:\\b.md", 300.0f);
-
-    // C から B へ戻る → LoadFile + scroll_y=300
-    auto r1 = service_.GoBack(L"C:\\c.md", 500.0f);
-    EXPECT_EQ(r1.type, NavigationService::NavigateResult::Type::LoadFile);
-    EXPECT_EQ(r1.target, L"C:\\b.md");
-    EXPECT_FLOAT_EQ(r1.scroll_y, 300.0f);
-
-    // B から A へ戻る → LoadFile + scroll_y=100
-    auto r2 = service_.GoBack(L"C:\\b.md", 300.0f);
-    EXPECT_EQ(r2.type, NavigationService::NavigateResult::Type::LoadFile);
-    EXPECT_EQ(r2.target, L"C:\\a.md");
-    EXPECT_FLOAT_EQ(r2.scroll_y, 100.0f);
-
-    // A から B へ進む → LoadFile + scroll_y=300
-    auto r3 = service_.GoForward(L"C:\\a.md", 100.0f);
-    EXPECT_EQ(r3.type, NavigationService::NavigateResult::Type::LoadFile);
-    EXPECT_EQ(r3.target, L"C:\\b.md");
-    EXPECT_FLOAT_EQ(r3.scroll_y, 300.0f);
-
-    // B から C へ進む → LoadFile + scroll_y=500
-    auto r4 = service_.GoForward(L"C:\\b.md", 300.0f);
-    EXPECT_EQ(r4.type, NavigationService::NavigateResult::Type::LoadFile);
-    EXPECT_EQ(r4.target, L"C:\\c.md");
-    EXPECT_FLOAT_EQ(r4.scroll_y, 500.0f);
-}
-
-TEST_F(NavigationServiceTest, BackFromDifferentFilePreservesCurrentScroll)
-{
-    // ファイルAで scroll_y=150 の状態を記録してBへ遷移
-    service_.PushHistory(L"C:\\a.md", 150.0f);
-
-    // B(scroll_y=400) から戻る → Aのファイルロード
-    auto back = service_.GoBack(L"C:\\b.md", 400.0f);
-    EXPECT_EQ(back.type, NavigationService::NavigateResult::Type::LoadFile);
-    EXPECT_FLOAT_EQ(back.scroll_y, 150.0f);
-
-    // 進む → B(scroll_y=400) へ戻る
-    auto fwd = service_.GoForward(L"C:\\a.md", 150.0f);
-    EXPECT_EQ(fwd.type, NavigationService::NavigateResult::Type::LoadFile);
-    EXPECT_EQ(fwd.target, L"C:\\b.md");
-    EXPECT_FLOAT_EQ(fwd.scroll_y, 400.0f);
-}
-
-TEST_F(NavigationServiceTest, LoadFileResultAlwaysHasScrollY)
-{
-    // scroll_y=0 でもLoadFile結果に含まれることを確認
-    service_.PushHistory(L"C:\\a.md", 0.0f);
-    auto result = service_.GoBack(L"C:\\b.md", 0.0f);
-    EXPECT_EQ(result.type, NavigationService::NavigateResult::Type::LoadFile);
-    EXPECT_FLOAT_EQ(result.scroll_y, 0.0f);
+    auto result = HandleLinkClick(L"");
+    EXPECT_EQ(result.type, LinkClickResult::Type::None);
 }

--- a/tests/test_reducer.cpp
+++ b/tests/test_reducer.cpp
@@ -152,7 +152,7 @@ TEST_F(ReducerTest, MouseLeave_ClearsTooltip) {
     EXPECT_TRUE(HasEffect<effect::ClearTooltip>(effects));
 }
 
-// ---- 未処理アクションテスト ----
+// ---- コマンド系アクションテスト ----
 
 TEST_F(ReducerTest, ReloadFileAction_EmitsReloadEffect) {
     auto effects = Reduce(state, ReloadFileAction{});
@@ -160,8 +160,178 @@ TEST_F(ReducerTest, ReloadFileAction_EmitsReloadEffect) {
     EXPECT_TRUE(std::holds_alternative<effect::ReloadFile>(effects[0]));
 }
 
-TEST_F(ReducerTest, NoOpAction_EmptyEffects) {
-    // NoOpAction は空の副作用リストを返す
-    auto effects = Reduce(state, NoOpAction{});
+TEST_F(ReducerTest, OpenFileAction_EmitsOpenFileDialog) {
+    auto effects = Reduce(state, OpenFileAction{});
+    EXPECT_EQ(effects.size(), 1u);
+    EXPECT_TRUE(HasEffect<effect::OpenFileDialog>(effects));
+}
+
+TEST_F(ReducerTest, FileWatchAction_EmitsCheckFileChanges) {
+    auto effects = Reduce(state, FileWatchAction{});
+    EXPECT_EQ(effects.size(), 1u);
+    EXPECT_TRUE(HasEffect<effect::CheckFileChanges>(effects));
+}
+
+TEST_F(ReducerTest, ImageLoadedAction_EmitsNotifyImageLoaded) {
+    auto effects = Reduce(state, ImageLoadedAction{});
+    EXPECT_EQ(effects.size(), 1u);
+    EXPECT_TRUE(HasEffect<effect::NotifyImageLoaded>(effects));
+}
+
+// ---- ナビゲーションテスト ----
+
+TEST_F(ReducerTest, NavigateBack_NoHistory_NoEffects) {
+    auto effects = Reduce(state, NavigateBackAction{});
     EXPECT_TRUE(effects.empty());
+}
+
+TEST_F(ReducerTest, NavigateBack_DifferentFile_EmitsLoadFile) {
+    state.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\current.md");
+    state.nav_history.Push(NavEntry{ L"C:\\prev.md", 50.0f });
+
+    auto effects = Reduce(state, NavigateBackAction{});
+    EXPECT_TRUE(HasEffect<effect::LoadFile>(effects));
+}
+
+TEST_F(ReducerTest, NavigateBack_SameFile_ScrollsAndInvalidates) {
+    state.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\file.md");
+    state.nav_history.Push(NavEntry{ L"C:\\file.md", 50.0f });
+    state.viewport.ScrollTo(200.0f);
+
+    auto effects = Reduce(state, NavigateBackAction{});
+    EXPECT_FLOAT_EQ(state.viewport.GetScrollY(), 50.0f);
+    EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
+    EXPECT_TRUE(HasEffect<effect::BitmapManage>(effects));
+}
+
+TEST_F(ReducerTest, NavigateForward_NoHistory_NoEffects) {
+    auto effects = Reduce(state, NavigateForwardAction{});
+    EXPECT_TRUE(effects.empty());
+}
+
+TEST_F(ReducerTest, XButtonBack_DelegatesToNavigateBack) {
+    state.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\current.md");
+    state.nav_history.Push(NavEntry{ L"C:\\prev.md", 0.0f });
+
+    auto effects = Reduce(state, XButtonBackAction{});
+    EXPECT_TRUE(HasEffect<effect::LoadFile>(effects));
+}
+
+// ---- DropFiles / ShowHelp テスト ----
+
+TEST_F(ReducerTest, DropFiles_PushesHistoryAndLoads) {
+    state.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\current.md");
+
+    auto effects = Reduce(state, DropFilesAction{ std::pmr::wstring(L"C:\\dropped.md") });
+    EXPECT_TRUE(HasEffect<effect::LoadFile>(effects));
+    EXPECT_TRUE(state.nav_history.CanGoBack());
+}
+
+TEST_F(ReducerTest, DropFiles_EmptyDoc_NoPush) {
+    // ドキュメントが空ならナビゲーション履歴にプッシュしない
+    auto effects = Reduce(state, DropFilesAction{ std::pmr::wstring(L"C:\\dropped.md") });
+    EXPECT_TRUE(HasEffect<effect::LoadFile>(effects));
+    EXPECT_FALSE(state.nav_history.CanGoBack());
+}
+
+TEST_F(ReducerTest, ShowHelp_EmitsLoadFile) {
+    state.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\file.md");
+
+    auto effects = Reduce(state, ShowHelpAction{});
+    EXPECT_TRUE(HasEffect<effect::LoadFile>(effects));
+    EXPECT_TRUE(state.nav_history.CanGoBack());
+}
+
+// ---- リサイズ / DPI テスト ----
+
+TEST_F(ReducerTest, Resize_ZeroSize_NoEffects) {
+    auto effects = Reduce(state, ResizeAction{ 0, 0 });
+    EXPECT_TRUE(effects.empty());
+}
+
+TEST_F(ReducerTest, Resize_Normal_EmitsResizeEnd) {
+    state.cached_dpi_scale = 1.0f;
+    auto effects = Reduce(state, ResizeAction{ 800, 600 });
+
+    EXPECT_TRUE(HasEffect<effect::RendererResize>(effects));
+    EXPECT_TRUE(HasEffect<effect::PerformResizeEnd>(effects));
+    EXPECT_FALSE(state.pane_layout_valid);
+}
+
+TEST_F(ReducerTest, Resize_Sizing_EmitsSizingUpdate) {
+    state.is_sizing = true;
+    state.cached_dpi_scale = 1.0f;
+    auto effects = Reduce(state, ResizeAction{ 800, 600 });
+
+    EXPECT_TRUE(HasEffect<effect::RendererResize>(effects));
+    EXPECT_TRUE(HasEffect<effect::PerformSizingUpdate>(effects));
+    EXPECT_FALSE(HasEffect<effect::PerformResizeEnd>(effects));
+}
+
+TEST_F(ReducerTest, DpiChanged_UpdatesScale) {
+    auto effects = Reduce(state, DpiChangedAction{ 192, RECT{0, 0, 800, 600} });
+
+    EXPECT_FLOAT_EQ(state.cached_dpi_scale, 2.0f);
+    EXPECT_TRUE(HasEffect<effect::RendererSetDpi>(effects));
+    EXPECT_TRUE(HasEffect<effect::ClearFileCache>(effects));
+    EXPECT_TRUE(HasEffect<effect::SetWindowPosition>(effects));
+}
+
+// ---- テーマ / ズームテスト ----
+
+TEST_F(ReducerTest, ToggleDarkMode_EmitsApplyThemeChange) {
+    auto effects = Reduce(state, ToggleDarkModeAction{});
+
+    EXPECT_TRUE(HasEffect<effect::ApplyThemeChange>(effects));
+    EXPECT_FALSE(state.pane_layout_valid);
+}
+
+TEST_F(ReducerTest, ZoomIn_EmitsApplyThemeChange) {
+    state.cached_theme.zoom = 1.0f;
+    auto effects = Reduce(state, ZoomAction{ ZoomDirection::In });
+
+    EXPECT_TRUE(HasEffect<effect::ApplyThemeChange>(effects));
+    EXPECT_FALSE(state.pane_layout_valid);
+}
+
+// ---- HWheel テスト ----
+
+TEST_F(ReducerTest, HWheel_EmitsSetTimer) {
+    auto effects = Reduce(state, HWheelAction{ 120, 1000 });
+    EXPECT_TRUE(HasEffect<effect::SetTimer>(effects));
+}
+
+// ---- CaptureChanged テスト ----
+
+TEST_F(ReducerTest, CaptureChanged_ResetsGesture) {
+    // ジェスチャーがアクティブでない場合、InvalidateWindow は出ない
+    auto effects = Reduce(state, CaptureChangedAction{});
+    EXPECT_FALSE(HasEffect<effect::InvalidateWindow>(effects));
+}
+
+// ---- タイマーテスト（代表ケース） ----
+
+TEST_F(ReducerTest, Timer_Toast_EmitsInvalidate) {
+    state.toast.Show(L"test");
+    auto effects = Reduce(state, TimerAction{ 6 }); // app_timer::TOAST = 6
+    EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
+}
+
+TEST_F(ReducerTest, Timer_DeferredLayout_EmitsProcessDeferredLayout) {
+    auto effects = Reduce(state, TimerAction{ 3 }); // app_timer::DEFERRED_LAYOUT = 3
+    EXPECT_TRUE(HasEffect<effect::ProcessDeferredLayout>(effects));
+}
+
+// ---- Destroy / ParseComplete テスト ----
+
+TEST_F(ReducerTest, Destroy_EmitsDestroyEffect) {
+    auto effects = Reduce(state, DestroyAction{});
+    EXPECT_EQ(effects.size(), 1u);
+    EXPECT_TRUE(HasEffect<effect::Destroy>(effects));
+}
+
+TEST_F(ReducerTest, ParseComplete_EmitsHandleParseComplete) {
+    auto effects = Reduce(state, ParseCompleteAction{});
+    EXPECT_EQ(effects.size(), 1u);
+    EXPECT_TRUE(HasEffect<effect::HandleParseComplete>(effects));
 }

--- a/tests/test_reducer.cpp
+++ b/tests/test_reducer.cpp
@@ -154,8 +154,14 @@ TEST_F(ReducerTest, MouseLeave_ClearsTooltip) {
 
 // ---- 未処理アクションテスト ----
 
-TEST_F(ReducerTest, UnhandledAction_EmptyEffects) {
-    // Reducer が処理しないアクションは空の副作用リストを返す
+TEST_F(ReducerTest, ReloadFileAction_EmitsReloadEffect) {
     auto effects = Reduce(state, ReloadFileAction{});
+    EXPECT_EQ(effects.size(), 1u);
+    EXPECT_TRUE(std::holds_alternative<effect::ReloadFile>(effects[0]));
+}
+
+TEST_F(ReducerTest, NoOpAction_EmptyEffects) {
+    // NoOpAction は空の副作用リストを返す
+    auto effects = Reduce(state, NoOpAction{});
     EXPECT_TRUE(effects.empty());
 }


### PR DESCRIPTION
## Summary
- ナビゲーション（戻る/進む）、タイマー処理、リサイズ/DPI変更、テーマ/ズーム切替、スワイプ検出等のロジックをApp直接実行からReducer経由の副作用ディスパッチ方式に移行
- `NavigationService`クラスを廃止し、リンク判定のみの自由関数`HandleLinkClick`に簡素化。GoBack/GoForwardロジックはReducer内で`NavHistory`を直接操作する形に統合
- タイマーID定数を`timer_ids.h`に分離し、Reducerからコンポーネント非依存で参照可能に。`app_constants.h`ではstatic_assertで値の一致を検証
- `cached_dpi_scale`・`ThemeConstants`・`AnchorState`・`cached_total_height`をAppStateに移動し、Reducerが状態を直接参照・変更可能に
- 新規副作用型（`RendererResize`, `SetWindowPosition`, `ApplyThemeChange`, `HandleMouseEvent`等）を追加し、SideEffectExecutorのコールバック経由でApp側メソッドに委譲

## Test plan
- [x] 全1470テストがパス
- [x] アプリ起動・ファイル表示の動作確認
- [x] 戻る/進むナビゲーションの動作確認
- [x] ズームイン/アウト/リセットの動作確認
- [x] ダークモード切替の動作確認
- [x] ウィンドウリサイズ・DPI変更の動作確認
- [x] スワイプジェスチャーの動作確認
- [x] ファイルドロップの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)