### PR TITLE
パフォーマンス改善・テスト強化・テスト実行高速化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ cmake --build build --config Release -- //v:q //nologo
 
 ```
 cmake --build build --config Release -- //v:q //nologo
-ctest --test-dir build --output-on-failure -C Release -j0 2>&1 | grep -vE "^\s*(Start|[0-9]+/[0-9]+.*Passed)"
+build/tests/Release/mendo_tests.exe --gtest_brief=1
 ```
 
 ## 注意事項

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ cmake --build build --config Release -- //v:q //nologo
 
 ```
 cmake --build build --config Release -- //v:q //nologo
-ctest --test-dir build --output-on-failure -C Release -j0 2>&1 | grep -vE "^\s*(Start|[0-9]+/[0-9]+.*Passed)"
+build/tests/Release/mendo_tests.exe --gtest_brief=1
 ```
 
 ## 注意事項

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ cmake --build build --config Release
 
 ```
 cmake --build build --config Release
-ctest --test-dir build --output-on-failure -C Release
+build/tests/Release/mendo_tests.exe
 ```
 
 ## 使い方

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -154,7 +154,7 @@ bool App::Init(HWND hwnd)
         }
     );
 
-    mermaid_renderer_.Init(hwnd_, renderer_.GetRenderTarget(), [this]() {
+    mermaid_renderer_.Init(hwnd_, renderer_.GetRenderTarget(), renderer_.GetWICFactory(), [this]() {
         resource_manager_.ScheduleMermaidBatch();
     });
 

--- a/src/app/app_scroll.cpp
+++ b/src/app/app_scroll.cpp
@@ -11,8 +11,9 @@
 
 void App::UpdateScrollBar()
 {
-    // カスタムスクロールバーはRenderer側で描画するため、再描画をトリガーするのみ
-    Invalidate();
+    // カスタムスクロールバーはRenderer側で描画するため、MDペインの再描画をトリガーするのみ
+    const auto& layout = GetPaneLayout();
+    InvalidateMdPane(layout.md_rect);
 }
 
 void App::InvalidateHitPositions() noexcept

--- a/src/app/resource_manager.cpp
+++ b/src/app/resource_manager.cpp
@@ -70,6 +70,7 @@ int ResourceManager::ApplyCachedImages()
 
         // 解決済みパスのキャッシュを確認し、ディスクI/Oを回避
         auto [path_it, inserted] = resolved_image_paths_.try_emplace(i);
+        auto& abs_str = std::get<1>(*path_it);
         if (inserted) {
             std::filesystem::path img_path(node.image_data->src);
             if (img_path.is_relative()) {
@@ -82,9 +83,8 @@ int ResourceManager::ApplyCachedImages()
                 resolved_image_paths_.erase(i);
                 continue;
             }
-            std::get<1>(*path_it) = abs_path.wstring();
+            abs_str = abs_path.wstring();
         }
-        const std::wstring& abs_str = std::get<1>(*path_it);
 
         if (image_loader_->GetCachedImage(abs_str, diagram)) {
             node.image_data->width = diagram.width;

--- a/src/app/resource_manager.cpp
+++ b/src/app/resource_manager.cpp
@@ -79,12 +79,12 @@ int ResourceManager::ApplyCachedImages()
             std::error_code ec;
             const auto abs_path = std::filesystem::canonical(img_path, ec);
             if (ec) {
-                resolved_image_paths_.erase(path_it);
+                resolved_image_paths_.erase(i);
                 continue;
             }
-            path_it->second = abs_path.wstring();
+            std::get<1>(*path_it) = abs_path.wstring();
         }
-        const std::wstring& abs_str = path_it->second;
+        const std::wstring& abs_str = std::get<1>(*path_it);
 
         if (image_loader_->GetCachedImage(abs_str, diagram)) {
             node.image_data->width = diagram.width;

--- a/src/app/resource_manager.h
+++ b/src/app/resource_manager.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <map>
+#include "flat_map.h"
 #include <string>
 #include <functional>
 #include <windows.h>
@@ -79,6 +79,6 @@ private:
     float last_mermaid_content_width_ = 0.0f;
     bool mermaid_batch_loading_ = false;
     size_t mermaid_batch_next_ = 0;
-    std::map<size_t, std::wstring> resolved_image_paths_;
+    FlatMap<size_t, std::wstring> resolved_image_paths_;
     bool pending_flush_ = false;
 };

--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -63,7 +63,7 @@ void Document::BuildHeadingIndices(const std::pmr::vector<size_t>& heading_indic
         const auto& node = nodes_[i];
         toc_.AddEntry(node, static_cast<int>(i));
         if (!node.anchor_id().empty()) {
-            anchor_index_.emplace(std::pmr::wstring(node.anchor_id()), static_cast<int>(i));
+            anchor_index_.try_emplace(std::pmr::wstring(node.anchor_id()), static_cast<int>(i));
         }
     }
 }

--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -63,7 +63,7 @@ void Document::BuildHeadingIndices(const std::pmr::vector<size_t>& heading_indic
         const auto& node = nodes_[i];
         toc_.AddEntry(node, static_cast<int>(i));
         if (!node.anchor_id().empty()) {
-            anchor_index_.try_emplace(std::pmr::wstring(node.anchor_id()), static_cast<int>(i));
+            anchor_index_.emplace(std::pmr::wstring(node.anchor_id()), static_cast<int>(i));
         }
     }
 }

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
-#include <map>
+#include <unordered_map>
 #include <memory_resource>
 
 class Document {
@@ -48,7 +48,7 @@ private:
     std::pmr::wstring file_path_;
     std::pmr::string raw_utf8_;
     TableOfContents toc_;
-    std::pmr::map<std::pmr::wstring, int> anchor_index_;
+    std::pmr::unordered_map<std::pmr::wstring, int> anchor_index_;
     std::pmr::vector<size_t> image_node_indices_;
     std::pmr::vector<size_t> mermaid_node_indices_;
 };

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
-#include <unordered_map>
+#include <map>
 #include <memory_resource>
 
 class Document {
@@ -48,7 +48,7 @@ private:
     std::pmr::wstring file_path_;
     std::pmr::string raw_utf8_;
     TableOfContents toc_;
-    std::pmr::unordered_map<std::pmr::wstring, int> anchor_index_;
+    std::pmr::map<std::pmr::wstring, int> anchor_index_;
     std::pmr::vector<size_t> image_node_indices_;
     std::pmr::vector<size_t> mermaid_node_indices_;
 };

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -4,7 +4,7 @@
 #include "memory_resource.h"
 #include "md4c.h"
 #include <stack>
-#include <unordered_map>
+#include <map>
 #include <charconv>
 #include <format>
 #include <iterator>
