### PR TITLE
リファクタリング: AppState分解・Reducer分割・app.cpp分割

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ add_executable(mendo WIN32
     src/main.cpp
     src/window/window.cpp
     src/app/app.cpp
+    src/app/app_file.cpp
     src/app/app_scroll.cpp
     src/app/app_mouse.cpp
     src/app/app_navigate.cpp

--- a/docs/refactoring-todo.md
+++ b/docs/refactoring-todo.md
@@ -1,0 +1,48 @@
+# リファクタリング残課題
+
+2026-04-15 のアプリ全体リファクタリングで発見されたが、スコープ外としてスキップした課題。
+
+## 1. マウスアクション構造体の未使用 dip_x/dip_y フィールド削除
+
+`app_events.h` の8つのマウスアクション構造体（`LButtonDownAction`, `LButtonUpAction`, `MouseMoveAction`, `MouseHoverAction`, `LButtonDblClkAction`, `RButtonDownAction`, `RButtonUpAction`, `RButtonMoveAction`）に `float dip_x, dip_y` フィールドがあるが、Reducer では `a.px, a.py` しか参照されていない。DIP変換は `App::OnLButtonDown()` 等の内部で `PixelToDip()` により行われるため、アクション構造体側のフィールドは不要。`AppAction` variant のサイズを不必要に肥大化させている。
+
+**対処方針:** 8構造体から `dip_x`/`dip_y` を削除し `px`/`py` のみ残す。`App` 内の `Dispatch()` 呼び出し箇所で引数を修正する。
+
+## 2. ShowToast / CopySelectionToClipboard の Reducer 統一
+
+Reducer 経由と直接呼び出しの2つの経路が存在し、「Reducer が唯一の状態変更点」という設計原則が崩れている。
+
+### ShowToast
+
+- Reducer 経路: `effect::ShowToast` → `SideEffectExecutor` が `state_->interaction.toast.Show()` + `SetTimer` + `InvalidateRect`
+- 直接経路: `App::ShowToast()` が同じ処理を直接実行（`app_file.cpp` の `DoLoadMarkdownFile` エラー時等）
+
+### CopySelectionToClipboard
+
+- Reducer 経路: `Ctrl+C` → `CopyClipboardAction` → Reducer が `effect::ClipboardWrite` を生成
+- 直接経路: コンテキストメニューの `IDM_COPY` (`app_context_menu.cpp`) → `App::CopySelectionToClipboard()` が直接クリップボード書き込み
+
+**対処方針:** コンテキストメニューの `IDM_COPY` は `Dispatch(CopyClipboardAction{})` に変更。`App::ShowToast` の呼び出し元は SideEffect リスト経由で `effect::ShowToast` を発行するように変更する。
+
+## 3. ThemeConstants の手動同期リスク
+
+`app_navigate.cpp` の `SyncPaneThemeCache()` が `Theme` から `ThemeConstants` へ7フィールドを手動コピーしている。`Theme` に新しいフィールドが追加され Reducer で使われるようになった場合、ここに追加し忘れるとバグになる。
+
+```cpp
+// app_navigate.cpp:57-69
+void App::SyncPaneThemeCache()
+{
+    const auto& theme = renderer_.GetTheme();
+    state_.window.cached_theme = ThemeConstants{
+        .pane_item_height = theme.pane_item_height,
+        .pane_header_height = theme.pane_header_height,
+        .splitter_width = theme.splitter_width,
+        .margin_left = theme.margin_left,
+        .margin_right = theme.margin_right,
+        .heading_spacing_above = theme.heading_spacing_above,
+        .zoom = theme.zoom,
+    };
+}
+```
+
+**対処方針:** `Theme` クラスに `ThemeConstants ToReducerConstants() const` ファクトリメソッドを追加し、変換ロジックを `Theme` 側に集約する。フィールド追加時にコンパイルエラーで漏れを検出できるよう designated initializer を維持する。

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -55,20 +55,20 @@ bool App::Init(HWND hwnd)
         return false;
     }
 
-    layout_service_.emplace(renderer_.GetLayout(), state_.viewport);
+    layout_service_.emplace(renderer_.GetLayout(), state_.view.viewport);
 
     // PixelToDip用にDPIスケールをキャッシュ (OnDpiChangedで更新)
     const float init_dpi = static_cast<float>(GetDpiForWindow(hwnd_));
-    state_.cached_dpi_scale = (init_dpi > 0.0f) ? (init_dpi / DEFAULT_DPI) : 1.0f;
+    state_.window.cached_dpi_scale = (init_dpi > 0.0f) ? (init_dpi / DEFAULT_DPI) : 1.0f;
 
     // タスクスケジューラを初期化（画像デコード・キャッシュ書き込み共用）
     scheduler_.Init(mermaid_util::ComputeWorkerCount(
         std::thread::hardware_concurrency()));
 
-    file_cache_.Init(state_.cached_dpi_scale, scheduler_);
+    file_cache_.Init(state_.window.cached_dpi_scale, scheduler_);
     mermaid_renderer_.SetFileCache(&file_cache_);
 
