### PR TITLE
最小化・復元時のタイトルバー引き伸ばしフラッシュを修正

### DIFF
--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -503,8 +503,20 @@ LRESULT Win32Window::HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam)
         return 0;
 
     case WM_SIZE:
+        // Windows 11 は SIZE_MINIMIZED 時に (0,0) ではなくタスクバーサムネイル寸法
+        // （例: 237×39）を通知してくる。そのままResizeBuffersを呼ぶとスワップチェーンが
+        // その小サイズになり、DWM合成時にアプリサイズへ引き伸ばされてフラッシュになる。
+        if (wParam == SIZE_MINIMIZED) {
+            return 0;
+        }
         app_->OnResize(LOWORD(lParam), HIWORD(lParam));
         RepositionSearchEdit();
+        // ResizeBuffers直後のバックバッファは未定義。DWMが復元アニメーション中に
+        // その未定義フレームを合成してしまう前に、同期的にWM_PAINTを走らせて
+        // 新フレームをPresentしておく。
+        if (wParam == SIZE_RESTORED || wParam == SIZE_MAXIMIZED) {
+            UpdateWindow(hwnd_);
+        }
         return 0;
 
     case WM_ACTIVATE:

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -507,15 +507,18 @@ LRESULT Win32Window::HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam)
         // （例: 237×39）を通知してくる。そのままResizeBuffersを呼ぶとスワップチェーンが
         // その小サイズになり、DWM合成時にアプリサイズへ引き伸ばされてフラッシュになる。
         if (wParam == SIZE_MINIMIZED) {
+            was_minimized_ = true;
             return 0;
         }
         app_->OnResize(LOWORD(lParam), HIWORD(lParam));
         RepositionSearchEdit();
         // ResizeBuffers直後のバックバッファは未定義。DWMが復元アニメーション中に
         // その未定義フレームを合成してしまう前に、同期的にWM_PAINTを走らせて
-        // 新フレームをPresentしておく。
-        if (wParam == SIZE_RESTORED || wParam == SIZE_MAXIMIZED) {
+        // 新フレームをPresentしておく。対話的リサイズでは不要なので、
+        // 最小化からの復元時に限定する。
+        if (was_minimized_ && (wParam == SIZE_RESTORED || wParam == SIZE_MAXIMIZED)) {
             UpdateWindow(hwnd_);
+            was_minimized_ = false;
         }
         return 0;
 

--- a/src/window/window.h
+++ b/src/window/window.h
@@ -47,6 +47,7 @@ private:
     HWND search_edit_ = nullptr;
     bool in_sys_menu_ = false;   // システムメニューのモーダルループ中フラグ
     bool tracking_mouse_ = false; // TrackMouseEvent によるマウス追跡中フラグ
+    bool was_minimized_ = false;  // 直前が最小化状態だったかのフラグ（復元時の同期描画ガード用）
 
     // WM_NCHITTEST用DPIメトリクスキャッシュ（WM_DPICHANGED時に更新）
     int cached_nchit_border_ = 4;


### PR DESCRIPTION
## Summary
- Windows 11 が `WM_SIZE(SIZE_MINIMIZED)` で (0,0) ではなくタスクバーサムネイル寸法 (例: 237×39) を通知するため、スワップチェーンが小サイズへ `ResizeBuffers` され、DWM 合成時にアプリサイズへ引き伸ばされて一瞬タイトルバーが画面全体を覆うフラッシュが発生していた。`wParam == SIZE_MINIMIZED` を直接判定してスキップする。
- 復元側は `ResizeBuffers` 直後のバックバッファが未定義のまま DWM が復元アニメーションで合成するのを避けるため、`SIZE_RESTORED`/`SIZE_MAXIMIZED` 後に `UpdateWindow` で同期的に WM_PAINT を走らせて新フレームを Present する。

## 切り分けの経緯
`OutputDebugStringW` で WM_SIZE を観測したところ、SIZE_MINIMIZED が `(237, 39)` を通知していることを確認。従来の `width/height == 0` ガード（`ReduceResize` / `D2DRenderBackend::Resize`）では弾けない挙動だった。

## Test plan
- [ ] 最小化ボタンクリック時のフラッシュが発生しないことを確認
- [ ] タスクバーアイコンクリックによる最小化/復元時にフラッシュが発生しないことを確認
- [ ] 最小化→復元でタイトルバー/本文が正常に描画されることを確認
- [ ] 通常のウィンドウリサイズ・最大化・復元が従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)