### PR TITLE
OnResizeEnd のMermaidレンダリングをバッチ化しUIブロックを解消

### DIFF
--- a/src/app/app_scroll.cpp
+++ b/src/app/app_scroll.cpp
@@ -114,8 +114,6 @@ void App::OnResizeEnd()
 
     ScheduleDeferredLayoutIfNeeded();
 
-    // RequestMermaidRenders は同期I/Oでブロックするため、バッチ経由で処理する
-    resource_manager_.InvalidateMermaidForWidthChange();
     resource_manager_.ScheduleMermaidBatch();
 }
 

--- a/src/app/app_scroll.cpp
+++ b/src/app/app_scroll.cpp
@@ -114,7 +114,9 @@ void App::OnResizeEnd()
 
     ScheduleDeferredLayoutIfNeeded();
 
-    resource_manager_.RequestMermaidRenders();
+    // RequestMermaidRenders は同期I/Oでブロックするため、バッチ経由で処理する
+    resource_manager_.InvalidateMermaidForWidthChange();
+    resource_manager_.ScheduleMermaidBatch();
 }
 
 void App::RefreshPaneLayout()

--- a/src/app/resource_manager.cpp
+++ b/src/app/resource_manager.cpp
@@ -132,11 +132,11 @@ void ResourceManager::OnImageLoadComplete()
 // Mermaidリソース
 // ============================================================
 
-int ResourceManager::RequestMermaidRenders()
+void ResourceManager::InvalidateMermaidForWidthChange()
 {
     const float content_width = cb_.get_content_width();
     if (content_width <= 0.0f) {
-        return 0;
+        return;
     }
 
     if (last_mermaid_content_width_ > 0.0f &&
@@ -160,6 +160,16 @@ int ResourceManager::RequestMermaidRenders()
         mermaid_->ClearPendingQueue();
     }
     last_mermaid_content_width_ = content_width;
+}
+
+int ResourceManager::RequestMermaidRenders()
+{
+    InvalidateMermaidForWidthChange();
+
+    const float content_width = cb_.get_content_width();
+    if (content_width <= 0.0f) {
+        return 0;
+    }
 
     const float viewport_top = viewport_->GetScrollY();
     const float viewport_height = cb_.get_viewport_height();

--- a/src/app/resource_manager.cpp
+++ b/src/app/resource_manager.cpp
@@ -224,6 +224,8 @@ void ResourceManager::ProcessMermaidBatch()
 {
     MENDO_PROFILE("ProcessMermaidBatch");
 
+    InvalidateMermaidForWidthChange();
+
     const float content_width = cb_.get_content_width();
     if (content_width <= 0.0f) {
         cb_.kill_timer(TIMER_MERMAID_BATCH);

--- a/src/app/resource_manager.cpp
+++ b/src/app/resource_manager.cpp
@@ -132,9 +132,8 @@ void ResourceManager::OnImageLoadComplete()
 // Mermaidリソース
 // ============================================================
 
-void ResourceManager::InvalidateMermaidForWidthChange()
+void ResourceManager::InvalidateMermaidForWidthChange(float content_width)
 {
-    const float content_width = cb_.get_content_width();
     if (content_width <= 0.0f) {
         return;
     }
@@ -157,16 +156,17 @@ void ResourceManager::InvalidateMermaidForWidthChange()
         if (any_invalidated) {
             mermaid_->ClearCache();
         }
-        mermaid_->ClearPendingQueue();
+        // 旧幅で処理中のin-flightリクエストを無効化し、完了時に旧bitmapで上書きされるのを防ぐ
+        mermaid_->CancelPending();
     }
     last_mermaid_content_width_ = content_width;
 }
 
 int ResourceManager::RequestMermaidRenders()
 {
-    InvalidateMermaidForWidthChange();
-
     const float content_width = cb_.get_content_width();
+    InvalidateMermaidForWidthChange(content_width);
+
     if (content_width <= 0.0f) {
         return 0;
     }
@@ -224,9 +224,9 @@ void ResourceManager::ProcessMermaidBatch()
 {
     MENDO_PROFILE("ProcessMermaidBatch");
 
-    InvalidateMermaidForWidthChange();
-
     const float content_width = cb_.get_content_width();
+    InvalidateMermaidForWidthChange(content_width);
+
     if (content_width <= 0.0f) {
         cb_.kill_timer(TIMER_MERMAID_BATCH);
         return;

--- a/src/app/resource_manager.h
+++ b/src/app/resource_manager.h
@@ -49,7 +49,6 @@ public:
 
     // --- Mermaidリソース ---
     int RequestMermaidRenders();
-    void InvalidateMermaidForWidthChange();
     void OnMermaidRenderComplete();
     void CancelMermaidBatch();
     void ScheduleMermaidBatch();
@@ -68,6 +67,8 @@ public:
     bool IsBatchLoading() const noexcept { return mermaid_batch_loading_; }
 
 private:
+    void InvalidateMermaidForWidthChange(float content_width);
+
     Document* doc_ = nullptr;
     LayoutCache* cache_ = nullptr;
     ViewportManager* viewport_ = nullptr;

--- a/src/app/resource_manager.h
+++ b/src/app/resource_manager.h
@@ -49,6 +49,7 @@ public:
 
     // --- Mermaidリソース ---
     int RequestMermaidRenders();
+    void InvalidateMermaidForWidthChange();
     void OnMermaidRenderComplete();
     void CancelMermaidBatch();
     void ScheduleMermaidBatch();


### PR DESCRIPTION
## Summary
- ウィンドウリサイズ完了時 (`OnResizeEnd`) に走っていた `RequestMermaidRenders` の同期I/Oブロックを解消し、タイマー駆動の `ScheduleMermaidBatch` 経由に切り替え
- 幅変化による bitmap 無効化処理 (`InvalidateMermaidForWidthChange`) を切り出し、`ProcessMermaidBatch` 先頭で実行することで `ScheduleMermaidBatch` を呼ぶ全経路で幅変化を一貫して検知
- `last_mermaid_content_width_` の更新タイミングを実バッチ実行時に揃え、別経路で幅が変わった際のズレを回避

## Test plan
- [ ] リリースビルドが通る (`cmake --build build --config Release`)
- [ ] ウィンドウをリサイズ操作中・完了後にUIがブロックしない
- [ ] リサイズ後、可視範囲のMermaid図が新しい幅で再レンダリングされる
- [ ] 既存の `RequestMermaidRenders` 経路（ファイルオープン・ナビゲーション）でも従来どおりMermaid図が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)