### PR TITLE
リファクタリング: マウスアクション・ShowToast/Copy統一・ThemeConstants改善

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -561,9 +561,7 @@ void App::OnCaptureChanged()
 
 void App::ShowToast(std::wstring_view message)
 {
-    state_.interaction.toast.Show(message);
-    SetTimer(hwnd_, app_timer::TOAST, app_timer::FRAME_INTERVAL_MS, nullptr);
-    Invalidate();
+    effect_executor_.ExecuteOne(effect::ShowToast{ std::pmr::wstring{message} });
 }
 
 void App::OnDestroy()

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -561,7 +561,7 @@ void App::OnCaptureChanged()
 
 void App::ShowToast(std::wstring_view message)
 {
-    effect_executor_.ExecuteOne(effect::ShowToast{ std::pmr::wstring{message} });
+    effect_executor_.ExecuteOne(effect::ShowToast{ std::wstring{message} });
 }
 
 void App::OnDestroy()

--- a/src/app/app_context_menu.cpp
+++ b/src/app/app_context_menu.cpp
@@ -59,7 +59,7 @@ void App::OnContextMenu(int screen_x, int screen_y)
         break;
     }
     case IDM_COPY:
-        CopySelectionToClipboard();
+        Dispatch(CopyClipboardAction{});
         break;
     case IDM_TOGGLE_DARK_MODE:
         Dispatch(ToggleDarkModeAction{});

--- a/src/app/app_events.h
+++ b/src/app/app_events.h
@@ -86,50 +86,34 @@ struct NoOpAction {};
 // ──── アクション: マウスイベント系 ────
 
 struct LButtonDownAction {
-    float dip_x;
-    float dip_y;
     int px;
     int py;
 };
 struct LButtonUpAction {
-    float dip_x;
-    float dip_y;
     int px;
     int py;
 };
 struct MouseMoveAction {
-    float dip_x;
-    float dip_y;
     int px;
     int py;
 };
 struct MouseHoverAction {
-    float dip_x;
-    float dip_y;
     int px;
     int py;
 };
 struct LButtonDblClkAction {
-    float dip_x;
-    float dip_y;
     int px;
     int py;
 };
 struct RButtonDownAction {
-    float dip_x;
-    float dip_y;
     int px;
     int py;
 };
 struct RButtonUpAction {
-    float dip_x;
-    float dip_y;
     int px;
     int py;
 };
 struct RButtonMoveAction {
-    float dip_x;
-    float dip_y;
     int px;
     int py;
 };

--- a/src/app/app_navigate.cpp
+++ b/src/app/app_navigate.cpp
@@ -56,16 +56,7 @@ void App::PushNavHistory()
 
 void App::SyncPaneThemeCache()
 {
-    const auto& theme = renderer_.GetTheme();
-    state_.window.cached_theme = ThemeConstants{
-        .pane_item_height = theme.pane_item_height,
-        .pane_header_height = theme.pane_header_height,
-        .splitter_width = theme.splitter_width,
-        .margin_left = theme.margin_left,
-        .margin_right = theme.margin_right,
-        .heading_spacing_above = theme.heading_spacing_above,
-        .zoom = theme.zoom,
-    };
+    state_.window.cached_theme = renderer_.GetTheme().ToReducerConstants();
 }
 
 void App::FinishThemeOrZoomChange(const AnchorState& anchor, float offset_scale)

--- a/src/app/app_state.h
+++ b/src/app/app_state.h
@@ -17,6 +17,7 @@
 #include "hit_test_service.h"
 #include "hover_throttle.h"
 #include "pane_layout.h"
+#include "theme_constants.h"
 #include <string>
 #include <string_view>
 #include <memory_resource>
@@ -26,17 +27,6 @@ struct AnchorState {
     int idx = -1;
     float y_before = 0.0f;
     float offset = 0.0f;
-};
-
-// Reducer がテーマ定数を参照するためのキャッシュ。
-struct ThemeConstants {
-    float pane_item_height = 28.0f;
-    float pane_header_height = 32.0f;
-    float splitter_width = 4.0f;
-    float margin_left = 0.0f;
-    float margin_right = 0.0f;
-    float heading_spacing_above = 0.0f;
-    float zoom = 1.0f;
 };
 
 // ---- ドメイン状態: ドキュメントとレイアウトキャッシュ ----

