### PR TITLE
起動時にヘルプが表示されないフォールバック漏れを修正

### DIFF
--- a/src/app/app.h
+++ b/src/app/app.h
@@ -195,6 +195,8 @@ private:
     void DoLoadMarkdownFile();
     void BeginAsyncLoad(const std::pmr::wstring& path);
     void FinishLoadMarkdownFile(bool heights_estimated = false);
+    // ロード失敗時のフォールバック: 初回起動で空画面になるのを避けるためヘルプを表示する
+    void HandleLoadFailureFallback();
     float CalcScrollForDiff(size_t diff_pos, float viewport_height, float fallback_scroll) const;
     void ApplyMermaidCacheHeights(float md_width);
     bool ShouldDeferForTruncateRewrite(bool is_prefix_only, size_t old_size, size_t new_size);

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -105,12 +105,22 @@ void App::DoLoadMarkdownFile()
         auto load_result = file_load_service_.ExecuteLoad(state_.document.doc, state_.document.layout_cache);
         if (!load_result) {
             ShowToast(FileLoadErrorMessage(load_result.error(), i18n::S()));
-            Invalidate();
+            HandleLoadFailureFallback();
             return;
         }
     }
 
     FinishLoadMarkdownFile();
+}
+
+void App::HandleLoadFailureFallback()
+{
+    if (state_.document.doc.IsEmpty()) {
+        LoadHelpDocument();
+    }
+    else {
+        Invalidate();
+    }
 }
 
 void App::OnParseComplete()
@@ -123,7 +133,7 @@ void App::OnParseComplete()
         MENDO_TRACE("OnParseComplete: no result (cancelled or load failed)");
         // LoadFile失敗時、FileWatcherがpausedのまま残るのを防ぐ
         doc_service_.ResumeWatching();
-        Invalidate();
+        HandleLoadFailureFallback();
         return;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,8 +47,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nC
         int argc = 0;
         LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
         const bool arg_given = argv && argc > 1 && argv[1][0] != L'\0';
-        const bool has_valid_file = arg_given
-            && GetFileAttributesW(argv[1]) != INVALID_FILE_ATTRIBUTES;
+        const bool has_valid_file = arg_given && GetFileAttributesW(argv[1]) != INVALID_FILE_ATTRIBUTES;
 
         if (has_valid_file) {
             window.LoadMarkdownFile(argv[1]);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,27 +37,32 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nC
             return 1;
         }
 
-        // コマンドラインで有効なファイルが指定されていればそれを読み込み、
-        // なければ前回のファイルを復元、それも無ければヘルプを表示する。
+        // 起動時のドキュメント決定フロー:
+        //   引数が有効なファイル  → そのファイルを開く
+        //   引数なし              → 前回ファイル復元、無ければヘルプ
+        //   引数あり かつ無効     → 前回復元せず直接ヘルプ (ユーザの指定意図を尊重)
         // CommandLineToArgvWで正規のパースを行い、引用符やスペースを正しく処理する。
-        // 引数が存在しないファイル/フラグ文字列（例: --version）でも確実にヘルプへ
-        // 落ちるよう、GetFileAttributesW で実在を検証する。
+        // 引数が --version 等のフラグ文字列でも確実にヘルプへ落とすため
+        // GetFileAttributesW で実在を検証する。
         int argc = 0;
         LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-        const bool has_valid_file = argv && argc > 1 && argv[1][0] != L'\0'
+        const bool arg_given = argv && argc > 1 && argv[1][0] != L'\0';
+        const bool has_valid_file = arg_given
             && GetFileAttributesW(argv[1]) != INVALID_FILE_ATTRIBUTES;
 
         if (has_valid_file) {
             window.LoadMarkdownFile(argv[1]);
         }
         else {
-            const std::pmr::wstring last = window.LoadLastFilePath();
+            std::pmr::wstring last;
+            if (!arg_given) {
+                last = window.LoadLastFilePath();
+            }
             if (!last.empty()) {
                 window.RestoreScrollPosition();
                 window.LoadMarkdownFile(last);
             }
             else {
-                // 初回起動または前回ファイルが存在しない場合、ヘルプを表示
                 wchar_t cwd[MAX_PATH];
                 if (GetCurrentDirectoryW(MAX_PATH, cwd)) {
                     window.ShowDirectory(cwd);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,17 +37,18 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nC
             return 1;
         }
 
-        // コマンドラインでファイルが指定されていればそれを読み込み、なければ前回のファイルを復元
-        // CommandLineToArgvWで正規のパースを行い、引用符やスペースを正しく処理する
-        std::wstring_view initial_path;
+        // コマンドラインで有効なファイルが指定されていればそれを読み込み、
+        // なければ前回のファイルを復元、それも無ければヘルプを表示する。
+        // CommandLineToArgvWで正規のパースを行い、引用符やスペースを正しく処理する。
+        // 引数が存在しないファイル/フラグ文字列（例: --version）でも確実にヘルプへ
+        // 落ちるよう、GetFileAttributesW で実在を検証する。
         int argc = 0;
         LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-        if (argv && argc > 1) {
-            initial_path = argv[1];
-        }
+        const bool has_valid_file = argv && argc > 1 && argv[1][0] != L'\0'
+            && GetFileAttributesW(argv[1]) != INVALID_FILE_ATTRIBUTES;
 
-        if (!initial_path.empty()) {
-            window.LoadMarkdownFile(initial_path);
+        if (has_valid_file) {
+            window.LoadMarkdownFile(argv[1]);
         }
         else {
             const std::pmr::wstring last = window.LoadLastFilePath();


### PR DESCRIPTION
## Summary

- winget モデレータの起動確認スクリーンショットでヘルプが表示されていなかった問題の修正
- `mendo --version` のように存在しないファイル/フラグ文字列が渡されると、初回ロード失敗が空画面のまま残っていた
- 起動時の CLI 引数検証と、ロード失敗パスでのヘルプフォールバックを二段構えで追加

## 原因

`main.cpp` は argv[1] を無条件に `LoadMarkdownFile` へ渡していた。存在しないパスでも `DocumentService::NeedsAsyncLoad` が true を返す (`ExceedsFileSize` が失敗時 true のため) ので非同期ロード経路へ入り、失敗した `OnParseComplete` は `Invalidate` するだけで、初期状態の空ドキュメントがそのまま表示されていた。

## 変更内容

- **src/main.cpp**: `GetFileAttributesW` で argv[1] の実在を検証し、無効な場合はそのままヘルプ表示経路へ合流 (スピナー一瞬描画の UX 劣化を回避する一次防御)
- **src/app/app_file.cpp**: `DoLoadMarkdownFile` / `OnParseComplete` のエラーパスで、ドキュメントが空 (初回起動) の場合はヘルプへフォールバック (ドラッグ&ドロップ等の他経路にも効く二次防御)
- **src/app/app.h**: 共通化した `HandleLoadFailureFallback` を private メソッドとして宣言

## Test plan

- [x] `cmake --build build --config Release` でビルド成功
- [x] `mendo_tests.exe` 1617件全パス
- [ ] `mendo` (引数なし) で日本語/英語ヘルプが表示されることを確認
- [ ] `mendo --version` で英語ヘルプが表示されることを確認 (モデレータ検証シナリオ)
- [ ] `mendo path/to/存在しないファイル.md` でヘルプが表示されることを確認
- [ ] 既に別ファイルを表示中に存在しないファイルを開こうとすると、トーストのみで元の表示を維持することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)