@@ -111,7 +111,7 @@ struct ParseContext {
     std::pmr::vector<std::pmr::wstring> link_urls{ parse_resource.resource() };
 
     // アンカーIDの一意性追跡: スラグ -> 出現回数
-    std::pmr::unordered_map<std::pmr::wstring, int> anchor_counts{ parse_resource.resource() };
+    std::pmr::map<std::pmr::wstring, int> anchor_counts{ parse_resource.resource() };
 
     // 画像スパン追跡
     std::pmr::wstring pending_image_src{ parse_resource.resource() };

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -4,7 +4,7 @@
 #include "memory_resource.h"
 #include "md4c.h"
 #include <stack>
-#include <map>
+#include <unordered_map>
 #include <charconv>
 #include <format>
 #include <iterator>
@@ -111,7 +111,7 @@ struct ParseContext {
     std::pmr::vector<std::pmr::wstring> link_urls{ parse_resource.resource() };
 
     // アンカーIDの一意性追跡: スラグ -> 出現回数
-    std::pmr::map<std::pmr::wstring, int> anchor_counts{ parse_resource.resource() };
+    std::pmr::unordered_map<std::pmr::wstring, int> anchor_counts{ parse_resource.resource() };
 
     // 画像スパン追跡
     std::pmr::wstring pending_image_src{ parse_resource.resource() };
@@ -148,12 +148,14 @@ struct ParseContext {
         run.set_strikethrough(current_span.strikethrough);
         if (current_span.link_url_index >= 0 && current_node) {
             const auto& url = link_urls[static_cast<size_t>(current_span.link_url_index)];
-            // ノードのURLプール内で重複を検索し、なければ追加
+            // ノードのURLプール内で重複を検索し、なければ追加。
+            // 同一リンク内のテキストは連続呼び出しされるため、末尾から逆走査して
+            // 直近の一致を最速で検出する（O(n²) → 実質 O(1) の高速パス）。
             int16_t node_idx = -1;
             const auto url_count = current_node->link_urls.size();
-            for (size_t i = 0; i < url_count; i++) {
-                if (current_node->link_urls[i] == url) {
-                    node_idx = static_cast<int16_t>(i);
+            for (size_t i = url_count; i > 0; i--) {
+                if (current_node->link_urls[i - 1] == url) {
+                    node_idx = static_cast<int16_t>(i - 1);
                     break;
                 }
             }

--- a/src/io/image_loader.cpp
+++ b/src/io/image_loader.cpp
@@ -2,8 +2,8 @@
 #include "file_loader.h"
 #include "task_scheduler.h"
 #include "ui_constants.h"
+#include "wic_util.h"
 #include "win_handle.h"
-#include <optional>
 #include <shlwapi.h>
 
 #pragma comment(lib, "shlwapi.lib")
@@ -51,53 +51,6 @@ static Microsoft::WRL::ComPtr<IStream> ReadFileToStream(const std::wstring& path
     return stream;
 }
 
-// WIC デコードパイプラインの共通処理。
-// IStream から画像をデコードし、FormatConverter とピクセルサイズを返す。
-// LoadImage（同期）と RequestLoadAsync（非同期）の両方から使用される。
-struct WicDecodeResult {
-    Microsoft::WRL::ComPtr<IWICFormatConverter> converter;
-    UINT pixel_width = 0;
-    UINT pixel_height = 0;
-};
-
-static std::optional<WicDecodeResult> DecodeFromStream(
-    IWICImagingFactory* wic, IStream* stream)
-{
-    Microsoft::WRL::ComPtr<IWICBitmapDecoder> decoder;
-    HRESULT hr = wic->CreateDecoderFromStream(
-        stream, nullptr, WICDecodeMetadataCacheOnLoad, &decoder);
-    if (FAILED(hr)) {
-        return std::nullopt;
-    }
-
-    Microsoft::WRL::ComPtr<IWICBitmapFrameDecode> frame;
-    hr = decoder->GetFrame(0, &frame);
-    if (FAILED(hr)) {
-        return std::nullopt;
-    }
-
-    Microsoft::WRL::ComPtr<IWICFormatConverter> converter;
-    hr = wic->CreateFormatConverter(&converter);
-    if (FAILED(hr)) {
-        return std::nullopt;
-    }
-
-    hr = converter->Initialize(
-        frame.Get(), GUID_WICPixelFormat32bppPBGRA,
-        WICBitmapDitherTypeNone, nullptr, 0.0f,
-        WICBitmapPaletteTypeCustom);
-    if (FAILED(hr)) {
-        return std::nullopt;
-    }
-
-    UINT w = 0, h = 0;
-    hr = frame->GetSize(&w, &h);
-    if (FAILED(hr)) {
-        return std::nullopt;
-    }
-
-    return WicDecodeResult{ converter, w, h };
-}
 
 ImageLoader::~ImageLoader()
 {
@@ -165,7 +118,7 @@ bool ImageLoader::LoadImage(const std::wstring& abs_path, DiagramEntry& out)
         return false;
     }
 
-    const auto decoded = DecodeFromStream(wic_factory_.Get(), stream.Get());
+    const auto decoded = wic_util::DecodeFromStream(wic_factory_.Get(), stream.Get());
     if (!decoded) {
         return false;
     }
@@ -176,19 +129,11 @@ bool ImageLoader::LoadImage(const std::wstring& abs_path, DiagramEntry& out)
         return false;
     }
 
-    // ピクセルサイズを DIP に変換
-    float scale_x, scale_y;
-    GetDpiScale(scale_x, scale_y);
-
-    CachedImage cached;
-    cached.bitmap = bitmap;
-    cached.width = static_cast<float>(decoded->pixel_width) / scale_x;
-    cached.height = static_cast<float>(decoded->pixel_height) / scale_y;
-
+    // ピクセルサイズを DIP に変換してキャッシュに登録
+    const auto [width, height] = CreateAndCacheImage(abs_path, bitmap, decoded->pixel_width, decoded->pixel_height);
     out.bitmap = bitmap;
-    out.width = cached.width;
-    out.height = cached.height;
-    cache_.Insert(abs_path, std::move(cached));
+    out.width = width;
+    out.height = height;
     return true;
 }
 
@@ -229,7 +174,7 @@ void ImageLoader::RequestLoadAsync(const std::wstring& abs_path, Callback on_com
         if (wic_factory_) {
             const auto stream = ReadFileToStream(path);
             if (stream) {
-                if (const auto decoded = DecodeFromStream(wic_factory_.Get(), stream.Get())) {
+                if (const auto decoded = wic_util::DecodeFromStream(wic_factory_.Get(), stream.Get())) {
                     result.converter = decoded->converter;
                     result.width = static_cast<float>(decoded->pixel_width);
                     result.height = static_cast<float>(decoded->pixel_height);
@@ -274,20 +219,14 @@ void ImageLoader::ProcessCompletedDecodes()
 
     Callback last_cb;
 
-    float scale_x, scale_y;
-    GetDpiScale(scale_x, scale_y);
-
     for (auto& r : results) {
         if (r.success && r.converter && render_target_) {
             if (!cache_.Contains(r.path)) {
                 Microsoft::WRL::ComPtr<ID2D1Bitmap> bitmap;
                 const HRESULT hr = render_target_->CreateBitmapFromWicBitmap(r.converter.Get(), &bitmap);
                 if (SUCCEEDED(hr) && bitmap) {
-                    CachedImage cached;
-                    cached.bitmap = bitmap;
-                    cached.width = r.width / scale_x;
-                    cached.height = r.height / scale_y;
-                    cache_.Insert(r.path, std::move(cached));
+                    CreateAndCacheImage(r.path, std::move(bitmap),
+                        static_cast<UINT>(r.width), static_cast<UINT>(r.height));
                 }
             }
         }
@@ -306,6 +245,24 @@ void ImageLoader::InsertCacheEntry(const std::wstring& path, float width, float 
     cached.width = width;
     cached.height = height;
     cache_.Insert(path, std::move(cached));
+}
+
+std::pair<float, float> ImageLoader::CreateAndCacheImage(
+    const std::wstring& path, Microsoft::WRL::ComPtr<ID2D1Bitmap> bitmap,
+    UINT pixel_width, UINT pixel_height)
+{
+    float scale_x, scale_y;
+    GetDpiScale(scale_x, scale_y);
+
+    CachedImage cached;
+    cached.bitmap = std::move(bitmap);
+    cached.width = static_cast<float>(pixel_width) / scale_x;
+    cached.height = static_cast<float>(pixel_height) / scale_y;
+
+    const float w = cached.width;
+    const float h = cached.height;
+    cache_.Insert(path, std::move(cached));
+    return { w, h };
 }
 
 void ImageLoader::CancelPending()

--- a/src/io/image_loader.h
+++ b/src/io/image_loader.h
@@ -70,6 +70,8 @@ private:
     };
 
     void GetDpiScale(float& scale_x, float& scale_y) const;
+    std::pair<float, float> CreateAndCacheImage(const std::wstring& path,
+        Microsoft::WRL::ComPtr<ID2D1Bitmap> bitmap, UINT pixel_width, UINT pixel_height);
 
     static constexpr size_t MAX_CACHE_ENTRIES = 128;
 

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -83,8 +83,8 @@ IDWriteTextFormat* DWriteTextMeasurer::GetTextFormat(const Node& node) noexcept
     return fmt_body_.Get();
 }
 
-void DWriteTextMeasurer::ApplyCellRunFormatting(IDWriteTextLayout* layout,
-    const std::pmr::vector<TextRun>& runs)
+void DWriteTextMeasurer::ApplyRunFormatting(IDWriteTextLayout* layout,
+    const std::pmr::vector<TextRun>& runs, std::optional<NodeType> node_type)
 {
     for (const auto& run : runs) {
         const DWRITE_TEXT_RANGE range{ run.start, run.length };
@@ -95,13 +95,21 @@ void DWriteTextMeasurer::ApplyCellRunFormatting(IDWriteTextLayout* layout,
             layout->SetFontStyle(DWRITE_FONT_STYLE_ITALIC, range);
         }
         if (run.code()) {
-            layout->SetFontFamilyName(theme_->monospace_font.c_str(), range);
-            layout->SetFontSize(theme_->font_size_code, range);
+            // CodeBlock 内ではインラインコードフォーマットを適用しない
+            if (!node_type || *node_type != NodeType::CodeBlock) {
+                layout->SetFontFamilyName(theme_->monospace_font.c_str(), range);
+                // Heading 内ではコードフォントサイズを変更しない（見出しサイズを維持）
+                if (!node_type || *node_type != NodeType::Heading) {
+                    layout->SetFontSize(theme_->font_size_code, range);
+                }
+            }
         }
         if (run.strikethrough()) {
             layout->SetStrikethrough(TRUE, range);
         }
-        if (run.has_link()) {
+        // テーブルセル（node_type なし）ではリンクの下線を適用する。
+        // 通常ノードではApplyNodeEffects（描画パス）で下線＋色を一括適用するため、ここではスキップ。
+        if (!node_type && run.has_link()) {
             layout->SetUnderline(TRUE, range);
         }
     }
@@ -173,24 +181,7 @@ void DWriteTextMeasurer::MeasureNode(Node& node, NodeLayoutEntry& entry, float m
     }
 
     // ラン単位のフォーマットを適用
-    for (const auto& run : node.runs) {
-        const DWRITE_TEXT_RANGE range{ run.start, run.length };
-        if (run.bold()) {
-            layout->SetFontWeight(DWRITE_FONT_WEIGHT_EXTRA_BOLD, range);
-        }
-        if (run.italic()) {
-            layout->SetFontStyle(DWRITE_FONT_STYLE_ITALIC, range);
-        }
-        if (run.code() && node.type != NodeType::CodeBlock) {
-            layout->SetFontFamilyName(theme_->monospace_font.c_str(), range);
-            if (node.type != NodeType::Heading) {
-                layout->SetFontSize(theme_->font_size_code, range);
-            }
-        }
-        if (run.strikethrough()) {
-            layout->SetStrikethrough(TRUE, range);
-        }
-    }
+    ApplyRunFormatting(layout.Get(), node.runs, node.type);
 
     // Alert ノード: アイコン文字のフォントウェイトを設定
     if (node.type == NodeType::BlockQuote && node.alert_type != AlertType::None
@@ -244,7 +235,7 @@ void DWriteTextMeasurer::MeasureTableCells(Node& node, NodeLayoutEntry& entry,
                 &tl.cell_layouts[ci]);
 
             if (tl.cell_layouts[ci]) {
-                ApplyCellRunFormatting(tl.cell_layouts[ci].Get(), cell.runs);
+                ApplyRunFormatting(tl.cell_layouts[ci].Get(), cell.runs, std::nullopt);
                 DWRITE_TEXT_METRICS metrics{};
                 tl.cell_layouts[ci]->GetMetrics(&metrics);
                 natural_widths[c] = std::max(natural_widths[c], metrics.width);

--- a/src/layout/dwrite_measurer.h
+++ b/src/layout/dwrite_measurer.h
@@ -3,6 +3,7 @@
 #include <dwrite.h>
 #include <wrl/client.h>
 #include <memory_resource>
+#include <optional>
 
 
 // ITextMeasurerのDirectWrite実装。
@@ -22,7 +23,8 @@ public:
 private:
     bool CreateAllFormats();
     IDWriteTextFormat* GetTextFormat(const Node& node) noexcept;
-    void ApplyCellRunFormatting(IDWriteTextLayout* layout, const std::pmr::vector<TextRun>& runs);
+    void ApplyRunFormatting(IDWriteTextLayout* layout, const std::pmr::vector<TextRun>& runs,
+        std::optional<NodeType> node_type);
     void MeasureTableCells(Node& node, NodeLayoutEntry& entry, std::pmr::vector<float>& natural_widths);
     void FinalizeTableLayout(Node& node, NodeLayoutEntry& entry, float max_width, size_t col_count, std::pmr::vector<float>& natural_widths);
 

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -21,6 +21,7 @@ struct TableLayoutData {
     std::pmr::vector<float> row_heights;
     std::pmr::vector<float> natural_col_widths; // リサイズ高速パス用キャッシュ
     std::pmr::vector<uint32_t> row_flat_offsets; // 各行の線形化テキスト先頭オフセット（ヒットテスト高速化用）
+    std::pmr::vector<uint8_t> row_bgs_computed; // 各行のインラインコード背景計算済みフラグ
 
     // フラットインデックスへの変換
     constexpr size_t CellIndex(size_t row, size_t col) const noexcept { return row * col_count + col; }
@@ -142,6 +143,7 @@ public:
             if (e.table_layout) {
                 e.table_layout->cell_layouts.clear();
                 e.table_layout->cell_inline_code_bgs.clear();
+                e.table_layout->row_bgs_computed.clear();
                 e.table_layout->natural_col_widths.clear();
                 e.table_layout->col_count = 0;
             }
@@ -170,6 +172,7 @@ public:
             e.text_layout.Reset();
             if (e.table_layout) {
                 e.table_layout->cell_layouts.clear();
+                e.table_layout->row_bgs_computed.clear();
                 e.table_layout->natural_col_widths.clear();
                 e.table_layout->col_count = 0;
             }

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -1,16 +1,15 @@
 #include "mermaid.h"
+#include "config_store.h"
 #include "mermaid_file_cache.h"
 #include "mermaid_util.h"
 #include "utility.h"
+#include "wic_util.h"
 #include "resource.h"
-#include <shlwapi.h>
-#include <shlobj.h>
 #include <wrl/event.h>
 #include <filesystem>
 #include <functional>
 
 #pragma comment(lib, "windowscodecs.lib")
-#pragma comment(lib, "shlwapi.lib")
 
 static std::span<const std::byte> LoadMermaidJsGzFromResource()
 {
@@ -157,12 +156,11 @@ static Microsoft::WRL::ComPtr<IStream> CreateMemoryStream(const void* data, size
 
 static std::pmr::wstring GetWebView2UserDataFolder()
 {
-    wchar_t* appdata = nullptr;
-    if (FAILED(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &appdata))) {
+    const auto base = config::GetConfigDir();
+    if (base.empty()) {
         return L"";
     }
-    const auto path = std::filesystem::path(appdata) / L"mendo" / L"WebView2Data";
-    CoTaskMemFree(appdata);
+    const auto path = base / L"WebView2Data";
     std::filesystem::create_directories(path);
     return std::pmr::wstring{ path.native() };
 }
@@ -210,19 +208,24 @@ void MermaidRenderer::Shutdown()
     initialized_ = false;
 }
 
-void MermaidRenderer::Init(HWND hwnd, ID2D1RenderTarget* render_target, std::move_only_function<void()> on_ready)
+void MermaidRenderer::Init(HWND hwnd, ID2D1RenderTarget* render_target, IWICImagingFactory* wic,
+    std::move_only_function<void()> on_ready)
 {
     hwnd_ = hwnd;
     render_target_ = render_target;
     on_all_ready_ = std::move(on_ready);
 
-    // PNGデコード用のWICファクトリを作成（ファイルキャッシュからの復元に必要）
-    CoCreateInstance(
-        CLSID_WICImagingFactory,
-        nullptr,
-        CLSCTX_INPROC_SERVER,
-        IID_PPV_ARGS(&wic_factory_)
-    );
+    // PNGデコード用のWICファクトリ（D2DRenderBackendから共有）
+    if (wic) {
+        wic_factory_ = wic;
+    } else {
+        CoCreateInstance(
+            CLSID_WICImagingFactory,
+            nullptr,
+            CLSCTX_INPROC_SERVER,
+            IID_PPV_ARGS(&wic_factory_)
+        );
+    }
 }
 
 void MermaidRenderer::EnsureInitialized()
@@ -856,42 +859,17 @@ HRESULT MermaidRenderer::CreateBitmapFromPngStream(IStream* stream, ID2D1Bitmap*
     const LARGE_INTEGER zero = {};
     stream->Seek(zero, STREAM_SEEK_SET, nullptr);
 
-    Microsoft::WRL::ComPtr<IWICBitmapDecoder> decoder;
-    HRESULT hr = wic_factory_->CreateDecoderFromStream(
-        stream, nullptr, WICDecodeMetadataCacheOnLoad, &decoder);
+    const auto decoded = wic_util::DecodeFromStream(wic_factory_.Get(), stream);
+    if (!decoded) {
+        return E_FAIL;
+    }
+
+    const HRESULT hr = render_target_->CreateBitmapFromWicBitmap(decoded->converter.Get(), bitmap);
     if (FAILED(hr)) {
         return hr;
     }
 
-    Microsoft::WRL::ComPtr<IWICBitmapFrameDecode> frame;
-    hr = decoder->GetFrame(0, &frame);
-    if (FAILED(hr)) {
-        return hr;
-    }
-
-    Microsoft::WRL::ComPtr<IWICFormatConverter> converter;
-    hr = wic_factory_->CreateFormatConverter(&converter);
-    if (FAILED(hr)) {
-        return hr;
-    }
-
-    hr = converter->Initialize(
-        frame.Get(), GUID_WICPixelFormat32bppPBGRA,
-        WICBitmapDitherTypeNone, nullptr, 0.0f,
-        WICBitmapPaletteTypeCustom);
-    if (FAILED(hr)) {
-        return hr;
-    }
-
-    hr = render_target_->CreateBitmapFromWicBitmap(converter.Get(), bitmap);
-    if (FAILED(hr)) {
-        return hr;
-    }
-
-    UINT w = 0, h = 0;
-    frame->GetSize(&w, &h);
-    *width = static_cast<float>(w);
-    *height = static_cast<float>(h);
-
+    *width = static_cast<float>(decoded->pixel_width);
+    *height = static_cast<float>(decoded->pixel_height);
     return S_OK;
 }

--- a/src/mermaid/mermaid.h
+++ b/src/mermaid/mermaid.h
@@ -31,8 +31,10 @@ public:
 
     // レンダラーを初期化する。hwndはメインアプリウィンドウ。
     // render_targetはD2Dビットマップの作成に使用する。
+    // wicはPNGデコード用のWICファクトリ（nullの場合は内部で作成する）。
     // on_readyはWebView2の初期化完了時にUIスレッドで呼び出される。
-    void Init(HWND hwnd, ID2D1RenderTarget* render_target, std::move_only_function<void()> on_ready);
+    void Init(HWND hwnd, ID2D1RenderTarget* render_target, IWICImagingFactory* wic,
+        std::move_only_function<void()> on_ready);
 
     // WebView2が初期化済みでレンダリング可能な場合にtrueを返す。
     constexpr bool IsReady() const noexcept { return ready_; }

--- a/src/render/command_gen_table.cpp
+++ b/src/render/command_gen_table.cpp
@@ -97,6 +97,9 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
                 flat_offset = tl.row_flat_offsets[r + 1];
             } else {
                 advance_flat_offset(flat_offset, row, 0, row.cells.size());
+                if (r + 1 < node.table_rows().size()) {
+                    flat_offset++;
+                }
             }
             y = row_bottom;
             continue;

--- a/src/render/command_gen_table.cpp
+++ b/src/render/command_gen_table.cpp
@@ -92,11 +92,13 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
 
         const float row_bottom = y + row_h + border;
         if (row_bottom < viewport_top || y > viewport_bottom) {
-            advance_flat_offset(flat_offset, row, 0, row.cells.size());
-            y = row_bottom;
-            if (r + 1 < node.table_rows().size()) {
-                flat_offset++;
+            // プリコンピュート済みの行オフセットを使い、O(cells) の走査を O(1) に削減
+            if (r + 1 < node.table_rows().size() && r + 1 < tl.row_flat_offsets.size()) {
+                flat_offset = tl.row_flat_offsets[r + 1];
+            } else {
+                advance_flat_offset(flat_offset, row, 0, row.cells.size());
             }
+            y = row_bottom;
             continue;
         }
 

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -377,6 +377,7 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry,
     if (first_pass) {
         entry.effects_applied = true;
         tl.cell_inline_code_bgs.resize(row_count * tl.col_count);
+        tl.row_bgs_computed.resize(row_count, 0);
     }
 
     const float border = TABLE_BORDER_WIDTH;
@@ -393,28 +394,8 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry,
             row_y = row_bottom;
             continue;
         }
-        // 行の全セルを走査済みかを判定: 行のフラット範囲が確保されており、
-        // いずれかのセルに背景があるか、全セルが空(インラインコードなし)なら完了とみなす。
-        bool bgs_done = false;
-        if (!first_pass && tl.CellIndex(r, 0) < tl.cell_inline_code_bgs.size()) {
-            // first_pass でリサイズ済みなのでフラグとして先頭セルの capacity を利用:
-            // first_pass 後に need_bgs=true で走査されたセルは emplace_back か reserve(0) で
-            // 容量が 0 でなくなるが、ここでは簡便にインラインコードランの有無で判定する。
-            bgs_done = true;
-            const auto cc = row.cells.size();
-            for (size_t c = 0; c < cc; c++) {
-                // インラインコードランを持つセルに背景がなければ未処理
-                for (const auto& run : row.cells[c].runs) {
-                    if (run.code() && run.length > 0 && tl.cell_inline_code_bgs[tl.CellIndex(r, c)].empty()) {
-                        bgs_done = false;
-                        break;
-                    }
-                }
-                if (!bgs_done) {
-                    break;
-                }
-            }
-        }
+        // row_bgs_computed フラグで O(1) 判定（O(cells × runs) の走査を排除）
+        const bool bgs_done = !first_pass && r < tl.row_bgs_computed.size() && tl.row_bgs_computed[r];
         const bool need_bgs = row_visible && !bgs_done;
 
         // 2回目以降: インラインコード背景の計算が不要な行はスキップ
@@ -443,6 +424,10 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry,
                     }
                 }
             }
+        }
+        // この行のインラインコード背景計算が完了したことを記録
+        if (need_bgs && r < tl.row_bgs_computed.size()) {
+            tl.row_bgs_computed[r] = true;
         }
         row_y = row_bottom;
     }

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -2,6 +2,7 @@
 #include "syntax.h"
 #include "resource.h"
 #include "ui_constants.h"
+#include "wic_util.h"
 #include "profiler.h"
 #include <algorithm>
 #include <cmath>
@@ -65,15 +66,8 @@ void Renderer::LoadAppIconBitmap()
         return;
     }
 
-    ComPtr<IWICFormatConverter> converter;
-    hr = wic->CreateFormatConverter(&converter);
-    if (FAILED(hr)) {
-        return;
-    }
-
-    hr = converter->Initialize(wic_bitmap.Get(), GUID_WICPixelFormat32bppPBGRA,
-        WICBitmapDitherTypeNone, nullptr, 0.0, WICBitmapPaletteTypeMedianCut);
-    if (FAILED(hr)) {
+    auto converter = wic_util::ConvertBitmapSource(wic, wic_bitmap.Get());
+    if (!converter) {
         return;
     }
 

--- a/src/util/flat_map.h
+++ b/src/util/flat_map.h
@@ -31,7 +31,8 @@ private:
     containers c;
 
     // キーを探す。end以外が返った際はキーと戻り値が一致することを比較して確定すること。
-    constexpr auto find_key(this auto& self, const key_type& key) noexcept {
+    constexpr auto find_key(this auto& self, const key_type& key) noexcept
+    {
         auto iter = self.c.keys.begin();
         const auto end = self.c.keys.end();
         if (self.c.keys.size() < linear_search_threshold) {
@@ -46,23 +47,29 @@ private:
     }
 
 public:
-    constexpr auto zip(this auto& self) noexcept {
+    constexpr auto zip(this auto& self) noexcept
+    {
         return std::ranges::zip_view{ self.c.keys, self.c.values };
     }
-    constexpr auto begin(this auto& self) noexcept {
+    constexpr auto begin(this auto& self) noexcept
+    {
         return self.zip().begin();
     }
-    constexpr auto end(this auto& self) noexcept {
+    constexpr auto end(this auto& self) noexcept
+    {
         return self.zip().end();
     }
-    constexpr auto cbegin() const noexcept {
+    constexpr auto cbegin() const noexcept
+    {
         return zip().cbegin();
     }
-    constexpr auto cend() const noexcept {
+    constexpr auto cend() const noexcept
+    {
         return zip().cend();
     }
 
-    constexpr auto find(this auto& self, const key_type& key) noexcept {
+    constexpr auto find(this auto& self, const key_type& key) noexcept
+    {
         const auto key_it = self.find_key(key);
         if (key_it != self.c.keys.end() && *key_it == key) {
             return self.begin() + (key_it - self.c.keys.begin());
@@ -70,48 +77,51 @@ public:
         return self.end();
     }
 
-    constexpr bool contains(const key_type& key) const noexcept {
+    constexpr bool contains(const key_type& key) const noexcept
+    {
         const auto key_it{ find_key(key) };
         return key_it != c.keys.cend() && *key_it == key;
     }
-    constexpr bool empty() const noexcept {
+    constexpr bool empty() const noexcept
+    {
         return c.keys.empty();
     }
-    constexpr size_t size() const noexcept {
+    constexpr size_t size() const noexcept
+    {
         return c.keys.size();
     }
-    constexpr void clear() noexcept {
+    constexpr void clear() noexcept
+    {
         c.keys.clear();
         c.values.clear();
     }
-    constexpr void reserve(size_t n) {
+    constexpr void reserve(size_t n)
+    {
         c.keys.reserve(n);
         c.values.reserve(n);
     }
-    constexpr void shrink_to_fit() {
+    constexpr void shrink_to_fit()
+    {
         c.keys.shrink_to_fit();
         c.values.shrink_to_fit();
     }
 
     template <class... Args>
-    constexpr auto try_emplace(const key_type& key, Args&&... args) {
+    constexpr auto try_emplace(const key_type& key, Args&&... args)
+    {
         const auto key_it{ find_key(key) };
         const auto dist{ key_it - c.keys.begin() };
         if (key_it != c.keys.end() && *key_it == key) {
             return std::pair{ begin() + dist, false };
         }
         c.keys.insert(key_it, key);
-        try {
-            c.values.emplace(c.values.begin() + dist, std::forward<Args>(args)...);
-        } catch (...) {
-            c.keys.erase(c.keys.begin() + dist);
-            throw;
-        }
+        c.values.emplace(c.values.begin() + dist, std::forward<Args>(args)...);
         return std::pair{ begin() + dist, true };
     }
 
     template <class M>
-    constexpr auto insert_or_assign(const key_type& key, M&& m) {
+    constexpr auto insert_or_assign(const key_type& key, M&& m)
+    {
         const auto key_it{ find_key(key) };
         const auto dist{ key_it - c.keys.begin() };
         if (key_it != c.keys.end() && *key_it == key) {
@@ -119,17 +129,13 @@ public:
             return std::pair{ begin() + dist, false };
         }
         c.keys.insert(key_it, key);
-        try {
-            c.values.emplace(c.values.begin() + dist, std::forward<M>(m));
-        } catch (...) {
-            c.keys.erase(c.keys.begin() + dist);
-            throw;
-        }
+        c.values.emplace(c.values.begin() + dist, std::forward<M>(m));
         return std::pair{ begin() + dist, true };
     }
 
     template <class Iterator>
-    constexpr auto erase(const Iterator it) {
+    constexpr auto erase(const Iterator it)
+    {
         if (auto e{ end() }; it == e) {
             return e;
         }
@@ -139,7 +145,8 @@ public:
         return begin() + dist;
     }
 
-    constexpr auto erase(const key_type& key) {
+    constexpr auto erase(const key_type& key)
+    {
         const auto key_it{ find_key(key) };
         if (key_it != c.keys.end() && *key_it == key) {
             const auto dist{ key_it - c.keys.begin() };
@@ -150,7 +157,8 @@ public:
         return end();
     }
 
-    constexpr void swap(FlatMap& other) noexcept {
+    constexpr void swap(FlatMap& other) noexcept
+    {
         std::ranges::swap(c.keys, other.c.keys);
         std::ranges::swap(c.values, other.c.values);
     }

--- a/src/util/flat_map.h
+++ b/src/util/flat_map.h
@@ -101,7 +101,12 @@ public:
             return std::pair{ begin() + dist, false };
         }
         c.keys.insert(key_it, key);
-        c.values.emplace(c.values.begin() + dist, std::forward<Args>(args)...);
+        try {
+            c.values.emplace(c.values.begin() + dist, std::forward<Args>(args)...);
+        } catch (...) {
+            c.keys.erase(c.keys.begin() + dist);
+            throw;
+        }
         return std::pair{ begin() + dist, true };
     }
 
@@ -114,7 +119,12 @@ public:
             return std::pair{ begin() + dist, false };
         }
         c.keys.insert(key_it, key);
-        c.values.emplace(c.values.begin() + dist, std::forward<M>(m));
+        try {
+            c.values.emplace(c.values.begin() + dist, std::forward<M>(m));
+        } catch (...) {
+            c.keys.erase(c.keys.begin() + dist);
+            throw;
+        }
         return std::pair{ begin() + dist, true };
     }
 

--- a/src/util/flat_map.h
+++ b/src/util/flat_map.h
@@ -1,0 +1,150 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include <ranges>
+#include <algorithm>
+#include <tuple>
+#include <memory_resource>
+
+// ソート済み pmr::vector ベースの連想コンテナ。
+// std::map / std::unordered_map と異なりメモリが連続するため、
+// 小〜中規模（数百エントリ以下）で CPU キャッシュ効率が高い。
+// 挿入・削除は O(n) だが、検索は小規模で線形、大規模で O(log n)。
+template <typename Key, typename T>
+class FlatMap {
+public:
+    using key_type = Key;
+    using mapped_type = T;
+    using value_type = std::pair<key_type, mapped_type>;
+    using key_container_type = std::pmr::vector<key_type>;
+    using mapped_container_type = std::pmr::vector<mapped_type>;
+
+    struct containers {
+        key_container_type keys;
+        mapped_container_type values;
+    };
+
+    static constexpr std::size_t linear_search_threshold{ 16 };
+
+private:
+    containers c;
+
+    // キーを探す。end以外が返った際はキーと戻り値が一致することを比較して確定すること。
+    constexpr auto find_key(this auto& self, const key_type& key) noexcept {
+        auto iter = self.c.keys.begin();
+        const auto end = self.c.keys.end();
+        if (self.c.keys.size() < linear_search_threshold) {
+            while (iter != end && *iter < key) {
+                (void)++iter;
+            }
+        }
+        else {
+            iter = std::ranges::lower_bound(iter, end, key);
+        }
+        return iter;
+    }
+
+public:
+    constexpr auto zip(this auto& self) noexcept {
+        return std::ranges::zip_view{ self.c.keys, self.c.values };
+    }
+    constexpr auto begin(this auto& self) noexcept {
+        return self.zip().begin();
+    }
+    constexpr auto end(this auto& self) noexcept {
+        return self.zip().end();
+    }
+    constexpr auto cbegin() const noexcept {
+        return zip().cbegin();
+    }
+    constexpr auto cend() const noexcept {
+        return zip().cend();
+    }
+
+    constexpr auto find(this auto& self, const key_type& key) noexcept {
+        const auto key_it = self.find_key(key);
+        if (key_it != self.c.keys.end() && *key_it == key) {
+            return self.begin() + (key_it - self.c.keys.begin());
+        }
+        return self.end();
+    }
+
+    constexpr auto& keys(this auto& self) noexcept { return self.c.keys; }
+    constexpr auto& values(this auto& self) noexcept { return self.c.values; }
+
+    constexpr bool contains(const key_type& key) const noexcept {
+        const auto key_it{ find_key(key) };
+        return key_it != c.keys.cend() && *key_it == key;
+    }
+    constexpr bool empty() const noexcept {
+        return c.keys.empty();
+    }
+    constexpr size_t size() const noexcept {
+        return c.keys.size();
+    }
+    constexpr void clear() noexcept {
+        c.keys.clear();
+        c.values.clear();
+    }
+    constexpr void reserve(size_t n) {
+        c.keys.reserve(n);
+        c.values.reserve(n);
+    }
+    constexpr void shrink_to_fit() {
+        c.keys.shrink_to_fit();
+        c.values.shrink_to_fit();
+    }
+
+    template <class... Args>
+    constexpr auto try_emplace(const key_type& key, Args&&... args) {
+        const auto key_it{ find_key(key) };
+        const auto dist{ key_it - c.keys.begin() };
+        if (key_it != c.keys.end() && *key_it == key) {
+            return std::pair{ begin() + dist, false };
+        }
+        c.keys.insert(key_it, key);
+        c.values.emplace(c.values.begin() + dist, std::forward<Args>(args)...);
+        return std::pair{ begin() + dist, true };
+    }
+
+    template <class M>
+    constexpr auto insert_or_assign(const key_type& key, M&& m) {
+        const auto key_it{ find_key(key) };
+        const auto dist{ key_it - c.keys.begin() };
+        if (key_it != c.keys.end() && *key_it == key) {
+            c.values[dist] = std::forward<M>(m);
+            return std::pair{ begin() + dist, false };
+        }
+        c.keys.insert(key_it, key);
+        c.values.emplace(c.values.begin() + dist, std::forward<M>(m));
+        return std::pair{ begin() + dist, true };
+    }
+
+    template <class Iterator>
+    constexpr auto erase(const Iterator it) {
+        if (auto e{ end() }; it == e) {
+            return e;
+        }
+        const auto dist{ it - begin() };
+        c.keys.erase(c.keys.begin() + dist);
+        c.values.erase(c.values.begin() + dist);
+        return begin() + dist;
+    }
+
+    constexpr auto erase(const key_type& key) {
+        const auto key_it{ find_key(key) };
+        if (key_it != c.keys.end() && *key_it == key) {
+            const auto dist{ key_it - c.keys.begin() };
+            c.keys.erase(key_it);
+            c.values.erase(c.values.begin() + dist);
+            return begin() + dist;
+        }
+        return end();
+    }
+
+    constexpr void swap(FlatMap& other) noexcept {
+        std::ranges::swap(c.keys, other.c.keys);
+        std::ranges::swap(c.values, other.c.values);
+    }
+};

--- a/src/util/flat_map.h
+++ b/src/util/flat_map.h
@@ -70,9 +70,6 @@ public:
         return self.end();
     }
 
-    constexpr auto& keys(this auto& self) noexcept { return self.c.keys; }
-    constexpr auto& values(this auto& self) noexcept { return self.c.values; }
-
     constexpr bool contains(const key_type& key) const noexcept {
         const auto key_it{ find_key(key) };
         return key_it != c.keys.cend() && *key_it == key;

--- a/src/util/lru_cache.h
+++ b/src/util/lru_cache.h
@@ -1,49 +1,52 @@
 #pragma once
-#include <list>
-#include <unordered_map>
+#include <vector>
+#include <algorithm>
 #include <cstddef>
+#include <cstdint>
 
 // 固定サイズの LRU (Least Recently Used) キャッシュ。
-// Find() でアクセスするとアクセス順が更新される。
+// キーと値を連続メモリ上に保持し、CPU キャッシュの局所性を最大化する。
+// Find() でアクセスするとアクセス世代が更新される。
 // 容量超過時は最も古いエントリが自動的に破棄される。
-// O(1) の検索・挿入・削除。
-// スレッド安全ではない。const Find() も内部の順序を変更するため、
+// 検索は O(n) だが、エントリ数が数百以下であれば
+// std::list ベースの O(1) LRU よりキャッシュラインの恩恵で高速。
+// スレッド安全ではない。const Find() も内部の世代を変更するため、
 // 複数スレッドからの同時アクセスには外部で排他制御が必要。
 template <typename Key, typename Value>
 class LruCache {
 public:
-    explicit LruCache(size_t max_entries) : max_entries_(max_entries) {}
-
-    // キーに対応する値を検索し、見つかった場合はアクセス順を更新する。
-    Value* Find(const Key& key)
+    explicit LruCache(size_t max_entries) : max_entries_(max_entries)
     {
-        auto it = map_.find(key);
-        if (it == map_.end()) {
-            return nullptr;
-        }
-        // 先頭に移動（最近使用）
-        order_.splice(order_.begin(), order_, it->second);
-        return &it->second->value;
+        keys_.reserve(max_entries);
+        values_.reserve(max_entries);
+        generations_.reserve(max_entries);
     }
 
-    const Value* Find(const Key& key) const
+    // キーに対応する値を検索し、見つかった場合はアクセス世代を更新する。
+    // const 版も世代を更新する（mutable）。
+    auto* Find(this auto& self, const Key& key)
     {
-        auto it = map_.find(key);
-        if (it == map_.end()) {
-            return nullptr;
+        for (size_t i = 0; i < self.size_; i++) {
+            if (self.keys_[i] == key) {
+                self.generations_[i] = ++self.generation_counter_;
+                return &self.values_[i];
+            }
         }
-        // const版でもアクセス順は更新する（mutableなorder_）
-        order_.splice(order_.begin(), order_, it->second);
-        return &it->second->value;
+        return decltype(&self.values_[0]){ nullptr };
     }
 
-    // キーが存在するかチェック（アクセス順は更新しない）。
+    // キーが存在するかチェック（アクセス世代は更新しない）。
     bool Contains(const Key& key) const
     {
-        return map_.find(key) != map_.end();
+        for (size_t i = 0; i < size_; i++) {
+            if (keys_[i] == key) {
+                return true;
+            }
+        }
+        return false;
     }
 
-    // エントリを挿入する。既存キーの場合は値を上書きしてアクセス順を更新する。
+    // エントリを挿入する。既存キーの場合は値を上書きしてアクセス世代を更新する。
     // 容量超過時は最も古いエントリを自動的に破棄する。
     void Insert(const Key& key, Value value)
     {
@@ -51,42 +54,62 @@ public:
             return;
         }
 
-        auto it = map_.find(key);
-        if (it != map_.end()) {
-            it->second->value = std::move(value);
-            order_.splice(order_.begin(), order_, it->second);
+        // 既存キーの更新
+        for (size_t i = 0; i < size_; i++) {
+            if (keys_[i] == key) {
+                values_[i] = std::move(value);
+                generations_[i] = ++generation_counter_;
+                return;
+            }
+        }
+
+        // 容量超過時は最古エントリを破棄して上書き
+        if (size_ >= max_entries_) {
+            const size_t oldest = FindOldestIndex();
+            keys_[oldest] = key;
+            values_[oldest] = std::move(value);
+            generations_[oldest] = ++generation_counter_;
             return;
         }
 
-        // 容量超過時は最古エントリを破棄
-        if (map_.size() >= max_entries_) {
-            auto& oldest = order_.back();
-            map_.erase(oldest.key);
-            order_.pop_back();
-        }
-
-        order_.push_front({ key, std::move(value) });
-        map_.emplace(key, order_.begin());
+        // 新規追加
+        keys_.push_back(key);
+        values_.push_back(std::move(value));
+        generations_.push_back(++generation_counter_);
+        ++size_;
     }
 
     void Clear()
     {
-        order_.clear();
-        map_.clear();
+        keys_.clear();
+        values_.clear();
+        generations_.clear();
+        size_ = 0;
+        generation_counter_ = 0;
     }
 
-    size_t Size() const noexcept { return map_.size(); }
-    bool Empty() const noexcept { return map_.empty(); }
+    size_t Size() const noexcept { return size_; }
+    bool Empty() const noexcept { return size_ == 0; }
     size_t MaxSize() const noexcept { return max_entries_; }
 
 private:
-    struct Entry {
-        Key key;
-        Value value;
-    };
+    size_t FindOldestIndex() const noexcept
+    {
+        size_t oldest = 0;
+        uint64_t min_gen = generations_[0];
+        for (size_t i = 1; i < size_; i++) {
+            if (generations_[i] < min_gen) {
+                min_gen = generations_[i];
+                oldest = i;
+            }
+        }
+        return oldest;
+    }
 
-    mutable std::list<Entry> order_;   // front=最新, back=最古
-    // splice はイテレータを無効化しないため、map_ のイテレータは常に有効
-    std::unordered_map<Key, typename std::list<Entry>::iterator> map_;
+    std::vector<Key> keys_;
+    std::vector<Value> values_;
+    mutable std::vector<uint64_t> generations_;
+    mutable uint64_t generation_counter_ = 0;
+    size_t size_ = 0;
     size_t max_entries_;
 };

--- a/src/util/wic_util.h
+++ b/src/util/wic_util.h
@@ -1,0 +1,80 @@
+#pragma once
+#include <wincodec.h>
+#include <d2d1.h>
+#include <wrl/client.h>
+#include <optional>
+
+namespace wic_util {
+
+// WIC デコード結果。ピクセルサイズと FormatConverter を保持する。
+struct DecodeResult {
+    Microsoft::WRL::ComPtr<IWICFormatConverter> converter;
+    UINT pixel_width = 0;
+    UINT pixel_height = 0;
+};
+
+// IStream から画像をデコードし、GUID_WICPixelFormat32bppPBGRA 形式の
+// FormatConverter とピクセルサイズを返す。
+// image_loader（同期/非同期）と mermaid（PNGキャッシュ復元）の両方から使用される。
+inline std::optional<DecodeResult> DecodeFromStream(
+    IWICImagingFactory* wic, IStream* stream)
+{
+    Microsoft::WRL::ComPtr<IWICBitmapDecoder> decoder;
+    HRESULT hr = wic->CreateDecoderFromStream(
+        stream, nullptr, WICDecodeMetadataCacheOnLoad, &decoder);
+    if (FAILED(hr)) {
+        return std::nullopt;
+    }
+
+    Microsoft::WRL::ComPtr<IWICBitmapFrameDecode> frame;
+    hr = decoder->GetFrame(0, &frame);
+    if (FAILED(hr)) {
+        return std::nullopt;
+    }
+
+    Microsoft::WRL::ComPtr<IWICFormatConverter> converter;
+    hr = wic->CreateFormatConverter(&converter);
+    if (FAILED(hr)) {
+        return std::nullopt;
+    }
+
+    hr = converter->Initialize(
+        frame.Get(), GUID_WICPixelFormat32bppPBGRA,
+        WICBitmapDitherTypeNone, nullptr, 0.0f,
+        WICBitmapPaletteTypeCustom);
+    if (FAILED(hr)) {
+        return std::nullopt;
+    }
+
+    UINT w = 0, h = 0;
+    hr = frame->GetSize(&w, &h);
+    if (FAILED(hr)) {
+        return std::nullopt;
+    }
+
+    return DecodeResult{ std::move(converter), w, h };
+}
+
+// IWICBitmapSource を GUID_WICPixelFormat32bppPBGRA に変換する。
+// HICON 由来の IWICBitmap など、デコーダを経由しないソースに使用する。
+inline Microsoft::WRL::ComPtr<IWICFormatConverter> ConvertBitmapSource(
+    IWICImagingFactory* wic, IWICBitmapSource* source)
+{
+    Microsoft::WRL::ComPtr<IWICFormatConverter> converter;
+    HRESULT hr = wic->CreateFormatConverter(&converter);
+    if (FAILED(hr)) {
+        return nullptr;
+    }
+
+    hr = converter->Initialize(
+        source, GUID_WICPixelFormat32bppPBGRA,
+        WICBitmapDitherTypeNone, nullptr, 0.0f,
+        WICBitmapPaletteTypeCustom);
+    if (FAILED(hr)) {
+        return nullptr;
+    }
+
+    return converter;
+}
+
+} // namespace wic_util

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,8 @@ add_executable(mendo_tests
     test_search_bar_controller.cpp
     test_session_service.cpp
     test_reducer.cpp
+    test_flat_map.cpp
+    test_string_convert.cpp
 )
 
 target_include_directories(mendo_tests PRIVATE ${WEBVIEW2_INCLUDE} ${WIL_INCLUDE})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,3 @@ target_compile_definitions(mendo_tests PRIVATE MENDO_TESTING)
 if(MSVC)
     target_compile_options(mendo_tests PRIVATE /W4 /utf-8)
 endif()
-
-include(GoogleTest)
-gtest_add_tests(TARGET mendo_tests)

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -2,7 +2,7 @@
 #include <memory_resource>
 #include <string_view>
 #include "document_utils.h"
-#include "layout_cache.h"
+#include "test_helpers.h"
 #include "parser.h"
 
 // ============================================================
@@ -1067,20 +1067,6 @@ TEST(IsPrefixOnlyDiff, IntegrationWithFindFirstDifference)
 // CalcScrollYForDiff
 // ============================================================
 
-// ヘルパー: 等間隔ノードの LayoutCache を構築する
-static LayoutCache MakeCache(int count, float node_height = 100.0f)
-{
-    LayoutCache cache;
-    cache.Resize(count);
-    float y = 0.0f;
-    for (int i = 0; i < count; ++i) {
-        cache[i].y_position = y;
-        cache[i].height = node_height;
-        y += node_height;
-    }
-    return cache;
-}
-
 // ヘルパー: source_offset を等間隔に設定したノード列を構築する
 static std::pmr::vector<Node> MakeNodes(int count, uint32_t offset_step = 100)
 {
@@ -1103,7 +1089,7 @@ TEST(CalcScrollYForDiff, FallbackWhenNodeNotFound)
     // すべてのノードの source_offset が diff_pos より大きい
     auto nodes = MakeNodes(3, 100);
     nodes[0].source_offset = 50;
-    auto cache = MakeCache(3);
+    auto cache = MakeUniformCache(3);
     // diff_pos=10 < 全ノードの最小 offset(50) → -1 → fallback
     EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, "content", 10, 500.0f, 99.0f), 99.0f);
 }
@@ -1112,7 +1098,7 @@ TEST(CalcScrollYForDiff, ScrollsToNodeStartWithMargin)
 {
     // 3ノード: offset=0,100,200 / y=0,100,200 / height=100
     auto nodes = MakeNodes(3, 100);
-    auto cache = MakeCache(3, 100.0f);
+    auto cache = MakeUniformCache(3, 100.0f);
     std::string content(300, 'x');
 
     // diff_pos=0 → node 0, y=0, margin=500*0.2=100 → max(0, 0-100)=0
@@ -1129,7 +1115,7 @@ TEST(CalcScrollYForDiff, IntraNodeFractionInterpolation)
 {
     // 2ノード: offset=0,100 / y=0,1000 / height=1000
     auto nodes = MakeNodes(2, 100);
-    auto cache = MakeCache(2, 1000.0f);
+    auto cache = MakeUniformCache(2, 1000.0f);
     std::string content(200, 'x');
 
     // diff_pos=50 → node 0 (offset=0), next_start=100
@@ -1144,7 +1130,7 @@ TEST(CalcScrollYForDiff, FractionClampsToOne)
 {
     // diff_pos がノード範囲を超える場合でも fraction は 1.0 でクランプ
     auto nodes = MakeNodes(2, 100);
-    auto cache = MakeCache(2, 1000.0f);
+    auto cache = MakeUniformCache(2, 1000.0f);
     std::string content(200, 'x');
 
     // diff_pos=99 → node 0, fraction=99/100=0.99
@@ -1161,7 +1147,7 @@ TEST(CalcScrollYForDiff, SkipsUnsetSourceOffsets)
     nodes[0].source_offset = 0;
     nodes[1].source_offset = UINT32_MAX; // 未設定（HorizontalRule等）
     nodes[2].source_offset = 200;
-    auto cache = MakeCache(3, 100.0f);
+    auto cache = MakeUniformCache(3, 100.0f);
     std::string content(300, 'x');
 
     // diff_pos=100 → node 0 (offset=0), next valid = node 2 (offset=200)
@@ -1177,7 +1163,7 @@ TEST(CalcScrollYForDiff, LastNodeUsesContentSizeAsNextStart)
     // 最後のノードでは content.size() が next_start として使われる
     auto nodes = MakeNodes(1, 0);
     nodes[0].source_offset = 0;
-    auto cache = MakeCache(1, 1000.0f);
+    auto cache = MakeUniformCache(1, 1000.0f);
     std::string content(100, 'x');
 
     // diff_pos=50, next_start=content.size()=100
@@ -1192,7 +1178,7 @@ TEST(CalcScrollYForDiff, CacheSizeMismatchFallback)
 {
     // ノード数とキャッシュサイズが不一致の場合のフォールバック
     auto nodes = MakeNodes(5, 100);
-    auto cache = MakeCache(3, 100.0f); // キャッシュは3つだけ
+    auto cache = MakeUniformCache(3, 100.0f); // キャッシュは3つだけ
 
     // diff_pos=400 → node 4 だがキャッシュは3つ → fallback
     EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, std::string(500, 'x'), 400, 500.0f, 77.0f), 77.0f);
@@ -1222,4 +1208,142 @@ TEST(CalcScrollYForDiff, ParsedMarkdownIntegration)
     float result = CalcScrollYForDiff(nodes, cache, md, diff_pos, 500.0f, 0.0f);
     // スクロール位置は 0 以上で、fallback(0) とは異なる値が期待される
     EXPECT_GE(result, 0.0f);
+}
+
+// ============================================================
+// ToLowerAscii
+// ============================================================
+
+TEST(ToLowerAscii, AllUppercase)
+{
+    EXPECT_EQ(ToLowerAscii(L"HELLO"), L"hello");
+}
+
+TEST(ToLowerAscii, AllLowercase)
+{
+    EXPECT_EQ(ToLowerAscii(L"hello"), L"hello");
+}
+
+TEST(ToLowerAscii, MixedCase)
+{
+    EXPECT_EQ(ToLowerAscii(L"HeLLo WoRLd"), L"hello world");
+}
+
+TEST(ToLowerAscii, Empty)
+{
+    EXPECT_TRUE(ToLowerAscii(L"").empty());
+}
+
+TEST(ToLowerAscii, NonAsciiUnchanged)
+{
+    EXPECT_EQ(ToLowerAscii(L"日本語"), L"日本語");
+}
+
+TEST(ToLowerAscii, DigitsAndSymbols)
+{
+    EXPECT_EQ(ToLowerAscii(L"ABC-123_XYZ"), L"abc-123_xyz");
+}
+
+TEST(ToLowerAscii, BoundaryChars)
+{
+    // A(0x41)の直前@(0x40)、Z(0x5A)の直後[(0x5B)は変換されないこと
+    EXPECT_EQ(ToLowerAscii(L"@A[Z"), L"@a[z");
+}
+
+// ============================================================
+// IsMarkdownFile
+// ============================================================
+
+TEST(IsMarkdownFile, DotMd)
+{
+    EXPECT_TRUE(IsMarkdownFile(L"readme.md"));
+}
+
+TEST(IsMarkdownFile, DotMarkdown)
+{
+    EXPECT_TRUE(IsMarkdownFile(L"doc.markdown"));
+}
+
+TEST(IsMarkdownFile, DotMkd)
+{
+    EXPECT_TRUE(IsMarkdownFile(L"notes.mkd"));
+}
+
+TEST(IsMarkdownFile, UpperCaseExtension)
+{
+    EXPECT_TRUE(IsMarkdownFile(L"README.MD"));
+}
+
+TEST(IsMarkdownFile, MixedCaseExtension)
+{
+    EXPECT_TRUE(IsMarkdownFile(L"test.Markdown"));
+}
+
+TEST(IsMarkdownFile, FullPath)
+{
+    EXPECT_TRUE(IsMarkdownFile(L"C:\\Users\\user\\Documents\\file.md"));
+}
+
+TEST(IsMarkdownFile, NotMarkdown)
+{
+    EXPECT_FALSE(IsMarkdownFile(L"test.txt"));
+}
+
+TEST(IsMarkdownFile, NoExtension)
+{
+    EXPECT_FALSE(IsMarkdownFile(L"readme"));
+}
+
+TEST(IsMarkdownFile, EmptyPath)
+{
+    EXPECT_FALSE(IsMarkdownFile(L""));
+}
+
+TEST(IsMarkdownFile, DotOnly)
+{
+    EXPECT_FALSE(IsMarkdownFile(L"."));
+}
+
+TEST(IsMarkdownFile, SimilarExtension)
+{
+    EXPECT_FALSE(IsMarkdownFile(L"file.mdd"));
+}
+
+TEST(IsMarkdownFile, HtmlFile)
+{
+    EXPECT_FALSE(IsMarkdownFile(L"page.html"));
+}
+
+TEST(IsMarkdownFile, DotInDirectory)
+{
+    EXPECT_TRUE(IsMarkdownFile(L"C:\\my.project\\docs\\readme.md"));
+}
+
+// ============================================================
+// IsHelpPath
+// ============================================================
+
+TEST(IsHelpPath, CorrectPath)
+{
+    EXPECT_TRUE(IsHelpPath(L"mendo://help"));
+}
+
+TEST(IsHelpPath, WrongPath)
+{
+    EXPECT_FALSE(IsHelpPath(L"mendo://other"));
+}
+
+TEST(IsHelpPath, EmptyPath)
+{
+    EXPECT_FALSE(IsHelpPath(L""));
+}
+
+TEST(IsHelpPath, PartialMatch)
+{
+    EXPECT_FALSE(IsHelpPath(L"mendo://hel"));
+}
+
+TEST(IsHelpPath, CaseSensitive)
+{
+    EXPECT_FALSE(IsHelpPath(L"MENDO://HELP"));
 }

--- a/tests/test_file_loader.cpp
+++ b/tests/test_file_loader.cpp
@@ -32,14 +32,14 @@ protected:
         return path;
     }
 
-    // 非同期ファイル監視のポーリングを待つヘルパー
-    bool PollForChange(FileWatcher& watcher, int max_ms = 2000)
+    // イベントハンドルを使って変更通知を待つヘルパー
+    void WaitForEvent(FileWatcher& watcher, int timeout_ms = 2000)
     {
-        for (int elapsed = 0; elapsed < max_ms; elapsed += 50) {
-            watcher.CheckForChanges();
-            Sleep(50);
+        HANDLE h = watcher.GetEventHandle();
+        if (h) {
+            WaitForSingleObject(h, static_cast<DWORD>(timeout_ms));
         }
-        return true;
+        watcher.CheckForChanges();
     }
 };
 
@@ -110,15 +110,9 @@ TEST_F(FileLoaderTest, WatcherDetectsChange)
     bool changed = false;
     watcher.StartWatching(path.native().c_str(), [&]() { changed = true; });
 
-    // 異なるタイムスタンプを確保するため、少し待ってからファイルを変更
-    Sleep(300);
+    Sleep(100);
     WriteFile(L"watch.md", "modified");
-
-    // 非同期通知をポーリングで待つ
-    for (int i = 0; i < 40 && !changed; i++) {
-        Sleep(50);
-        watcher.CheckForChanges();
-    }
+    WaitForEvent(watcher);
     EXPECT_TRUE(changed);
 }
 
@@ -145,9 +139,8 @@ TEST_F(FileLoaderTest, StopWatchingPreventsCallback)
     watcher.StartWatching(path.native().c_str(), [&]() { changed = true; });
     watcher.StopWatching();
 
-    Sleep(300);
     WriteFile(L"stop.md", "modified");
-    Sleep(100);
+    Sleep(50);
     watcher.CheckForChanges();
     EXPECT_FALSE(changed);
 }
@@ -185,23 +178,18 @@ TEST_F(FileLoaderTest, WatcherRestartOnNewFile)
     // 別のファイルの監視に切り替え
     watcher.StartWatching(path2.native().c_str(), [&]() { change_count++; });
 
-    // 元のファイルを変更 - コールバックが発火しないこと
-    Sleep(300);
+    // 元のファイルを変更 - ファイル名フィルタでコールバックが発火しないこと
+    Sleep(100);
     WriteFile(L"watch1.md", "modified1");
-    // watch1の変更通知を拾いつつ、ファイル名フィルタで弾くことを確認
-    for (int i = 0; i < 20; i++) {
-        Sleep(50);
-        watcher.CheckForChanges();
+    for (int i = 0; i < 10; i++) {
+        WaitForEvent(watcher, 100);
     }
     EXPECT_EQ(change_count, 0);
 
     // 新しいファイルを変更 - コールバックが発火すること
-    Sleep(300);
+    Sleep(100);
     WriteFile(L"watch2.md", "modified2");
-    for (int i = 0; i < 40 && change_count == 0; i++) {
-        Sleep(50);
-        watcher.CheckForChanges();
-    }
+    WaitForEvent(watcher);
     EXPECT_EQ(change_count, 1);
 }
 
@@ -240,23 +228,15 @@ TEST_F(FileLoaderTest, WatchPausedAfterChangeDetected)
     int change_count = 0;
     watcher.StartWatching(path.native().c_str(), [&]() { change_count++; });
 
-    // ファイルを変更して検出を待つ
-    Sleep(300);
+    Sleep(100);
     WriteFile(L"pause.md", "modified1");
-    for (int i = 0; i < 40 && change_count == 0; i++) {
-        Sleep(50);
-        watcher.CheckForChanges();
-    }
+    WaitForEvent(watcher);
     ASSERT_EQ(change_count, 1);
 
     // 変更検出後は一時停止（コールバック抑制、I/Oは継続）
-    // 追加の保存はコールバックを呼ばず蓄積される
-    Sleep(300);
+    Sleep(100);
     WriteFile(L"pause.md", "modified2");
-    for (int i = 0; i < 40; i++) {
-        Sleep(50);
-        watcher.CheckForChanges();
-    }
+    WaitForEvent(watcher, 500);
     EXPECT_EQ(change_count, 1);
 
     // ResumeWatching で蓄積された変更が通知される
@@ -272,26 +252,17 @@ TEST_F(FileLoaderTest, ResumeWatchingReenablesDetection)
     int change_count = 0;
     watcher.StartWatching(path.native().c_str(), [&]() { change_count++; });
 
-    // 最初の変更を検出
-    Sleep(300);
+    Sleep(100);
     WriteFile(L"resume.md", "modified1");
-    for (int i = 0; i < 40 && change_count == 0; i++) {
-        Sleep(50);
-        watcher.CheckForChanges();
-    }
+    WaitForEvent(watcher);
     ASSERT_EQ(change_count, 1);
 
-    // 監視を再開（リロード完了をシミュレート）
     watcher.ResumeWatching();
     EXPECT_NE(watcher.GetEventHandle(), nullptr);
 
-    // 2回目の変更を検出
-    Sleep(300);
+    Sleep(100);
     WriteFile(L"resume.md", "modified2");
-    for (int i = 0; i < 40 && change_count == 1; i++) {
-        Sleep(50);
-        watcher.CheckForChanges();
-    }
+    WaitForEvent(watcher);
     EXPECT_EQ(change_count, 2);
 }
 

--- a/tests/test_flat_map.cpp
+++ b/tests/test_flat_map.cpp
@@ -1,0 +1,442 @@
+#include <gtest/gtest.h>
+#include "flat_map.h"
+#include <string>
+#include <vector>
+
+static std::vector<int> CollectKeys(const FlatMap<int, int>& m)
+{
+    std::vector<int> keys;
+    for (auto&& [k, v] : m) {
+        keys.push_back(k);
+    }
+    return keys;
+}
+
+// ═══════════════════════════════════════════════
+// 基本操作
+// ═══════════════════════════════════════════════
+
+TEST(FlatMap, EmptyMapIsEmpty)
+{
+    FlatMap<int, int> m;
+    EXPECT_TRUE(m.empty());
+    EXPECT_EQ(m.size(), 0u);
+}
+
+TEST(FlatMap, TryEmplaceInsertsNew)
+{
+    FlatMap<int, std::string> m;
+    auto [it, inserted] = m.try_emplace(1, "one");
+    EXPECT_TRUE(inserted);
+    EXPECT_EQ(m.size(), 1u);
+    auto&& [k, v] = *it;
+    EXPECT_EQ(k, 1);
+    EXPECT_EQ(v, "one");
+}
+
+TEST(FlatMap, TryEmplaceDuplicateDoesNotOverwrite)
+{
+    FlatMap<int, std::string> m;
+    m.try_emplace(1, "one");
+    auto [it, inserted] = m.try_emplace(1, "ONE");
+    EXPECT_FALSE(inserted);
+    EXPECT_EQ(m.size(), 1u);
+    auto&& [k, v] = *it;
+    EXPECT_EQ(v, "one");
+}
+
+TEST(FlatMap, InsertOrAssignInsertsNew)
+{
+    FlatMap<int, int> m;
+    auto [it, inserted] = m.insert_or_assign(5, 50);
+    EXPECT_TRUE(inserted);
+    EXPECT_EQ(m.size(), 1u);
+    auto&& [k, v] = *it;
+    EXPECT_EQ(k, 5);
+    EXPECT_EQ(v, 50);
+}
+
+TEST(FlatMap, InsertOrAssignOverwritesExisting)
+{
+    FlatMap<int, int> m;
+    m.insert_or_assign(5, 50);
+    auto [it, inserted] = m.insert_or_assign(5, 99);
+    EXPECT_FALSE(inserted);
+    EXPECT_EQ(m.size(), 1u);
+    auto&& [k, v] = *it;
+    EXPECT_EQ(v, 99);
+}
+
+TEST(FlatMap, FindExistingKey)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(3, 30);
+    m.try_emplace(1, 10);
+    m.try_emplace(5, 50);
+
+    auto it = m.find(3);
+    EXPECT_NE(it, m.end());
+    auto&& [k, v] = *it;
+    EXPECT_EQ(v, 30);
+}
+
+TEST(FlatMap, FindMissingKeyReturnsEnd)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(1, 10);
+    EXPECT_EQ(m.find(99), m.end());
+}
+
+TEST(FlatMap, ContainsExisting)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(42, 0);
+    EXPECT_TRUE(m.contains(42));
+}
+
+TEST(FlatMap, ContainsMissing)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(42, 0);
+    EXPECT_FALSE(m.contains(7));
+}
+
+// ═══════════════════════════════════════════════
+// ソート順の維持
+// ═══════════════════════════════════════════════
+
+TEST(FlatMap, MaintainsSortedOrder)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(5, 50);
+    m.try_emplace(1, 10);
+    m.try_emplace(3, 30);
+    m.try_emplace(7, 70);
+    m.try_emplace(2, 20);
+
+    EXPECT_EQ(CollectKeys(m), (std::vector<int>{1, 2, 3, 5, 7}));
+}
+
+TEST(FlatMap, InsertOrAssignMaintainsSortedOrder)
+{
+    FlatMap<int, int> m;
+    m.insert_or_assign(10, 100);
+    m.insert_or_assign(2, 20);
+    m.insert_or_assign(6, 60);
+
+    EXPECT_EQ(CollectKeys(m), (std::vector<int>{2, 6, 10}));
+}
+
+// ═══════════════════════════════════════════════
+// 削除
+// ═══════════════════════════════════════════════
+
+TEST(FlatMap, EraseByKey)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(1, 10);
+    m.try_emplace(2, 20);
+    m.try_emplace(3, 30);
+
+    m.erase(2);
+    EXPECT_EQ(m.size(), 2u);
+    EXPECT_FALSE(m.contains(2));
+    EXPECT_TRUE(m.contains(1));
+    EXPECT_TRUE(m.contains(3));
+}
+
+TEST(FlatMap, EraseByKeyMissing)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(1, 10);
+    m.erase(99);
+    EXPECT_EQ(m.size(), 1u);
+}
+
+TEST(FlatMap, EraseByIterator)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(1, 10);
+    m.try_emplace(2, 20);
+    m.try_emplace(3, 30);
+
+    auto it = m.find(2);
+    m.erase(it);
+    EXPECT_EQ(m.size(), 2u);
+    EXPECT_FALSE(m.contains(2));
+}
+
+TEST(FlatMap, EraseEndIteratorIsNoOp)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(1, 10);
+    m.erase(m.end());
+    EXPECT_EQ(m.size(), 1u);
+}
+
+TEST(FlatMap, EraseLastElement)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(1, 10);
+    m.erase(1);
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(FlatMap, EraseFirstElement)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(1, 10);
+    m.try_emplace(2, 20);
+    m.try_emplace(3, 30);
+
+    m.erase(1);
+    EXPECT_EQ(m.size(), 2u);
+    EXPECT_FALSE(m.contains(1));
+    EXPECT_EQ(CollectKeys(m), (std::vector<int>{2, 3}));
+}
+
+// ═══════════════════════════════════════════════
+// clear / reserve / shrink_to_fit
+// ═══════════════════════════════════════════════
+
+TEST(FlatMap, ClearEmptiesMap)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(1, 10);
+    m.try_emplace(2, 20);
+    m.clear();
+    EXPECT_TRUE(m.empty());
+    EXPECT_EQ(m.size(), 0u);
+}
+
+TEST(FlatMap, ReserveDoesNotChangeSize)
+{
+    FlatMap<int, int> m;
+    m.reserve(100);
+    EXPECT_EQ(m.size(), 0u);
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(FlatMap, ShrinkToFitDoesNotChangeContents)
+{
+    FlatMap<int, int> m;
+    m.reserve(100);
+    m.try_emplace(1, 10);
+    m.try_emplace(2, 20);
+    m.shrink_to_fit();
+    EXPECT_EQ(m.size(), 2u);
+    EXPECT_TRUE(m.contains(1));
+    EXPECT_TRUE(m.contains(2));
+}
+
+// ═══════════════════════════════════════════════
+// swap
+// ═══════════════════════════════════════════════
+
+TEST(FlatMap, SwapExchangesContents)
+{
+    FlatMap<int, int> a;
+    a.try_emplace(1, 10);
+    a.try_emplace(2, 20);
+
+    FlatMap<int, int> b;
+    b.try_emplace(3, 30);
+
+    a.swap(b);
+    EXPECT_EQ(a.size(), 1u);
+    EXPECT_TRUE(a.contains(3));
+    EXPECT_EQ(b.size(), 2u);
+    EXPECT_TRUE(b.contains(1));
+    EXPECT_TRUE(b.contains(2));
+}
+
+// ═══════════════════════════════════════════════
+// 線形探索 → 二分探索の閾値
+// ═══════════════════════════════════════════════
+
+TEST(FlatMap, LinearSearchBelowThreshold)
+{
+    FlatMap<int, int> m;
+    for (int i = 15; i >= 0; i--) {
+        m.try_emplace(i, i * 10);
+    }
+    EXPECT_EQ(m.size(), 16u);
+
+    for (int i = 0; i < 16; i++) {
+        auto it = m.find(i);
+        ASSERT_NE(it, m.end());
+        auto&& [k, v] = *it;
+        EXPECT_EQ(v, i * 10);
+    }
+}
+
+TEST(FlatMap, BinarySearchAboveThreshold)
+{
+    FlatMap<int, int> m;
+    for (int i = 30; i >= 0; i--) {
+        m.try_emplace(i, i * 10);
+    }
+    EXPECT_EQ(m.size(), 31u);
+
+    // 全要素を検索
+    for (int i = 0; i <= 30; i++) {
+        auto it = m.find(i);
+        ASSERT_NE(it, m.end());
+        auto&& [k, v] = *it;
+        EXPECT_EQ(v, i * 10);
+    }
+    // 存在しないキー
+    EXPECT_EQ(m.find(31), m.end());
+    EXPECT_EQ(m.find(-1), m.end());
+}
+
+TEST(FlatMap, AtExactThreshold)
+{
+    // 閾値丁度（16要素）の境界チェック
+    constexpr auto threshold = FlatMap<int, int>::linear_search_threshold;
+    FlatMap<int, int> m;
+    for (int i = 0; i < static_cast<int>(threshold); i++) {
+        m.try_emplace(i * 2, i); // 偶数キーのみ
+    }
+    EXPECT_EQ(m.size(), threshold);
+
+    // 存在するキー（偶数）
+    for (int i = 0; i < static_cast<int>(threshold); i++) {
+        EXPECT_TRUE(m.contains(i * 2));
+    }
+    // 存在しないキー（奇数）
+    for (int i = 0; i < static_cast<int>(threshold); i++) {
+        EXPECT_FALSE(m.contains(i * 2 + 1));
+    }
+}
+
+// ═══════════════════════════════════════════════
+// 文字列キー・値のテスト
+// ═══════════════════════════════════════════════
+
+TEST(FlatMap, StringKeyAndValue)
+{
+    FlatMap<std::pmr::string, std::pmr::string> m;
+    m.try_emplace(std::pmr::string{"banana"}, std::pmr::string{"yellow"});
+    m.try_emplace(std::pmr::string{"apple"}, std::pmr::string{"red"});
+    m.try_emplace(std::pmr::string{"cherry"}, std::pmr::string{"red"});
+
+    EXPECT_EQ(m.size(), 3u);
+
+    auto it = m.find(std::pmr::string{"banana"});
+    ASSERT_NE(it, m.end());
+    auto&& [k, v] = *it;
+    EXPECT_EQ(v, "yellow");
+
+    // ソート順: apple < banana < cherry
+    std::vector<std::string> keys;
+    for (auto&& [key, val] : m) {
+        keys.emplace_back(key);
+    }
+    EXPECT_EQ(keys, (std::vector<std::string>{"apple", "banana", "cherry"}));
+}
+
+// ═══════════════════════════════════════════════
+// イテレーション
+// ═══════════════════════════════════════════════
+
+TEST(FlatMap, IterateEmpty)
+{
+    FlatMap<int, int> m;
+    EXPECT_EQ(m.begin(), m.end());
+}
+
+TEST(FlatMap, ConstIteration)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(1, 10);
+    m.try_emplace(2, 20);
+
+    const auto& cm = m;
+    int sum = 0;
+    for (auto&& [k, v] : cm) {
+        sum += v;
+    }
+    EXPECT_EQ(sum, 30);
+}
+
+// ═══════════════════════════════════════════════
+// エッジケース
+// ═══════════════════════════════════════════════
+
+TEST(FlatMap, FindOnEmptyMap)
+{
+    FlatMap<int, int> m;
+    EXPECT_EQ(m.find(0), m.end());
+}
+
+TEST(FlatMap, ContainsOnEmptyMap)
+{
+    FlatMap<int, int> m;
+    EXPECT_FALSE(m.contains(0));
+}
+
+TEST(FlatMap, InsertAfterClear)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(1, 10);
+    m.clear();
+    m.try_emplace(2, 20);
+    EXPECT_EQ(m.size(), 1u);
+    EXPECT_TRUE(m.contains(2));
+    EXPECT_FALSE(m.contains(1));
+}
+
+TEST(FlatMap, EraseAllElementsOneByOne)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(1, 10);
+    m.try_emplace(2, 20);
+    m.try_emplace(3, 30);
+
+    m.erase(2);
+    m.erase(1);
+    m.erase(3);
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(FlatMap, InsertAndEraseInterleaved)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(1, 10);
+    m.try_emplace(2, 20);
+    m.erase(1);
+    m.try_emplace(3, 30);
+    m.erase(2);
+    m.try_emplace(1, 100);
+
+    EXPECT_EQ(m.size(), 2u);
+    EXPECT_TRUE(m.contains(1));
+    EXPECT_TRUE(m.contains(3));
+
+    auto it = m.find(1);
+    ASSERT_NE(it, m.end());
+    auto&& [k, v] = *it;
+    EXPECT_EQ(v, 100);
+}
+
+TEST(FlatMap, ZeroKey)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(0, 42);
+    EXPECT_TRUE(m.contains(0));
+    auto it = m.find(0);
+    ASSERT_NE(it, m.end());
+    auto&& [k, v] = *it;
+    EXPECT_EQ(v, 42);
+}
+
+TEST(FlatMap, NegativeKeys)
+{
+    FlatMap<int, int> m;
+    m.try_emplace(-5, 50);
+    m.try_emplace(-1, 10);
+    m.try_emplace(3, 30);
+
+    EXPECT_EQ(CollectKeys(m), (std::vector<int>{-5, -1, 3}));
+}

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "layout_cache.h"
+
+// 等間隔ノードの LayoutCache を構築するテスト用ヘルパー。
+// 複数テストファイルで共通して使用される。
+inline LayoutCache MakeUniformCache(int count, float node_height = 100.0f)
+{
+    LayoutCache cache;
+    cache.Resize(count);
+    float y = 0.0f;
+    for (int i = 0; i < count; ++i) {
+        cache[i].y_position = y;
+        cache[i].height = node_height;
+        y += node_height;
+    }
+    return cache;
+}

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -4,6 +4,7 @@
 #include "command_generator.h"
 #include "dwrite_measurer.h"
 #include "parser.h"
+#include "test_helpers.h"
 #include <dwrite.h>
 #include <wrl/client.h>
 
@@ -901,35 +902,22 @@ TEST(RecomputeYPositionsTest, AllNodeTypesProduceValidPositions)
 
 // ---- FindFirstVisibleNodeIndex テスト（layout_cache.h のフリー関数） ----
 
-static LayoutCache MakeSimpleCache(int count, float node_height)
-{
-    LayoutCache cache;
-    cache.Resize(count);
-    float y = 0.0f;
-    for (int i = 0; i < count; ++i) {
-        cache[i].y_position = y;
-        cache[i].height = node_height;
-        y += node_height;
-    }
-    return cache;
-}
-
 TEST(FindFirstVisibleNodeIndex, AtStart)
 {
-    auto cache = MakeSimpleCache(10, 50.0f);
+    auto cache = MakeUniformCache(10, 50.0f);
     EXPECT_EQ(FindFirstVisibleNodeIndex(cache, 10, 0.0f), 0);
 }
 
 TEST(FindFirstVisibleNodeIndex, MidDocument)
 {
-    auto cache = MakeSimpleCache(10, 50.0f);
+    auto cache = MakeUniformCache(10, 50.0f);
     // viewport_top = 120 → ノード2 (y=100, bottom=150) が最初の可視ノード
     EXPECT_EQ(FindFirstVisibleNodeIndex(cache, 10, 120.0f), 2);
 }
 
 TEST(FindFirstVisibleNodeIndex, ExactBoundary)
 {
-    auto cache = MakeSimpleCache(10, 50.0f);
+    auto cache = MakeUniformCache(10, 50.0f);
     // viewport_top = 50 → ノード0はy=50で終了、ノード1はy=50で開始
     // ノード0の下端(50) == viewport_top(50)なので除外される
     EXPECT_EQ(FindFirstVisibleNodeIndex(cache, 10, 50.0f), 1);
@@ -937,7 +925,7 @@ TEST(FindFirstVisibleNodeIndex, ExactBoundary)
 
 TEST(FindFirstVisibleNodeIndex, PastEnd)
 {
-    auto cache = MakeSimpleCache(5, 50.0f);
+    auto cache = MakeUniformCache(5, 50.0f);
     // viewport_top = 300、すべてのノードはy=250で終了
     EXPECT_EQ(FindFirstVisibleNodeIndex(cache, 5, 300.0f), 5);
 }
@@ -950,7 +938,7 @@ TEST(FindFirstVisibleNodeIndex, EmptyCache)
 
 TEST(FindFirstVisibleNodeIndex, SingleNode)
 {
-    auto cache = MakeSimpleCache(1, 100.0f);
+    auto cache = MakeUniformCache(1, 100.0f);
     EXPECT_EQ(FindFirstVisibleNodeIndex(cache, 1, 0.0f), 0);
     EXPECT_EQ(FindFirstVisibleNodeIndex(cache, 1, 50.0f), 0);
     EXPECT_EQ(FindFirstVisibleNodeIndex(cache, 1, 100.0f), 1); // ノードを過ぎた位置
@@ -958,7 +946,7 @@ TEST(FindFirstVisibleNodeIndex, SingleNode)
 
 TEST(FindFirstVisibleNodeIndex, LastNodeVisible)
 {
-    auto cache = MakeSimpleCache(10, 50.0f);
+    auto cache = MakeUniformCache(10, 50.0f);
     // viewport_top = 449 → ノード8は450で終了、まだ可視
     EXPECT_EQ(FindFirstVisibleNodeIndex(cache, 10, 449.0f), 8);
 }

--- a/tests/test_lru_cache.cpp
+++ b/tests/test_lru_cache.cpp
@@ -117,3 +117,125 @@ TEST(LruCache, SizeZero)
     EXPECT_FALSE(cache.Contains(1));
 }
 
+TEST(LruCache, MaxSize)
+{
+    LruCache<int, int> cache(5);
+    EXPECT_EQ(cache.MaxSize(), 5u);
+}
+
+TEST(LruCache, MaxSizeZero)
+{
+    LruCache<int, int> cache(0);
+    EXPECT_EQ(cache.MaxSize(), 0u);
+}
+
+TEST(LruCache, EmptyAfterConstruction)
+{
+    LruCache<int, int> cache(10);
+    EXPECT_TRUE(cache.Empty());
+    EXPECT_EQ(cache.Size(), 0u);
+}
+
+TEST(LruCache, ContainsDoesNotUpdateOrder)
+{
+    LruCache<int, int> cache(2);
+    cache.Insert(1, 10);
+    cache.Insert(2, 20);
+
+    // Contains は世代を更新しない
+    EXPECT_TRUE(cache.Contains(1));
+
+    // 3を追加すると最古の1が削除される（Containsでは更新されない）
+    cache.Insert(3, 30);
+    EXPECT_EQ(cache.Find(1), nullptr);
+    EXPECT_NE(cache.Find(2), nullptr);
+    EXPECT_NE(cache.Find(3), nullptr);
+}
+
+TEST(LruCache, StressInsertMany)
+{
+    LruCache<int, int> cache(100);
+    for (int i = 0; i < 1000; i++) {
+        cache.Insert(i, i * 10);
+    }
+    EXPECT_EQ(cache.Size(), 100u);
+
+    // 最後の100個だけ残る
+    for (int i = 0; i < 900; i++) {
+        EXPECT_EQ(cache.Find(i), nullptr);
+    }
+    for (int i = 900; i < 1000; i++) {
+        auto* v = cache.Find(i);
+        ASSERT_NE(v, nullptr);
+        EXPECT_EQ(*v, i * 10);
+    }
+}
+
+TEST(LruCache, InsertExistingKeyUpdatesOrder)
+{
+    LruCache<int, int> cache(3);
+    cache.Insert(1, 10);
+    cache.Insert(2, 20);
+    cache.Insert(3, 30);
+
+    // key=1 を再挿入して世代を更新
+    cache.Insert(1, 100);
+    // key=4 を追加すると最古の key=2 が削除される
+    cache.Insert(4, 40);
+    EXPECT_NE(cache.Find(1), nullptr);
+    EXPECT_EQ(cache.Find(2), nullptr);
+    EXPECT_NE(cache.Find(3), nullptr);
+    EXPECT_NE(cache.Find(4), nullptr);
+}
+
+TEST(LruCache, ClearAndReuse)
+{
+    LruCache<int, int> cache(3);
+    cache.Insert(1, 10);
+    cache.Insert(2, 20);
+    cache.Clear();
+
+    cache.Insert(3, 30);
+    EXPECT_EQ(cache.Size(), 1u);
+    EXPECT_FALSE(cache.Contains(1));
+    EXPECT_FALSE(cache.Contains(2));
+    EXPECT_TRUE(cache.Contains(3));
+}
+
+TEST(LruCache, FindMissingReturnsNull)
+{
+    LruCache<int, int> cache(5);
+    cache.Insert(1, 10);
+    EXPECT_EQ(cache.Find(999), nullptr);
+}
+
+TEST(LruCache, ModifyValueThroughFind)
+{
+    LruCache<int, std::string> cache(3);
+    cache.Insert(1, "original");
+    auto* v = cache.Find(1);
+    ASSERT_NE(v, nullptr);
+    *v = "modified";
+    auto* v2 = cache.Find(1);
+    EXPECT_EQ(*v2, "modified");
+}
+
+TEST(LruCache, EvictionOrderWithMultipleAccesses)
+{
+    LruCache<int, int> cache(3);
+    cache.Insert(1, 10);
+    cache.Insert(2, 20);
+    cache.Insert(3, 30);
+
+    // 1と2にアクセスして世代を更新
+    cache.Find(1);
+    cache.Find(2);
+
+    // 4を追加 → 最古の3が削除される
+    cache.Insert(4, 40);
+    EXPECT_NE(cache.Find(1), nullptr);
+    EXPECT_NE(cache.Find(2), nullptr);
+    EXPECT_EQ(cache.Find(3), nullptr);
+    EXPECT_NE(cache.Find(4), nullptr);
+}
+

--- a/tests/test_mermaid_file_cache.cpp
+++ b/tests/test_mermaid_file_cache.cpp
@@ -175,14 +175,14 @@ TEST_F(MermaidFileCacheTest, EvictsOldestWhenMaxEntriesExceeded)
 
     // 3エントリを格納（タイムスタンプの差を確保）
     cache_.StoreAsync(1, 100.0f, 50.0f, MakeDummyPng(100));
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
     cache_.StoreAsync(2, 100.0f, 50.0f, MakeDummyPng(100));
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
     cache_.StoreAsync(3, 100.0f, 50.0f, MakeDummyPng(100));
     EXPECT_EQ(cache_.EntryCount(), 3u);
 
     // 4つ目を追加 → 最古のエントリ(key=1)が削除される
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
     cache_.StoreAsync(4, 100.0f, 50.0f, MakeDummyPng(100));
     EXPECT_EQ(cache_.EntryCount(), 3u);
 
@@ -208,13 +208,13 @@ TEST_F(MermaidFileCacheTest, EvictsWhenMaxSizeExceeded)
     InitCache();
 
     cache_.StoreAsync(1, 100.0f, 50.0f, MakeDummyPng(200));
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
     cache_.StoreAsync(2, 100.0f, 50.0f, MakeDummyPng(200));
     EXPECT_EQ(cache_.EntryCount(), 2u);
     EXPECT_EQ(cache_.TotalSize(), 400u);
 
     // 300バイト追加 → 合計700 > 500 → 最古エントリを削除
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
     cache_.StoreAsync(3, 100.0f, 50.0f, MakeDummyPng(300));
     // key=1が削除されて合計500バイト以内になる
     EXPECT_LE(cache_.TotalSize(), 500u);
@@ -512,13 +512,13 @@ TEST_F(MermaidFileCacheTest, LookupRefreshesTimestamp)
 
     // key=1を最初に格納
     cache_.StoreAsync(1, 100.0f, 50.0f, MakeDummyPng(100));
-    std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     // key=2を格納（key=1より新しいタイムスタンプ）
     cache_.StoreAsync(2, 100.0f, 50.0f, MakeDummyPng(100));
     scheduler_.Shutdown();
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     cache_.SetCacheDir(temp_dir_);
     cache_.SetLimits(2, 1ULL * 1024 * 1024 * 1024);
@@ -588,7 +588,7 @@ TEST_F(MermaidFileCacheTest, LookupDimensionsDoesNotUpdateLru)
     InitCache();
 
     cache_.StoreAsync(1, 100.0f, 50.0f, MakeDummyPng(100));
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
     cache_.StoreAsync(2, 200.0f, 100.0f, MakeDummyPng(100));
     EXPECT_EQ(cache_.EntryCount(), 2u);
 
@@ -597,7 +597,7 @@ TEST_F(MermaidFileCacheTest, LookupDimensionsDoesNotUpdateLru)
     EXPECT_TRUE(cache_.LookupDimensions(1, entry));
 
     // key=3を追加 → LRU未更新のkey=1が最古として削除されるはず
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
     cache_.StoreAsync(3, 300.0f, 150.0f, MakeDummyPng(100));
     EXPECT_EQ(cache_.EntryCount(), 2u);
 

--- a/tests/test_mermaid_renderer.cpp
+++ b/tests/test_mermaid_renderer.cpp
@@ -62,7 +62,7 @@ TEST_F(MermaidRendererTest, DefaultConstructionNotInitialized)
 
 TEST_F(MermaidRendererTest, InitDoesNotStartWebView2)
 {
-    renderer_->Init(nullptr, nullptr, nullptr);
+    renderer_->Init(nullptr, nullptr, nullptr, nullptr);
 
     EXPECT_FALSE(renderer_->IsReady());
     EXPECT_FALSE(renderer_->IsInitialized());
@@ -74,7 +74,7 @@ TEST_F(MermaidRendererTest, InitDoesNotStartWebView2)
 
 TEST_F(MermaidRendererTest, NonMermaidNodeDoesNotTriggerInit)
 {
-    renderer_->Init(nullptr, nullptr, nullptr);
+    renderer_->Init(nullptr, nullptr, nullptr, nullptr);
 
     auto node = MakeNonMermaidNode();
     NodeLayoutEntry layout{};
@@ -91,7 +91,7 @@ TEST_F(MermaidRendererTest, NonMermaidNodeDoesNotTriggerInit)
 
 TEST_F(MermaidRendererTest, MermaidCacheMissTriggersInit)
 {
-    renderer_->Init(nullptr, nullptr, nullptr);
+    renderer_->Init(nullptr, nullptr, nullptr, nullptr);
 
     auto node = MakeMermaidNode("graph TD; A-->B;");
     NodeLayoutEntry layout{};
@@ -110,7 +110,7 @@ TEST_F(MermaidRendererTest, MermaidCacheMissTriggersInit)
 
 TEST_F(MermaidRendererTest, MultipleRequestsDoNotReinitialize)
 {
-    renderer_->Init(nullptr, nullptr, nullptr);
+    renderer_->Init(nullptr, nullptr, nullptr, nullptr);
 
     auto node1 = MakeMermaidNode("graph TD; A-->B;");
     auto node2 = MakeMermaidNode("graph LR; X-->Y;");
@@ -144,7 +144,7 @@ TEST_F(MermaidRendererTest, RequestRenderBeforeInitIsSafe)
 
 TEST_F(MermaidRendererTest, CancelPendingBeforeInitIsSafe)
 {
-    renderer_->Init(nullptr, nullptr, nullptr);
+    renderer_->Init(nullptr, nullptr, nullptr, nullptr);
     renderer_->CancelPending();
     renderer_->ClearPendingQueue();
 
@@ -153,7 +153,7 @@ TEST_F(MermaidRendererTest, CancelPendingBeforeInitIsSafe)
 
 TEST_F(MermaidRendererTest, ClearCacheBeforeInitIsSafe)
 {
-    renderer_->Init(nullptr, nullptr, nullptr);
+    renderer_->Init(nullptr, nullptr, nullptr, nullptr);
     renderer_->ClearCache();
 
     EXPECT_FALSE(renderer_->IsInitialized());

--- a/tests/test_search_state.cpp
+++ b/tests/test_search_state.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 #include "search_state.h"
-#include "layout_cache.h"
+#include "test_helpers.h"
 #include <memory_resource>
 
 // ヘルパー: テキストを持つ単純なNodeを作成
@@ -27,20 +27,6 @@ static Node MakeTableNode(const wchar_t* cell0, const wchar_t* cell1)
     row.cells.push_back(std::move(c1));
     n.table_data->rows.push_back(std::move(row));
     return n;
-}
-
-// ヘルパー: LayoutCacheを構築
-static LayoutCache MakeCache(int count, float node_height = 100.0f)
-{
-    LayoutCache cache;
-    cache.Resize(count);
-    float y = 0.0f;
-    for (int i = 0; i < count; ++i) {
-        cache[i].y_position = y;
-        cache[i].height = node_height;
-        y += node_height;
-    }
-    return cache;
 }
 
 // ═══════════════════════════════════════════════
@@ -393,7 +379,7 @@ TEST(SearchStateTest, SetCurrentMatchNearSelectsFirstAfterScroll)
     s.ExecuteSearch(nodes);
     ASSERT_EQ(s.GetMatchCount(), 3);
 
-    auto cache = MakeCache(3, 100.0f);  // y=0,100,200
+    auto cache = MakeUniformCache(3, 100.0f);  // y=0,100,200
     s.SetCurrentMatchNear(150.0f, cache);
     EXPECT_EQ(s.GetCurrentMatchIndex(), 2);  // node2 @ y=200
 }
@@ -407,7 +393,7 @@ TEST(SearchStateTest, SetCurrentMatchNearSelectsFirstWhenAllAbove)
     s.ExecuteSearch(nodes);
     ASSERT_EQ(s.GetMatchCount(), 1);
 
-    auto cache = MakeCache(1, 100.0f);  // y=0
+    auto cache = MakeUniformCache(1, 100.0f);  // y=0
     s.SetCurrentMatchNear(500.0f, cache);
     EXPECT_EQ(s.GetCurrentMatchIndex(), 0);  // フォールバック
 }

--- a/tests/test_string_convert.cpp
+++ b/tests/test_string_convert.cpp
@@ -1,0 +1,187 @@
+#include <gtest/gtest.h>
+#include "string_convert.h"
+
+using namespace string_convert;
+
+// ═══════════════════════════════════════════════
+// Utf8ToWide
+// ═══════════════════════════════════════════════
+
+TEST(StringConvert, Utf8ToWideAscii)
+{
+    auto result = Utf8ToWide("Hello");
+    EXPECT_EQ(result, L"Hello");
+}
+
+TEST(StringConvert, Utf8ToWideEmpty)
+{
+    auto result = Utf8ToWide("");
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(StringConvert, Utf8ToWideJapanese)
+{
+    auto result = Utf8ToWide("日本語テスト");
+    EXPECT_EQ(result, L"日本語テスト");
+}
+
+TEST(StringConvert, Utf8ToWideEmoji)
+{
+    // BMP外の絵文字（サロゲートペアになる）
+    auto result = Utf8ToWide("\xF0\x9F\x98\x80"); // 😀
+    EXPECT_EQ(result.size(), 2u); // サロゲートペア
+}
+
+TEST(StringConvert, Utf8ToWideMixed)
+{
+    auto result = Utf8ToWide("Hello, 世界!");
+    EXPECT_EQ(result, L"Hello, 世界!");
+}
+
+TEST(StringConvert, Utf8ToWideRefVersion)
+{
+    std::pmr::wstring out;
+    Utf8ToWide("test", out);
+    EXPECT_EQ(out, L"test");
+}
+
+TEST(StringConvert, Utf8ToWideRefClearsOnEmpty)
+{
+    std::pmr::wstring out = L"old";
+    Utf8ToWide("", out);
+    EXPECT_TRUE(out.empty());
+}
+
+// ═══════════════════════════════════════════════
+// WideToUtf8
+// ═══════════════════════════════════════════════
+
+TEST(StringConvert, WideToUtf8Ascii)
+{
+    auto result = WideToUtf8(L"Hello");
+    EXPECT_EQ(result, "Hello");
+}
+
+TEST(StringConvert, WideToUtf8Empty)
+{
+    auto result = WideToUtf8(L"");
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(StringConvert, WideToUtf8Japanese)
+{
+    auto result = WideToUtf8(L"日本語テスト");
+    EXPECT_EQ(result, "日本語テスト");
+}
+
+TEST(StringConvert, WideToUtf8RefVersion)
+{
+    std::string out;
+    WideToUtf8(L"test", out);
+    EXPECT_EQ(out, "test");
+}
+
+TEST(StringConvert, WideToUtf8RefClearsOnEmpty)
+{
+    std::string out = "old";
+    WideToUtf8(L"", out);
+    EXPECT_TRUE(out.empty());
+}
+
+// ═══════════════════════════════════════════════
+// ラウンドトリップ
+// ═══════════════════════════════════════════════
+
+TEST(StringConvert, RoundTripAscii)
+{
+    std::string original = "Hello, World!";
+    auto wide = Utf8ToWide(original);
+    auto back = WideToUtf8(wide);
+    EXPECT_EQ(back, original);
+}
+
+TEST(StringConvert, RoundTripJapanese)
+{
+    std::string original = "マークダウンビュアー";
+    auto wide = Utf8ToWide(original);
+    auto back = WideToUtf8(wide);
+    EXPECT_EQ(back, original);
+}
+
+TEST(StringConvert, RoundTripMixed)
+{
+    std::string original = "# 見出し\n\nHello 世界 123";
+    auto wide = Utf8ToWide(original);
+    auto back = WideToUtf8(wide);
+    EXPECT_EQ(back, original);
+}
+
+TEST(StringConvert, RoundTripSpecialChars)
+{
+    std::string original = "a\tb\nc\r\nd";
+    auto wide = Utf8ToWide(original);
+    auto back = WideToUtf8(wide);
+    EXPECT_EQ(back, original);
+}
+
+TEST(StringConvert, RoundTripEmoji)
+{
+    std::string original = "\xF0\x9F\x98\x80\xF0\x9F\x8E\x89"; // 😀🎉
+    auto wide = Utf8ToWide(original);
+    auto back = WideToUtf8(wide);
+    EXPECT_EQ(back, original);
+}
+
+// ═══════════════════════════════════════════════
+// エッジケース
+// ═══════════════════════════════════════════════
+
+TEST(StringConvert, SingleCharUtf8ToWide)
+{
+    auto result = Utf8ToWide("A");
+    EXPECT_EQ(result, L"A");
+    EXPECT_EQ(result.size(), 1u);
+}
+
+TEST(StringConvert, SingleCharWideToUtf8)
+{
+    auto result = WideToUtf8(L"A");
+    EXPECT_EQ(result, "A");
+    EXPECT_EQ(result.size(), 1u);
+}
+
+TEST(StringConvert, LongString)
+{
+    std::string utf8(10000, 'x');
+    auto wide = Utf8ToWide(utf8);
+    EXPECT_EQ(wide.size(), 10000u);
+    auto back = WideToUtf8(wide);
+    EXPECT_EQ(back, utf8);
+}
+
+TEST(StringConvert, NullByteInMiddle)
+{
+    // string_view ベースなので null バイトも扱える
+    std::string utf8("a\0b", 3);
+    auto wide = Utf8ToWide(utf8);
+    EXPECT_EQ(wide.size(), 3u);
+    EXPECT_EQ(wide[0], L'a');
+    EXPECT_EQ(wide[1], L'\0');
+    EXPECT_EQ(wide[2], L'b');
+}
+
+TEST(StringConvert, MultiByteBoundary)
+{
+    // 2バイトUTF-8文字 (U+00E9 é)
+    auto result = Utf8ToWide("\xC3\xA9");
+    EXPECT_EQ(result, L"\u00E9");
+    EXPECT_EQ(result.size(), 1u);
+}
+
+TEST(StringConvert, ThreeByteBoundary)
+{
+    // 3バイトUTF-8文字 (U+3042 あ)
+    auto result = Utf8ToWide("\xE3\x81\x82");
+    EXPECT_EQ(result, L"\u3042");
+    EXPECT_EQ(result.size(), 1u);
+}

--- a/tests/test_types.cpp
+++ b/tests/test_types.cpp
@@ -145,3 +145,270 @@ TEST(TextRun, DefaultState)
     EXPECT_FALSE(run.strikethrough());
     EXPECT_FALSE(run.has_link());
 }
+
+// ---- TextRunフラグ操作 ----
+
+TEST(TextRun, SetBold)
+{
+    TextRun run;
+    run.set_bold(true);
+    EXPECT_TRUE(run.bold());
+}
+
+TEST(TextRun, SetItalic)
+{
+    TextRun run;
+    run.set_italic(true);
+    EXPECT_TRUE(run.italic());
+}
+
+TEST(TextRun, SetCode)
+{
+    TextRun run;
+    run.set_code(true);
+    EXPECT_TRUE(run.code());
+}
+
+TEST(TextRun, SetStrikethrough)
+{
+    TextRun run;
+    run.set_strikethrough(true);
+    EXPECT_TRUE(run.strikethrough());
+}
+
+TEST(TextRun, MultipleFlags)
+{
+    TextRun run;
+    run.set_bold(true);
+    run.set_italic(true);
+    run.set_code(true);
+    run.set_strikethrough(true);
+    EXPECT_TRUE(run.bold());
+    EXPECT_TRUE(run.italic());
+    EXPECT_TRUE(run.code());
+    EXPECT_TRUE(run.strikethrough());
+}
+
+TEST(TextRun, ClearFlag)
+{
+    TextRun run;
+    run.set_bold(true);
+    run.set_italic(true);
+    EXPECT_TRUE(run.bold());
+    EXPECT_TRUE(run.italic());
+
+    run.set_bold(false);
+    EXPECT_FALSE(run.bold());
+    EXPECT_TRUE(run.italic());
+}
+
+TEST(TextRun, SetAllThenClearAll)
+{
+    TextRun run;
+    run.set_bold(true);
+    run.set_italic(true);
+    run.set_code(true);
+    run.set_strikethrough(true);
+
+    run.set_bold(false);
+    run.set_italic(false);
+    run.set_code(false);
+    run.set_strikethrough(false);
+
+    EXPECT_FALSE(run.bold());
+    EXPECT_FALSE(run.italic());
+    EXPECT_FALSE(run.code());
+    EXPECT_FALSE(run.strikethrough());
+}
+
+TEST(TextRun, HasLinkWithIndex)
+{
+    TextRun run;
+    run.link_url_index = 0;
+    EXPECT_TRUE(run.has_link());
+}
+
+TEST(TextRun, HasLinkNegativeIndex)
+{
+    TextRun run;
+    run.link_url_index = -1;
+    EXPECT_FALSE(run.has_link());
+}
+
+// ---- AlertColorIndex ----
+
+TEST(AlertColorIndex, NoneReturnsSentinel)
+{
+    EXPECT_EQ(AlertColorIndex(AlertType::None), ALERT_TYPE_COUNT);
+}
+
+TEST(AlertColorIndex, NoteReturnsZero)
+{
+    EXPECT_EQ(AlertColorIndex(AlertType::Note), 0u);
+}
+
+TEST(AlertColorIndex, TipReturnsOne)
+{
+    EXPECT_EQ(AlertColorIndex(AlertType::Tip), 1u);
+}
+
+TEST(AlertColorIndex, ImportantReturnsTwo)
+{
+    EXPECT_EQ(AlertColorIndex(AlertType::Important), 2u);
+}
+
+TEST(AlertColorIndex, WarningReturnsThree)
+{
+    EXPECT_EQ(AlertColorIndex(AlertType::Warning), 3u);
+}
+
+TEST(AlertColorIndex, CautionReturnsFour)
+{
+    EXPECT_EQ(AlertColorIndex(AlertType::Caution), 4u);
+}
+
+// ---- Nodeアクセサ ----
+
+TEST(NodeTest, SetTextAndGetText)
+{
+    Node node;
+    node.SetText(L"Hello");
+    EXPECT_EQ(node.GetText(), L"Hello");
+    EXPECT_TRUE(node.HasText());
+}
+
+TEST(NodeTest, SetTextStringView)
+{
+    Node node;
+    std::wstring_view sv = L"Test text";
+    node.SetText(sv);
+    EXPECT_EQ(node.GetText(), L"Test text");
+}
+
+TEST(NodeTest, SetTextMove)
+{
+    Node node;
+    std::pmr::wstring s = L"Moved text";
+    node.SetText(std::move(s));
+    EXPECT_EQ(node.GetText(), L"Moved text");
+}
+
+TEST(NodeTest, SetTextCountsNewlines)
+{
+    Node node;
+    node.SetText(L"line1\nline2\nline3");
+    EXPECT_EQ(node.line_count, 2);
+}
+
+TEST(NodeTest, SetTextClearsUtf8)
+{
+    Node node;
+    node.text_utf8 = "original";
+    node.SetText(L"new text");
+    EXPECT_TRUE(node.text_utf8.empty());
+}
+
+TEST(NodeTest, LazyConversionFromUtf8)
+{
+    Node node;
+    node.text_utf8 = "Lazy conversion";
+    EXPECT_TRUE(node.HasText());
+    EXPECT_EQ(node.GetText(), L"Lazy conversion");
+}
+
+TEST(NodeTest, LazyConversionJapanese)
+{
+    Node node;
+    node.text_utf8 = "日本語";
+    EXPECT_EQ(node.GetText(), L"日本語");
+}
+
+TEST(NodeTest, HasTextEmptyUtf8AndNoWide)
+{
+    Node node;
+    EXPECT_FALSE(node.HasText());
+}
+
+TEST(NodeTest, EnsureTable)
+{
+    Node node;
+    EXPECT_FALSE(node.has_table());
+    node.ensure_table();
+    EXPECT_TRUE(node.has_table());
+    // 再度呼んでもクラッシュしない
+    node.ensure_table();
+    EXPECT_TRUE(node.has_table());
+}
+
+TEST(NodeTest, EnsureImage)
+{
+    Node node;
+    EXPECT_FALSE(node.has_image());
+    node.ensure_image();
+    EXPECT_TRUE(node.has_image());
+}
+
+TEST(NodeTest, EnsureHeading)
+{
+    Node node;
+    EXPECT_FALSE(node.has_heading());
+    node.ensure_heading();
+    EXPECT_TRUE(node.has_heading());
+}
+
+TEST(NodeTest, EnsureCode)
+{
+    Node node;
+    EXPECT_FALSE(node.has_code());
+    node.ensure_code();
+    EXPECT_TRUE(node.has_code());
+}
+
+TEST(NodeTest, AnchorIdWithoutHeadingData)
+{
+    Node node;
+    EXPECT_TRUE(node.anchor_id().empty());
+}
+
+TEST(NodeTest, AnchorIdWithHeadingData)
+{
+    Node node;
+    node.ensure_heading();
+    node.heading_data->anchor_id = L"test-anchor";
+    EXPECT_EQ(node.anchor_id(), L"test-anchor");
+}
+
+TEST(NodeTest, SyntaxTokensWithoutCodeData)
+{
+    Node node;
+    EXPECT_TRUE(node.syntax_tokens().empty());
+}
+
+TEST(NodeTest, SyntaxTokensMutCreatesCodeData)
+{
+    Node node;
+    EXPECT_FALSE(node.has_code());
+    auto& tokens = node.syntax_tokens_mut();
+    EXPECT_TRUE(node.has_code());
+    EXPECT_TRUE(tokens.empty());
+}
+
+TEST(NodeTest, CodeBlockPreservesUtf8OnGetText)
+{
+    Node node;
+    node.type = NodeType::CodeBlock;
+    node.text_utf8 = "code content";
+    node.GetText(); // 遅延変換を発火
+    // CodeBlockはtext_utf8を保持する
+    EXPECT_FALSE(node.text_utf8.empty());
+}
+
+TEST(NodeTest, ParagraphReleasesUtf8OnGetText)
+{
+    Node node;
+    node.type = NodeType::Paragraph;
+    node.text_utf8 = "paragraph content";
+    node.GetText(); // 遅延変換を発火
+    // Paragraph等はtext_utf8を解放する
+    EXPECT_TRUE(node.text_utf8.empty());
+}

--- a/tests/test_viewport_manager.cpp
+++ b/tests/test_viewport_manager.cpp
@@ -1,22 +1,8 @@
 #include <gtest/gtest.h>
 #include <memory_resource>
 #include "viewport_manager.h"
-#include "layout_cache.h"
+#include "test_helpers.h"
 #include "types.h"
-
-// ヘルパー: 等間隔に配置されたノードで単純なLayoutCacheを構築する。
-static LayoutCache MakeTestCache(int count, float node_height = 50.0f)
-{
-    LayoutCache cache;
-    cache.Resize(count);
-    float y = 0.0f;
-    for (int i = 0; i < count; ++i) {
-        cache[i].y_position = y;
-        cache[i].height = node_height;
-        y += node_height;
-    }
-    return cache;
-}
 
 // ---- スクロールテスト ----
 
@@ -102,7 +88,7 @@ TEST(ViewportManagerTest, DirectScrollByAccumulates)
 TEST(ViewportManagerTest, FindFirstVisibleNodeStart)
 {
     ViewportManager vm;
-    auto cache = MakeTestCache(10, 50.0f);
+    auto cache = MakeUniformCache(10, 50.0f);
     vm.SyncMaxScroll(500.0f, 200.0f);
     vm.ScrollTo(0.0f);
     EXPECT_EQ(vm.FindFirstVisibleNode(cache, 10), 0);
@@ -111,7 +97,7 @@ TEST(ViewportManagerTest, FindFirstVisibleNodeStart)
 TEST(ViewportManagerTest, FindFirstVisibleNodeMiddle)
 {
     ViewportManager vm;
-    auto cache = MakeTestCache(10, 50.0f);
+    auto cache = MakeUniformCache(10, 50.0f);
     vm.SyncMaxScroll(500.0f, 200.0f);
     vm.ScrollTo(120.0f); // y=100のノード(インデックス2)が見えるはず
     EXPECT_EQ(vm.FindFirstVisibleNode(cache, 10), 2);
@@ -120,7 +106,7 @@ TEST(ViewportManagerTest, FindFirstVisibleNodeMiddle)
 TEST(ViewportManagerTest, FindFirstVisibleNodeEnd)
 {
     ViewportManager vm;
-    auto cache = MakeTestCache(10, 50.0f);
+    auto cache = MakeUniformCache(10, 50.0f);
     vm.SyncMaxScroll(500.0f, 200.0f);
     vm.ScrollTo(300.0f); // max_scroll=300, node 6 starts at y=300
     int idx = vm.FindFirstVisibleNode(cache, 10);
@@ -139,7 +125,7 @@ TEST(ViewportManagerTest, FindFirstVisibleNodeEmpty)
 TEST(ViewportManagerTest, AnchorCompensateScroll)
 {
     ViewportManager vm;
-    auto cache = MakeTestCache(5, 100.0f);
+    auto cache = MakeUniformCache(5, 100.0f);
     vm.SyncMaxScroll(500.0f, 200.0f);
     vm.ScrollTo(100.0f);
 
@@ -157,7 +143,7 @@ TEST(ViewportManagerTest, AnchorCompensateScroll)
 TEST(ViewportManagerTest, AnchorCompensateNegativeIndex)
 {
     ViewportManager vm;
-    auto cache = MakeTestCache(3, 100.0f);
+    auto cache = MakeUniformCache(3, 100.0f);
     vm.SyncMaxScroll(300.0f, 100.0f);
     vm.ScrollTo(50.0f);
     float before = vm.GetScrollY();
@@ -274,7 +260,7 @@ TEST(ViewportManagerTest, ScrollbarTracking)
 TEST(ViewportManagerTest, AnchorCompensateScrollClampsNegative)
 {
     ViewportManager vm;
-    auto cache = MakeTestCache(5, 100.0f);
+    auto cache = MakeUniformCache(5, 100.0f);
     vm.SyncMaxScroll(500.0f, 200.0f);
     vm.ScrollTo(50.0f);
 
@@ -292,7 +278,7 @@ TEST(ViewportManagerTest, AnchorCompensateScrollClampsNegative)
 TEST(ViewportManagerTest, AnchorCompensateScrollPositiveShiftOk)
 {
     ViewportManager vm;
-    auto cache = MakeTestCache(5, 100.0f);
+    auto cache = MakeUniformCache(5, 100.0f);
     vm.SyncMaxScroll(500.0f, 200.0f);
     vm.ScrollTo(100.0f);
 
@@ -309,7 +295,7 @@ TEST(ViewportManagerTest, ScrollRestoreRoundTrip)
 {
     // ノード+オフセットで保存→復元すると元のスクロール位置を再現できる
     ViewportManager vm;
-    auto cache = MakeTestCache(10, 50.0f); // total=500
+    auto cache = MakeUniformCache(10, 50.0f); // total=500
     vm.SyncMaxScroll(500.0f, 200.0f);      // max_scroll=300
     vm.ScrollTo(125.0f);                    // ノード2の途中
 
@@ -325,7 +311,7 @@ TEST(ViewportManagerTest, ScrollRestoreResilientToHeightChange)
 {
     // 画像未読み込み→読み込み後でレイアウトが変わっても正しいノードを指す
     ViewportManager vm;
-    auto cache = MakeTestCache(10, 50.0f);
+    auto cache = MakeUniformCache(10, 50.0f);
     vm.SyncMaxScroll(500.0f, 200.0f);
     vm.ScrollTo(200.0f); // ノード4の先頭
 
@@ -355,7 +341,7 @@ TEST(ViewportManagerTest, ScrollRestoreWithPartialNodeVisibility)
 {
     // ノードの途中で保存した場合、オフセットがノード内の位置を再現する
     ViewportManager vm;
-    auto cache = MakeTestCache(10, 100.0f); // total=1000
+    auto cache = MakeUniformCache(10, 100.0f); // total=1000
     vm.SyncMaxScroll(1000.0f, 300.0f);
     vm.ScrollTo(350.0f); // ノード3(y=300)の途中
 
@@ -371,7 +357,7 @@ TEST(ViewportManagerTest, ScrollRestoreWithPartialNodeVisibility)
 TEST(ViewportManagerTest, ScrollRestoreNodeClampedToSize)
 {
     // 保存されたノードインデックスが現在のノード数を超える場合は最終ノードに制限
-    auto cache = MakeTestCache(5, 100.0f);
+    auto cache = MakeUniformCache(5, 100.0f);
     int saved_node = 8; // 5個しかないので超過
     int clamped = std::min(saved_node, static_cast<int>(cache.size()) - 1);
     EXPECT_EQ(clamped, 4);
@@ -383,7 +369,7 @@ TEST(ViewportManagerTest, ScrollRestoreNodeClampedToSize)
 TEST(ViewportManagerTest, ScrollRestoreAtDocumentStart)
 {
     ViewportManager vm;
-    auto cache = MakeTestCache(10, 50.0f);
+    auto cache = MakeUniformCache(10, 50.0f);
     vm.SyncMaxScroll(500.0f, 200.0f);
     vm.ScrollTo(0.0f);
 
@@ -400,7 +386,7 @@ TEST(ViewportManagerTest, ScrollRestoreAtDocumentStart)
 TEST(ViewportManagerTest, ScrollRestoreAtDocumentEnd)
 {
     ViewportManager vm;
-    auto cache = MakeTestCache(10, 50.0f); // total=500
+    auto cache = MakeUniformCache(10, 50.0f); // total=500
     vm.SyncMaxScroll(500.0f, 200.0f);      // max_scroll=300
     vm.ScrollTo(300.0f);                    // 最下端
 
@@ -415,7 +401,7 @@ TEST(ViewportManagerTest, ScrollRestoreAnchorCompensationAfterHeightChange)
 {
     // ノードベース復元後に画像読み込みでアンカー補正が正しく機能する
     ViewportManager vm;
-    auto cache = MakeTestCache(10, 50.0f);
+    auto cache = MakeUniformCache(10, 50.0f);
     vm.SyncMaxScroll(500.0f, 200.0f);
 
     // ノード5(y=250)付近にスクロール復元


### PR DESCRIPTION
## Summary
- 描画・レイアウト・メモリの最適化（WICデコード統合、FlatMap/LruCache導入、重複コード削減）
- テストカバレッジ向上: 1492→1617テスト（+125テスト、FlatMap・StringConvert・TextRun・Node・DocumentUtils等）
- 遅いテストの高速化: FileWatcherをイベントベース待機に変更、MermaidFileCacheのsleep短縮
- テスト実行をctest廃止→バイナリ直接実行に変更（68秒→3.3秒）

## Changes
- `src/util/flat_map.h`: ソート済みpmr::vectorベースの連想コンテナ新規追加
- `src/util/lru_cache.h`: 固定サイズLRUキャッシュのリファクタリング
- `src/util/wic_util.h`: WICデコード共通ユーティリティ抽出
- `src/io/image_loader.cpp`, `src/mermaid/mermaid.cpp`: WICデコード・TextRunフォーマットの重複統合
- `src/render/renderer.cpp`, `src/layout/dwrite_measurer.cpp`: 描画パイプライン最適化
- `tests/test_flat_map.cpp`, `tests/test_string_convert.cpp`: 新規テストファイル
- `tests/test_helpers.h`: MakeUniformCacheヘルパー共有化（4ファイルの重複解消）
- `tests/test_file_loader.cpp`: Sleep→WaitForSingleObject、ポーリング廃止
- `tests/CMakeLists.txt`, `CLAUDE.md`: ctest廃止、--gtest_brief=1で直接実行

## Test plan
- [x] 全1617テストがパス（`mendo_tests.exe --gtest_brief=1`で3.3秒）
- [x] アプリの基本操作（ファイル読込・スクロール・検索・テーマ切替）の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)