--- a/src/app/side_effect.h
+++ b/src/app/side_effect.h
@@ -54,7 +54,7 @@ struct SaveConfig {};
 // ---- ツールチップ・トースト ----
 struct ShowTooltip { TooltipTarget target; int px; int py; };
 struct ClearTooltip {};
-struct ShowToast { std::pmr::wstring message; };
+struct ShowToast { std::wstring message; };
 
 // ---- レイアウト ----
 struct DeferredLayout {};

--- a/src/app/side_effect_executor.cpp
+++ b/src/app/side_effect_executor.cpp
@@ -30,194 +30,199 @@ void SideEffectExecutor::Init(HWND hwnd, ResourceManager& resource_manager,
     cb_ = std::move(cb);
 }
 
+void SideEffectExecutor::ExecuteOne(const SideEffect& e)
+{
+    std::visit(overloaded{
+        [this](const effect::InvalidateWindow&) {
+            InvalidateRect(hwnd_, nullptr, FALSE);
+        },
+        [this](const effect::InvalidateRect&) { // TODO: 部分 Invalidate 実装
+            InvalidateRect(hwnd_, nullptr, FALSE);
+        },
+        [this](const effect::InvalidateTitleBar&) {
+            InvalidateRect(hwnd_, nullptr, FALSE);
+        },
+        [this](const effect::SetTimer& e) {
+            ::SetTimer(hwnd_, e.id, e.ms, nullptr);
+        },
+        [this](const effect::KillTimer& e) {
+            ::KillTimer(hwnd_, e.id);
+        },
+        [this](const effect::SetCapture&) {
+            ::SetCapture(hwnd_);
+        },
+        [this](const effect::ReleaseCapture&) {
+            ::ReleaseCapture();
+        },
+        [this](const effect::SetCursor& e) {
+            HCURSOR cursor = nullptr;
+            switch (e.type) {
+            case effect::CursorType::Arrow:
+                cursor = cursors_->Arrow();
+                break;
+            case effect::CursorType::Hand:
+                cursor = cursors_->Hand();
+                break;
+            case effect::CursorType::IBeam:
+                cursor = cursors_->IBeam();
+                break;
+            case effect::CursorType::SizeWE:
+                cursor = cursors_->SizeWE();
+                break;
+            }
+            if (cursor) {
+                ::SetCursor(cursor);
+            }
+        },
+        [this](const effect::ClipboardWrite& e) {
+            WriteClipboardText(hwnd_, e.text);
+        },
+        [](const effect::ShellOpen& e) {
+            ShellExecuteW(nullptr, L"open", e.url.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+        },
+        [this](const effect::ShowWindowCmd& e) {
+            ShowWindow(hwnd_, e.cmd);
+        },
+        [this](const effect::PostMessage& e) {
+            PostMessageW(hwnd_, e.msg, e.wp, e.lp);
+        },
+        [this](const effect::SetWindowTitle& e) {
+            SetWindowTextW(hwnd_, e.title.c_str());
+        },
+        [this](const effect::LoadFile& e) {
+            cb_.load_file(e.path);
+        },
+        [this](const effect::ReloadFile&) {
+            cb_.reload_file();
+        },
+        [this](const effect::OpenFileDialog&) {
+            cb_.open_file_dialog();
+        },
+        [](const effect::SaveFile& e) {
+            WriteAllBytes(std::filesystem::path(e.path), e.data.data(), e.data.size());
+        },
+        [this](const effect::SaveConfig&) {
+            config_->Flush();
+        },
+        [this](const effect::ShowTooltip& e) {
+            POINT screen_pos = { e.px, e.py };
+            ClientToScreen(hwnd_, &screen_pos);
+            if (state_->interaction.tooltip.Update(e.target, screen_pos)) {
+                ::SetTimer(hwnd_, app_timer::TOOLTIP, TOOLTIP_DELAY_MS, nullptr);
+            }
+            else if (e.target.IsEmpty()) {
+                ::KillTimer(hwnd_, app_timer::TOOLTIP);
+            }
+        },
+        [this](const effect::ClearTooltip&) {
+            ::KillTimer(hwnd_, app_timer::TOOLTIP);
+        },
+        [this](const effect::ShowToast& e) {
+            state_->interaction.toast.Show(e.message);
+            ::SetTimer(hwnd_, app_timer::TOAST, app_timer::FRAME_INTERVAL_MS, nullptr);
+            InvalidateRect(hwnd_, nullptr, FALSE);
+        },
+        [this](const effect::DeferredLayout&) {
+            if (layout_service_->HasDirtyNodes()) {
+                ::SetTimer(hwnd_, app_timer::DEFERRED_LAYOUT, app_timer::FRAME_INTERVAL_MS, nullptr);
+            }
+        },
+        [this](const effect::BitmapManage&) {
+            resource_manager_->ScheduleBitmapManage();
+        },
+        [this](const effect::MermaidBatch&) {
+            resource_manager_->ScheduleMermaidBatch();
+        },
+        [this](const effect::StartFileWatch& e) {
+            doc_service_->StartWatching(e.path, [hwnd = hwnd_]() {
+                ::KillTimer(hwnd, app_timer::FILE_RELOAD_DEBOUNCE);
+                ::SetTimer(hwnd, app_timer::FILE_RELOAD_DEBOUNCE, app_timer::FILE_RELOAD_DEBOUNCE_MS, nullptr);
+            });
+        },
+        [this](const effect::StopFileWatch&) {
+            doc_service_->StopWatching();
+        },
+        [this](const effect::ResumeFileWatch&) {
+            doc_service_->ResumeWatching();
+        },
+        [this](const effect::LoadImages&) {
+            resource_manager_->LoadImages();
+        },
+        [this](const effect::RequestMermaidRenders&) {
+            resource_manager_->RequestMermaidRenders();
+        },
+        [this](const effect::CancelMermaidBatch&) {
+            resource_manager_->CancelMermaidBatch();
+        },
+        [this](const effect::InvalidatePaneCache& e) {
+            cb_.invalidate_pane_cache(e.pane);
+        },
+        [this](const effect::RefreshPaneLayout&) {
+            cb_.refresh_pane_layout();
+        },
+        [this](const effect::ApplyDarkMode& e) {
+            ApplyDarkModeToWindow(hwnd_, e.dark);
+        },
+        [this](const effect::CheckFileChanges&) {
+            doc_service_->CheckForChanges();
+        },
+        [this](const effect::NotifyImageLoaded&) {
+            resource_manager_->OnAppImageLoaded();
+        },
+        [this](const effect::RendererResize& e) {
+            cb_.renderer_resize(e.width, e.height);
+        },
+        [this](const effect::RendererSetDpi& e) {
+            cb_.renderer_set_dpi(e.dpi);
+        },
+        [this](const effect::SetWindowPosition& e) {
+            SetWindowPos(hwnd_, nullptr, e.x, e.y, e.cx, e.cy, SWP_NOZORDER | SWP_NOACTIVATE);
+        },
+        [this](const effect::ClearFileCache&) {
+            cb_.clear_file_cache();
+        },
+        [this](const effect::PerformResizeEnd&) {
+            cb_.perform_resize_end();
+        },
+        [this](const effect::PerformSizingUpdate&) {
+            cb_.perform_sizing_update();
+        },
+        [this](const effect::ApplyThemeChange& e) {
+            cb_.apply_theme_change(e);
+        },
+        [this](const effect::ProcessDeferredLayout&) {
+            cb_.process_deferred_layout();
+        },
+        [this](const effect::TickLoadingAnimation&) {
+            cb_.tick_loading_animation();
+        },
+        [this](const effect::ProcessMermaidBatchTimer&) {
+            cb_.process_mermaid_batch_timer();
+        },
+        [this](const effect::ProcessBitmapManage&) {
+            cb_.process_bitmap_manage();
+        },
+        [this](const effect::MermaidInitRetry&) {
+            cb_.mermaid_init_retry();
+        },
+        [this](const effect::Destroy&) {
+            cb_.destroy();
+        },
+        [this](const effect::HandleParseComplete&) {
+            cb_.handle_parse_complete();
+        },
+        [this](const effect::HandleMouseEvent& e) {
+            cb_.handle_mouse_event(e.type, e.px, e.py);
+        },
+        [this](const effect::HandleContextMenu& e) {
+            cb_.handle_context_menu(e.screen_x, e.screen_y);
+        },
+        }, e);
+}
+
 void SideEffectExecutor::Execute(const SideEffectList& effects)
 {
     for (const auto& e : effects) {
-        std::visit(overloaded{
-            [this](const effect::InvalidateWindow&) {
-                InvalidateRect(hwnd_, nullptr, FALSE);
-            },
-            [this](const effect::InvalidateRect&) { // TODO: 部分 Invalidate 実装
-                InvalidateRect(hwnd_, nullptr, FALSE);
-            },
-            [this](const effect::InvalidateTitleBar&) {
-                InvalidateRect(hwnd_, nullptr, FALSE);
-            },
-            [this](const effect::SetTimer& e) {
-                ::SetTimer(hwnd_, e.id, e.ms, nullptr);
-            },
-            [this](const effect::KillTimer& e) {
-                ::KillTimer(hwnd_, e.id);
-            },
-            [this](const effect::SetCapture&) {
-                ::SetCapture(hwnd_);
-            },
-            [this](const effect::ReleaseCapture&) {
-                ::ReleaseCapture();
-            },
-            [this](const effect::SetCursor& e) {
-                HCURSOR cursor = nullptr;
-                switch (e.type) {
-                case effect::CursorType::Arrow:
-                    cursor = cursors_->Arrow();
-                    break;
-                case effect::CursorType::Hand:
-                    cursor = cursors_->Hand();
-                    break;
-                case effect::CursorType::IBeam:
-                    cursor = cursors_->IBeam();
-                    break;
-                case effect::CursorType::SizeWE:
-                    cursor = cursors_->SizeWE();
-                    break;
-                }
-                if (cursor) {
-                    ::SetCursor(cursor);
-                }
-            },
-            [this](const effect::ClipboardWrite& e) {
-                WriteClipboardText(hwnd_, e.text);
-            },
-            [](const effect::ShellOpen& e) {
-                ShellExecuteW(nullptr, L"open", e.url.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
-            },
-            [this](const effect::ShowWindowCmd& e) {
-                ShowWindow(hwnd_, e.cmd);
-            },
-            [this](const effect::PostMessage& e) {
-                PostMessageW(hwnd_, e.msg, e.wp, e.lp);
-            },
-            [this](const effect::SetWindowTitle& e) {
-                SetWindowTextW(hwnd_, e.title.c_str());
-            },
-            [this](const effect::LoadFile& e) {
-                cb_.load_file(e.path);
-            },
-            [this](const effect::ReloadFile&) {
-                cb_.reload_file();
-            },
-            [this](const effect::OpenFileDialog&) {
-                cb_.open_file_dialog();
-            },
-            [](const effect::SaveFile& e) {
-                WriteAllBytes(std::filesystem::path(e.path), e.data.data(), e.data.size());
-            },
-            [this](const effect::SaveConfig&) {
-                config_->Flush();
-            },
-            [this](const effect::ShowTooltip& e) {
-                POINT screen_pos = { e.px, e.py };
-                ClientToScreen(hwnd_, &screen_pos);
-                if (state_->interaction.tooltip.Update(e.target, screen_pos)) {
-                    ::SetTimer(hwnd_, app_timer::TOOLTIP, TOOLTIP_DELAY_MS, nullptr);
-                }
-                else if (e.target.IsEmpty()) {
-                    ::KillTimer(hwnd_, app_timer::TOOLTIP);
-                }
-            },
-            [this](const effect::ClearTooltip&) {
-                ::KillTimer(hwnd_, app_timer::TOOLTIP);
-            },
-            [this](const effect::ShowToast& e) {
-                state_->interaction.toast.Show(e.message);
-                ::SetTimer(hwnd_, app_timer::TOAST, app_timer::FRAME_INTERVAL_MS, nullptr);
-                InvalidateRect(hwnd_, nullptr, FALSE);
-            },
-            [this](const effect::DeferredLayout&) {
-                if (layout_service_->HasDirtyNodes()) {
-                    ::SetTimer(hwnd_, app_timer::DEFERRED_LAYOUT, app_timer::FRAME_INTERVAL_MS, nullptr);
-                }
-            },
-            [this](const effect::BitmapManage&) {
-                resource_manager_->ScheduleBitmapManage();
-            },
-            [this](const effect::MermaidBatch&) {
-                resource_manager_->ScheduleMermaidBatch();
-            },
-            [this](const effect::StartFileWatch& e) {
-                doc_service_->StartWatching(e.path, [hwnd = hwnd_]() {
-                    ::KillTimer(hwnd, app_timer::FILE_RELOAD_DEBOUNCE);
-                    ::SetTimer(hwnd, app_timer::FILE_RELOAD_DEBOUNCE, app_timer::FILE_RELOAD_DEBOUNCE_MS, nullptr);
-                });
-            },
-            [this](const effect::StopFileWatch&) {
-                doc_service_->StopWatching();
-            },
-            [this](const effect::ResumeFileWatch&) {
-                doc_service_->ResumeWatching();
-            },
-            [this](const effect::LoadImages&) {
-                resource_manager_->LoadImages();
-            },
-            [this](const effect::RequestMermaidRenders&) {
-                resource_manager_->RequestMermaidRenders();
-            },
-            [this](const effect::CancelMermaidBatch&) {
-                resource_manager_->CancelMermaidBatch();
-            },
-            [this](const effect::InvalidatePaneCache& e) {
-                cb_.invalidate_pane_cache(e.pane);
-            },
-            [this](const effect::RefreshPaneLayout&) {
-                cb_.refresh_pane_layout();
-            },
-            [this](const effect::ApplyDarkMode& e) {
-                ApplyDarkModeToWindow(hwnd_, e.dark);
-            },
-            [this](const effect::CheckFileChanges&) {
-                doc_service_->CheckForChanges();
-            },
-            [this](const effect::NotifyImageLoaded&) {
-                resource_manager_->OnAppImageLoaded();
-            },
-            [this](const effect::RendererResize& e) {
-                cb_.renderer_resize(e.width, e.height);
-            },
-            [this](const effect::RendererSetDpi& e) {
-                cb_.renderer_set_dpi(e.dpi);
-            },
-            [this](const effect::SetWindowPosition& e) {
-                SetWindowPos(hwnd_, nullptr, e.x, e.y, e.cx, e.cy, SWP_NOZORDER | SWP_NOACTIVATE);
-            },
-            [this](const effect::ClearFileCache&) {
-                cb_.clear_file_cache();
-            },
-            [this](const effect::PerformResizeEnd&) {
-                cb_.perform_resize_end();
-            },
-            [this](const effect::PerformSizingUpdate&) {
-                cb_.perform_sizing_update();
-            },
-            [this](const effect::ApplyThemeChange& e) {
-                cb_.apply_theme_change(e);
-            },
-            [this](const effect::ProcessDeferredLayout&) {
-                cb_.process_deferred_layout();
-            },
-            [this](const effect::TickLoadingAnimation&) {
-                cb_.tick_loading_animation();
-            },
-            [this](const effect::ProcessMermaidBatchTimer&) {
-                cb_.process_mermaid_batch_timer();
-            },
-            [this](const effect::ProcessBitmapManage&) {
-                cb_.process_bitmap_manage();
-            },
-            [this](const effect::MermaidInitRetry&) {
-                cb_.mermaid_init_retry();
-            },
-            [this](const effect::Destroy&) {
-                cb_.destroy();
-            },
-            [this](const effect::HandleParseComplete&) {
-                cb_.handle_parse_complete();
-            },
-            [this](const effect::HandleMouseEvent& e) {
-                cb_.handle_mouse_event(e.type, e.px, e.py);
-            },
-            [this](const effect::HandleContextMenu& e) {
-                cb_.handle_context_menu(e.screen_x, e.screen_y);
-            },
-            }, e);
+        ExecuteOne(e);
     }
 }

--- a/src/app/side_effect_executor.h
+++ b/src/app/side_effect_executor.h
@@ -44,6 +44,7 @@ public:
         ConfigService& config, AppState& state,
         LayoutService& layout_service, Callbacks cb);
     void Execute(const SideEffectList& effects);
+    void ExecuteOne(const SideEffect& e);
 
 private:
     HWND hwnd_ = nullptr;

--- a/src/theme/theme.cpp
+++ b/src/theme/theme.cpp
@@ -18,6 +18,19 @@ float Theme::GetHeadingSize(int level) const noexcept
     return font_size_h[level - 1];
 }
 
