### PR TITLE
デッドコードClearPendingQueueを削除

### DIFF
--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -520,12 +520,6 @@ void MermaidRenderer::CancelPending()
     }
 }
 
-void MermaidRenderer::ClearPendingQueue() noexcept
-{
-    decltype(pending_requests_) empty;
-    pending_requests_.swap(empty);
-}
-
 uint64_t MermaidRenderer::HashCode(std::string_view code_utf8, float max_width, bool dark_mode) const noexcept
 {
     return mermaid_util::HashCode(code_utf8, max_width, dark_mode);

--- a/src/mermaid/mermaid.h
+++ b/src/mermaid/mermaid.h
@@ -65,10 +65,6 @@ public:
     // nodesベクターが置き換えられる前に呼び出す必要がある。
     void CancelPending();
 
-    // 保留キューのみをクリアする（処理中のレンダリングには影響しない）。
-    // リサイズ時に古い幅のリクエストを破棄するために使用する。
-    void ClearPendingQueue() noexcept;
-
     // WebView2初期化リトライのタイマーハンドラ
     void OnInitRetryTimer();
 

--- a/tests/test_mermaid_renderer.cpp
+++ b/tests/test_mermaid_renderer.cpp
@@ -139,14 +139,13 @@ TEST_F(MermaidRendererTest, RequestRenderBeforeInitIsSafe)
 }
 
 // ═══════════════════════════════════════════════
-// CancelPending / ClearPendingQueue / ClearCache は初期化前でも安全
+// CancelPending / ClearCache は初期化前でも安全
 // ═══════════════════════════════════════════════
 
 TEST_F(MermaidRendererTest, CancelPendingBeforeInitIsSafe)
 {
     renderer_->Init(nullptr, nullptr, nullptr, nullptr);
     renderer_->CancelPending();
-    renderer_->ClearPendingQueue();
 
     EXPECT_FALSE(renderer_->IsInitialized());
 }


### PR DESCRIPTION
## Summary
- PR #90 で `ClearPendingQueue` の本番呼出しを `CancelPending` に置き換えた結果、本番コードから呼び出されなくなったため削除
- `CancelPending` は `ClearPendingQueue` の上位互換（保留キューのクリアに加えワーカーの `current_request` もリセット）
- `CancelPendingBeforeInitIsSafe` テストから `ClearPendingQueue` 呼出を除去し、テスト名コメントも更新

## Test plan
- [x] Release ビルドが通る
- [x] `mendo_tests.exe` が全 1617 テスト通過
- [x] `src/` `tests/` 内に `ClearPendingQueue` の参照が残っていないことを grep で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)