-    resource_manager_.Init(state_.doc, state_.layout_cache, state_.viewport, image_loader_, mermaid_renderer_,
+    resource_manager_.Init(state_.document.doc, state_.document.layout_cache, state_.view.viewport, image_loader_, mermaid_renderer_,
         theme_service_, renderer_, BuildResourceManagerCallbacks());
     effect_executor_.Init(hwnd_, resource_manager_, cursors_, doc_service_, config_,
         state_, *layout_service_, {
@@ -77,7 +77,7 @@ bool App::Init(HWND hwnd)
             .open_file_dialog = [this]() {
                 const auto path = FileLoader::OpenFileDialog(hwnd_);
                 if (!path.empty()) {
-                    if (!state_.doc.GetFilePath().empty()) {
+                    if (!state_.document.doc.GetFilePath().empty()) {
                         PushNavHistory();
                     }
                     LoadMarkdownFile(path);
@@ -171,11 +171,11 @@ bool App::Init(HWND hwnd)
     });
 
     theme_service_.LoadDarkMode();
-    state_.viewport.SetZoomIndex(theme_service_.LoadZoomIndex());
-    if (theme_service_.IsDarkMode() || state_.viewport.GetZoomIndex() != ZOOM_DEFAULT_INDEX) {
-        renderer_.SetTheme(theme_service_.CreateTheme(state_.viewport.GetZoomIndex()));
-        if (state_.viewport.GetZoomIndex() != ZOOM_DEFAULT_INDEX) {
-            state_.panes.ApplyZoom(state_.viewport.GetCurrentZoom());
+    state_.view.viewport.SetZoomIndex(theme_service_.LoadZoomIndex());
+    if (theme_service_.IsDarkMode() || state_.view.viewport.GetZoomIndex() != ZOOM_DEFAULT_INDEX) {
+        renderer_.SetTheme(theme_service_.CreateTheme(state_.view.viewport.GetZoomIndex()));
+        if (state_.view.viewport.GetZoomIndex() != ZOOM_DEFAULT_INDEX) {
+            state_.view.panes.ApplyZoom(state_.view.viewport.GetCurrentZoom());
         }
     }
     if (theme_service_.IsDarkMode()) {
@@ -189,19 +189,19 @@ bool App::Init(HWND hwnd)
     {
         const auto* rt = renderer_.GetRenderTarget();
         const float window_w = rt ? rt->GetSize().width : 1600.0f;
-        state_.titlebar.UpdateLayout(window_w);
+        state_.window.titlebar.UpdateLayout(window_w);
     }
 
     LoadPaneState();
 
     state_.ctx_menu.Init(renderer_.GetD2DFactory(), renderer_.GetDWriteFactory());
 
-    state_.tooltip.Init(hwnd_);
+    state_.interaction.tooltip.Init(hwnd_);
     if (theme_service_.IsDarkMode()) {
-        state_.tooltip.ApplyDarkMode(true);
+        state_.interaction.tooltip.ApplyDarkMode(true);
     }
 
-    state_.search_bar_ctrl.Init(state_.search_state, state_.viewport, state_.layout_cache, BuildSearchBarCallbacks());
+    state_.search.search_bar_ctrl.Init(state_.search.search_state, state_.view.viewport, state_.document.layout_cache, BuildSearchBarCallbacks());
 
     return true;
 }
@@ -212,7 +212,7 @@ bool App::Init(HWND hwnd)
 
 App::DipPoint App::PixelToDip(int px, int py) const noexcept
 {
-    return { px / state_.cached_dpi_scale, py / state_.cached_dpi_scale };
+    return { px / state_.window.cached_dpi_scale, py / state_.window.cached_dpi_scale };
 }
 
 PaneScrollInfo App::ComputePaneScrollInfo(
@@ -227,11 +227,11 @@ void App::HandleScrollbarClick(float dip_y, const PaneScrollInfo& info,
     const float thumb_y = ComputeThumbY(info, scroll.scroll_y);
 
     if (dip_y >= thumb_y && dip_y <= thumb_y + info.thumb_height) {
-        state_.panes.SetDragScrollOffset(dip_y - thumb_y);
+        state_.view.panes.SetDragScrollOffset(dip_y - thumb_y);
     }
     else {
-        state_.panes.SetDragScrollOffset(info.thumb_height * 0.5f);
-        const float new_thumb_y = dip_y - state_.panes.GetDragScrollOffset();
+        state_.view.panes.SetDragScrollOffset(info.thumb_height * 0.5f);
+        const float new_thumb_y = dip_y - state_.view.panes.GetDragScrollOffset();
         scroll.scroll_y = ScrollFromThumbY(info, new_thumb_y);
         scroll.max_scroll = info.max_scroll;
         cache_dirty = true;
@@ -242,7 +242,7 @@ void App::HandleScrollbarClick(float dip_y, const PaneScrollInfo& info,
 void App::HandleScrollbarDrag(float dip_y, const PaneScrollInfo& info,
     ScrollState& scroll, bool& cache_dirty)
 {
-    const float new_thumb_y = dip_y - state_.panes.GetDragScrollOffset();
+    const float new_thumb_y = dip_y - state_.view.panes.GetDragScrollOffset();
     scroll.scroll_y = ScrollFromThumbY(info, new_thumb_y);
     scroll.max_scroll = info.max_scroll;
     cache_dirty = true;
@@ -274,7 +274,7 @@ void App::FinalizeLayout(float md_pane_height)
 // ペインレイアウト
 // ============================================================
 
-const PaneLayout& App::GetPaneLayout() const
+const PaneLayout& App::GetPaneLayout()
 {
     if (!state_.pane_layout_valid) {
         auto* rt = renderer_.GetRenderTarget();
@@ -284,8 +284,8 @@ const PaneLayout& App::GetPaneLayout() const
         }
         const auto size = rt->GetSize();
         state_.cached_window_width_for_layout = size.width;
-        const float tb_h = state_.titlebar.GetHeight();
-        state_.cached_pane_layout = state_.panes.ComputeLayout(size.width, size.height,
+        const float tb_h = state_.window.titlebar.GetHeight();
+        state_.cached_pane_layout = state_.view.panes.ComputeLayout(size.width, size.height,
             renderer_.GetTheme().splitter_width, tb_h);
         state_.pane_layout_valid = true;
     }
@@ -294,7 +294,7 @@ const PaneLayout& App::GetPaneLayout() const
 
 void App::InvalidatePane(const PaneRect& rect) noexcept
 {
-    const float scale = state_.cached_dpi_scale;
+    const float scale = state_.window.cached_dpi_scale;
     RECT rc;
     rc.left = static_cast<LONG>(rect.x * scale);
     rc.top = static_cast<LONG>(rect.y * scale);
@@ -305,7 +305,7 @@ void App::InvalidatePane(const PaneRect& rect) noexcept
 
 void App::InvalidateTitleBar() noexcept
 {
-    const float tb_h = state_.titlebar.GetHeight();
+    const float tb_h = state_.window.titlebar.GetHeight();
     if (tb_h <= 0.0f) {
         return;
     }
@@ -317,18 +317,18 @@ void App::InvalidateTitleBar() noexcept
     InvalidatePane(PaneRect{ 0.0f, 0.0f, state_.cached_window_width_for_layout, tb_h });
 }
 
-PaneZone App::PaneAtPoint(float dip_x, [[maybe_unused]] float dip_y) const
+PaneZone App::PaneAtPoint(float dip_x, [[maybe_unused]] float dip_y)
 {
     const auto* rt = renderer_.GetRenderTarget();
     if (!rt) {
         return PaneZone::None;
     }
     const auto size = rt->GetSize();
-    return state_.panes.DetectZone(dip_x, size.width, size.height,
+    return state_.view.panes.DetectZone(dip_x, size.width, size.height,
         renderer_.GetTheme().splitter_width);
 }
 
-float App::GetMarkdownPaneWidth() const
+float App::GetMarkdownPaneWidth()
 {
     const auto layout = GetPaneLayout();
     return layout.md_rect.width;
@@ -363,7 +363,7 @@ void App::OnPaint()
         {
             MENDO_PROFILE("EnsureVisibleLayout");
             updated = layout_service_->EnsureVisibleLayout(
-                state_.doc, state_.layout_cache, layout.md_rect.width, layout.md_rect.height);
+                state_.document.doc, state_.document.layout_cache, layout.md_rect.width, layout.md_rect.height);
         }
 
         if (updated) {
@@ -372,9 +372,9 @@ void App::OnPaint()
     }
     // 目次ペインの同期: mdペインのスクロール位置からアクティブ見出しを判定し、
     // 目次ペインを自動スクロールする
-    if (state_.panes.IsTocPaneVisible() && !show_loading) {
+    if (state_.view.panes.IsTocPaneVisible() && !show_loading) {
         const float toc_margin = layout.md_rect.y + renderer_.GetTheme().heading_spacing_above;
-        const int new_active = state_.doc.GetToc().FindActiveIndex(state_.layout_cache, state_.viewport.GetScrollY(), toc_margin);
+        const int new_active = state_.document.doc.GetToc().FindActiveIndex(state_.document.layout_cache, state_.view.viewport.GetScrollY(), toc_margin);
         if (new_active != state_.active_toc_index) {
             state_.active_toc_index = new_active;
             renderer_.InvalidateTocPaneCache();
@@ -383,9 +383,9 @@ void App::OnPaint()
             if (new_active >= 0) {
                 const auto& theme = renderer_.GetTheme();
                 const float item_y = static_cast<float>(new_active) * theme.pane_item_height;
-                const float total = static_cast<float>(state_.doc.GetToc().GetEntries().size()) * theme.pane_item_height;
+                const float total = static_cast<float>(state_.document.doc.GetToc().GetEntries().size()) * theme.pane_item_height;
                 const auto info = ComputeScrollInfo(layout.toc_rect, theme.pane_header_height, total);
-                auto& toc_scroll = state_.panes.TocScroll();
+                auto& toc_scroll = state_.view.panes.TocScroll();
                 toc_scroll.max_scroll = info.max_scroll;
                 float& sy = toc_scroll.scroll_y;
                 sy = std::clamp(sy, 0.0f, info.max_scroll);
@@ -418,8 +418,8 @@ void App::OnPaint()
     }
     else {
         // 検索マッチ情報をコマンドジェネレータに設定
-        if (state_.search_state.IsVisible() && state_.search_state.IsHighlightEnabled() && !state_.search_state.GetMatches().empty()) {
-            renderer_.SetSearchMatches(&state_.search_state.GetMatches(), state_.search_state.GetCurrentMatchIndex());
+        if (state_.search.search_state.IsVisible() && state_.search.search_state.IsHighlightEnabled() && !state_.search.search_state.GetMatches().empty()) {
+            renderer_.SetSearchMatches(&state_.search.search_state.GetMatches(), state_.search.search_state.GetCurrentMatchIndex());
         }
         else {
             renderer_.SetSearchMatches(nullptr, -1);
@@ -427,17 +427,17 @@ void App::OnPaint()
 
         // 描画前パス: 可視ノードに描画エフェクトを適用（Render の前に実行）
         renderer_.PrepareVisibleEffects(
-            state_.doc.GetNodesMut(), state_.layout_cache,
-            state_.viewport.GetScrollY(), layout.md_rect.height);
+            state_.document.doc.GetNodesMut(), state_.document.layout_cache,
+            state_.view.viewport.GetScrollY(), layout.md_rect.height);
 
         {
             MENDO_PROFILE("Renderer::Render");
             renderer_.Render({
-                state_.doc.GetNodes(), state_.layout_cache,
-                state_.viewport.GetSelection(), layout.md_rect, sp, tb, gs, ts, sb,
-                state_.viewport.GetScrollY(), layout_service_->GetTotalHeight(),
-                static_cast<int>(state_.nav_hover), state_.hovered_copy_node, state_.hovered_save_node,
-                state_.nav_history.CanGoBack(), state_.nav_history.CanGoForward(),
+                state_.document.doc.GetNodes(), state_.document.layout_cache,
+                state_.view.viewport.GetSelection(), layout.md_rect, sp, tb, gs, ts, sb,
+                state_.view.viewport.GetScrollY(), layout_service_->GetTotalHeight(),
+                static_cast<int>(state_.interaction.nav_hover), state_.interaction.hovered_copy_node, state_.interaction.hovered_save_node,
+                state_.view.nav_history.CanGoBack(), state_.view.nav_history.CanGoForward(),
                 layout_service_->HasDirtyNodes()
                 });
         }
@@ -454,459 +454,6 @@ void App::OnResize(UINT width, UINT height)
 void App::OnDpiChanged(UINT dpi, const RECT* suggested)
 {
     Dispatch(DpiChangedAction{ dpi, *suggested });
-}
-
-// ============================================================
-// ファイル読み込み
-// ============================================================
-
-void App::LoadHelpDocument()
-{
-    if (IsHelpPath(state_.doc.GetFilePath())) {
-        return;
-    }
-
-    const auto rc = LoadRcData(i18n::S().help_resource_id);
-    if (rc.empty()) {
-        return;
-    }
-
-    KillTimer(hwnd_, app_timer::LOADING_ANIM);
-    file_load_service_.StopLoading();
-    state_.viewport.ClearSelection();
-    CancelPendingResources();
-    renderer_.ShrinkBuffers();
-    doc_service_.StopWatching();
-
-    std::pmr::string utf8(reinterpret_cast<const char*>(rc.data()), rc.size());
-    state_.doc = Document::FromMarkdown(std::move(utf8), HELP_PATH);
-    state_.layout_cache.Reset(state_.doc.GetNodes().size());
-
-    state_.file_explorer.SetCurrentFile(L"");
-    renderer_.InvalidateFilePaneCache();
-
-    state_.panes.ResetScrollStates();
-    renderer_.InvalidateTocPaneCache();
-
-    // ビューポート優先レイアウト + 遅延処理
-    state_.viewport.SetScrollY(0.0f);
-    {
-        const auto pane_layout = GetPaneLayout();
-        layout_service_->ViewportLayout(state_.doc, state_.layout_cache,
-            pane_layout.md_rect.width, pane_layout.md_rect.height);
-        SyncMaxScroll(pane_layout.md_rect.height);
-    }
-    UpdateScrollBar();
-    Invalidate();
-    ScheduleDeferredLayoutIfNeeded();
-
-    UpdateTitleBar();
-}
-
-void App::BeginAsyncLoad(const std::pmr::wstring& path)
-{
-    file_load_service_.SetLoadingPath(path);
-    if (DocumentService::NeedsLoadingAnimation(path) && !state_.pending_prefix_shrink) {
-        file_load_service_.StartLoading(path);
-        SetTimer(hwnd_, app_timer::LOADING_ANIM, app_timer::FRAME_INTERVAL_MS, nullptr);
-        Invalidate();
-        UpdateWindow(hwnd_);
-    }
-    file_load_service_.StartAsyncLoad(scheduler_, hwnd_, app_msg::PARSE_COMPLETE, renderer_.GetTheme());
-}
-
-void App::LoadMarkdownFile(std::wstring_view path)
-{
-    KillTimer(hwnd_, app_timer::FILE_RELOAD_DEBOUNCE);
-    state_.pending_prefix_shrink = false;
-    // 仮想パスは NeedsAsyncLoad が true を返し非同期ロードが失敗するため、
-    // 先に検出して同期ロードに回す。
-    if (IsHelpPath(path)) {
-        LoadHelpDocument();
-        return;
-    }
-    const std::pmr::wstring path_str{ path };
-    if (!DocumentService::NeedsAsyncLoad(path_str)) {
-        file_load_service_.SetLoadingPath(path_str);
-        DoLoadMarkdownFile();
-    }
-    else {
-        BeginAsyncLoad(path_str);
-    }
-}
-
-void App::DoLoadMarkdownFile()
-{
-    MENDO_PROFILE("DoLoadMarkdownFile");
-
-    // ヘルプ仮想パスの場合は専用ルートへ
-    if (IsHelpPath(file_load_service_.GetLoadingPath())) {
-        LoadHelpDocument();
-        return;
-    }
-
-    KillTimer(hwnd_, app_timer::LOADING_ANIM);
-
-    {
-        MENDO_PROFILE("ExecuteLoad(FileIO+Parse)");
-        auto load_result = file_load_service_.ExecuteLoad(state_.doc, state_.layout_cache);
-        if (!load_result) {
-            ShowToast(FileLoadErrorMessage(load_result.error(), i18n::S()));
-            Invalidate();
-            return;
-        }
-    }
-
-    FinishLoadMarkdownFile();
-}
-
-void App::OnParseComplete()
-{
-    KillTimer(hwnd_, app_timer::LOADING_ANIM);
-    file_load_service_.StopLoading();
-
-    auto result = file_load_service_.TakeAsyncResult();
-    if (!result) {
-        MENDO_TRACE("OnParseComplete: no result (cancelled or load failed)");
-        // LoadFile失敗時、FileWatcherがpausedのまま残るのを防ぐ
-        doc_service_.ResumeWatching();
-        Invalidate();
-        return;
-    }
-
-    // 差分ベースのスキップ／スクロール復元は同一パスのリロード時のみ有効。
-    // 非同期のファイルオープンでも OnParseComplete() が使われるため、
-    // 別ファイル読み込み時は差分ロジックをスキップする。
-    if (_wcsicmp(result->doc.GetFilePath().c_str(), state_.doc.GetFilePath().c_str()) == 0) {
-        const std::string_view old_view(state_.doc.GetRawUtf8());
-        const std::string_view new_view(result->doc.GetRawUtf8());
-        const size_t diff_pos = FindFirstDifference(old_view, new_view);
-
-        MENDO_TRACEF("OnParseComplete: reload node_count=%zu diff_pos=%zu old_size=%zu new_size=%zu",
-            result->doc.GetNodes().size(), diff_pos, old_view.size(), new_view.size());
-
-        if (diff_pos == std::string_view::npos) {
-            // 差分なし → リロード不要、監視再開
-            state_.pending_prefix_shrink = false;
-            doc_service_.ResumeWatching();
-            Invalidate();
-            return;
-        }
-
-        // diff_pos が短い方の末尾と一致 = 片方がもう片方のprefixで、
-        // ファイルの伸縮に過ぎない場合はスクロール位置を維持する
-        const bool is_prefix_only = IsPrefixOnlyDiff(diff_pos, old_view.size(), new_view.size());
-
-        // エディタの truncate→rewrite 2段階保存の前半（ファイル縮小）を検出。
-        // state_.doc を更新せず元のコンテンツを保持することで、次のリロードで
-        // 「元コンテンツ vs 最終コンテンツ」の正確な差分を検出できるようにする。
-        if (ShouldDeferForTruncateRewrite(is_prefix_only, old_view.size(), new_view.size())) {
-            return;
-        }
-
-        if (is_prefix_only) {
-            // prefix-only はファイル末尾の伸縮のみ。FinishReload が
-            // ResizePreservingPrefix で旧キャッシュの実測高さを保持する。
-            resource_manager_.CancelMermaidBatch();
-            state_.doc = std::move(result->doc);
-            FinishReload(true, diff_pos, state_.reload_old_scroll);
-            return;
-        }
-
-        state_.reload_diff_pos = diff_pos;
-    }
-    else {
-        // 別ファイルの非同期ロードではリロード用の差分スクロールを使わない
-        state_.reload_diff_pos = std::string_view::npos;
-    }
-
-    state_.doc = std::move(result->doc);
-    state_.layout_cache = std::move(result->cache);
-
-    FinishLoadMarkdownFile(/* heights_estimated = */ true);
-}
-
-void App::FinishLoadMarkdownFile(bool heights_estimated)
-{
-    state_.viewport.ClearSelection();
-    state_.search_bar_ctrl.Reset();
-    PostMessage(hwnd_, app_msg::SEARCH_UNFOCUS, app_param::SEARCH_UNFOCUS_FILE_SWITCH, 0);
-    state_.active_toc_index = -1;
-    CancelPendingResources();
-    renderer_.ShrinkBuffers();
-
-    const std::pmr::wstring dir = state_.doc.GetDirectory();
-    if (!dir.empty()) {
-        state_.file_explorer.SetDirectory(dir);
-        state_.file_explorer.SetCurrentFile(state_.doc.GetFilePath());
-    }
-
-    state_.panes.ResetScrollStates();
-    renderer_.InvalidateFilePaneCache();
-    renderer_.InvalidateTocPaneCache();
-
-    // ビューポート優先レイアウト: 可視範囲のみ計測し、残りは遅延処理に委ねる。
-    const auto pane_layout = GetPaneLayout();
-    const float md_width = pane_layout.md_rect.width;
-    const float md_height = pane_layout.md_rect.height;
-
-    // スクロール位置の復元
-    float scroll_y = 0.0f;
-
-    const bool has_reload_diff = (state_.reload_diff_pos != std::string_view::npos);
-
-    MENDO_TRACEF("FinishLoad: has_reload_diff=%d HasNodeRestore=%d HasNavScroll=%d nav_scroll_y=%.1f heights_estimated=%d",
-        has_reload_diff ? 1 : 0,
-        state_.scroll_restore.HasNodeRestore() ? 1 : 0,
-        state_.scroll_restore.HasNavScroll() ? 1 : 0,
-        state_.scroll_restore.HasNavScroll() ? state_.scroll_restore.pending_nav_scroll_y : -1.0f,
-        heights_estimated ? 1 : 0);
-
-    // cache.Reset()直後は全ノードの高さが0のため、スクロール復元前に
-    // ノード高さを推定し、Mermaidキャッシュの実測値で補正する
-    if (has_reload_diff
-        || state_.scroll_restore.HasNodeRestore()
-        || (state_.scroll_restore.HasNavScroll() && state_.scroll_restore.pending_nav_scroll_y > 0.0f)) {
-        if (!heights_estimated) {
-            MENDO_PROFILE("EstimateNodeHeights");
-            EstimateNodeHeights(state_.doc.GetNodes(), state_.layout_cache, renderer_.GetTheme());
-        }
-        ApplyMermaidCacheHeights(md_width);
-    }
-
-    if (has_reload_diff) {
-        scroll_y = CalcScrollForDiff(state_.reload_diff_pos, md_height, state_.reload_old_scroll);
-        state_.reload_diff_pos = std::string_view::npos;
-    }
-    else if (state_.scroll_restore.HasNodeRestore()) {
-        const int node = std::min(state_.scroll_restore.pending_restore_node,
-            static_cast<int>(state_.layout_cache.size()) - 1);
-        if (node >= 0) {
-            scroll_y = std::max(0.0f,
-                state_.layout_cache[node].y_position + static_cast<float>(state_.scroll_restore.pending_restore_offset));
-        }
-        state_.scroll_restore.ClearNodeRestore();
-    }
-    else if (state_.scroll_restore.HasNavScroll()) {
-        scroll_y = state_.scroll_restore.ConsumeNavScroll();
-        // 遅延レイアウトのドリフト補正用（セッション復元と同じ仕組み）
-        state_.scroll_restore.pending_restore_scroll_y = scroll_y;
-    }
-    else {
-        // 新規ファイルオープン: 前回ナビゲーションの残留値をクリア
-        state_.scroll_restore.pending_restore_scroll_y = -1;
-    }
-
-    MENDO_TRACEF("FinishLoad: scroll_y=%.1f (0=top of file)", scroll_y);
-
-    state_.viewport.SetScrollY(scroll_y);
-
-    // 推定→計測の高さ差をアンカー補償
-    const bool need_anchor = (scroll_y > 0.0f);
-    const auto anchor = need_anchor ? SaveAnchor() : AnchorState{};
-
-    {
-        MENDO_PROFILE("ViewportLayout(Initial)");
-        layout_service_->ViewportLayout(state_.doc, state_.layout_cache, md_width, md_height);
-    }
-
-    if (need_anchor) {
-        state_.viewport.AnchorCompensateScroll(anchor.idx, anchor.y_before, state_.layout_cache);
-    }
-
-    FinalizeLayout(md_height);
-
-    UpdateTitleBar();
-
-    doc_service_.StartWatching(state_.doc.GetFilePath(), [this]() {
-        KillTimer(hwnd_, app_timer::FILE_RELOAD_DEBOUNCE);
-        SetTimer(hwnd_, app_timer::FILE_RELOAD_DEBOUNCE, app_timer::FILE_RELOAD_DEBOUNCE_MS, nullptr);
-    });
-}
-
-void App::ReloadCurrentFile()
-{
-    const auto& path = state_.doc.GetFilePath();
-    if (path.empty() || IsHelpPath(path)) {
-        return;
-    }
-    // ローディングアニメーション表示中は重複リロードを抑制
-    if (file_load_service_.IsLoading()) {
-        return;
-    }
-
-    if (DocumentService::NeedsAsyncLoad(path)) {
-        MENDO_TRACE("ReloadCurrentFile: async path");
-        state_.reload_old_scroll = state_.viewport.GetScrollY();
-        BeginAsyncLoad(path);
-    }
-    else {
-        MENDO_TRACE("ReloadCurrentFile: sync path (DoReloadCurrentFile)");
-        DoReloadCurrentFile();
-    }
-}
-
-void App::DoReloadCurrentFile()
-{
-    MENDO_PROFILE("DoReloadCurrentFile");
-
-    KillTimer(hwnd_, app_timer::LOADING_ANIM);
-    file_load_service_.StopLoading();
-    state_.active_toc_index = -1;
-
-    if (state_.doc.GetFilePath().empty()) {
-        return;
-    }
-
-    const float old_scroll = state_.viewport.GetScrollY();
-
-    CancelPendingResources();
-
-    // ファイルを読み込み、旧コンテンツとの差分位置をコピーなしで計算
-    auto load_result = [this]() {
-        MENDO_PROFILE("Reload::LoadFile");
-        return FileLoader::LoadFile(state_.doc.GetFilePath());
-    }();
-    if (!load_result) {
-        doc_service_.ResumeWatching();
-        return;
-    }
-    std::pmr::string new_utf8 = std::move(*load_result);
-    const std::string_view old_view(state_.doc.GetRawUtf8());
-    const std::string_view new_view(new_utf8);
-    const size_t diff_pos = FindFirstDifference(old_view, new_view);
-
-    MENDO_TRACEF("DoReload: diff_pos=%zu old_size=%zu new_size=%zu old_scroll=%.1f",
-        diff_pos, old_view.size(), new_view.size(), old_scroll);
-
-    // 差分がなければリロード不要。エディタの保存操作が複数の通知を
-    // 発生させた場合に、レイアウトキャッシュの不要なリセットを防ぐ。
-    if (diff_pos == std::string_view::npos) {
-        state_.pending_prefix_shrink = false;
-        doc_service_.ResumeWatching();
-        return;
-    }
-
-    // 変更箇所のスクロール位置を決定
-    // diff_pos が短い方の末尾と一致 = 片方がもう片方のprefixで、
-    // ファイルの伸縮に過ぎない場合はスクロール位置を維持する
-    const bool is_prefix_only = IsPrefixOnlyDiff(diff_pos, old_view.size(), new_view.size());
-
-    // エディタの truncate→rewrite 2段階保存の前半（ファイル縮小）を検出。
-    // state_.doc を更新せず元のコンテンツを保持し、次のリロードで正確な差分を検出する。
-    if (ShouldDeferForTruncateRewrite(is_prefix_only, old_view.size(), new_view.size())) {
-        return;
-    }
-
-    // ドキュメントを新コンテンツで更新
-    {
-        MENDO_PROFILE("Reload::ReplaceFromMarkdown");
-        state_.doc.ReplaceFromMarkdown(std::move(new_utf8));
-    }
-
-    FinishReload(is_prefix_only, diff_pos, old_scroll);
-}
-
-// DoReloadCurrentFile / OnParseComplete 共通のリロード後処理。
-// ドキュメントは更新済みの状態で呼ばれる。
-// is_prefix_only: ファイル末尾の伸縮のみか
-// diff_pos: 差分開始位置 (prefix-only の場合は使用しない)
-// old_scroll: リロード前のスクロール位置
-void App::FinishReload(bool is_prefix_only, size_t diff_pos, float old_scroll)
-{
-    if (is_prefix_only) {
-        state_.layout_cache.ResizePreservingPrefix(state_.doc.GetNodes().size());
-    }
-    else {
-        state_.layout_cache.Reset(state_.doc.GetNodes().size(), false);
-        EstimateNodeHeights(state_.doc.GetNodes(), state_.layout_cache, renderer_.GetTheme());
-    }
-
-    renderer_.InvalidateTocPaneCache();
-
-    const auto pane_layout = GetPaneLayout();
-    const float md_width = pane_layout.md_rect.width;
-    const float md_height = pane_layout.md_rect.height;
-
-    if (!is_prefix_only) {
-        // Mermaidブロックの推定高さをファイルキャッシュの実測値で上書きし、
-        // スクロール位置のずれを防ぐ
-        ApplyMermaidCacheHeights(md_width);
-    }
-
-    const float desired_scroll = is_prefix_only
-        ? old_scroll
-        : CalcScrollForDiff(diff_pos, md_height, old_scroll);
-
-    MENDO_TRACEF("FinishReload: desired_scroll=%.1f old_scroll=%.1f is_prefix_only=%d",
-        desired_scroll, old_scroll, is_prefix_only ? 1 : 0);
-
-    // スクロール位置を設定してからViewportLayoutを呼ぶことで、
-    // 変更箇所周辺の可視ノードが優先的に計測される
-    state_.viewport.SetScrollY(desired_scroll);
-
-    {
-        MENDO_PROFILE("Reload::ViewportLayout");
-        layout_service_->ViewportLayout(state_.doc, state_.layout_cache, md_width, md_height);
-    }
-
-    FinalizeLayout(md_height);
-
-    if (state_.search_state.IsVisible() && !state_.search_state.GetQuery().empty()) {
-        state_.search_bar_ctrl.RunSearchAndLocate(state_.doc.GetNodes());
-    }
-
-    doc_service_.ResumeWatching();
-}
-
-bool App::ShouldDeferForTruncateRewrite(bool is_prefix_only, size_t old_size, size_t new_size)
-{
-    if (is_prefix_only && new_size < old_size) {
-        // prefix-only shrink が連続する場合もすべて defer する。
-        // エディタによっては truncate が複数回発生してから rewrite されることがある。
-        state_.pending_prefix_shrink = true;
-        doc_service_.ResumeWatching();
-        return true;
-    }
-    state_.pending_prefix_shrink = false;
-    return false;
-}
-
-float App::CalcScrollForDiff(size_t diff_pos, float viewport_height, float fallback_scroll) const
-{
-    MENDO_TRACEF("CalcScrollForDiff: diff_pos=%zu node_count=%zu", diff_pos, state_.doc.GetNodes().size());
-    return CalcScrollYForDiff(
-        state_.doc.GetNodes(), state_.layout_cache,
-        std::string_view(state_.doc.GetRawUtf8()),
-        diff_pos, viewport_height, fallback_scroll);
-}
-
-void App::ApplyMermaidCacheHeights(float md_width)
-{
-    const float content_width = renderer_.GetTheme().ContentWidth(md_width);
-    const bool dark_mode = theme_service_.IsDarkMode();
-    const auto& nodes = state_.doc.GetNodes();
-    bool any_applied = false;
-    for (size_t i : state_.doc.GetMermaidNodeIndices()) {
-        const auto hash = mermaid_util::HashCode(nodes[i].text_utf8, content_width, dark_mode);
-        MermaidFileCache::CacheEntry fentry;
-        if (file_cache_.LookupDimensions(hash, fentry)) {
-            state_.layout_cache[i].height = fentry.css_height;
-            any_applied = true;
-        }
-    }
-    if (any_applied) {
-        RecomputeYPositions(state_.doc.GetNodesMut(), state_.layout_cache, renderer_.GetTheme());
-    }
-}
-
-void App::UpdateTitleBar()
-{
-    const int zoom_percent = static_cast<int>(ZOOM_STEPS[state_.viewport.GetZoomIndex()] * 100.0f + 0.5f);
-    auto title = BuildTitleString(state_.doc.GetFilePath(), zoom_percent);
-    SetWindowTextW(hwnd_, title.c_str());
-    state_.cached_title_text = std::move(title);
-    InvalidateTitleBar();
 }
 
 // OnAppImageLoaded / OnAppReloadFile はWM_APPメッセージ経由でresource_manager_に委譲
@@ -932,8 +479,8 @@ void App::OnMouseWheel(int px, int py, short delta, bool ctrl)
     }
 
     // 軸ロック用: 縦スクロール発生をスワイプ検出器に通知
-    const bool had_overlay = state_.swipe_detector.IsOverlayVisible();
-    state_.swipe_detector.NotifyVScroll(GetTickCount64());
+    const bool had_overlay = state_.interaction.swipe_detector.IsOverlayVisible();
+    state_.interaction.swipe_detector.NotifyVScroll(GetTickCount64());
     if (had_overlay) {
         KillTimer(hwnd_, app_timer::SWIPE_OVERLAY);
         Invalidate();
@@ -943,7 +490,7 @@ void App::OnMouseWheel(int px, int py, short delta, bool ctrl)
     const auto pane_layout = GetPaneLayout();
     const auto zone = DetectPaneZone(dip.x, pane_layout,
         renderer_.GetTheme().splitter_width,
-        state_.panes.IsFilePaneVisible(), state_.panes.IsTocPaneVisible());
+        state_.view.panes.IsFilePaneVisible(), state_.view.panes.IsTocPaneVisible());
 
     const MouseWheelEvent event{ delta, false, zone };
     Dispatch(controller_.HandleMouseWheel(event));
@@ -1014,7 +561,7 @@ void App::OnCaptureChanged()
 
 void App::ShowToast(std::wstring_view message)
 {
-    state_.toast.Show(message);
+    state_.interaction.toast.Show(message);
     SetTimer(hwnd_, app_timer::TOAST, app_timer::FRAME_INTERVAL_MS, nullptr);
     Invalidate();
 }
@@ -1053,15 +600,15 @@ void App::OnDestroy()
     }
 }
 
-RECT App::GetSearchEditRect() const
+RECT App::GetSearchEditRect()
 {
-    if (!state_.search_state.IsVisible()) {
+    if (!state_.search.search_state.IsVisible()) {
         return { 0, 0, 1, 1 };
     }
     const auto& layout = GetPaneLayout();
     const auto& r = layout.md_rect;
-    const auto sbl = ComputeSearchBarLayout(r.x, r.width, r.y + r.height, !state_.search_state.GetQuery().empty());
-    const float s = state_.cached_dpi_scale;
+    const auto sbl = ComputeSearchBarLayout(r.x, r.width, r.y + r.height, !state_.search.search_state.GetQuery().empty());
+    const float s = state_.window.cached_dpi_scale;
     return {
         static_cast<LONG>(sbl.input_rect.left * s),
         static_cast<LONG>(sbl.input_rect.top * s),
@@ -1076,8 +623,8 @@ RECT App::GetSearchEditRect() const
 
 void App::SaveLastFilePath()
 {
-    if (!IsHelpPath(state_.doc.GetFilePath())) {
-        session_.SaveLastFilePath(state_.doc.GetFilePath());
+    if (!IsHelpPath(state_.document.doc.GetFilePath())) {
+        session_.SaveLastFilePath(state_.document.doc.GetFilePath());
     }
 }
 
@@ -1099,7 +646,7 @@ void App::ShowDirectory(std::wstring_view dir_path)
 
 void App::SavePaneState()
 {
-    session_.SavePaneState(state_.panes);
+    session_.SavePaneState(state_.view.panes);
 }
 
 void App::LoadPaneState()
@@ -1111,7 +658,7 @@ void App::LoadPaneState()
             client_width = static_cast<float>(rc.right - rc.left);
         }
     }
-    session_.LoadPaneState(state_.panes, client_width);
+    session_.LoadPaneState(state_.view.panes, client_width);
 }
 
 void App::SaveScrollPosition()
@@ -1120,7 +667,7 @@ void App::SaveScrollPosition()
     if (node < 0) {
         return;
     }
-    session_.SaveScrollPosition(node, state_.viewport.GetScrollY(), state_.layout_cache[node].y_position);
+    session_.SaveScrollPosition(node, state_.view.viewport.GetScrollY(), state_.document.layout_cache[node].y_position);
 }
 
 // ============================================================
@@ -1140,11 +687,11 @@ ResourceManager::Callbacks App::BuildResourceManagerCallbacks()
             return GetPaneLayout().md_rect.height;
         },
         .recompute_layout = [this]() {
-            layout_service_->RecomputeAfterDiagram(state_.doc, state_.layout_cache, renderer_.GetTheme());
+            layout_service_->RecomputeAfterDiagram(state_.document.doc, state_.document.layout_cache, renderer_.GetTheme());
         },
         .recompute_layout_anchored = [this]() {
             const auto anchor = SaveAnchor();
-            layout_service_->RecomputeAfterDiagram(state_.doc, state_.layout_cache, renderer_.GetTheme());
+            layout_service_->RecomputeAfterDiagram(state_.document.doc, state_.document.layout_cache, renderer_.GetTheme());
             const auto layout = GetPaneLayout();
             RestoreAnchor(anchor, layout.md_rect.height);
             Invalidate();

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -7,10 +7,8 @@
 #include "mermaid_file_cache.h"
 #include "mermaid.h"
 #include "image_loader.h"
-#include "file_watcher.h"
 #include "document_service.h"
 #include "document_utils.h"
-#include "pane.h"
 #include "layout_service.h"
 #include "app_controller.h"
 #include "config_service.h"
@@ -88,20 +86,17 @@ public:
     void OnSearchClose() { Dispatch(CloseSearchBarAction{}); }
     void OnSearchNext() { Dispatch(SearchNextAction{}); }
     void OnSearchPrev() { Dispatch(SearchPrevAction{}); }
-    bool IsSearchBarVisible() const noexcept { return state_.search_state.IsVisible(); }
+    bool IsSearchBarVisible() const noexcept { return state_.search.search_state.IsVisible(); }
     void OnToggleCaseSensitive() { Dispatch(ToggleCaseSensitiveAction{}); }
     void OnToggleHighlight() { Dispatch(ToggleHighlightAction{}); }
     void SetSearchSelection(int sel_start, int sel_end) { Dispatch(SearchSelectionAction{ sel_start, sel_end }); }
     void SetImeComposition(std::wstring_view comp) { Dispatch(ImeCompositionAction{ std::pmr::wstring{comp} }); }
-    RECT GetSearchEditRect() const;
-
-    // 検索バーコントローラへのアクセス（app_mouse.cppでのドラッグ/ホバー処理用）
-    SearchBarController& GetSearchBarCtrl() noexcept { return state_.search_bar_ctrl; }
+    RECT GetSearchEditRect();
 
     // 前回セッションのスクロール位置復元用（LoadMarkdownFileの前に呼ぶ）
     void SetPendingRestoreNode(int node, int offset, float scroll_y = -1.0f) noexcept
     {
-        state_.scroll_restore.SetNodeRestore(node, offset, scroll_y);
+        state_.view.scroll_restore.SetNodeRestore(node, offset, scroll_y);
     }
 
     // サイズ変更状態 — Reducer経由で状態変更
@@ -121,12 +116,12 @@ public:
     void InvalidateTitleBar() noexcept;
 
     // Win32Windowのカーソル/再描画用にDPIスケールを公開
-    constexpr float GetDpiScale() const noexcept { return state_.cached_dpi_scale; }
+    constexpr float GetDpiScale() const noexcept { return state_.window.cached_dpi_scale; }
 
     // カスタムタイトルバー
-    float GetTitleBarHeightDip() const noexcept { return state_.titlebar.GetHeight(); }
-    TitleBarHitZone TitleBarHitTest(float dip_x, float dip_y) const noexcept { return state_.titlebar.HitTest(dip_x, dip_y); }
-    bool IsOverMdScrollbar(float dip_x, float dip_y) const;
+    float GetTitleBarHeightDip() const noexcept { return state_.window.titlebar.GetHeight(); }
+    TitleBarHitZone TitleBarHitTest(float dip_x, float dip_y) const noexcept { return state_.window.titlebar.HitTest(dip_x, dip_y); }
+    bool IsOverMdScrollbar(float dip_x, float dip_y);
     bool IsOverMdScrollbar(float dip_x, float dip_y, const ::PaneLayout& layout) const noexcept;
     void OnActivate(bool active) { Dispatch(ActivateAction{ active }); }
 
@@ -222,10 +217,10 @@ private:
     void SaveScrollPosition();
 
     // ペインレイアウト（結果はキャッシュされる）
-    const ::PaneLayout& GetPaneLayout() const;
+    const ::PaneLayout& GetPaneLayout();
     void InvalidatePaneLayoutCache() noexcept { state_.pane_layout_valid = false; }
-    ::PaneZone PaneAtPoint(float dip_x, float dip_y) const;
-    float GetMarkdownPaneWidth() const;
+    ::PaneZone PaneAtPoint(float dip_x, float dip_y);
+    float GetMarkdownPaneWidth();
 
     // Reducer 用テーマ定数キャッシュの同期
     void SyncPaneThemeCache();

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -144,7 +144,7 @@ private:
 
     // ヒットテスト
     using HitResult = HitTestService::HitResult;
-    HitResult HitTest(int screen_x, int screen_y) const;
+    HitResult HitTest(int screen_x, int screen_y);
     std::optional<std::pmr::wstring> GetLinkAtHit(const HitResult& hit) const;
 
     // リンク・アンカーナビゲーション

--- a/src/app/app_clipboard.cpp
+++ b/src/app/app_clipboard.cpp
@@ -1,6 +1,5 @@
 #include "app.h"
 #include "document_utils.h"
-#include "pane_layout.h"
 #include "mermaid_util.h"
 #include "mermaid_file_cache.h"
 #include "win_handle.h"
@@ -27,7 +26,7 @@ void App::OnLButtonDblClk(int px, int py)
     if (hit.node_index < 0) {
         return;
     }
-    const auto& text = state_.doc.GetNodes()[hit.node_index].GetText();
+    const auto& text = state_.document.doc.GetNodes()[hit.node_index].GetText();
     if (text.empty()) {
         return;
     }
@@ -36,8 +35,8 @@ void App::OnLButtonDblClk(int px, int py)
         return;
     }
 
-    state_.viewport.SetAnchor(hit.node_index, wb.start);
-    state_.viewport.SetSelection(TextSelection::MakeOrdered(hit.node_index, wb.start, hit.node_index, wb.end));
+    state_.view.viewport.SetAnchor(hit.node_index, wb.start);
+    state_.view.viewport.SetSelection(TextSelection::MakeOrdered(hit.node_index, wb.start, hit.node_index, wb.end));
     const auto layout = GetPaneLayout();
     InvalidateMdPane(layout.md_rect);
 }
@@ -53,16 +52,16 @@ void App::SetClipboardText(std::wstring_view text) const
 
 void App::CopySelectionToClipboard() const
 {
-    if (!state_.viewport.GetSelection().active) {
+    if (!state_.view.viewport.GetSelection().active) {
         return;
     }
-    const std::pmr::wstring result = ExtractSelectedText(state_.doc.GetNodes(), state_.viewport.GetSelection());
+    const std::pmr::wstring result = ExtractSelectedText(state_.document.doc.GetNodes(), state_.view.viewport.GetSelection());
     SetClipboardText(result);
 }
 
 void App::CopyCodeBlockToClipboard(int node_index) const
 {
-    const auto& nodes = state_.doc.GetNodes();
+    const auto& nodes = state_.document.doc.GetNodes();
     if (node_index < 0 || node_index >= static_cast<int>(nodes.size())) {
         return;
     }
@@ -71,7 +70,7 @@ void App::CopyCodeBlockToClipboard(int node_index) const
 
 void App::SaveDiagramAsPng(int node_index)
 {
-    const auto& nodes = state_.doc.GetNodes();
+    const auto& nodes = state_.document.doc.GetNodes();
     if (node_index < 0 || node_index >= static_cast<int>(nodes.size())) {
         return;
     }

--- a/src/app/app_context_menu.cpp
+++ b/src/app/app_context_menu.cpp
@@ -31,14 +31,14 @@ void App::OnContextMenu(int screen_x, int screen_y)
     ContextMenuParams params;
     params.screen_x = screen_x;
     params.screen_y = screen_y;
-    params.dpi_scale = state_.cached_dpi_scale;
-    params.can_go_back = state_.nav_history.CanGoBack();
-    params.can_go_forward = state_.nav_history.CanGoForward();
-    params.has_file = !state_.doc.GetFilePath().empty();
-    params.has_selection = state_.viewport.GetSelection().active && state_.viewport.GetSelection().start_node >= 0;
+    params.dpi_scale = state_.window.cached_dpi_scale;
+    params.can_go_back = state_.view.nav_history.CanGoBack();
+    params.can_go_forward = state_.view.nav_history.CanGoForward();
+    params.has_file = !state_.document.doc.GetFilePath().empty();
+    params.has_selection = state_.view.viewport.GetSelection().active && state_.view.viewport.GetSelection().start_node >= 0;
     params.dark_mode_checked = theme_service_.IsDarkMode();
-    params.file_pane_checked = state_.panes.IsFilePaneVisible();
-    params.toc_pane_checked = state_.panes.IsTocPaneVisible();
+    params.file_pane_checked = state_.view.panes.IsFilePaneVisible();
+    params.toc_pane_checked = state_.view.panes.IsTocPaneVisible();
     params.show_file_items = (zone == PaneZone::MdPane);
     params.theme = &renderer_.GetTheme();
 
@@ -52,7 +52,7 @@ void App::OnContextMenu(int screen_x, int screen_y)
         Dispatch(NavigateForwardAction{});
         break;
     case IDM_EDIT_FILE: {
-        const auto& file_path = state_.doc.GetFilePath();
+        const auto& file_path = state_.document.doc.GetFilePath();
         if (IsEditableTextFile(file_path)) {
             ShellExecuteW(hwnd_, L"open", file_path.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
         }

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -1,0 +1,471 @@
+#include "app.h"
+#include "app_constants.h"
+#include "file_loader.h"
+#include "i18n.h"
+#include "document_utils.h"
+#include "mermaid_util.h"
+#include "layout.h"
+#include "profiler.h"
+#include "utility.h"
+#include <algorithm>
+
+// ============================================================
+// ファイル読み込み
+// ============================================================
+
+void App::LoadHelpDocument()
+{
+    if (IsHelpPath(state_.document.doc.GetFilePath())) {
+        return;
+    }
+
+    const auto rc = LoadRcData(i18n::S().help_resource_id);
+    if (rc.empty()) {
+        return;
+    }
+
+    KillTimer(hwnd_, app_timer::LOADING_ANIM);
+    file_load_service_.StopLoading();
+    state_.view.viewport.ClearSelection();
+    CancelPendingResources();
+    renderer_.ShrinkBuffers();
+    doc_service_.StopWatching();
+
+    std::pmr::string utf8(reinterpret_cast<const char*>(rc.data()), rc.size());
+    state_.document.doc = Document::FromMarkdown(std::move(utf8), HELP_PATH);
+    state_.document.layout_cache.Reset(state_.document.doc.GetNodes().size());
+
+    state_.file_explorer.SetCurrentFile(L"");
+    renderer_.InvalidateFilePaneCache();
+
+    state_.view.panes.ResetScrollStates();
+    renderer_.InvalidateTocPaneCache();
+
+    // ビューポート優先レイアウト + 遅延処理
+    state_.view.viewport.SetScrollY(0.0f);
+    {
+        const auto pane_layout = GetPaneLayout();
+        layout_service_->ViewportLayout(state_.document.doc, state_.document.layout_cache,
+            pane_layout.md_rect.width, pane_layout.md_rect.height);
+        SyncMaxScroll(pane_layout.md_rect.height);
+    }
+    UpdateScrollBar();
+    Invalidate();
+    ScheduleDeferredLayoutIfNeeded();
+
+    UpdateTitleBar();
+}
+
+void App::BeginAsyncLoad(const std::pmr::wstring& path)
+{
+    file_load_service_.SetLoadingPath(path);
+    if (DocumentService::NeedsLoadingAnimation(path) && !state_.pending_prefix_shrink) {
+        file_load_service_.StartLoading(path);
+        SetTimer(hwnd_, app_timer::LOADING_ANIM, app_timer::FRAME_INTERVAL_MS, nullptr);
+        Invalidate();
+        UpdateWindow(hwnd_);
+    }
+    file_load_service_.StartAsyncLoad(scheduler_, hwnd_, app_msg::PARSE_COMPLETE, renderer_.GetTheme());
+}
+
+void App::LoadMarkdownFile(std::wstring_view path)
+{
+    KillTimer(hwnd_, app_timer::FILE_RELOAD_DEBOUNCE);
+    state_.pending_prefix_shrink = false;
+    // 仮想パスは NeedsAsyncLoad が true を返し非同期ロードが失敗するため、
+    // 先に検出して同期ロードに回す。
+    if (IsHelpPath(path)) {
+        LoadHelpDocument();
+        return;
+    }
+    const std::pmr::wstring path_str{ path };
+    if (!DocumentService::NeedsAsyncLoad(path_str)) {
+        file_load_service_.SetLoadingPath(path_str);
+        DoLoadMarkdownFile();
+    }
+    else {
+        BeginAsyncLoad(path_str);
+    }
+}
+
+void App::DoLoadMarkdownFile()
+{
+    MENDO_PROFILE("DoLoadMarkdownFile");
+
+    // ヘルプ仮想パスの場合は専用ルートへ
+    if (IsHelpPath(file_load_service_.GetLoadingPath())) {
+        LoadHelpDocument();
+        return;
+    }
+
+    KillTimer(hwnd_, app_timer::LOADING_ANIM);
+
+    {
+        MENDO_PROFILE("ExecuteLoad(FileIO+Parse)");
+        auto load_result = file_load_service_.ExecuteLoad(state_.document.doc, state_.document.layout_cache);
+        if (!load_result) {
+            ShowToast(FileLoadErrorMessage(load_result.error(), i18n::S()));
+            Invalidate();
+            return;
+        }
+    }
+
+    FinishLoadMarkdownFile();
+}
+
+void App::OnParseComplete()
+{
+    KillTimer(hwnd_, app_timer::LOADING_ANIM);
+    file_load_service_.StopLoading();
+
+    auto result = file_load_service_.TakeAsyncResult();
+    if (!result) {
+        MENDO_TRACE("OnParseComplete: no result (cancelled or load failed)");
+        // LoadFile失敗時、FileWatcherがpausedのまま残るのを防ぐ
+        doc_service_.ResumeWatching();
+        Invalidate();
+        return;
+    }
+
+    // 差分ベースのスキップ／スクロール復元は同一パスのリロード時のみ有効。
+    // 非同期のファイルオープンでも OnParseComplete() が使われるため、
+    // 別ファイル読み込み時は差分ロジックをスキップする。
+    if (_wcsicmp(result->doc.GetFilePath().c_str(), state_.document.doc.GetFilePath().c_str()) == 0) {
+        const std::string_view old_view(state_.document.doc.GetRawUtf8());
+        const std::string_view new_view(result->doc.GetRawUtf8());
+        const size_t diff_pos = FindFirstDifference(old_view, new_view);
+
+        MENDO_TRACEF("OnParseComplete: reload node_count=%zu diff_pos=%zu old_size=%zu new_size=%zu",
+            result->doc.GetNodes().size(), diff_pos, old_view.size(), new_view.size());
+
+        if (diff_pos == std::string_view::npos) {
+            // 差分なし → リロード不要、監視再開
+            state_.pending_prefix_shrink = false;
+            doc_service_.ResumeWatching();
+            Invalidate();
+            return;
+        }
+
+        // diff_pos が短い方の末尾と一致 = 片方がもう片方のprefixで、
+        // ファイルの伸縮に過ぎない場合はスクロール位置を維持する
+        const bool is_prefix_only = IsPrefixOnlyDiff(diff_pos, old_view.size(), new_view.size());
+
+        // エディタの truncate→rewrite 2段階保存の前半（ファイル縮小）を検出。
+        // state_.document.doc を更新せず元のコンテンツを保持することで、次のリロードで
+        // 「元コンテンツ vs 最終コンテンツ」の正確な差分を検出できるようにする。
+        if (ShouldDeferForTruncateRewrite(is_prefix_only, old_view.size(), new_view.size())) {
+            return;
+        }
+
+        if (is_prefix_only) {
+            // prefix-only はファイル末尾の伸縮のみ。FinishReload が
+            // ResizePreservingPrefix で旧キャッシュの実測高さを保持する。
+            resource_manager_.CancelMermaidBatch();
+            state_.document.doc = std::move(result->doc);
+            FinishReload(true, diff_pos, state_.reload_old_scroll);
+            return;
+        }
+
+        state_.reload_diff_pos = diff_pos;
+    }
+    else {
+        // 別ファイルの非同期ロードではリロード用の差分スクロールを使わない
+        state_.reload_diff_pos = std::string_view::npos;
+    }
+
+    state_.document.doc = std::move(result->doc);
+    state_.document.layout_cache = std::move(result->cache);
+
+    FinishLoadMarkdownFile(/* heights_estimated = */ true);
+}
+
+void App::FinishLoadMarkdownFile(bool heights_estimated)
+{
+    state_.view.viewport.ClearSelection();
+    state_.search.search_bar_ctrl.Reset();
+    PostMessage(hwnd_, app_msg::SEARCH_UNFOCUS, app_param::SEARCH_UNFOCUS_FILE_SWITCH, 0);
+    state_.active_toc_index = -1;
+    CancelPendingResources();
+    renderer_.ShrinkBuffers();
+
+    const std::pmr::wstring dir = state_.document.doc.GetDirectory();
+    if (!dir.empty()) {
+        state_.file_explorer.SetDirectory(dir);
+        state_.file_explorer.SetCurrentFile(state_.document.doc.GetFilePath());
+    }
+
+    state_.view.panes.ResetScrollStates();
+    renderer_.InvalidateFilePaneCache();
+    renderer_.InvalidateTocPaneCache();
+
+    // ビューポート優先レイアウト: 可視範囲のみ計測し、残りは遅延処理に委ねる。
+    const auto pane_layout = GetPaneLayout();
+    const float md_width = pane_layout.md_rect.width;
+    const float md_height = pane_layout.md_rect.height;
+
+    // スクロール位置の復元
+    float scroll_y = 0.0f;
+
+    const bool has_reload_diff = (state_.reload_diff_pos != std::string_view::npos);
+
+    MENDO_TRACEF("FinishLoad: has_reload_diff=%d HasNodeRestore=%d HasNavScroll=%d nav_scroll_y=%.1f heights_estimated=%d",
+        has_reload_diff ? 1 : 0,
+        state_.view.scroll_restore.HasNodeRestore() ? 1 : 0,
+        state_.view.scroll_restore.HasNavScroll() ? 1 : 0,
+        state_.view.scroll_restore.HasNavScroll() ? state_.view.scroll_restore.pending_nav_scroll_y : -1.0f,
+        heights_estimated ? 1 : 0);
+
+    // cache.Reset()直後は全ノードの高さが0のため、スクロール復元前に
+    // ノード高さを推定し、Mermaidキャッシュの実測値で補正する
+    if (has_reload_diff
+        || state_.view.scroll_restore.HasNodeRestore()
+        || (state_.view.scroll_restore.HasNavScroll() && state_.view.scroll_restore.pending_nav_scroll_y > 0.0f)) {
+        if (!heights_estimated) {
+            MENDO_PROFILE("EstimateNodeHeights");
+            EstimateNodeHeights(state_.document.doc.GetNodes(), state_.document.layout_cache, renderer_.GetTheme());
+        }
+        ApplyMermaidCacheHeights(md_width);
+    }
+
+    if (has_reload_diff) {
+        scroll_y = CalcScrollForDiff(state_.reload_diff_pos, md_height, state_.reload_old_scroll);
+        state_.reload_diff_pos = std::string_view::npos;
+    }
+    else if (state_.view.scroll_restore.HasNodeRestore()) {
+        const int node = std::min(state_.view.scroll_restore.pending_restore_node,
+            static_cast<int>(state_.document.layout_cache.size()) - 1);
+        if (node >= 0) {
+            scroll_y = std::max(0.0f,
+                state_.document.layout_cache[node].y_position + static_cast<float>(state_.view.scroll_restore.pending_restore_offset));
+        }
+        state_.view.scroll_restore.ClearNodeRestore();
+    }
+    else if (state_.view.scroll_restore.HasNavScroll()) {
+        scroll_y = state_.view.scroll_restore.ConsumeNavScroll();
+        // 遅延レイアウトのドリフト補正用（セッション復元と同じ仕組み）
+        state_.view.scroll_restore.pending_restore_scroll_y = scroll_y;
+    }
+    else {
+        // 新規ファイルオープン: 前回ナビゲーションの残留値をクリア
+        state_.view.scroll_restore.pending_restore_scroll_y = -1;
+    }
+
+    MENDO_TRACEF("FinishLoad: scroll_y=%.1f (0=top of file)", scroll_y);
+
+    state_.view.viewport.SetScrollY(scroll_y);
+
+    // 推定→計測の高さ差をアンカー補償
+    const bool need_anchor = (scroll_y > 0.0f);
+    const auto anchor = need_anchor ? SaveAnchor() : AnchorState{};
+
+    {
+        MENDO_PROFILE("ViewportLayout(Initial)");
+        layout_service_->ViewportLayout(state_.document.doc, state_.document.layout_cache, md_width, md_height);
+    }
+
+    if (need_anchor) {
+        state_.view.viewport.AnchorCompensateScroll(anchor.idx, anchor.y_before, state_.document.layout_cache);
+    }
+
+    FinalizeLayout(md_height);
+
+    UpdateTitleBar();
+
+    doc_service_.StartWatching(state_.document.doc.GetFilePath(), [this]() {
+        KillTimer(hwnd_, app_timer::FILE_RELOAD_DEBOUNCE);
+        SetTimer(hwnd_, app_timer::FILE_RELOAD_DEBOUNCE, app_timer::FILE_RELOAD_DEBOUNCE_MS, nullptr);
+    });
+}
+
+// ============================================================
+// リロード
+// ============================================================
+
+void App::ReloadCurrentFile()
+{
+    const auto& path = state_.document.doc.GetFilePath();
+    if (path.empty() || IsHelpPath(path)) {
+        return;
+    }
+    // ローディングアニメーション表示中は重複リロードを抑制
+    if (file_load_service_.IsLoading()) {
+        return;
+    }
+
+    if (DocumentService::NeedsAsyncLoad(path)) {
+        MENDO_TRACE("ReloadCurrentFile: async path");
+        state_.reload_old_scroll = state_.view.viewport.GetScrollY();
+        BeginAsyncLoad(path);
+    }
+    else {
+        MENDO_TRACE("ReloadCurrentFile: sync path (DoReloadCurrentFile)");
+        DoReloadCurrentFile();
+    }
+}
+
+void App::DoReloadCurrentFile()
+{
+    MENDO_PROFILE("DoReloadCurrentFile");
+
+    KillTimer(hwnd_, app_timer::LOADING_ANIM);
+    file_load_service_.StopLoading();
+    state_.active_toc_index = -1;
+
+    if (state_.document.doc.GetFilePath().empty()) {
+        return;
+    }
+
+    const float old_scroll = state_.view.viewport.GetScrollY();
+
+    CancelPendingResources();
+
+    // ファイルを読み込み、旧コンテンツとの差分位置をコピーなしで計算
+    auto load_result = [this]() {
+        MENDO_PROFILE("Reload::LoadFile");
+        return FileLoader::LoadFile(state_.document.doc.GetFilePath());
+    }();
+    if (!load_result) {
+        doc_service_.ResumeWatching();
+        return;
+    }
+    std::pmr::string new_utf8 = std::move(*load_result);
+    const std::string_view old_view(state_.document.doc.GetRawUtf8());
+    const std::string_view new_view(new_utf8);
+    const size_t diff_pos = FindFirstDifference(old_view, new_view);
+
+    MENDO_TRACEF("DoReload: diff_pos=%zu old_size=%zu new_size=%zu old_scroll=%.1f",
+        diff_pos, old_view.size(), new_view.size(), old_scroll);
+
+    // 差分がなければリロード不要。エディタの保存操作が複数の通知を
+    // 発生させた場合に、レイアウトキャッシュの不要なリセットを防ぐ。
+    if (diff_pos == std::string_view::npos) {
+        state_.pending_prefix_shrink = false;
+        doc_service_.ResumeWatching();
+        return;
+    }
+
+    // 変更箇所のスクロール位置を決定
+    // diff_pos が短い方の末尾と一致 = 片方がもう片方のprefixで、
+    // ファイルの伸縮に過ぎない場合はスクロール位置を維持する
+    const bool is_prefix_only = IsPrefixOnlyDiff(diff_pos, old_view.size(), new_view.size());
+
+    // エディタの truncate→rewrite 2段階保存の前半（ファイル縮小）を検出。
+    // state_.document.doc を更新せず元のコンテンツを保持し、次のリロードで正確な差分を検出する。
+    if (ShouldDeferForTruncateRewrite(is_prefix_only, old_view.size(), new_view.size())) {
+        return;
+    }
+
+    // ドキュメントを新コンテンツで更新
+    {
+        MENDO_PROFILE("Reload::ReplaceFromMarkdown");
+        state_.document.doc.ReplaceFromMarkdown(std::move(new_utf8));
+    }
+
+    FinishReload(is_prefix_only, diff_pos, old_scroll);
+}
+
+// DoReloadCurrentFile / OnParseComplete 共通のリロード後処理。
+// ドキュメントは更新済みの状態で呼ばれる。
+// is_prefix_only: ファイル末尾の伸縮のみか
+// diff_pos: 差分開始位置 (prefix-only の場合は使用しない)
+// old_scroll: リロード前のスクロール位置
+void App::FinishReload(bool is_prefix_only, size_t diff_pos, float old_scroll)
+{
+    if (is_prefix_only) {
+        state_.document.layout_cache.ResizePreservingPrefix(state_.document.doc.GetNodes().size());
+    }
+    else {
+        state_.document.layout_cache.Reset(state_.document.doc.GetNodes().size(), false);
+        EstimateNodeHeights(state_.document.doc.GetNodes(), state_.document.layout_cache, renderer_.GetTheme());
+    }
+
+    renderer_.InvalidateTocPaneCache();
+
+    const auto pane_layout = GetPaneLayout();
+    const float md_width = pane_layout.md_rect.width;
+    const float md_height = pane_layout.md_rect.height;
+
+    if (!is_prefix_only) {
+        // Mermaidブロックの推定高さをファイルキャッシュの実測値で上書きし、
+        // スクロール位置のずれを防ぐ
+        ApplyMermaidCacheHeights(md_width);
+    }
+
+    const float desired_scroll = is_prefix_only
+        ? old_scroll
+        : CalcScrollForDiff(diff_pos, md_height, old_scroll);
+
+    MENDO_TRACEF("FinishReload: desired_scroll=%.1f old_scroll=%.1f is_prefix_only=%d",
+        desired_scroll, old_scroll, is_prefix_only ? 1 : 0);
+
+    // スクロール位置を設定してからViewportLayoutを呼ぶことで、
+    // 変更箇所周辺の可視ノードが優先的に計測される
+    state_.view.viewport.SetScrollY(desired_scroll);
+
+    {
+        MENDO_PROFILE("Reload::ViewportLayout");
+        layout_service_->ViewportLayout(state_.document.doc, state_.document.layout_cache, md_width, md_height);
+    }
+
+    FinalizeLayout(md_height);
+
+    if (state_.search.search_state.IsVisible() && !state_.search.search_state.GetQuery().empty()) {
+        state_.search.search_bar_ctrl.RunSearchAndLocate(state_.document.doc.GetNodes());
+    }
+
+    doc_service_.ResumeWatching();
+}
+
+// ============================================================
+// ファイル読み込みヘルパー
+// ============================================================
+
+bool App::ShouldDeferForTruncateRewrite(bool is_prefix_only, size_t old_size, size_t new_size)
+{
+    if (is_prefix_only && new_size < old_size) {
+        // prefix-only shrink が連続する場合もすべて defer する。
+        // エディタによっては truncate が複数回発生してから rewrite されることがある。
+        state_.pending_prefix_shrink = true;
+        doc_service_.ResumeWatching();
+        return true;
+    }
+    state_.pending_prefix_shrink = false;
+    return false;
+}
+
+float App::CalcScrollForDiff(size_t diff_pos, float viewport_height, float fallback_scroll) const
+{
+    MENDO_TRACEF("CalcScrollForDiff: diff_pos=%zu node_count=%zu", diff_pos, state_.document.doc.GetNodes().size());
+    return CalcScrollYForDiff(
+        state_.document.doc.GetNodes(), state_.document.layout_cache,
+        std::string_view(state_.document.doc.GetRawUtf8()),
+        diff_pos, viewport_height, fallback_scroll);
+}
+
+void App::ApplyMermaidCacheHeights(float md_width)
+{
+    const float content_width = renderer_.GetTheme().ContentWidth(md_width);
+    const bool dark_mode = theme_service_.IsDarkMode();
+    const auto& nodes = state_.document.doc.GetNodes();
+    bool any_applied = false;
+    for (size_t i : state_.document.doc.GetMermaidNodeIndices()) {
+        const auto hash = mermaid_util::HashCode(nodes[i].text_utf8, content_width, dark_mode);
+        MermaidFileCache::CacheEntry fentry;
+        if (file_cache_.LookupDimensions(hash, fentry)) {
+            state_.document.layout_cache[i].height = fentry.css_height;
+            any_applied = true;
+        }
+    }
+    if (any_applied) {
+        RecomputeYPositions(state_.document.doc.GetNodesMut(), state_.document.layout_cache, renderer_.GetTheme());
+    }
+}
+
+void App::UpdateTitleBar()
+{
+    const int zoom_percent = static_cast<int>(ZOOM_STEPS[state_.view.viewport.GetZoomIndex()] * 100.0f + 0.5f);
+    auto title = BuildTitleString(state_.document.doc.GetFilePath(), zoom_percent);
+    SetWindowTextW(hwnd_, title.c_str());
+    state_.cached_title_text = std::move(title);
+    InvalidateTitleBar();
+}

--- a/src/app/app_mouse.cpp
+++ b/src/app/app_mouse.cpp
@@ -115,7 +115,7 @@ void App::UpdateTooltip(const TooltipTarget& target, int px, int py)
 {
     POINT screen_pos = { px, py };
     ClientToScreen(hwnd_, &screen_pos);
-    if (state_.tooltip.Update(target, screen_pos)) {
+    if (state_.interaction.tooltip.Update(target, screen_pos)) {
         SetTimer(hwnd_, app_timer::TOOLTIP, TOOLTIP_DELAY_MS, nullptr);
     }
     else if (target.IsEmpty()) {
@@ -126,15 +126,15 @@ void App::UpdateTooltip(const TooltipTarget& target, int px, int py)
 void App::ClearTooltip()
 {
     KillTimer(hwnd_, app_timer::TOOLTIP);
-    state_.tooltip.Hide();
-    state_.tooltip.ResetTarget();
+    state_.interaction.tooltip.Hide();
+    state_.interaction.tooltip.ResetTarget();
 }
 
 void App::RefreshFilePane()
 {
     state_.file_explorer.Refresh();
-    if (!state_.doc.GetFilePath().empty()) {
-        state_.file_explorer.SetCurrentFile(state_.doc.GetFilePath());
+    if (!state_.document.doc.GetFilePath().empty()) {
+        state_.file_explorer.SetCurrentFile(state_.document.doc.GetFilePath());
     }
     renderer_.InvalidateFilePaneCache();
     Invalidate();
@@ -153,7 +153,7 @@ bool App::OnRButtonDown(int px, int py)
     if (!renderer_.GetRenderTarget()) {
         return false;
     }
-    if (state_.viewport.IsDragging()) {
+    if (state_.view.viewport.IsDragging()) {
         return false;
     }
     const auto dip = PixelToDip(px, py);
@@ -161,22 +161,22 @@ bool App::OnRButtonDown(int px, int py)
     if (zone != PaneZone::MdPane) {
         return false;
     }
-    state_.gesture.OnRButtonDown(dip.x, dip.y);
+    state_.interaction.gesture.OnRButtonDown(dip.x, dip.y);
     SetCapture(hwnd_);
     return true;
 }
 
 bool App::OnRButtonUp(int px, int py)
 {
-    if (state_.gesture.GetPhase() == GesturePhase::Idle) {
+    if (state_.interaction.gesture.GetPhase() == GesturePhase::Idle) {
         return false;
     }
-    const auto result = state_.gesture.OnRButtonUp();
+    const auto result = state_.interaction.gesture.OnRButtonUp();
     ReleaseCapture();
 
     switch (result) {
     case GestureResult::ShowContextMenu: {
-        state_.gesture.Reset();
+        state_.interaction.gesture.Reset();
         POINT pt{ px, py };
         ClientToScreen(hwnd_, &pt);
         OnContextMenu(pt.x, pt.y);
@@ -203,9 +203,9 @@ void App::OnRButtonMove(int px, int py)
         return;
     }
     const auto dip = PixelToDip(px, py);
-    state_.gesture.OnMouseMove(dip.x, dip.y);
+    state_.interaction.gesture.OnMouseMove(dip.x, dip.y);
 
-    if (state_.gesture.IsGestureActive()) {
+    if (state_.interaction.gesture.IsGestureActive()) {
         Invalidate();
     }
 }
@@ -226,21 +226,20 @@ void App::OnXButtonForward()
 
 App::HitResult App::HitTest(int screen_x, int screen_y) const
 {
-    const auto pane_layout = GetPaneLayout();
     return state_.hit_test.HitTest({
-        state_.doc.GetNodes(), state_.layout_cache, renderer_.GetTheme(),
-        state_.viewport.GetScrollY(), pane_layout.md_rect.x,
-        state_.cached_dpi_scale, screen_x, screen_y
+        state_.document.doc.GetNodes(), state_.document.layout_cache, renderer_.GetTheme(),
+        state_.view.viewport.GetScrollY(), state_.cached_pane_layout.md_rect.x,
+        state_.window.cached_dpi_scale, screen_x, screen_y
         });
 }
 
 std::optional<std::pmr::wstring> App::GetLinkAtHit(const HitResult& hit) const
 {
-    if (hit.node_index < 0 || hit.node_index >= static_cast<int>(state_.doc.GetNodes().size())) {
+    if (hit.node_index < 0 || hit.node_index >= static_cast<int>(state_.document.doc.GetNodes().size())) {
         return std::nullopt;
     }
 
-    return FindLinkAtPosition(state_.doc.GetNodes()[hit.node_index], hit.text_pos);
+    return FindLinkAtPosition(state_.document.doc.GetNodes()[hit.node_index], hit.text_pos);
 }
 
 // ============================================================
@@ -257,7 +256,7 @@ bool App::TryHandlePaneScrollbarClick(float dip_x, float dip_y, const PaneRect& 
 
     if ((local_x >= rect.width - PANE_SCROLLBAR_WIDTH - 4.0f) && (total_content > scroll_info.content_height)) {
         SetCapture(hwnd_);
-        state_.panes.StartDrag(target);
+        state_.view.panes.StartDrag(target);
         bool dirty = false;
         HandleScrollbarClick(dip_y, scroll_info, scroll, dirty);
         if (dirty) {
@@ -273,7 +272,7 @@ void App::HandleFilePaneClick(float dip_x, float dip_y, const PaneLayout& layout
     const auto& theme = renderer_.GetTheme();
 
     if (ProcessSidePaneHeaderClick(dip_x, dip_y, layout.file_rect, theme.pane_header_height, true,
-        [this]() { state_.panes.ToggleFilePane(); RefreshPaneLayout(); },
+        [this]() { state_.view.panes.ToggleFilePane(); RefreshPaneLayout(); },
         [this]() { RefreshFilePane(); })) {
         return;
     }
@@ -283,20 +282,20 @@ void App::HandleFilePaneClick(float dip_x, float dip_y, const PaneLayout& layout
 
     if (TryHandlePaneScrollbarClick(dip_x, dip_y, layout.file_rect,
         PaneController::DragTarget::FileScrollbar,
-        scroll_info, total_content, state_.panes.FileScroll(),
+        scroll_info, total_content, state_.view.panes.FileScroll(),
         &Renderer::InvalidateFilePaneCache)) {
         return;
     }
-    const float local_y = dip_y - scroll_info.content_top + state_.panes.FileScroll().scroll_y;
+    const float local_y = dip_y - scroll_info.content_top + state_.view.panes.FileScroll().scroll_y;
     const int idx = state_.file_explorer.HitTest(local_y, theme.pane_item_height);
     if (idx >= 0 && idx < static_cast<int>(state_.file_explorer.GetEntries().size())) {
         const auto& file_entry = state_.file_explorer.GetEntries()[idx];
         if (file_entry.is_directory) {
             state_.file_explorer.SetDirectory(file_entry.full_path);
-            if (!state_.doc.GetFilePath().empty()) {
-                state_.file_explorer.SetCurrentFile(state_.doc.GetFilePath());
+            if (!state_.document.doc.GetFilePath().empty()) {
+                state_.file_explorer.SetCurrentFile(state_.document.doc.GetFilePath());
             }
-            state_.panes.FileScroll() = {};
+            state_.view.panes.FileScroll() = {};
             renderer_.InvalidateFilePaneCache();
             Invalidate();
         }
@@ -317,36 +316,36 @@ void App::HandleTocPaneClick(float dip_x, float dip_y, const PaneLayout& layout)
     const auto& theme = renderer_.GetTheme();
 
     if (ProcessSidePaneHeaderClick(dip_x, dip_y, layout.toc_rect, theme.pane_header_height, false,
-        [this]() { state_.panes.ToggleTocPane(); RefreshPaneLayout(); },
+        [this]() { state_.view.panes.ToggleTocPane(); RefreshPaneLayout(); },
         []() {})) {
         return;
     }
 
-    const float total_content = static_cast<float>(state_.doc.GetToc().GetEntries().size()) * theme.pane_item_height;
+    const float total_content = static_cast<float>(state_.document.doc.GetToc().GetEntries().size()) * theme.pane_item_height;
     const auto scroll_info = ComputePaneScrollInfo(layout.toc_rect, total_content);
 
     if (TryHandlePaneScrollbarClick(dip_x, dip_y, layout.toc_rect,
         PaneController::DragTarget::TocScrollbar,
-        scroll_info, total_content, state_.panes.TocScroll(),
+        scroll_info, total_content, state_.view.panes.TocScroll(),
         &Renderer::InvalidateTocPaneCache)) {
         return;
     }
-    const float local_y = dip_y - scroll_info.content_top + state_.panes.TocScroll().scroll_y;
-    const int idx = state_.doc.GetToc().HitTest(local_y, theme.pane_item_height);
-    if (idx >= 0 && idx < static_cast<int>(state_.doc.GetToc().GetEntries().size())) {
+    const float local_y = dip_y - scroll_info.content_top + state_.view.panes.TocScroll().scroll_y;
+    const int idx = state_.document.doc.GetToc().HitTest(local_y, theme.pane_item_height);
+    if (idx >= 0 && idx < static_cast<int>(state_.document.doc.GetToc().GetEntries().size())) {
         PushNavHistory();
-        const auto& toc_entry = state_.doc.GetToc().GetEntries()[idx];
-        NavigateToAnchor(state_.doc.GetNodes()[toc_entry.node_index].anchor_id());
+        const auto& toc_entry = state_.document.doc.GetToc().GetEntries()[idx];
+        NavigateToAnchor(state_.document.doc.GetNodes()[toc_entry.node_index].anchor_id());
     }
 }
 
 bool App::HandleTitleBarClick(float dip_x, float dip_y)
 {
-    if (dip_y >= state_.titlebar.GetHeight()) {
+    if (dip_y >= state_.window.titlebar.GetHeight()) {
         return false;
     }
 
-    const auto tb_zone = state_.titlebar.HitTest(dip_x, dip_y);
+    const auto tb_zone = state_.window.titlebar.HitTest(dip_x, dip_y);
     switch (tb_zone) {
     case TitleBarHitZone::OpenFile:
         Dispatch(OpenFileAction{});
@@ -384,9 +383,9 @@ bool App::HandleTitleBarClick(float dip_x, float dip_y)
 void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const PaneLayout& pane_layout)
 {
     // 検索バーのクリック処理
-    if (state_.search_state.IsVisible()) {
+    if (state_.search.search_state.IsVisible()) {
         const auto& r = pane_layout.md_rect;
-        const auto sbl = ComputeSearchBarLayout(r.x, r.width, r.y + r.height, !state_.search_state.GetQuery().empty());
+        const auto sbl = ComputeSearchBarLayout(r.x, r.width, r.y + r.height, !state_.search.search_state.GetQuery().empty());
         if (dip_y >= sbl.bar_top) {
             if (PointInRect(dip_x, dip_y, sbl.up_btn)) {
                 OnSearchPrev();
@@ -411,8 +410,8 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
             if (PointInRect(dip_x, dip_y, sbl.input_rect)) {
                 const float text_left = sbl.input_rect.left + SEARCH_INPUT_TEXT_PAD_LEFT;
                 const float input_w = sbl.input_rect.right - SEARCH_INPUT_TEXT_PAD_RIGHT - text_left;
-                const int pos = renderer_.HitTestSearchInput(state_.search_state.GetQuery(), dip_x - text_left, input_w);
-                state_.search_bar_ctrl.StartDrag(pos);
+                const int pos = renderer_.HitTestSearchInput(state_.search.search_state.GetQuery(), dip_x - text_left, input_w);
+                state_.search.search_bar_ctrl.StartDrag(pos);
                 SetCapture(hwnd_);
                 PostMessage(hwnd_, app_msg::SEARCH_FOCUS, app_param::SEARCH_FOCUS_SET_CARET, static_cast<LPARAM>(pos));
                 return;
@@ -434,9 +433,9 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
     // コピーボタンのクリック判定（クリック位置で再判定）
     const float content_width = renderer_.GetTheme().ContentWidth(pane_layout.md_rect.width);
     const MdPaneHitContext hit_ctx{
-        state_.doc.GetNodes(), state_.layout_cache, renderer_.GetTheme(),
-        state_.viewport.GetScrollY(), pane_layout.md_rect.x,
-        state_.cached_dpi_scale, px, py,
+        state_.document.doc.GetNodes(), state_.document.layout_cache, renderer_.GetTheme(),
+        state_.view.viewport.GetScrollY(), pane_layout.md_rect.x,
+        state_.window.cached_dpi_scale, px, py,
         content_width, pane_layout.md_rect.height
     };
     const auto copy_node = state_.hit_test.CopyButtonHitTest(hit_ctx);
@@ -458,16 +457,16 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
             const float sb_left = pane_layout.md_rect.x + pane_layout.md_rect.width - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
             if (dip_x >= sb_left - PANE_SCROLLBAR_HIT_PADDING) {
                 SetCapture(hwnd_);
-                state_.panes.StartDrag(PaneController::DragTarget::MdScrollbar);
-                state_.viewport.SetScrollbarTracking(true);
+                state_.view.panes.StartDrag(PaneController::DragTarget::MdScrollbar);
+                state_.view.viewport.SetScrollbarTracking(true);
                 const auto info = ComputeScrollInfo(pane_layout.md_rect, 0.0f, total_h);
-                const float thumb_y = ComputeThumbY(info, state_.viewport.GetScrollY());
+                const float thumb_y = ComputeThumbY(info, state_.view.viewport.GetScrollY());
                 if (dip_y >= thumb_y && dip_y <= thumb_y + info.thumb_height) {
-                    state_.panes.SetDragScrollOffset(dip_y - thumb_y);
+                    state_.view.panes.SetDragScrollOffset(dip_y - thumb_y);
                 }
                 else {
-                    state_.panes.SetDragScrollOffset(info.thumb_height * 0.5f);
-                    const float new_thumb_y = dip_y - state_.panes.GetDragScrollOffset();
+                    state_.view.panes.SetDragScrollOffset(info.thumb_height * 0.5f);
+                    const float new_thumb_y = dip_y - state_.view.panes.GetDragScrollOffset();
                     ScrollTo(ScrollFromThumbY(info, new_thumb_y));
                     Invalidate();
                 }
@@ -478,12 +477,12 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
 
     // MDペイン: 選択ロジック
     SetCapture(hwnd_);
-    state_.viewport.SetClickStart(px, py);
+    state_.view.viewport.SetClickStart(px, py);
     auto hit = HitTest(px, py);
     if (hit.node_index >= 0) {
-        state_.viewport.SetAnchor(hit.node_index, hit.text_pos);
-        state_.viewport.SetDragging(true);
-        state_.viewport.GetSelectionMut().Clear();
+        state_.view.viewport.SetAnchor(hit.node_index, hit.text_pos);
+        state_.view.viewport.SetDragging(true);
+        state_.view.viewport.GetSelectionMut().Clear();
         InvalidateMdPane(pane_layout.md_rect);
     }
 }
@@ -505,18 +504,18 @@ void App::OnLButtonDown(int px, int py)
         dip.x,
         pane_layout,
         renderer_.GetTheme().splitter_width,
-        state_.panes.IsFilePaneVisible(),
-        state_.panes.IsTocPaneVisible()
+        state_.view.panes.IsFilePaneVisible(),
+        state_.view.panes.IsTocPaneVisible()
     );
 
     switch (zone) {
     case PaneZone::Splitter1:
         SetCapture(hwnd_);
-        state_.panes.StartDrag(PaneController::DragTarget::Splitter1);
+        state_.view.panes.StartDrag(PaneController::DragTarget::Splitter1);
         return;
     case PaneZone::Splitter2:
         SetCapture(hwnd_);
-        state_.panes.StartDrag(PaneController::DragTarget::Splitter2);
+        state_.view.panes.StartDrag(PaneController::DragTarget::Splitter2);
         return;
     case PaneZone::FilePane:
         HandleFilePaneClick(dip.x, dip.y, pane_layout);
@@ -534,20 +533,20 @@ void App::OnLButtonDown(int px, int py)
 
 void App::OnLButtonUp(int px, int py)
 {
-    if (state_.search_bar_ctrl.IsDragging()) {
-        state_.search_bar_ctrl.EndDrag();
+    if (state_.search.search_bar_ctrl.IsDragging()) {
+        state_.search.search_bar_ctrl.EndDrag();
         ReleaseCapture();
         return;
     }
 
     ReleaseCapture();
 
-    if (state_.panes.GetDragTarget() != PaneController::DragTarget::None) {
-        const bool was_md_scrollbar = (state_.panes.GetDragTarget() == PaneController::DragTarget::MdScrollbar);
+    if (state_.view.panes.GetDragTarget() != PaneController::DragTarget::None) {
+        const bool was_md_scrollbar = (state_.view.panes.GetDragTarget() == PaneController::DragTarget::MdScrollbar);
         if (was_md_scrollbar) {
-            state_.viewport.SetScrollbarTracking(false);
+            state_.view.viewport.SetScrollbarTracking(false);
         }
-        state_.panes.EndDrag();
+        state_.view.panes.EndDrag();
         RECT rc;
         GetClientRect(hwnd_, &rc);
         OnResize(static_cast<UINT>(rc.right - rc.left), static_cast<UINT>(rc.bottom - rc.top));
@@ -557,21 +556,21 @@ void App::OnLButtonUp(int px, int py)
         return;
     }
 
-    if (state_.viewport.IsDragging()) {
+    if (state_.view.viewport.IsDragging()) {
         const auto hit = HitTest(px, py);
         if (hit.node_index >= 0) {
-            state_.viewport.SetSelection(TextSelection::MakeOrdered(
-                state_.viewport.GetAnchorNode(),
-                state_.viewport.GetAnchorPos(),
+            state_.view.viewport.SetSelection(TextSelection::MakeOrdered(
+                state_.view.viewport.GetAnchorNode(),
+                state_.view.viewport.GetAnchorPos(),
                 hit.node_index,
                 hit.text_pos
             ));
         }
-        state_.viewport.SetDragging(false);
+        state_.view.viewport.SetDragging(false);
 
-        const int dx = px - state_.viewport.GetClickStartX();
-        const int dy = py - state_.viewport.GetClickStartY();
-        if (!state_.viewport.GetSelection().active && (dx * dx + dy * dy) < CLICK_DISTANCE_THRESHOLD_SQ) {
+        const int dx = px - state_.view.viewport.GetClickStartX();
+        const int dy = py - state_.view.viewport.GetClickStartY();
+        if (!state_.view.viewport.GetSelection().active && (dx * dx + dy * dy) < CLICK_DISTANCE_THRESHOLD_SQ) {
             const auto link = GetLinkAtHit(hit);
             if (link.has_value()) {
                 HandleLinkClick(link.value());
@@ -596,69 +595,69 @@ void App::OnMouseMove(int px, int py)
     const float splitter_w = renderer_.GetTheme().splitter_width;
 
     // 検索バー内ドラッグ選択
-    if (state_.search_bar_ctrl.IsDragging()) {
+    if (state_.search.search_bar_ctrl.IsDragging()) {
         const auto layout = GetPaneLayout();
         const auto& r = layout.md_rect;
-        const auto sbl = ComputeSearchBarLayout(r.x, r.width, r.y + r.height, !state_.search_state.GetQuery().empty());
+        const auto sbl = ComputeSearchBarLayout(r.x, r.width, r.y + r.height, !state_.search.search_state.GetQuery().empty());
         const float text_left = sbl.input_rect.left + SEARCH_INPUT_TEXT_PAD_LEFT;
         const float input_w = sbl.input_rect.right - SEARCH_INPUT_TEXT_PAD_RIGHT - text_left;
-        const int pos = renderer_.HitTestSearchInput(state_.search_state.GetQuery(), dip.x - text_left, input_w);
-        if (pos != state_.search_bar_ctrl.GetCaretPos() ||
-            state_.search_bar_ctrl.GetDragAnchor() != state_.search_bar_ctrl.GetSelectionStart()) {
-            PostMessage(hwnd_, app_msg::SEARCH_FOCUS, app_param::SEARCH_FOCUS_SET_SELECTION, MAKELPARAM(state_.search_bar_ctrl.GetDragAnchor(), pos));
+        const int pos = renderer_.HitTestSearchInput(state_.search.search_state.GetQuery(), dip.x - text_left, input_w);
+        if (pos != state_.search.search_bar_ctrl.GetCaretPos() ||
+            state_.search.search_bar_ctrl.GetDragAnchor() != state_.search.search_bar_ctrl.GetSelectionStart()) {
+            PostMessage(hwnd_, app_msg::SEARCH_FOCUS, app_param::SEARCH_FOCUS_SET_SELECTION, MAKELPARAM(state_.search.search_bar_ctrl.GetDragAnchor(), pos));
         }
         return;
     }
 
-    if (state_.panes.GetDragTarget() == PaneController::DragTarget::Splitter1) {
-        state_.panes.DragSplitter1To(dip_x, size.width, splitter_w);
+    if (state_.view.panes.GetDragTarget() == PaneController::DragTarget::Splitter1) {
+        state_.view.panes.DragSplitter1To(dip_x, size.width, splitter_w);
         InvalidatePaneLayoutCache();
         Invalidate();
         return;
     }
 
-    if (state_.panes.GetDragTarget() == PaneController::DragTarget::FileScrollbar) {
+    if (state_.view.panes.GetDragTarget() == PaneController::DragTarget::FileScrollbar) {
         const auto layout = GetPaneLayout();
         const float total = static_cast<float>(state_.file_explorer.GetEntries().size()) * renderer_.GetTheme().pane_item_height;
-        HandleSidePaneScrollDrag(dip.y, layout.file_rect, total, state_.panes.FileScroll(), &Renderer::InvalidateFilePaneCache);
+        HandleSidePaneScrollDrag(dip.y, layout.file_rect, total, state_.view.panes.FileScroll(), &Renderer::InvalidateFilePaneCache);
         return;
     }
 
-    if (state_.panes.GetDragTarget() == PaneController::DragTarget::TocScrollbar) {
+    if (state_.view.panes.GetDragTarget() == PaneController::DragTarget::TocScrollbar) {
         const auto layout = GetPaneLayout();
-        const float total = static_cast<float>(state_.doc.GetToc().GetEntries().size()) * renderer_.GetTheme().pane_item_height;
-        HandleSidePaneScrollDrag(dip.y, layout.toc_rect, total, state_.panes.TocScroll(), &Renderer::InvalidateTocPaneCache);
+        const float total = static_cast<float>(state_.document.doc.GetToc().GetEntries().size()) * renderer_.GetTheme().pane_item_height;
+        HandleSidePaneScrollDrag(dip.y, layout.toc_rect, total, state_.view.panes.TocScroll(), &Renderer::InvalidateTocPaneCache);
         return;
     }
 
-    if (state_.panes.GetDragTarget() == PaneController::DragTarget::MdScrollbar) {
+    if (state_.view.panes.GetDragTarget() == PaneController::DragTarget::MdScrollbar) {
         if (layout_service_) {
             const auto layout = GetPaneLayout();
             const float total_h = layout_service_->GetTotalHeight();
             const auto info = ComputeScrollInfo(layout.md_rect, 0.0f, total_h);
-            const float new_thumb_y = dip.y - state_.panes.GetDragScrollOffset();
+            const float new_thumb_y = dip.y - state_.view.panes.GetDragScrollOffset();
             ScrollTo(ScrollFromThumbY(info, new_thumb_y));
             Invalidate();
         }
         return;
     }
 
-    if (state_.panes.GetDragTarget() == PaneController::DragTarget::Splitter2) {
-        state_.panes.DragSplitter2To(dip_x, size.width, splitter_w);
+    if (state_.view.panes.GetDragTarget() == PaneController::DragTarget::Splitter2) {
+        state_.view.panes.DragSplitter2To(dip_x, size.width, splitter_w);
         InvalidatePaneLayoutCache();
         Invalidate();
         return;
     }
 
     // MDペイン: ドラッグ選択
-    if (!state_.viewport.IsDragging()) {
+    if (!state_.view.viewport.IsDragging()) {
         return;
     }
     const auto hit = HitTest(px, py);
     if (hit.node_index >= 0) {
-        state_.viewport.SetSelection(TextSelection::MakeOrdered(
-            state_.viewport.GetAnchorNode(),
-            state_.viewport.GetAnchorPos(),
+        state_.view.viewport.SetSelection(TextSelection::MakeOrdered(
+            state_.view.viewport.GetAnchorNode(),
+            state_.view.viewport.GetAnchorPos(),
             hit.node_index,
             hit.text_pos
         ));
@@ -678,17 +677,17 @@ void App::OnMouseHover(int px, int py)
     const float dip_y = dip.y;
 
     // タイトルバーのホバー処理
-    if (dip_y < state_.titlebar.GetHeight()) {
-        const auto tb_zone = state_.titlebar.HitTest(dip_x, dip_y);
+    if (dip_y < state_.window.titlebar.GetHeight()) {
+        const auto tb_zone = state_.window.titlebar.HitTest(dip_x, dip_y);
         SetCursor(cursors_.Arrow());
-        if (state_.titlebar.SetHovered(tb_zone)) {
+        if (state_.window.titlebar.SetHovered(tb_zone)) {
             InvalidateTitleBar();
         }
         UpdateTooltip(BuildTitleBarTooltip(tb_zone, IsZoomed(hwnd_)), px, py);
         return;
     }
     // タイトルバー外に出たらホバーをリセット
-    if (state_.titlebar.SetHovered(TitleBarHitZone::None)) {
+    if (state_.window.titlebar.SetHovered(TitleBarHitZone::None)) {
         InvalidateTitleBar();
     }
 
@@ -697,8 +696,8 @@ void App::OnMouseHover(int px, int py)
         dip_x,
         pane_layout,
         renderer_.GetTheme().splitter_width,
-        state_.panes.IsFilePaneVisible(),
-        state_.panes.IsTocPaneVisible()
+        state_.view.panes.IsFilePaneVisible(),
+        state_.view.panes.IsTocPaneVisible()
     );
 
     int new_file_hover = -1;
@@ -706,14 +705,14 @@ void App::OnMouseHover(int px, int py)
 
     // ペインゾーン外に出たら閉じる/更新ボタンのホバーをリセット
     if (zone != PaneZone::FilePane) {
-        bool changed = state_.panes.SetFileCloseHovered(false);
-        changed |= state_.panes.SetFileRefreshHovered(false);
+        bool changed = state_.view.panes.SetFileCloseHovered(false);
+        changed |= state_.view.panes.SetFileRefreshHovered(false);
         if (changed) {
             renderer_.InvalidateFilePaneCache();
             InvalidatePane(pane_layout.file_rect);
         }
     }
-    if (zone != PaneZone::TocPane && state_.panes.SetTocCloseHovered(false)) {
+    if (zone != PaneZone::TocPane && state_.view.panes.SetTocCloseHovered(false)) {
         renderer_.InvalidateTocPaneCache();
         InvalidatePane(pane_layout.toc_rect);
     }
@@ -729,9 +728,9 @@ void App::OnMouseHover(int px, int py)
         const auto& entries = state_.file_explorer.GetEntries();
         const auto hr = ProcessSidePaneHover(dip_x, dip_y,
             pane_layout.file_rect, header_h, renderer_.GetTheme().pane_item_height,
-            true, state_.panes.FileScroll().scroll_y,
-            [this](bool v) { return state_.panes.SetFileCloseHovered(v); },
-            [this](bool v) { return state_.panes.SetFileRefreshHovered(v); },
+            true, state_.view.panes.FileScroll().scroll_y,
+            [this](bool v) { return state_.view.panes.SetFileCloseHovered(v); },
+            [this](bool v) { return state_.view.panes.SetFileRefreshHovered(v); },
             [this](float y, float h) { return state_.file_explorer.HitTest(y, h); },
             [&](bool close_hit, bool refresh_hit, int idx) -> TooltipTarget {
             if (close_hit) {
@@ -765,17 +764,17 @@ void App::OnMouseHover(int px, int py)
     }
     case PaneZone::TocPane: {
         const float header_h = renderer_.GetTheme().pane_header_height;
-        const auto& toc_entries = state_.doc.GetToc().GetEntries();
+        const auto& toc_entries = state_.document.doc.GetToc().GetEntries();
         const auto hr = ProcessSidePaneHover(dip_x, dip_y,
             pane_layout.toc_rect, header_h, renderer_.GetTheme().pane_item_height,
-            false, state_.panes.TocScroll().scroll_y,
-            [this](bool v) { return state_.panes.SetTocCloseHovered(v); },
+            false, state_.view.panes.TocScroll().scroll_y,
+            [this](bool v) { return state_.view.panes.SetTocCloseHovered(v); },
             [](bool) { return false; },
-            [this](float y, float h) { return state_.doc.GetToc().HitTest(y, h); },
+            [this](float y, float h) { return state_.document.doc.GetToc().HitTest(y, h); },
             [&](bool close_hit, bool, int idx) -> TooltipTarget {
             if (close_hit) { return { TooltipTarget::Zone::TocPaneButton, i18n::S().tooltip_pane_close }; }
             if (idx >= 0 && idx < static_cast<int>(toc_entries.size())) {
-                return { TooltipTarget::Zone::TocPaneItem, state_.doc.GetNodes()[toc_entries[idx].node_index].GetText() };
+                return { TooltipTarget::Zone::TocPaneItem, state_.document.doc.GetNodes()[toc_entries[idx].node_index].GetText() };
             }
             return {};
         });
@@ -797,11 +796,11 @@ void App::OnMouseHover(int px, int py)
         break;
     }
 
-    if (state_.panes.SetHoveredFileIndex(new_file_hover)) {
+    if (state_.view.panes.SetHoveredFileIndex(new_file_hover)) {
         renderer_.InvalidateFilePaneCache();
         InvalidatePane(pane_layout.file_rect);
     }
-    if (state_.panes.SetHoveredTocIndex(new_toc_hover)) {
+    if (state_.view.panes.SetHoveredTocIndex(new_toc_hover)) {
         renderer_.InvalidateTocPaneCache();
         InvalidatePane(pane_layout.toc_rect);
     }
@@ -810,13 +809,13 @@ void App::OnMouseHover(int px, int py)
 void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const PaneLayout& pane_layout)
 {
     // 検索バー上のホバー処理
-    if (state_.search_state.IsVisible()) {
+    if (state_.search.search_state.IsVisible()) {
         const auto& r = pane_layout.md_rect;
-        const auto sbl = ComputeSearchBarLayout(r.x, r.width, r.y + r.height, !state_.search_state.GetQuery().empty());
-        const auto old_hover = state_.search_bar_ctrl.GetHover();
+        const auto sbl = ComputeSearchBarLayout(r.x, r.width, r.y + r.height, !state_.search.search_state.GetQuery().empty());
+        const auto old_hover = state_.search.search_bar_ctrl.GetHover();
 
         if (dip_y >= sbl.bar_top) {
-            const auto hover = state_.search_bar_ctrl.UpdateHover(dip_x, dip_y, sbl);
+            const auto hover = state_.search.search_bar_ctrl.UpdateHover(dip_x, dip_y, sbl);
 
             if (PointInRect(dip_x, dip_y, sbl.input_rect)) {
                 SetCursor(cursors_.IBeam());
@@ -854,7 +853,7 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
         }
 
         if (old_hover != SearchBarController::HoverZone::None) {
-            state_.search_bar_ctrl.ResetHover();
+            state_.search.search_bar_ctrl.ResetHover();
             Invalidate();
         }
     }
@@ -867,11 +866,11 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
     }
 
     const auto nav_hit = state_.hit_test.NavButtonHitTest(dip_x, dip_y, pane_layout.md_rect);
-    const auto old_nav_hover = state_.nav_hover;
-    state_.nav_hover = nav_hit;
+    const auto old_nav_hover = state_.interaction.nav_hover;
+    state_.interaction.nav_hover = nav_hit;
     if (nav_hit != NavButtonHover::None) {
-        state_.hovered_copy_node = -1;
-        state_.hovered_save_node = -1;
+        state_.interaction.hovered_copy_node = -1;
+        state_.interaction.hovered_save_node = -1;
         SetCursor(cursors_.Hand());
         if (nav_hit != old_nav_hover) {
             InvalidateMdPane(pane_layout.md_rect);
@@ -897,55 +896,55 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
     // コピー/保存ボタンのホバー判定（距離スロットリングで不要な再計算を回避）
     const float content_width = renderer_.GetTheme().ContentWidth(pane_layout.md_rect.width);
     const MdPaneHitContext hit_ctx{
-        state_.doc.GetNodes(), state_.layout_cache, renderer_.GetTheme(),
-        state_.viewport.GetScrollY(), pane_layout.md_rect.x,
-        state_.cached_dpi_scale, px, py,
+        state_.document.doc.GetNodes(), state_.document.layout_cache, renderer_.GetTheme(),
+        state_.view.viewport.GetScrollY(), pane_layout.md_rect.x,
+        state_.window.cached_dpi_scale, px, py,
         content_width, pane_layout.md_rect.height
     };
     {
-        const int cdx = px - state_.hover_throttle.last_copy_hit_pos.x;
-        const int cdy = py - state_.hover_throttle.last_copy_hit_pos.y;
+        const int cdx = px - state_.interaction.hover_throttle.last_copy_hit_pos.x;
+        const int cdy = py - state_.interaction.hover_throttle.last_copy_hit_pos.y;
         if (cdx * cdx + cdy * cdy > HOVER_THROTTLE_DISTANCE_SQ) {
-            state_.hover_throttle.last_copy_hit_pos = { px, py };
-            const int old_copy_hover = state_.hovered_copy_node;
-            state_.hovered_copy_node = state_.hit_test.CopyButtonHitTest(hit_ctx);
-            if (state_.hovered_copy_node != old_copy_hover) {
+            state_.interaction.hover_throttle.last_copy_hit_pos = { px, py };
+            const int old_copy_hover = state_.interaction.hovered_copy_node;
+            state_.interaction.hovered_copy_node = state_.hit_test.CopyButtonHitTest(hit_ctx);
+            if (state_.interaction.hovered_copy_node != old_copy_hover) {
                 InvalidateMdPane(pane_layout.md_rect);
             }
         }
     }
-    if (state_.hovered_copy_node >= 0) {
+    if (state_.interaction.hovered_copy_node >= 0) {
         SetCursor(cursors_.Hand());
         UpdateTooltip({ TooltipTarget::Zone::CopyButton, i18n::S().tooltip_copy }, px, py);
         return;
     }
 
     {
-        const int sdx = px - state_.hover_throttle.last_save_hit_pos.x;
-        const int sdy = py - state_.hover_throttle.last_save_hit_pos.y;
+        const int sdx = px - state_.interaction.hover_throttle.last_save_hit_pos.x;
+        const int sdy = py - state_.interaction.hover_throttle.last_save_hit_pos.y;
         if (sdx * sdx + sdy * sdy > HOVER_THROTTLE_DISTANCE_SQ) {
-            state_.hover_throttle.last_save_hit_pos = { px, py };
-            const int old_save_hover = state_.hovered_save_node;
-            state_.hovered_save_node = state_.hit_test.SaveButtonHitTest(hit_ctx);
-            if (state_.hovered_save_node != old_save_hover) {
+            state_.interaction.hover_throttle.last_save_hit_pos = { px, py };
+            const int old_save_hover = state_.interaction.hovered_save_node;
+            state_.interaction.hovered_save_node = state_.hit_test.SaveButtonHitTest(hit_ctx);
+            if (state_.interaction.hovered_save_node != old_save_hover) {
                 InvalidateMdPane(pane_layout.md_rect);
             }
         }
     }
-    if (state_.hovered_save_node >= 0) {
+    if (state_.interaction.hovered_save_node >= 0) {
         SetCursor(cursors_.Hand());
         UpdateTooltip({ TooltipTarget::Zone::SaveButton, i18n::S().tooltip_save_image }, px, py);
         return;
     }
 
     // リンク・画像のヒットテスト
-    const int dx = px - state_.hover_throttle.last_md_hit_pos.x;
-    const int dy = py - state_.hover_throttle.last_md_hit_pos.y;
+    const int dx = px - state_.interaction.hover_throttle.last_md_hit_pos.x;
+    const int dy = py - state_.interaction.hover_throttle.last_md_hit_pos.y;
     if (dx * dx + dy * dy > HOVER_THROTTLE_DISTANCE_SQ) {
         const auto hit = HitTest(px, py);
         const auto link = GetLinkAtHit(hit);
-        state_.hover_throttle.last_md_cursor_hand = link.has_value();
-        state_.hover_throttle.last_md_hit_pos = { px, py };
+        state_.interaction.hover_throttle.last_md_cursor_hand = link.has_value();
+        state_.interaction.hover_throttle.last_md_hit_pos = { px, py };
 
         // リンクまたは画像のツールチップ
         TooltipTarget tt;
@@ -954,7 +953,7 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
             tt.text = *link;
         }
         else if (hit.node_index >= 0) {
-            const auto& nodes = state_.doc.GetNodes();
+            const auto& nodes = state_.document.doc.GetNodes();
             const auto& node = nodes[hit.node_index];
             if (node.type == NodeType::Image && node.has_image()) {
                 tt.zone = TooltipTarget::Zone::MdImage;
@@ -968,7 +967,7 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
         }
         UpdateTooltip(tt, px, py);
     }
-    SetCursor(state_.hover_throttle.last_md_cursor_hand ? cursors_.Hand() : cursors_.IBeam());
+    SetCursor(state_.interaction.hover_throttle.last_md_cursor_hand ? cursors_.Hand() : cursors_.IBeam());
 }
 
 bool App::IsOverMdScrollbar(float dip_x, float dip_y, const PaneLayout& layout) const noexcept
@@ -990,7 +989,7 @@ bool App::IsOverMdScrollbar(float dip_x, float dip_y, const PaneLayout& layout) 
     return dip_x >= sb_left - PANE_SCROLLBAR_HIT_PADDING && dip_x <= sb_right;
 }
 
-bool App::IsOverMdScrollbar(float dip_x, float dip_y) const
+bool App::IsOverMdScrollbar(float dip_x, float dip_y)
 {
     return IsOverMdScrollbar(dip_x, dip_y, GetPaneLayout());
 }

--- a/src/app/app_mouse.cpp
+++ b/src/app/app_mouse.cpp
@@ -224,11 +224,12 @@ void App::OnXButtonForward()
 // ヒットテスト
 // ============================================================
 
-App::HitResult App::HitTest(int screen_x, int screen_y) const
+App::HitResult App::HitTest(int screen_x, int screen_y)
 {
+    const auto& layout = GetPaneLayout();
     return state_.hit_test.HitTest({
         state_.document.doc.GetNodes(), state_.document.layout_cache, renderer_.GetTheme(),
-        state_.view.viewport.GetScrollY(), state_.cached_pane_layout.md_rect.x,
+        state_.view.viewport.GetScrollY(), layout.md_rect.x,
         state_.window.cached_dpi_scale, screen_x, screen_y
         });
 }

--- a/src/app/app_navigate.cpp
+++ b/src/app/app_navigate.cpp
@@ -31,13 +31,13 @@ void App::HandleLinkClick(std::wstring_view url)
 
 void App::NavigateToAnchor(std::wstring_view anchor)
 {
-    const int idx = state_.doc.FindAnchorIndex(anchor);
+    const int idx = state_.document.doc.FindAnchorIndex(anchor);
     if (idx < 0) {
         return;
     }
 
     const auto layout = GetPaneLayout();
-    float target_y = state_.layout_cache[idx].y_position - renderer_.GetTheme().heading_spacing_above - layout.md_rect.y;
+    float target_y = state_.document.layout_cache[idx].y_position - renderer_.GetTheme().heading_spacing_above - layout.md_rect.y;
     target_y = std::max(0.0f, target_y);
     ScrollTo(target_y);
     UpdateScrollBar();
@@ -47,7 +47,7 @@ void App::NavigateToAnchor(std::wstring_view anchor)
 
 void App::PushNavHistory()
 {
-    state_.nav_history.Push(NavEntry{ state_.doc.GetFilePath(), state_.viewport.GetScrollY() });
+    state_.view.nav_history.Push(NavEntry{ state_.document.doc.GetFilePath(), state_.view.viewport.GetScrollY() });
 }
 
 // ============================================================
@@ -57,7 +57,7 @@ void App::PushNavHistory()
 void App::SyncPaneThemeCache()
 {
     const auto& theme = renderer_.GetTheme();
-    state_.cached_theme = ThemeConstants{
+    state_.window.cached_theme = ThemeConstants{
         .pane_item_height = theme.pane_item_height,
         .pane_header_height = theme.pane_header_height,
         .splitter_width = theme.splitter_width,
@@ -77,7 +77,7 @@ void App::FinishThemeOrZoomChange(const AnchorState& anchor, float offset_scale)
     float md_height = layout.md_rect.height;
 
     // 表示領域を優先的にレイアウトし、残りは遅延処理に委ねる
-    layout_service_->ViewportLayout(state_.doc, state_.layout_cache, md_width, md_height);
+    layout_service_->ViewportLayout(state_.document.doc, state_.document.layout_cache, md_width, md_height);
 
     RestoreAnchorWithScale(anchor, offset_scale);
 
@@ -102,10 +102,10 @@ void App::HandleApplyThemeChange(const effect::ApplyThemeChange& e)
     else {
         // DarkMode
         theme_service_.ToggleDarkMode();
-        renderer_.SetTheme(theme_service_.CreateTheme(state_.viewport.GetZoomIndex()));
+        renderer_.SetTheme(theme_service_.CreateTheme(state_.view.viewport.GetZoomIndex()));
         const bool dark = theme_service_.IsDarkMode();
         ApplyDarkModeToWindow(hwnd_, dark);
-        state_.tooltip.ApplyDarkMode(dark);
+        state_.interaction.tooltip.ApplyDarkMode(dark);
         mermaid_renderer_.CancelPending();
         mermaid_renderer_.ClearCache();
         FinishThemeOrZoomChange(anchor, e.offset_scale);

--- a/src/app/app_scroll.cpp
+++ b/src/app/app_scroll.cpp
@@ -18,14 +18,14 @@ void App::UpdateScrollBar()
 
 void App::InvalidateHitPositions() noexcept
 {
-    state_.hover_throttle.Reset();
+    state_.interaction.hover_throttle.Reset();
     ClearTooltip();
 }
 
 void App::ScrollTo(float position)
 {
-    state_.scroll_restore.pending_restore_scroll_y = -1;
-    state_.viewport.ScrollTo(position);
+    state_.view.scroll_restore.pending_restore_scroll_y = -1;
+    state_.view.viewport.ScrollTo(position);
     InvalidateHitPositions();
 }
 
@@ -42,13 +42,13 @@ void App::InvalidateMdPane(const PaneRect& md_rect)
 void App::SyncMaxScroll(float md_pane_height)
 {
     const float total = layout_service_->GetTotalHeight();
-    state_.cached_total_height = total;
-    state_.viewport.SyncMaxScroll(total, md_pane_height);
+    state_.view.cached_total_height = total;
+    state_.view.viewport.SyncMaxScroll(total, md_pane_height);
 }
 
 int App::FindFirstVisibleNode() const noexcept
 {
-    return state_.viewport.FindFirstVisibleNode(state_.layout_cache, state_.doc.GetNodes().size());
+    return state_.view.viewport.FindFirstVisibleNode(state_.document.layout_cache, state_.document.doc.GetNodes().size());
 }
 
 AnchorState App::SaveAnchor() const
@@ -58,15 +58,15 @@ AnchorState App::SaveAnchor() const
 
 void App::RestoreAnchor(const AnchorState& anchor, float md_pane_height)
 {
-    state_.viewport.AnchorCompensateScroll(anchor.idx, anchor.y_before, state_.layout_cache);
+    state_.view.viewport.AnchorCompensateScroll(anchor.idx, anchor.y_before, state_.document.layout_cache);
     SyncMaxScroll(md_pane_height);
 }
 
 void App::RestoreAnchorWithScale(const AnchorState& anchor, float offset_scale)
 {
-    if (anchor.idx >= 0 && anchor.idx < static_cast<int>(state_.doc.GetNodes().size())) {
-        float anchor_y_after = state_.layout_cache[anchor.idx].y_position;
-        state_.viewport.SetScrollY(anchor_y_after + anchor.offset * offset_scale);
+    if (anchor.idx >= 0 && anchor.idx < static_cast<int>(state_.document.doc.GetNodes().size())) {
+        float anchor_y_after = state_.document.layout_cache[anchor.idx].y_position;
+        state_.view.viewport.SetScrollY(anchor_y_after + anchor.offset * offset_scale);
     }
 }
 
@@ -105,7 +105,7 @@ void App::OnResizeEnd()
 
     {
         MENDO_PROFILE("ViewportLayout(Resize)");
-        layout_service_->ViewportLayout(state_.doc, state_.layout_cache, md_width, md_height);
+        layout_service_->ViewportLayout(state_.document.doc, state_.document.layout_cache, md_width, md_height);
     }
 
     SyncMaxScroll(md_height);
@@ -137,7 +137,7 @@ void App::OnDeferredLayout()
     bool more;
     {
         MENDO_PROFILE("ProcessDirtyBatch");
-        more = layout_service_->ProcessDirtyBatch(state_.doc, state_.layout_cache, md_width, 200, ResourceManager::BATCH_TIME_BUDGET_US, md_height, ResourceManager::EVICT_BUFFER_SCREENS);
+        more = layout_service_->ProcessDirtyBatch(state_.document.doc, state_.document.layout_cache, md_width, 200, ResourceManager::BATCH_TIME_BUDGET_US, md_height, ResourceManager::EVICT_BUFFER_SCREENS);
     }
 
 #if MENDO_PROFILE_ENABLED
@@ -149,12 +149,12 @@ void App::OnDeferredLayout()
     }
 #endif
 
-    if (!state_.viewport.IsScrollbarTracking()) {
+    if (!state_.view.viewport.IsScrollbarTracking()) {
         // 中間バッチではアンカー補償のみ行い、SyncMaxScrollのクランプを遅延させる。
         // ビューポート後のノードが計測されるとtotal_heightが縮小し、中間的な
         // max_scrollに基づくクランプでscroll_yが不当に引き下げられるのを防ぐ。
         // 最終バッチでもMermaidレンダリング後までクランプを遅延させる（後述）。
-        state_.viewport.AnchorCompensateScroll(anchor.idx, anchor.y_before, state_.layout_cache);
+        state_.view.viewport.AnchorCompensateScroll(anchor.idx, anchor.y_before, state_.document.layout_cache);
     }
     else {
         SyncMaxScroll(md_height);
@@ -169,9 +169,9 @@ void App::OnDeferredLayout()
         resource_manager_.ScheduleMermaidBatch();
 
         // 全レイアウト確定後に前回セッションの生のscroll_yを適用する
-        if (state_.scroll_restore.pending_restore_scroll_y >= 0.0f) {
-            state_.viewport.SetScrollY(state_.scroll_restore.pending_restore_scroll_y);
-            state_.scroll_restore.pending_restore_scroll_y = -1.0f;
+        if (state_.view.scroll_restore.pending_restore_scroll_y >= 0.0f) {
+            state_.view.viewport.SetScrollY(state_.view.scroll_restore.pending_restore_scroll_y);
+            state_.view.scroll_restore.pending_restore_scroll_y = -1.0f;
         }
 
         SyncMaxScroll(md_height);

--- a/src/app/app_state.h
+++ b/src/app/app_state.h
@@ -39,60 +39,76 @@ struct ThemeConstants {
     float zoom = 1.0f;
 };
 
+// ---- ドメイン状態: ドキュメントとレイアウトキャッシュ ----
+struct DocumentState {
+    Document doc;
+    LayoutCache layout_cache;
+};
+
+// ---- 表示・スクロール・ペインの状態 ----
+struct ViewState {
+    ViewportManager viewport;
+    PaneController panes;
+    ScrollRestoration scroll_restore;
+    NavHistory nav_history;
+    float cached_total_height = 0.0f;
+};
+
+// ---- ユーザー入力・操作の状態 ----
+struct InteractionState {
+    MouseGesture gesture;
+    SwipeDetector swipe_detector;
+    HoverThrottle hover_throttle;
+    Tooltip tooltip;
+    ToastNotifier toast;
+    int hovered_copy_node = -1;
+    int hovered_save_node = -1;
+    HitTestService::NavButtonHover nav_hover = HitTestService::NavButtonHover::None;
+};
+
+// ---- 検索の状態 ----
+struct SearchGroup {
+    SearchState search_state;
+    SearchBarController search_bar_ctrl;
+};
+
+// ---- ウィンドウ・テーマの状態 ----
+struct WindowState {
+    TitleBar titlebar;
+    bool is_sizing = false;
+    bool window_active = true;
+    float cached_dpi_scale = 1.0f;
+    ThemeConstants cached_theme;
+};
+
 // アプリケーションの全状態を集約する構造体。
 // Win32ハンドルは含まない。状態に加えて一部のコントローラ
 // (ContextMenu, HitTestService, SearchBarController) を含む。
 // Reducer パターンの入出力として使用する。
 struct AppState {
-    // ---- ドメイン状態 ----
-    Document doc;
-    LayoutCache layout_cache;
-    ViewportManager viewport;
+    // ---- サブグループ ----
+    DocumentState document;
+    ViewState view;
+    InteractionState interaction;
+    SearchGroup search;
+    WindowState window;
 
-    // ---- UI状態 ----
-    PaneController panes;
-    SearchState search_state;
-    SearchBarController search_bar_ctrl;
-    NavHistory nav_history;
+    // ---- UIコンポーネント ----
     FileExplorer file_explorer;
-    MouseGesture gesture;
-    SwipeDetector swipe_detector;
-    TitleBar titlebar;
-    ToastNotifier toast;
-    Tooltip tooltip;
-    ScrollRestoration scroll_restore;
     ContextMenu ctx_menu;
     HitTestService hit_test;
-    HoverThrottle hover_throttle;
-
-    // ---- フラグ類 ----
-    bool is_sizing = false;
-    bool window_active = true;
-    int hovered_copy_node = -1;
-    int hovered_save_node = -1;
     int active_toc_index = -1;
-    HitTestService::NavButtonHover nav_hover = HitTestService::NavButtonHover::None;
 
     // ---- リロード管理 ----
     size_t reload_diff_pos = std::string_view::npos;
     float reload_old_scroll = 0.0f;
     bool pending_prefix_shrink = false;
 
-    // ---- キャッシュ ----
+    // ---- ペインレイアウトキャッシュ ----
     std::pmr::wstring cached_title_text = L"mendo";
-    mutable PaneLayout cached_pane_layout{};
-    mutable float cached_window_width_for_layout = 0.0f;
-    mutable bool pane_layout_valid = false;
-
-    // テーマから取得した定数のキャッシュ（ズーム/テーマ変更時に更新）。
-    // Reducer がペインスクロールの max_scroll 計算等に使用する。
-    ThemeConstants cached_theme;
-
-    // DPIスケール（ピクセル→DIP変換用）。OnDpiChanged で更新。
-    float cached_dpi_scale = 1.0f;
-
-    // ドキュメント総高さのキャッシュ。ViewportLayout 後に更新。
-    float cached_total_height = 0.0f;
+    PaneLayout cached_pane_layout{};
+    float cached_window_width_for_layout = 0.0f;
+    bool pane_layout_valid = false;
 };
 
 // 現在のスクロール位置からアンカーを保存する。Reducer と App の共通ヘルパー。

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -7,436 +7,492 @@
 AnchorState SaveAnchorFromState(const AppState& state) noexcept
 {
     AnchorState a;
-    a.idx = state.viewport.FindFirstVisibleNode(state.layout_cache, state.doc.GetNodes().size());
-    a.y_before = (a.idx >= 0) ? state.layout_cache[a.idx].y_position : 0.0f;
-    a.offset = state.viewport.GetScrollY() - a.y_before;
+    a.idx = state.view.viewport.FindFirstVisibleNode(state.document.layout_cache, state.document.doc.GetNodes().size());
+    a.y_before = (a.idx >= 0) ? state.document.layout_cache[a.idx].y_position : 0.0f;
+    a.offset = state.view.viewport.GetScrollY() - a.y_before;
     return a;
 }
 
-// ナビゲーション結果を副作用に変換するヘルパー。
-// NavHistory::GoBack/GoForward の結果に応じて LoadFile or 同一ファイル内スクロールを行う。
-static void ApplyNavResult(AppState& state, SideEffectList& effects, NavEntry&& entry)
+// ============================================================
+// 共通ヘルパー
+// ============================================================
+
+namespace {
+
+void ClearTooltip(AppState& state, SideEffectList& effects)
 {
-    if (entry.file_path != state.doc.GetFilePath() && !entry.file_path.empty()) {
-        // 別ファイルへのナビゲーション
-        state.scroll_restore.pending_nav_scroll_y = entry.scroll_y;
-        effects.emplace_back(effect::LoadFile{ std::move(entry.file_path) });
-    }
-    else {
-        // 同一ファイル内スクロール
-        state.scroll_restore.pending_restore_scroll_y = -1;
-        state.viewport.ScrollTo(entry.scroll_y);
-        state.hover_throttle.Reset();
-        state.tooltip.Hide();
-        state.tooltip.ResetTarget();
-        effects.emplace_back(effect::ClearTooltip{});
+    state.interaction.tooltip.Hide();
+    state.interaction.tooltip.ResetTarget();
+    effects.emplace_back(effect::ClearTooltip{});
+}
+
+void EmitScrollEffects(AppState& state, SideEffectList& effects, float old_scroll)
+{
+    if (state.view.viewport.GetScrollY() != old_scroll) {
+        ClearTooltip(state, effects);
+        state.interaction.hover_throttle.Reset();
         effects.emplace_back(effect::InvalidateWindow{});
         effects.emplace_back(effect::BitmapManage{});
     }
 }
 
-static void ReduceNavigateBack(AppState& state, SideEffectList& effects)
+float CalcPaneMaxScroll(const AppState& state, PaneZone pane)
+{
+    const float item_h = state.window.cached_theme.pane_item_height;
+    const float header_h = state.window.cached_theme.pane_header_height;
+    if (pane == PaneZone::FilePane) {
+        const float total = static_cast<float>(state.file_explorer.GetEntries().size()) * item_h;
+        return std::max(0.0f, total - (state.cached_pane_layout.file_rect.height - header_h));
+    }
+    else {
+        const float total = static_cast<float>(state.document.doc.GetToc().GetEntries().size()) * item_h;
+        return std::max(0.0f, total - (state.cached_pane_layout.toc_rect.height - header_h));
+    }
+}
+
+// ============================================================
+// ナビゲーション
+// ============================================================
+
+void ApplyNavResult(AppState& state, SideEffectList& effects, NavEntry&& entry)
+{
+    if (entry.file_path != state.document.doc.GetFilePath() && !entry.file_path.empty()) {
+        state.view.scroll_restore.pending_nav_scroll_y = entry.scroll_y;
+        effects.emplace_back(effect::LoadFile{ std::move(entry.file_path) });
+    }
+    else {
+        state.view.scroll_restore.pending_restore_scroll_y = -1;
+        state.view.viewport.ScrollTo(entry.scroll_y);
+        state.interaction.hover_throttle.Reset();
+        ClearTooltip(state, effects);
+        effects.emplace_back(effect::InvalidateWindow{});
+        effects.emplace_back(effect::BitmapManage{});
+    }
+}
+
+void ReduceNavigateBack(AppState& state, SideEffectList& effects)
 {
     NavEntry out;
-    if (state.nav_history.GoBack(NavEntry{ state.doc.GetFilePath(), state.viewport.GetScrollY() }, out)) {
+    if (state.view.nav_history.GoBack(NavEntry{ state.document.doc.GetFilePath(), state.view.viewport.GetScrollY() }, out)) {
         ApplyNavResult(state, effects, std::move(out));
     }
 }
 
-static void ReduceNavigateForward(AppState& state, SideEffectList& effects)
+void ReduceNavigateForward(AppState& state, SideEffectList& effects)
 {
     NavEntry out;
-    if (state.nav_history.GoForward(NavEntry{ state.doc.GetFilePath(), state.viewport.GetScrollY() }, out)) {
+    if (state.view.nav_history.GoForward(NavEntry{ state.document.doc.GetFilePath(), state.view.viewport.GetScrollY() }, out)) {
         ApplyNavResult(state, effects, std::move(out));
     }
 }
+
+// ============================================================
+// スクロール系アクション
+// ============================================================
+
+void ReduceKeyScroll(AppState& state, SideEffectList& effects, const KeyScrollAction& a)
+{
+    state.view.scroll_restore.pending_restore_scroll_y = -1;
+    const float old_scroll = state.view.viewport.GetScrollY();
+    const float page_size = state.cached_pane_layout.md_rect.height;
+    switch (a.type) {
+    case ScrollType::LineUp:
+        state.view.viewport.DirectScrollBy(-SCROLL_LINE_AMOUNT);
+        break;
+    case ScrollType::LineDown:
+        state.view.viewport.DirectScrollBy(SCROLL_LINE_AMOUNT);
+        break;
+    case ScrollType::PageUp:
+        state.view.viewport.DirectScrollBy(-page_size * SCROLL_PAGE_FACTOR);
+        break;
+    case ScrollType::PageDown:
+        state.view.viewport.DirectScrollBy(page_size * SCROLL_PAGE_FACTOR);
+        break;
+    case ScrollType::Home:
+        state.view.viewport.ScrollTo(0.0f);
+        break;
+    case ScrollType::End:
+        state.view.viewport.ScrollTo(state.view.viewport.GetMaxScroll());
+        break;
+    default:
+        break;
+    }
+    EmitScrollEffects(state, effects, old_scroll);
+}
+
+void ReduceDirectScrollBy(AppState& state, SideEffectList& effects, const DirectScrollByAction& a)
+{
+    state.view.scroll_restore.pending_restore_scroll_y = -1;
+    const float old_scroll = state.view.viewport.GetScrollY();
+    state.view.viewport.DirectScrollBy(a.delta);
+    EmitScrollEffects(state, effects, old_scroll);
+}
+
+void ReduceScrollPane(AppState& state, SideEffectList& effects, const ScrollPaneAction& a)
+{
+    if (a.pane == PaneZone::FilePane) {
+        if (state.view.panes.ScrollFilePaneBy(a.delta, CalcPaneMaxScroll(state, PaneZone::FilePane))) {
+            effects.emplace_back(effect::InvalidatePaneCache{ PaneZone::FilePane });
+            effects.emplace_back(effect::InvalidateWindow{});
+        }
+    }
+    else if (a.pane == PaneZone::TocPane) {
+        if (state.view.panes.ScrollTocPaneBy(a.delta, CalcPaneMaxScroll(state, PaneZone::TocPane))) {
+            effects.emplace_back(effect::InvalidatePaneCache{ PaneZone::TocPane });
+            effects.emplace_back(effect::InvalidateWindow{});
+        }
+    }
+}
+
+// ============================================================
+// ペイン・選択・クリップボード
+// ============================================================
+
+void ReduceTogglePane(AppState& state, SideEffectList& effects, const TogglePaneAction& a)
+{
+    switch (a.target) {
+    case PaneTarget::File: state.view.panes.ToggleFilePane(); break;
+    case PaneTarget::Toc:  state.view.panes.ToggleTocPane();  break;
+    }
+    state.pane_layout_valid = false;
+    effects.emplace_back(effect::RefreshPaneLayout{});
+}
+
+void ReduceSelectAll(AppState& state, SideEffectList& effects)
+{
+    state.view.viewport.SelectAll(state.document.doc.GetNodes());
+    effects.emplace_back(effect::InvalidateWindow{});
+}
+
+void ReduceClearSelection(AppState& state, SideEffectList& effects)
+{
+    if (state.search.search_state.IsVisible()) {
+        state.search.search_state.Hide();
+    }
+    else {
+        state.view.viewport.ClearSelection();
+    }
+    effects.emplace_back(effect::InvalidateWindow{});
+}
+
+void ReduceCopyClipboard(const AppState& state, SideEffectList& effects)
+{
+    if (state.view.viewport.GetSelection().active) {
+        effects.emplace_back(effect::ClipboardWrite{
+            ExtractSelectedText(state.document.doc.GetNodes(), state.view.viewport.GetSelection()) });
+    }
+}
+
+// ============================================================
+// ズーム・テーマ
+// ============================================================
+
+void ReduceZoom(AppState& state, SideEffectList& effects, const ZoomAction& a)
+{
+    float new_zoom = 0.0f;
+    switch (a.direction) {
+    case ZoomDirection::In:
+        new_zoom = state.view.viewport.ZoomIn();
+        break;
+    case ZoomDirection::Out:
+        new_zoom = state.view.viewport.ZoomOut();
+        break;
+    case ZoomDirection::Reset:
+        new_zoom = state.view.viewport.ZoomReset();
+        break;
+    }
+    if (new_zoom <= 0.0f) {
+        return;
+    }
+    const auto anchor = SaveAnchorFromState(state);
+    state.pane_layout_valid = false;
+    const float zoom_ratio = new_zoom / state.window.cached_theme.zoom;
+    state.view.panes.ApplyZoom(zoom_ratio);
+    state.document.layout_cache.InvalidateAllLayouts();
+    effects.emplace_back(effect::ApplyThemeChange{
+        .type = effect::ApplyThemeChange::Type::Zoom,
+        .anchor_idx = anchor.idx,
+        .anchor_y_before = anchor.y_before,
+        .anchor_offset = anchor.offset,
+        .offset_scale = zoom_ratio,
+        .new_zoom = new_zoom,
+        .zoom_index = state.view.viewport.GetZoomIndex(),
+        });
+}
+
+void ReduceToggleDarkMode(AppState& state, SideEffectList& effects)
+{
+    const auto anchor = SaveAnchorFromState(state);
+    state.pane_layout_valid = false;
+    state.document.layout_cache.InvalidateAllWithDiagrams(state.document.doc.GetNodes());
+    effects.emplace_back(effect::ApplyThemeChange{
+        .type = effect::ApplyThemeChange::Type::DarkMode,
+        .anchor_idx = anchor.idx,
+        .anchor_y_before = anchor.y_before,
+        .anchor_offset = anchor.offset,
+        .offset_scale = 1.0f,
+        .new_zoom = 0.0f,
+        .zoom_index = state.view.viewport.GetZoomIndex(),
+        });
+}
+
+// ============================================================
+// ウィンドウ・システムイベント
+// ============================================================
+
+void ReduceActivate(AppState& state, SideEffectList& effects, const ActivateAction& a)
+{
+    if (state.window.window_active != a.active) {
+        state.window.window_active = a.active;
+        effects.emplace_back(effect::InvalidateTitleBar{});
+    }
+    if (!a.active) {
+        ClearTooltip(state, effects);
+    }
+}
+
+void ReduceResize(AppState& state, SideEffectList& effects, const ResizeAction& a)
+{
+    if (a.width == 0 || a.height == 0) {
+        return;
+    }
+    state.pane_layout_valid = false;
+    effects.emplace_back(effect::RendererResize{ a.width, a.height });
+    const float window_w_dip = a.width / state.window.cached_dpi_scale;
+    state.window.titlebar.UpdateLayout(window_w_dip);
+    if (state.window.is_sizing) {
+        effects.emplace_back(effect::PerformSizingUpdate{});
+    }
+    else {
+        effects.emplace_back(effect::PerformResizeEnd{});
+    }
+}
+
+void ReduceDpiChanged(AppState& state, SideEffectList& effects, const DpiChangedAction& a)
+{
+    state.window.cached_dpi_scale = static_cast<float>(a.dpi) / 96.0f;
+    if (state.window.cached_dpi_scale <= 0.0f) {
+        state.window.cached_dpi_scale = 1.0f;
+    }
+    state.pane_layout_valid = false;
+    state.document.layout_cache.MarkAllDirty();
+    effects.emplace_back(effect::RendererSetDpi{ static_cast<float>(a.dpi) });
+    effects.emplace_back(effect::ClearFileCache{});
+    effects.emplace_back(effect::SetWindowPosition{
+        static_cast<int>(a.suggested.left),
+        static_cast<int>(a.suggested.top),
+        static_cast<int>(a.suggested.right - a.suggested.left),
+        static_cast<int>(a.suggested.bottom - a.suggested.top),
+        });
+}
+
+void ReduceHWheel(AppState& state, SideEffectList& effects, const HWheelAction& a)
+{
+    const bool had_overlay = state.interaction.swipe_detector.IsOverlayVisible();
+    const int old_direction = state.interaction.swipe_detector.GetOverlayDirection();
+    state.interaction.swipe_detector.OnHWheel(a.delta, a.tick);
+    effects.emplace_back(effect::SetTimer{ app_timer::SWIPE_OVERLAY,
+        static_cast<UINT>(SwipeDetector::COMMIT_TIMEOUT_MS) });
+    if (had_overlay != state.interaction.swipe_detector.IsOverlayVisible()
+        || old_direction != state.interaction.swipe_detector.GetOverlayDirection()) {
+        effects.emplace_back(effect::InvalidateWindow{});
+    }
+}
+
+// ============================================================
+// 検索系アクション
+// ============================================================
+
+void ReduceSearchStep(AppState& state, bool forward)
+{
+    if (state.search.search_state.IsVisible()) {
+        forward ? state.search.search_bar_ctrl.OnNext()
+                : state.search.search_bar_ctrl.OnPrev();
+    }
+    else {
+        state.search.search_bar_ctrl.OnOpen(state.document.doc.GetNodes());
+    }
+}
+
+void ReduceCaptureChanged(AppState& state, SideEffectList& effects)
+{
+    state.search.search_bar_ctrl.OnCaptureChanged();
+    if (state.interaction.gesture.GetPhase() != GesturePhase::Idle) {
+        state.interaction.gesture.Reset();
+        effects.emplace_back(effect::InvalidateWindow{});
+    }
+}
+
+// ============================================================
+// ファイル・ナビゲーション系アクション
+// ============================================================
+
+void ReduceDropFiles(AppState& state, SideEffectList& effects, const DropFilesAction& a)
+{
+    if (!state.document.doc.GetFilePath().empty()) {
+        state.view.nav_history.Push(NavEntry{ state.document.doc.GetFilePath(), state.view.viewport.GetScrollY() });
+    }
+    effects.emplace_back(effect::LoadFile{ std::pmr::wstring(a.path) });
+}
+
+void ReduceShowHelp(AppState& state, SideEffectList& effects)
+{
+    if (!state.document.doc.GetFilePath().empty() && !IsHelpPath(state.document.doc.GetFilePath())) {
+        state.view.nav_history.Push(NavEntry{ state.document.doc.GetFilePath(), state.view.viewport.GetScrollY() });
+    }
+    effects.emplace_back(effect::LoadFile{ std::pmr::wstring(HELP_PATH) });
+}
+
+// ============================================================
+// タイマー
+// ============================================================
+
+void ReduceTimer(AppState& state, SideEffectList& effects, const TimerAction& a)
+{
+    switch (a.timer_id) {
+    case app_timer::TOAST:
+        if (!state.interaction.toast.Tick()) {
+            effects.emplace_back(effect::KillTimer{ app_timer::TOAST });
+        }
+        effects.emplace_back(effect::InvalidateWindow{});
+        break;
+    case app_timer::SEARCH_CARET:
+        state.search.search_bar_ctrl.OnCaretBlinkTimer();
+        break;
+    case app_timer::TOOLTIP:
+        effects.emplace_back(effect::KillTimer{ app_timer::TOOLTIP });
+        state.interaction.tooltip.Show();
+        break;
+    case app_timer::SEARCH_DEBOUNCE:
+        state.search.search_bar_ctrl.OnDebounceTimer(state.document.doc.GetNodes());
+        break;
+    case app_timer::SWIPE_OVERLAY: {
+        const auto result = state.interaction.swipe_detector.Commit();
+        effects.emplace_back(effect::KillTimer{ app_timer::SWIPE_OVERLAY });
+        switch (result) {
+        case SwipeResult::Back:
+            ReduceNavigateBack(state, effects);
+            effects.emplace_back(effect::InvalidateWindow{});
+            break;
+        case SwipeResult::Forward:
+            ReduceNavigateForward(state, effects);
+            effects.emplace_back(effect::InvalidateWindow{});
+            break;
+        default:
+            break;
+        }
+        break;
+    }
+    case app_timer::DEFERRED_LAYOUT:
+        effects.emplace_back(effect::ProcessDeferredLayout{});
+        break;
+    case app_timer::LOADING_ANIM:
+        effects.emplace_back(effect::TickLoadingAnimation{});
+        effects.emplace_back(effect::InvalidateWindow{});
+        break;
+    case app_timer::MERMAID_BATCH:
+        effects.emplace_back(effect::ProcessMermaidBatchTimer{});
+        break;
+    case app_timer::BITMAP_MANAGE:
+        effects.emplace_back(effect::ProcessBitmapManage{});
+        break;
+    case app_timer::MERMAID_INIT_RETRY:
+        effects.emplace_back(effect::MermaidInitRetry{});
+        break;
+    case app_timer::FILE_RELOAD_DEBOUNCE:
+        effects.emplace_back(effect::KillTimer{ app_timer::FILE_RELOAD_DEBOUNCE });
+        effects.emplace_back(effect::ReloadFile{});
+        break;
+    default:
+        break;
+    }
+}
+
+} // namespace
+
+// ============================================================
+// Reducer: メインディスパッチ
+// ============================================================
 
 SideEffectList Reduce(AppState& state, const AppAction& action)
 {
     SideEffectList effects;
 
-    // ツールチップを非表示にしてタイマーを解除する共通処理
-    const auto clear_tooltip = [&]() {
-        state.tooltip.Hide();
-        state.tooltip.ResetTarget();
-        effects.emplace_back(effect::ClearTooltip{});
-    };
-
-    // スクロール位置が変化した場合の共通副作用を発行する
-    const auto emit_scroll_effects = [&](float old_scroll) {
-        if (state.viewport.GetScrollY() != old_scroll) {
-            clear_tooltip();
-            state.hover_throttle.Reset();
-            effects.emplace_back(effect::InvalidateWindow{});
-            effects.emplace_back(effect::BitmapManage{});
-        }
-    };
-
-    // ペインの max_scroll を計算するヘルパー
-    const auto calc_pane_max_scroll = [&](PaneZone pane) -> float {
-        const float item_h = state.cached_theme.pane_item_height;
-        const float header_h = state.cached_theme.pane_header_height;
-        if (pane == PaneZone::FilePane) {
-            const float total = static_cast<float>(state.file_explorer.GetEntries().size()) * item_h;
-            return std::max(0.0f, total - (state.cached_pane_layout.file_rect.height - header_h));
-        }
-        else {
-            const float total = static_cast<float>(state.doc.GetToc().GetEntries().size()) * item_h;
-            return std::max(0.0f, total - (state.cached_pane_layout.toc_rect.height - header_h));
-        }
-    };
-
     std::visit(overloaded{
         [](const NoOpAction&) {},
-        [&](const ScrollPaneAction& a) {
-            if (a.pane == PaneZone::FilePane) {
-                if (state.panes.ScrollFilePaneBy(a.delta, calc_pane_max_scroll(PaneZone::FilePane))) {
-                    effects.emplace_back(effect::InvalidatePaneCache{PaneZone::FilePane});
-                    effects.emplace_back(effect::InvalidateWindow{});
-                }
-            }
-            else if (a.pane == PaneZone::TocPane) {
-                if (state.panes.ScrollTocPaneBy(a.delta, calc_pane_max_scroll(PaneZone::TocPane))) {
-                    effects.emplace_back(effect::InvalidatePaneCache{PaneZone::TocPane});
-                    effects.emplace_back(effect::InvalidateWindow{});
-                }
-            }
-        },
-        [&](const TogglePaneAction& a) {
-            switch (a.target) {
-            case PaneTarget::File: state.panes.ToggleFilePane(); break;
-            case PaneTarget::Toc:  state.panes.ToggleTocPane();  break;
-            }
-            state.pane_layout_valid = false;
-            effects.emplace_back(effect::RefreshPaneLayout{});
-        },
-        [&](const KeyScrollAction& a) {
-            state.scroll_restore.pending_restore_scroll_y = -1;
-            const float old_scroll = state.viewport.GetScrollY();
-            const float page_size = state.cached_pane_layout.md_rect.height;
-            switch (a.type) {
-            case ScrollType::LineUp:
-                state.viewport.DirectScrollBy(-SCROLL_LINE_AMOUNT);
-                break;
-            case ScrollType::LineDown:
-                state.viewport.DirectScrollBy(SCROLL_LINE_AMOUNT);
-                break;
-            case ScrollType::PageUp:
-                state.viewport.DirectScrollBy(-page_size * SCROLL_PAGE_FACTOR);
-                break;
-            case ScrollType::PageDown:
-                state.viewport.DirectScrollBy(page_size * SCROLL_PAGE_FACTOR);
-                break;
-            case ScrollType::Home:
-                state.viewport.ScrollTo(0.0f);
-                break;
-            case ScrollType::End:
-                state.viewport.ScrollTo(state.viewport.GetMaxScroll());
-                break;
-            default:
-                break;
-            }
-            emit_scroll_effects(old_scroll);
-        },
-        [&](const DirectScrollByAction& a) {
-            state.scroll_restore.pending_restore_scroll_y = -1;
-            const float old_scroll = state.viewport.GetScrollY();
-            state.viewport.DirectScrollBy(a.delta);
-            emit_scroll_effects(old_scroll);
-        },
-        [&](const SelectAllAction&) {
-            state.viewport.SelectAll(state.doc.GetNodes());
-            effects.emplace_back(effect::InvalidateWindow{});
-        },
-        [&](const ClearSelectionAction&) {
-            if (state.search_state.IsVisible()) {
-                state.search_state.Hide();
-            }
-            else {
-                state.viewport.ClearSelection();
-            }
-            effects.emplace_back(effect::InvalidateWindow{});
-        },
-        [&](const CopyClipboardAction&) {
-            if (state.viewport.GetSelection().active) {
-                effects.emplace_back(effect::ClipboardWrite{
-                    ExtractSelectedText(state.doc.GetNodes(), state.viewport.GetSelection())});
-            }
-        },
-        [&](const ActivateAction& a) {
-            if (state.window_active != a.active) {
-                state.window_active = a.active;
-                effects.emplace_back(effect::InvalidateTitleBar{});
-            }
-            if (!a.active) {
-                clear_tooltip();
-            }
-        },
-        [&](const EnterSizeMoveAction&) {
-            state.is_sizing = true;
-        },
+
+        // ---- スクロール ----
+        [&](const KeyScrollAction& a) { ReduceKeyScroll(state, effects, a); },
+        [&](const DirectScrollByAction& a) { ReduceDirectScrollBy(state, effects, a); },
+        [&](const ScrollPaneAction& a) { ReduceScrollPane(state, effects, a); },
+
+        // ---- ペイン・選択・クリップボード ----
+        [&](const TogglePaneAction& a) { ReduceTogglePane(state, effects, a); },
+        [&](const SelectAllAction&) { ReduceSelectAll(state, effects); },
+        [&](const ClearSelectionAction&) { ReduceClearSelection(state, effects); },
+        [&](const CopyClipboardAction&) { ReduceCopyClipboard(state, effects); },
+
+        // ---- ズーム・テーマ ----
+        [&](const ZoomAction& a) { ReduceZoom(state, effects, a); },
+        [&](const ToggleDarkModeAction&) { ReduceToggleDarkMode(state, effects); },
+
+        // ---- ウィンドウ・システムイベント ----
+        [&](const ActivateAction& a) { ReduceActivate(state, effects, a); },
+        [&](const EnterSizeMoveAction&) { state.window.is_sizing = true; },
         [&](const ExitSizeMoveAction&) {
-            state.is_sizing = false;
+            state.window.is_sizing = false;
             effects.emplace_back(effect::PerformResizeEnd{});
         },
-        [&](const MouseLeaveAction&) {
-            clear_tooltip();
-        },
-        [&](const OpenSearchBarAction&) {
-            state.search_bar_ctrl.OnOpen(state.doc.GetNodes());
-        },
-        [&](const CloseSearchBarAction&) {
-            state.search_bar_ctrl.OnClose();
-        },
-        [&](const SearchNextAction&) {
-            state.search_state.IsVisible()
-                ? state.search_bar_ctrl.OnNext()
-                : state.search_bar_ctrl.OnOpen(state.doc.GetNodes());
-        },
-        [&](const SearchPrevAction&) {
-            state.search_state.IsVisible()
-                ? state.search_bar_ctrl.OnPrev()
-                : state.search_bar_ctrl.OnOpen(state.doc.GetNodes());
-        },
-        [&](const SearchTextChangedAction& a) {
-            state.search_bar_ctrl.OnTextChanged(a.text, state.doc.GetNodes());
-        },
-        [&](const ToggleCaseSensitiveAction&) {
-            state.search_bar_ctrl.OnToggleCaseSensitive(state.doc.GetNodes());
-        },
-        [&](const ToggleHighlightAction&) {
-            state.search_bar_ctrl.OnToggleHighlight();
-        },
-        [&](const SearchSelectionAction& a) {
-            state.search_bar_ctrl.SetSelection(a.sel_start, a.sel_end);
-        },
-        [&](const ImeCompositionAction& a) {
-            state.search_bar_ctrl.SetImeComposition(a.text);
-        },
-        [&](const CaptureChangedAction&) {
-            state.search_bar_ctrl.OnCaptureChanged();
-            if (state.gesture.GetPhase() != GesturePhase::Idle) {
-                state.gesture.Reset();
-                effects.emplace_back(effect::InvalidateWindow{});
-            }
-        },
-        [&](const DropFilesAction& a) {
-            if (!state.doc.GetFilePath().empty()) {
-                state.nav_history.Push(NavEntry{ state.doc.GetFilePath(), state.viewport.GetScrollY() });
-            }
-            effects.emplace_back(effect::LoadFile{ std::pmr::wstring(a.path) });
-        },
-        [&](const ShowHelpAction&) {
-            if (!state.doc.GetFilePath().empty() && !IsHelpPath(state.doc.GetFilePath())) {
-                state.nav_history.Push(NavEntry{ state.doc.GetFilePath(), state.viewport.GetScrollY() });
-            }
-            effects.emplace_back(effect::LoadFile{ std::pmr::wstring(HELP_PATH) });
-        },
-        [&](const OpenFileAction&) {
-            effects.emplace_back(effect::OpenFileDialog{});
-        },
-        [&](const ReloadFileAction&) {
-            effects.emplace_back(effect::ReloadFile{});
-        },
-        [&](const FileWatchAction&) {
-            effects.emplace_back(effect::CheckFileChanges{});
-        },
-        [&](const ImageLoadedAction&) {
-            effects.emplace_back(effect::NotifyImageLoaded{});
-        },
-        [&](const NavigateBackAction&) {
-            ReduceNavigateBack(state, effects);
-        },
-        [&](const NavigateForwardAction&) {
-            ReduceNavigateForward(state, effects);
-        },
-        [&](const XButtonBackAction&) {
-            ReduceNavigateBack(state, effects);
-        },
-        [&](const XButtonForwardAction&) {
-            ReduceNavigateForward(state, effects);
-        },
-        [&](const ZoomAction& a) {
-            float new_zoom = 0.0f;
-            switch (a.direction) {
-            case ZoomDirection::In:
-                new_zoom = state.viewport.ZoomIn();
-                break;
-            case ZoomDirection::Out:
-                new_zoom = state.viewport.ZoomOut();
-                break;
-            case ZoomDirection::Reset:
-                new_zoom = state.viewport.ZoomReset();
-                break;
-            }
-            if (new_zoom <= 0.0f) {
-                return;
-            }
-            // SaveAnchor はレイアウト無効化の前に実行
-            const auto anchor = SaveAnchorFromState(state);
-            state.pane_layout_valid = false;
-            const float zoom_ratio = new_zoom / state.cached_theme.zoom;
-            state.panes.ApplyZoom(zoom_ratio);
-            state.layout_cache.InvalidateAllLayouts();
-            effects.emplace_back(effect::ApplyThemeChange{
-                .type = effect::ApplyThemeChange::Type::Zoom,
-                .anchor_idx = anchor.idx,
-                .anchor_y_before = anchor.y_before,
-                .anchor_offset = anchor.offset,
-                .offset_scale = zoom_ratio,
-                .new_zoom = new_zoom,
-                .zoom_index = state.viewport.GetZoomIndex(),
-            });
-        },
-        [&](const ToggleDarkModeAction&) {
-            const auto anchor = SaveAnchorFromState(state);
-            state.pane_layout_valid = false;
-            state.layout_cache.InvalidateAllWithDiagrams(state.doc.GetNodes());
-            effects.emplace_back(effect::ApplyThemeChange{
-                .type = effect::ApplyThemeChange::Type::DarkMode,
-                .anchor_idx = anchor.idx,
-                .anchor_y_before = anchor.y_before,
-                .anchor_offset = anchor.offset,
-                .offset_scale = 1.0f,
-                .new_zoom = 0.0f,
-                .zoom_index = state.viewport.GetZoomIndex(),
-            });
-        },
-        [&](const ResizeAction& a) {
-            if (a.width == 0 || a.height == 0) {
-                return;
-            }
-            state.pane_layout_valid = false;
-            effects.emplace_back(effect::RendererResize{ a.width, a.height });
-            const float window_w_dip = a.width / state.cached_dpi_scale;
-            state.titlebar.UpdateLayout(window_w_dip);
-            if (state.is_sizing) {
-                // sizing中は簡易更新: RendererResize 後に PaneLayout 再計算 → max_scroll 同期
-                effects.emplace_back(effect::PerformSizingUpdate{});
-            }
-            else {
-                effects.emplace_back(effect::PerformResizeEnd{});
-            }
-        },
-        [&](const DpiChangedAction& a) {
-            state.cached_dpi_scale = static_cast<float>(a.dpi) / 96.0f;
-            if (state.cached_dpi_scale <= 0.0f) {
-                state.cached_dpi_scale = 1.0f;
-            }
-            state.pane_layout_valid = false;
-            state.layout_cache.MarkAllDirty();
-            effects.emplace_back(effect::RendererSetDpi{ static_cast<float>(a.dpi) });
-            effects.emplace_back(effect::ClearFileCache{});
-            effects.emplace_back(effect::SetWindowPosition{
-                static_cast<int>(a.suggested.left),
-                static_cast<int>(a.suggested.top),
-                static_cast<int>(a.suggested.right - a.suggested.left),
-                static_cast<int>(a.suggested.bottom - a.suggested.top),
-            });
-        },
-        [&](const HWheelAction& a) {
-            const bool had_overlay = state.swipe_detector.IsOverlayVisible();
-            const int old_direction = state.swipe_detector.GetOverlayDirection();
-            state.swipe_detector.OnHWheel(a.delta, a.tick);
-            effects.emplace_back(effect::SetTimer{ app_timer::SWIPE_OVERLAY,
-                static_cast<UINT>(SwipeDetector::COMMIT_TIMEOUT_MS) });
-            if (had_overlay != state.swipe_detector.IsOverlayVisible()
-                || old_direction != state.swipe_detector.GetOverlayDirection()) {
-                effects.emplace_back(effect::InvalidateWindow{});
-            }
-        },
-        [&](const LButtonDownAction& a) {
-            effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::LButtonDown, a.px, a.py });
-        },
-        [&](const LButtonUpAction& a) {
-            effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::LButtonUp, a.px, a.py });
-        },
-        [&](const MouseMoveAction& a) {
-            effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::MouseMove, a.px, a.py });
-        },
-        [&](const MouseHoverAction& a) {
-            effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::MouseHover, a.px, a.py });
-        },
-        [&](const LButtonDblClkAction& a) {
-            effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::LButtonDblClk, a.px, a.py });
-        },
-        [&](const RButtonDownAction& a) {
-            effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::RButtonDown, a.px, a.py });
-        },
-        [&](const RButtonUpAction& a) {
-            effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::RButtonUp, a.px, a.py });
-        },
-        [&](const RButtonMoveAction& a) {
-            effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::RButtonMove, a.px, a.py });
-        },
-        [&](const ContextMenuAction& a) {
-            effects.emplace_back(effect::HandleContextMenu{ a.screen_x, a.screen_y });
-        },
-        [&](const TimerAction& a) {
-            switch (a.timer_id) {
-            case app_timer::TOAST:
-                if (!state.toast.Tick()) {
-                    effects.emplace_back(effect::KillTimer{ app_timer::TOAST });
-                }
-                effects.emplace_back(effect::InvalidateWindow{});
-                break;
-            case app_timer::SEARCH_CARET:
-                state.search_bar_ctrl.OnCaretBlinkTimer();
-                break;
-            case app_timer::TOOLTIP:
-                effects.emplace_back(effect::KillTimer{ app_timer::TOOLTIP });
-                state.tooltip.Show();
-                break;
-            case app_timer::SEARCH_DEBOUNCE:
-                state.search_bar_ctrl.OnDebounceTimer(state.doc.GetNodes());
-                break;
-            case app_timer::SWIPE_OVERLAY: {
-                const auto result = state.swipe_detector.Commit();
-                effects.emplace_back(effect::KillTimer{ app_timer::SWIPE_OVERLAY });
-                switch (result) {
-                case SwipeResult::Back:
-                    ReduceNavigateBack(state, effects);
-                    effects.emplace_back(effect::InvalidateWindow{});
-                    break;
-                case SwipeResult::Forward:
-                    ReduceNavigateForward(state, effects);
-                    effects.emplace_back(effect::InvalidateWindow{});
-                    break;
-                default:
-                    break;
-                }
-                break;
-            }
-            case app_timer::DEFERRED_LAYOUT:
-                effects.emplace_back(effect::ProcessDeferredLayout{});
-                break;
-            case app_timer::LOADING_ANIM:
-                effects.emplace_back(effect::TickLoadingAnimation{});
-                effects.emplace_back(effect::InvalidateWindow{});
-                break;
-            case app_timer::MERMAID_BATCH:
-                effects.emplace_back(effect::ProcessMermaidBatchTimer{});
-                break;
-            case app_timer::BITMAP_MANAGE:
-                effects.emplace_back(effect::ProcessBitmapManage{});
-                break;
-            case app_timer::MERMAID_INIT_RETRY:
-                effects.emplace_back(effect::MermaidInitRetry{});
-                break;
-            case app_timer::FILE_RELOAD_DEBOUNCE:
-                effects.emplace_back(effect::KillTimer{ app_timer::FILE_RELOAD_DEBOUNCE });
-                effects.emplace_back(effect::ReloadFile{});
-                break;
-            default:
-                break;
-            }
-        },
-        [&](const DestroyAction&) {
-            effects.emplace_back(effect::Destroy{});
-        },
-        [&](const ParseCompleteAction&) {
-            effects.emplace_back(effect::HandleParseComplete{});
-        },
+        [&](const ResizeAction& a) { ReduceResize(state, effects, a); },
+        [&](const DpiChangedAction& a) { ReduceDpiChanged(state, effects, a); },
+        [&](const HWheelAction& a) { ReduceHWheel(state, effects, a); },
+
+        // ---- 検索 ----
+        [&](const OpenSearchBarAction&) { state.search.search_bar_ctrl.OnOpen(state.document.doc.GetNodes()); },
+        [&](const CloseSearchBarAction&) { state.search.search_bar_ctrl.OnClose(); },
+        [&](const SearchNextAction&) { ReduceSearchStep(state, true); },
+        [&](const SearchPrevAction&) { ReduceSearchStep(state, false); },
+        [&](const SearchTextChangedAction& a) { state.search.search_bar_ctrl.OnTextChanged(a.text, state.document.doc.GetNodes()); },
+        [&](const ToggleCaseSensitiveAction&) { state.search.search_bar_ctrl.OnToggleCaseSensitive(state.document.doc.GetNodes()); },
+        [&](const ToggleHighlightAction&) { state.search.search_bar_ctrl.OnToggleHighlight(); },
+        [&](const SearchSelectionAction& a) { state.search.search_bar_ctrl.SetSelection(a.sel_start, a.sel_end); },
+        [&](const ImeCompositionAction& a) { state.search.search_bar_ctrl.SetImeComposition(a.text); },
+
+        // ---- マウスイベント（SideEffect経由で委譲） ----
+        [&](const MouseLeaveAction&) { ClearTooltip(state, effects); },
+        [&](const CaptureChangedAction&) { ReduceCaptureChanged(state, effects); },
+        [&](const LButtonDownAction& a) { effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::LButtonDown, a.px, a.py }); },
+        [&](const LButtonUpAction& a) { effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::LButtonUp, a.px, a.py }); },
+        [&](const MouseMoveAction& a) { effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::MouseMove, a.px, a.py }); },
+        [&](const MouseHoverAction& a) { effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::MouseHover, a.px, a.py }); },
+        [&](const LButtonDblClkAction& a) { effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::LButtonDblClk, a.px, a.py }); },
+        [&](const RButtonDownAction& a) { effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::RButtonDown, a.px, a.py }); },
+        [&](const RButtonUpAction& a) { effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::RButtonUp, a.px, a.py }); },
+        [&](const RButtonMoveAction& a) { effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::RButtonMove, a.px, a.py }); },
+        [&](const ContextMenuAction& a) { effects.emplace_back(effect::HandleContextMenu{ a.screen_x, a.screen_y }); },
+
+        // ---- ナビゲーション ----
+        [&](const NavigateBackAction&) { ReduceNavigateBack(state, effects); },
+        [&](const NavigateForwardAction&) { ReduceNavigateForward(state, effects); },
+        [&](const XButtonBackAction&) { ReduceNavigateBack(state, effects); },
+        [&](const XButtonForwardAction&) { ReduceNavigateForward(state, effects); },
+
+        // ---- ファイル操作 ----
+        [&](const DropFilesAction& a) { ReduceDropFiles(state, effects, a); },
+        [&](const ShowHelpAction&) { ReduceShowHelp(state, effects); },
+        [&](const OpenFileAction&) { effects.emplace_back(effect::OpenFileDialog{}); },
+        [&](const ReloadFileAction&) { effects.emplace_back(effect::ReloadFile{}); },
+
+        // ---- 非同期・タイマー ----
+        [&](const TimerAction& a) { ReduceTimer(state, effects, a); },
+        [&](const FileWatchAction&) { effects.emplace_back(effect::CheckFileChanges{}); },
+        [&](const ImageLoadedAction&) { effects.emplace_back(effect::NotifyImageLoaded{}); },
+        [&](const ParseCompleteAction&) { effects.emplace_back(effect::HandleParseComplete{}); },
+
+        // ---- ライフサイクル ----
+        [&](const DestroyAction&) { effects.emplace_back(effect::Destroy{}); },
+
+        // ---- 未処理のアクション ----
         [](const auto&) {},
         }, action);
 

--- a/src/app/render_composer.cpp
+++ b/src/app/render_composer.cpp
@@ -5,18 +5,18 @@ namespace render_composer {
 GestureRenderState BuildGestureState(const AppState& state)
 {
     GestureRenderState gs;
-    gs.trail_active = state.gesture.IsGestureActive();
-    gs.trail_points = &state.gesture.GetTrailPoints();
-    gs.overlay_visible = state.gesture.IsOverlayVisible();
-    gs.direction = (state.gesture.GetDirection() == GestureDirection::Left) ? -1
-        : (state.gesture.GetDirection() == GestureDirection::Right) ? 1 : 0;
-    gs.overlay_alpha = state.gesture.GetOverlayAlpha();
+    gs.trail_active = state.interaction.gesture.IsGestureActive();
+    gs.trail_points = &state.interaction.gesture.GetTrailPoints();
+    gs.overlay_visible = state.interaction.gesture.IsOverlayVisible();
+    gs.direction = (state.interaction.gesture.GetDirection() == GestureDirection::Left) ? -1
+        : (state.interaction.gesture.GetDirection() == GestureDirection::Right) ? 1 : 0;
+    gs.overlay_alpha = state.interaction.gesture.GetOverlayAlpha();
 
     // タッチパッドスワイプのオーバーレイ（マウスジェスチャーが非アクティブの場合のみ）
-    if (!gs.overlay_visible && state.swipe_detector.IsOverlayVisible()) {
+    if (!gs.overlay_visible && state.interaction.swipe_detector.IsOverlayVisible()) {
         gs.overlay_visible = true;
-        gs.direction = state.swipe_detector.GetOverlayDirection();
-        gs.overlay_alpha = state.swipe_detector.GetOverlayAlpha();
+        gs.direction = state.interaction.swipe_detector.GetOverlayDirection();
+        gs.overlay_alpha = state.interaction.swipe_detector.GetOverlayAlpha();
     }
     return gs;
 }
@@ -24,53 +24,53 @@ GestureRenderState BuildGestureState(const AppState& state)
 SidePaneState BuildSidePaneState(const AppState& state, const PaneLayout& layout)
 {
     return { layout.file_rect, layout.toc_rect,
-             state.file_explorer.GetEntries(), state.panes.FileScroll(),
-             state.doc.GetToc().GetEntries(), state.doc.GetNodes(), state.panes.TocScroll(),
-             state.panes.GetHoveredFileIndex(), state.panes.GetHoveredTocIndex(), state.active_toc_index,
-             state.panes.IsFilePaneVisible(), state.panes.IsTocPaneVisible(),
-             state.panes.IsFileCloseHovered(), state.panes.IsFileRefreshHovered(),
-             state.panes.IsTocCloseHovered() };
+             state.file_explorer.GetEntries(), state.view.panes.FileScroll(),
+             state.document.doc.GetToc().GetEntries(), state.document.doc.GetNodes(), state.view.panes.TocScroll(),
+             state.view.panes.GetHoveredFileIndex(), state.view.panes.GetHoveredTocIndex(), state.active_toc_index,
+             state.view.panes.IsFilePaneVisible(), state.view.panes.IsTocPaneVisible(),
+             state.view.panes.IsFileCloseHovered(), state.view.panes.IsFileRefreshHovered(),
+             state.view.panes.IsTocCloseHovered() };
 }
 
 TitleBarRenderState BuildTitleBarState(const AppState& state,
     float window_width, bool is_dark_mode, bool is_maximized)
 {
     TitleBarRenderState tb;
-    tb.height = state.titlebar.GetHeight();
+    tb.height = state.window.titlebar.GetHeight();
     tb.window_width = window_width;
-    tb.open_file = state.titlebar.GetOpenFileButton();
-    tb.help = state.titlebar.GetHelpButton();
-    tb.theme_toggle = state.titlebar.GetThemeToggleButton();
-    tb.search = state.titlebar.GetSearchButton();
-    tb.file_toggle = state.titlebar.GetFileToggleButton();
-    tb.toc_toggle = state.titlebar.GetTocToggleButton();
-    tb.minimize = state.titlebar.GetMinimizeButton();
-    tb.maximize = state.titlebar.GetMaximizeButton();
-    tb.close = state.titlebar.GetCloseButton();
-    tb.icon_rect = state.titlebar.GetIconRect();
-    tb.title_text_rect = state.titlebar.GetTitleTextRect();
+    tb.open_file = state.window.titlebar.GetOpenFileButton();
+    tb.help = state.window.titlebar.GetHelpButton();
+    tb.theme_toggle = state.window.titlebar.GetThemeToggleButton();
+    tb.search = state.window.titlebar.GetSearchButton();
+    tb.file_toggle = state.window.titlebar.GetFileToggleButton();
+    tb.toc_toggle = state.window.titlebar.GetTocToggleButton();
+    tb.minimize = state.window.titlebar.GetMinimizeButton();
+    tb.maximize = state.window.titlebar.GetMaximizeButton();
+    tb.close = state.window.titlebar.GetCloseButton();
+    tb.icon_rect = state.window.titlebar.GetIconRect();
+    tb.title_text_rect = state.window.titlebar.GetTitleTextRect();
     tb.title_text = state.cached_title_text;
     tb.is_dark_mode = is_dark_mode;
-    tb.search_active = state.search_state.IsVisible();
-    tb.file_pane_visible = state.panes.IsFilePaneVisible();
-    tb.toc_pane_visible = state.panes.IsTocPaneVisible();
+    tb.search_active = state.search.search_state.IsVisible();
+    tb.file_pane_visible = state.view.panes.IsFilePaneVisible();
+    tb.toc_pane_visible = state.view.panes.IsTocPaneVisible();
     tb.is_maximized = is_maximized;
-    tb.window_active = state.window_active;
+    tb.window_active = state.window.window_active;
     return tb;
 }
 
 ToastRenderState BuildToastState(const AppState& state)
 {
     ToastRenderState ts;
-    ts.visible = state.toast.IsVisible();
-    ts.alpha = state.toast.GetRenderAlpha();
-    ts.message = state.toast.GetMessage();
+    ts.visible = state.interaction.toast.IsVisible();
+    ts.alpha = state.interaction.toast.GetRenderAlpha();
+    ts.message = state.interaction.toast.GetMessage();
     return ts;
 }
 
 SearchBarRenderState BuildSearchBarState(const AppState& state)
 {
-    return state.search_bar_ctrl.BuildRenderState();
+    return state.search.search_bar_ctrl.BuildRenderState();
 }
 
 } // namespace render_composer

--- a/src/app/side_effect_executor.cpp
+++ b/src/app/side_effect_executor.cpp
@@ -108,7 +108,7 @@ void SideEffectExecutor::Execute(const SideEffectList& effects)
             [this](const effect::ShowTooltip& e) {
                 POINT screen_pos = { e.px, e.py };
                 ClientToScreen(hwnd_, &screen_pos);
-                if (state_->tooltip.Update(e.target, screen_pos)) {
+                if (state_->interaction.tooltip.Update(e.target, screen_pos)) {
                     ::SetTimer(hwnd_, app_timer::TOOLTIP, TOOLTIP_DELAY_MS, nullptr);
                 }
                 else if (e.target.IsEmpty()) {
@@ -119,7 +119,7 @@ void SideEffectExecutor::Execute(const SideEffectList& effects)
                 ::KillTimer(hwnd_, app_timer::TOOLTIP);
             },
             [this](const effect::ShowToast& e) {
-                state_->toast.Show(e.message);
+                state_->interaction.toast.Show(e.message);
                 ::SetTimer(hwnd_, app_timer::TOAST, app_timer::FRAME_INTERVAL_MS, nullptr);
                 InvalidateRect(hwnd_, nullptr, FALSE);
             },

--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -36,6 +36,12 @@ void Document::ReplaceContent(ParseResult&& result)
     image_node_indices_ = std::move(result.image_indices);
     mermaid_node_indices_ = std::move(result.mermaid_indices);
     BuildHeadingIndices(result.heading_indices);
+
+    // パース直後にUTF-8→Wide一括変換を行い、描画時の暗黙的変換を排除する。
+    // CodeBlock以外のノードでは変換後にtext_utf8を解放してメモリを削減する。
+    for (auto& node : nodes_) {
+        node.EnsureTextConverted();
+    }
 }
 
 void Document::ReplaceFromMarkdown(std::pmr::string utf8)

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -183,10 +183,10 @@ struct Node {
         return !text_utf8.empty() || (text_valid_ && !text_.empty());
     }
 
-    // テキスト取得（text_utf8からの遅延変換付き）
-    // 変換後、CodeBlock以外のノードではtext_utf8を解放してメモリを削減する。
-    // CodeBlockはMermaidハッシュ計算でtext_utf8を直接参照するため保持する。
-    const std::pmr::wstring& GetText() const
+    // 明示的なUTF-8→Wide変換。パース完了後に一括呼び出しすることで、
+    // 描画時の暗黙的な変換とメモリ解放を排除する。
+    // CodeBlock以外ではtext_utf8を解放（Mermaidハッシュ計算で直接参照するCodeBlockは保持）。
+    void EnsureTextConverted() const
     {
         if (!text_valid_) {
             if (!text_utf8.empty()) {
@@ -200,6 +200,12 @@ struct Node {
             }
             text_valid_ = true;
         }
+    }
+
+    // テキスト取得。EnsureTextConverted() が事前に呼ばれていれば O(1) で返る。
+    const std::pmr::wstring& GetText() const
+    {
+        EnsureTextConverted();
         return text_;
     }
 

--- a/tests/test_reducer.cpp
+++ b/tests/test_reducer.cpp
@@ -8,7 +8,7 @@ protected:
 
     void SetUp() override {
         // スクロール範囲を設定（最大1000.0fまでスクロール可能）
-        state.viewport.SyncMaxScroll(1000.0f, 500.0f);
+        state.view.viewport.SyncMaxScroll(1000.0f, 500.0f);
         // PaneLayout のモック（ページサイズ用）
         state.cached_pane_layout.md_rect.height = 500.0f;
         state.pane_layout_valid = true;
@@ -18,44 +18,44 @@ protected:
 // ---- KeyScrollAction テスト ----
 
 TEST_F(ReducerTest, KeyScrollLineDown) {
-    const float old_scroll = state.viewport.GetScrollY();
+    const float old_scroll = state.view.viewport.GetScrollY();
     auto effects = Reduce(state, KeyScrollAction{ScrollType::LineDown});
 
-    EXPECT_GT(state.viewport.GetScrollY(), old_scroll);
+    EXPECT_GT(state.view.viewport.GetScrollY(), old_scroll);
     EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
     EXPECT_TRUE(HasEffect<effect::BitmapManage>(effects));
 }
 
 TEST_F(ReducerTest, KeyScrollLineUp_AtTop_NoEffect) {
     // スクロール位置0で上にスクロール → 変化なし → 副作用なし
-    state.viewport.ScrollTo(0.0f);
+    state.view.viewport.ScrollTo(0.0f);
     auto effects = Reduce(state, KeyScrollAction{ScrollType::LineUp});
 
-    EXPECT_FLOAT_EQ(state.viewport.GetScrollY(), 0.0f);
+    EXPECT_FLOAT_EQ(state.view.viewport.GetScrollY(), 0.0f);
     EXPECT_TRUE(effects.empty());
 }
 
 TEST_F(ReducerTest, KeyScrollPageDown) {
-    const float old_scroll = state.viewport.GetScrollY();
+    const float old_scroll = state.view.viewport.GetScrollY();
     auto effects = Reduce(state, KeyScrollAction{ScrollType::PageDown});
 
     // ページスクロールはラインスクロールより大きい
-    EXPECT_GT(state.viewport.GetScrollY() - old_scroll, 40.0f);
+    EXPECT_GT(state.view.viewport.GetScrollY() - old_scroll, 40.0f);
     EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
 }
 
 TEST_F(ReducerTest, KeyScrollHome) {
-    state.viewport.ScrollTo(500.0f);
+    state.view.viewport.ScrollTo(500.0f);
     auto effects = Reduce(state, KeyScrollAction{ScrollType::Home});
 
-    EXPECT_FLOAT_EQ(state.viewport.GetScrollY(), 0.0f);
+    EXPECT_FLOAT_EQ(state.view.viewport.GetScrollY(), 0.0f);
     EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
 }
 
 TEST_F(ReducerTest, KeyScrollEnd) {
     auto effects = Reduce(state, KeyScrollAction{ScrollType::End});
 
-    EXPECT_FLOAT_EQ(state.viewport.GetScrollY(), state.viewport.GetMaxScroll());
+    EXPECT_FLOAT_EQ(state.view.viewport.GetScrollY(), state.view.viewport.GetMaxScroll());
     EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
 }
 
@@ -64,7 +64,7 @@ TEST_F(ReducerTest, KeyScrollEnd) {
 TEST_F(ReducerTest, DirectScrollBy_Positive) {
     auto effects = Reduce(state, DirectScrollByAction{100.0f});
 
-    EXPECT_FLOAT_EQ(state.viewport.GetScrollY(), 100.0f);
+    EXPECT_FLOAT_EQ(state.view.viewport.GetScrollY(), 100.0f);
     EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
     EXPECT_TRUE(HasEffect<effect::BitmapManage>(effects));
 }
@@ -72,18 +72,18 @@ TEST_F(ReducerTest, DirectScrollBy_Positive) {
 TEST_F(ReducerTest, DirectScrollBy_ClampedAtMax) {
     auto effects = Reduce(state, DirectScrollByAction{99999.0f});
 
-    EXPECT_FLOAT_EQ(state.viewport.GetScrollY(), state.viewport.GetMaxScroll());
+    EXPECT_FLOAT_EQ(state.view.viewport.GetScrollY(), state.view.viewport.GetMaxScroll());
     EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
 }
 
 // ---- SelectAllAction テスト ----
 
 TEST_F(ReducerTest, SelectAll_WithNodes) {
-    state.doc = Document::FromMarkdown(std::pmr::string("Hello world\n\nSecond paragraph"), L"test.md");
+    state.document.doc = Document::FromMarkdown(std::pmr::string("Hello world\n\nSecond paragraph"), L"test.md");
 
     auto effects = Reduce(state, SelectAllAction{});
 
-    EXPECT_TRUE(state.viewport.GetSelection().active);
+    EXPECT_TRUE(state.view.viewport.GetSelection().active);
     EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
 }
 
@@ -93,43 +93,43 @@ TEST_F(ReducerTest, ClearSelection_WhenNotVisible) {
     // 検索バーが非表示の場合、選択をクリアする
     auto effects = Reduce(state, ClearSelectionAction{});
 
-    EXPECT_FALSE(state.viewport.GetSelection().active);
+    EXPECT_FALSE(state.view.viewport.GetSelection().active);
     EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
 }
 
 TEST_F(ReducerTest, ClearSelection_ClosesSearchBar) {
-    state.search_state.Show();
+    state.search.search_state.Show();
 
     auto effects = Reduce(state, ClearSelectionAction{});
 
     // 検索バーが閉じられる
-    EXPECT_FALSE(state.search_state.IsVisible());
+    EXPECT_FALSE(state.search.search_state.IsVisible());
     EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
 }
 
 // ---- NoOpAction テスト ----
 
 TEST_F(ReducerTest, NoOp_NoStateChange) {
-    const float scroll = state.viewport.GetScrollY();
+    const float scroll = state.view.viewport.GetScrollY();
     auto effects = Reduce(state, NoOpAction{});
 
-    EXPECT_FLOAT_EQ(state.viewport.GetScrollY(), scroll);
+    EXPECT_FLOAT_EQ(state.view.viewport.GetScrollY(), scroll);
     EXPECT_TRUE(effects.empty());
 }
 
 // ---- ActivateAction テスト ----
 
 TEST_F(ReducerTest, Activate_ChangesWindowActive) {
-    state.window_active = true;
+    state.window.window_active = true;
     auto effects = Reduce(state, ActivateAction{false});
 
-    EXPECT_FALSE(state.window_active);
+    EXPECT_FALSE(state.window.window_active);
     EXPECT_TRUE(HasEffect<effect::InvalidateTitleBar>(effects));
     EXPECT_TRUE(HasEffect<effect::ClearTooltip>(effects));
 }
 
 TEST_F(ReducerTest, Activate_NoChangeWhenSame) {
-    state.window_active = true;
+    state.window.window_active = true;
     auto effects = Reduce(state, ActivateAction{true});
 
     // 状態変化なし → InvalidateTitleBar なし
@@ -139,10 +139,10 @@ TEST_F(ReducerTest, Activate_NoChangeWhenSame) {
 // ---- EnterSizeMoveAction テスト ----
 
 TEST_F(ReducerTest, EnterSizeMove_SetsFlag) {
-    state.is_sizing = false;
+    state.window.is_sizing = false;
     Reduce(state, EnterSizeMoveAction{});
 
-    EXPECT_TRUE(state.is_sizing);
+    EXPECT_TRUE(state.window.is_sizing);
 }
 
 // ---- MouseLeaveAction テスト ----
@@ -186,20 +186,20 @@ TEST_F(ReducerTest, NavigateBack_NoHistory_NoEffects) {
 }
 
 TEST_F(ReducerTest, NavigateBack_DifferentFile_EmitsLoadFile) {
-    state.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\current.md");
-    state.nav_history.Push(NavEntry{ L"C:\\prev.md", 50.0f });
+    state.document.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\current.md");
+    state.view.nav_history.Push(NavEntry{ L"C:\\prev.md", 50.0f });
 
     auto effects = Reduce(state, NavigateBackAction{});
     EXPECT_TRUE(HasEffect<effect::LoadFile>(effects));
 }
 
 TEST_F(ReducerTest, NavigateBack_SameFile_ScrollsAndInvalidates) {
-    state.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\file.md");
-    state.nav_history.Push(NavEntry{ L"C:\\file.md", 50.0f });
-    state.viewport.ScrollTo(200.0f);
+    state.document.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\file.md");
+    state.view.nav_history.Push(NavEntry{ L"C:\\file.md", 50.0f });
+    state.view.viewport.ScrollTo(200.0f);
 
     auto effects = Reduce(state, NavigateBackAction{});
-    EXPECT_FLOAT_EQ(state.viewport.GetScrollY(), 50.0f);
+    EXPECT_FLOAT_EQ(state.view.viewport.GetScrollY(), 50.0f);
     EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
     EXPECT_TRUE(HasEffect<effect::BitmapManage>(effects));
 }
@@ -210,8 +210,8 @@ TEST_F(ReducerTest, NavigateForward_NoHistory_NoEffects) {
 }
 
 TEST_F(ReducerTest, XButtonBack_DelegatesToNavigateBack) {
-    state.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\current.md");
-    state.nav_history.Push(NavEntry{ L"C:\\prev.md", 0.0f });
+    state.document.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\current.md");
+    state.view.nav_history.Push(NavEntry{ L"C:\\prev.md", 0.0f });
 
     auto effects = Reduce(state, XButtonBackAction{});
     EXPECT_TRUE(HasEffect<effect::LoadFile>(effects));
@@ -220,26 +220,26 @@ TEST_F(ReducerTest, XButtonBack_DelegatesToNavigateBack) {
 // ---- DropFiles / ShowHelp テスト ----
 
 TEST_F(ReducerTest, DropFiles_PushesHistoryAndLoads) {
-    state.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\current.md");
+    state.document.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\current.md");
 
     auto effects = Reduce(state, DropFilesAction{ std::pmr::wstring(L"C:\\dropped.md") });
     EXPECT_TRUE(HasEffect<effect::LoadFile>(effects));
-    EXPECT_TRUE(state.nav_history.CanGoBack());
+    EXPECT_TRUE(state.view.nav_history.CanGoBack());
 }
 
 TEST_F(ReducerTest, DropFiles_EmptyDoc_NoPush) {
     // ドキュメントが空ならナビゲーション履歴にプッシュしない
     auto effects = Reduce(state, DropFilesAction{ std::pmr::wstring(L"C:\\dropped.md") });
     EXPECT_TRUE(HasEffect<effect::LoadFile>(effects));
-    EXPECT_FALSE(state.nav_history.CanGoBack());
+    EXPECT_FALSE(state.view.nav_history.CanGoBack());
 }
 
 TEST_F(ReducerTest, ShowHelp_EmitsLoadFile) {
-    state.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\file.md");
+    state.document.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\file.md");
 
     auto effects = Reduce(state, ShowHelpAction{});
     EXPECT_TRUE(HasEffect<effect::LoadFile>(effects));
-    EXPECT_TRUE(state.nav_history.CanGoBack());
+    EXPECT_TRUE(state.view.nav_history.CanGoBack());
 }
 
 // ---- リサイズ / DPI テスト ----
@@ -250,7 +250,7 @@ TEST_F(ReducerTest, Resize_ZeroSize_NoEffects) {
 }
 
 TEST_F(ReducerTest, Resize_Normal_EmitsResizeEnd) {
-    state.cached_dpi_scale = 1.0f;
+    state.window.cached_dpi_scale = 1.0f;
     auto effects = Reduce(state, ResizeAction{ 800, 600 });
 
     EXPECT_TRUE(HasEffect<effect::RendererResize>(effects));
@@ -259,8 +259,8 @@ TEST_F(ReducerTest, Resize_Normal_EmitsResizeEnd) {
 }
 
 TEST_F(ReducerTest, Resize_Sizing_EmitsSizingUpdate) {
-    state.is_sizing = true;
-    state.cached_dpi_scale = 1.0f;
+    state.window.is_sizing = true;
+    state.window.cached_dpi_scale = 1.0f;
     auto effects = Reduce(state, ResizeAction{ 800, 600 });
 
     EXPECT_TRUE(HasEffect<effect::RendererResize>(effects));
@@ -271,7 +271,7 @@ TEST_F(ReducerTest, Resize_Sizing_EmitsSizingUpdate) {
 TEST_F(ReducerTest, DpiChanged_UpdatesScale) {
     auto effects = Reduce(state, DpiChangedAction{ 192, RECT{0, 0, 800, 600} });
 
-    EXPECT_FLOAT_EQ(state.cached_dpi_scale, 2.0f);
+    EXPECT_FLOAT_EQ(state.window.cached_dpi_scale, 2.0f);
     EXPECT_TRUE(HasEffect<effect::RendererSetDpi>(effects));
     EXPECT_TRUE(HasEffect<effect::ClearFileCache>(effects));
     EXPECT_TRUE(HasEffect<effect::SetWindowPosition>(effects));
@@ -287,7 +287,7 @@ TEST_F(ReducerTest, ToggleDarkMode_EmitsApplyThemeChange) {
 }
 
 TEST_F(ReducerTest, ZoomIn_EmitsApplyThemeChange) {
-    state.cached_theme.zoom = 1.0f;
+    state.window.cached_theme.zoom = 1.0f;
     auto effects = Reduce(state, ZoomAction{ ZoomDirection::In });
 
     EXPECT_TRUE(HasEffect<effect::ApplyThemeChange>(effects));
@@ -312,7 +312,7 @@ TEST_F(ReducerTest, CaptureChanged_ResetsGesture) {
 // ---- タイマーテスト（代表ケース） ----
 
 TEST_F(ReducerTest, Timer_Toast_EmitsInvalidate) {
-    state.toast.Show(L"test");
+    state.interaction.toast.Show(L"test");
     auto effects = Reduce(state, TimerAction{ 6 }); // app_timer::TOAST = 6
     EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
 }


### PR DESCRIPTION
## Summary

- **AppState サブグループ化**: 25+フィールドのフラット構造を DocumentState / ViewState / InteractionState / SearchGroup / WindowState の5つに分解し、関心の分離を明確化
- **Reducer 分割**: 444行の巨大な `std::visit` ラムダを20+の名前付き関数（`ReduceKeyScroll`, `ReduceZoom`, `ReduceTimer` 等）に分割し、可読性を向上
- **app.cpp 分割**: ファイル読み込み/リロード (~450行) を `app_file.cpp` に分離し、app.cpp を 1,187行 → 734行に縮小
- **const 正当性修正**: AppState の mutable ペインレイアウトキャッシュを非mutableに変更し、`GetPaneLayout()` を非constに
- **Node テキスト管理改善**: `EnsureTextConverted()` を追加しパース直後に一括変換することで、描画時の暗黙的メモリ解放を排除
- **コード品質改善**: 不要な include 削除、デッドコード削除、重複ロジック統一、const_cast 排除

## Test plan

- [x] `cmake --build build --config Release` でビルド成功
- [x] `mendo_tests.exe` で 1617 テスト全パス
- [ ] アプリを起動してMarkdownファイルの閲覧・スクロール・検索・ズーム・ダークモード切替を確認
- [ ] ファイルの外部編集→自動リロードが正常に動作することを確認
- [ ] サイドペイン（ファイル・目次）の表示/非表示・リサイズが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)