+ThemeConstants Theme::ToReducerConstants() const noexcept
+{
+    return ThemeConstants{
+        .pane_item_height = pane_item_height,
+        .pane_header_height = pane_header_height,
+        .splitter_width = splitter_width,
+        .margin_left = margin_left,
+        .margin_right = margin_right,
+        .heading_spacing_above = heading_spacing_above,
+        .zoom = zoom,
+    };
+}
+
 void Theme::ApplyZoom(float new_zoom) noexcept
 {
     if (new_zoom <= 0.0f || zoom <= 0.0f) {

--- a/src/theme/theme.h
+++ b/src/theme/theme.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string>
 #include "types.h"
+#include "theme_constants.h"
 
 struct Theme {
     // 色
@@ -92,6 +93,9 @@ struct Theme {
         return (level == 2) ? h2_underline_thickness : hr_thickness;
     }
     constexpr bool IsDark() const noexcept { return (bg_color.r + bg_color.g + bg_color.b) < 1.5f; }
+
+    // Reducer用のテーマ定数キャッシュを生成する。
+    ThemeConstants ToReducerConstants() const noexcept;
 
     // すべてのスケーラブルなサイズ（フォントサイズ、マージン、スペーシング）にズーム倍率を適用する。
     // `zoom` を変更した後に呼び出して派生値を更新する。

--- a/src/theme/theme_constants.h
+++ b/src/theme/theme_constants.h
@@ -1,0 +1,12 @@
+#pragma once
+
+// Reducer がテーマ定数を参照するためのキャッシュ。
+struct ThemeConstants {
+    float pane_item_height = 28.0f;
+    float pane_header_height = 32.0f;
+    float splitter_width = 4.0f;
+    float margin_left = 0.0f;
+    float margin_right = 0.0f;
+    float heading_spacing_above = 0.0f;
+    float zoom = 1.0f;
+};


### PR DESCRIPTION
## Summary
- マウスアクション構造体8つから未使用の `dip_x`/`dip_y` フィールドを削除（Reducer では `px`/`py` のみ使用）
- コンテキストメニューの `IDM_COPY` を `Dispatch(CopyClipboardAction{})` 経由に変更し、Ctrl+C と同じ Reducer 経路に統一
- `App::ShowToast` を `SideEffectExecutor::ExecuteOne()` 経由に変更し、副作用の実行経路を一本化
- `ThemeConstants` を `theme_constants.h` に切り出し、`Theme::ToReducerConstants()` ファクトリメソッドを追加して手動フィールドコピーの同期漏れリスクを解消

## Test plan
- [x] Release ビルドが通ること
- [x] 全 1617 テストがパスすること
- [ ] ファイル読み込みエラー時のトースト表示が正常に動作すること
- [ ] コンテキストメニューからのコピーが正常に動作すること
- [ ] ダークモード切替・ズーム操作が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)