### PR TITLE
パフォーマンスレビューから13項目の改善を実装

### DIFF
--- a/src/app/app_mouse_hover.cpp
+++ b/src/app/app_mouse_hover.cpp
@@ -13,6 +13,12 @@ void App::OnMouseHover(int px, int py)
         return;
     }
 
+    // OS から同一座標の WM_MOUSEMOVE が連続して届くことがあるため、
+    // 完全同一座標なら後段の zone 判定・ヒットテストを全てスキップする。
+    if (state_.interaction.hover_throttle.ShouldSkipSameDispatch(px, py)) {
+        return;
+    }
+
     const auto dip = PixelToDip(px, py);
     const float dip_x = dip.x;
     const float dip_y = dip.y;

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -459,7 +459,12 @@ SideEffectList Reduce(AppState& state, const AppAction& action)
         [&](const ImeCompositionAction& a) { state.search.search_bar_ctrl.SetImeComposition(a.text); },
 
         // ---- マウスイベント（SideEffect経由で委譲） ----
-        [&](const MouseLeaveAction&) { ClearTooltip(state, effects); },
+        [&](const MouseLeaveAction&) {
+            // 再侵入時に同一座標の最初の WM_MOUSEMOVE が ShouldSkipSameDispatch で
+            // 弾かれるとカーソル/ツールチップの復帰が遅れるため、hover 状態もリセットする
+            state.interaction.hover_throttle.Reset();
+            ClearTooltip(state, effects);
+        },
         [&](const CaptureChangedAction&) { ReduceCaptureChanged(state, effects); },
         [&](const LButtonDownAction& a) { effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::LButtonDown, a.px, a.py }); },
         [&](const LButtonUpAction& a) { effects.emplace_back(effect::HandleMouseEvent{ effect::MouseEventType::LButtonUp, a.px, a.py }); },

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -149,11 +149,15 @@ struct ParseContext {
         if (current_span.link_url_index >= 0 && current_node) {
             const auto& url = link_urls[static_cast<size_t>(current_span.link_url_index)];
             // ノードのURLプール内で重複を検索し、なければ追加。
-            // 同一リンク内のテキストは連続呼び出しされるため、末尾から逆走査して
-            // 直近の一致を最速で検出する（O(n²) → 実質 O(1) の高速パス）。
+            // 同一リンク内のテキストは連続呼び出しされるため末尾一致が最多だが、
+            // 異種URLが混在すると末尾逆走査は O(n²) に退化する。
+            // 直近数件のみ比較する制限付き逆走査に切り替え、閾値超過時は重複追加を許容する
+            // （link_url_index は int16_t で十分な余裕があり、機能上は同値）。
+            constexpr size_t LINEAR_SCAN_LIMIT = 8;
             int16_t node_idx = -1;
             const auto url_count = current_node->link_urls.size();
-            for (size_t i = url_count; i > 0; i--) {
+            const auto scan_start = url_count > LINEAR_SCAN_LIMIT ? url_count - LINEAR_SCAN_LIMIT : 0;
+            for (size_t i = url_count; i > scan_start; i--) {
                 if (current_node->link_urls[i - 1] == url) {
                     node_idx = static_cast<int16_t>(i - 1);
                     break;
@@ -504,7 +508,9 @@ int OnEnterSpan(MD_SPANTYPE type, void* detail, void* userdata)
     case MD_SPAN_A: {
         auto* const a = static_cast<MD_SPAN_A_DETAIL*>(detail);
         if (a->href.text && a->href.size > 0) {
-            ctx->link_urls.emplace_back(Utf8ToWide(std::string_view{ a->href.text, static_cast<size_t>(a->href.size) }));
+            ctx->link_urls.emplace_back();
+            Utf8ToWide(std::string_view{ a->href.text, static_cast<size_t>(a->href.size) },
+                ctx->link_urls.back());
             ctx->current_span.link_url_index = static_cast<int>(ctx->link_urls.size()) - 1;
         }
         break;
@@ -512,7 +518,8 @@ int OnEnterSpan(MD_SPANTYPE type, void* detail, void* userdata)
     case MD_SPAN_IMG: {
         auto* const img = static_cast<MD_SPAN_IMG_DETAIL*>(detail);
         if (img->src.text && img->src.size > 0) {
-            ctx->pending_image_src = Utf8ToWide(std::string_view{ img->src.text, static_cast<size_t>(img->src.size) });
+            Utf8ToWide(std::string_view{ img->src.text, static_cast<size_t>(img->src.size) },
+                ctx->pending_image_src);
         }
         break;
     }

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -31,9 +31,29 @@ TableRowHit FindTableRow(const Node& node, const NodeLayoutEntry& entry,
         return { -1, 0.0f };
     }
     const auto& tl = *entry.table_layout;
+    const auto row_count = node.table_rows().size();
+    if (row_count == 0) {
+        return { -1, 0.0f };
+    }
+
+    // 事前計算された累積Y配列で二分探索。
+    // row_cum_y[r] = エントリ上端からの行 r の上端までの累積高さ（サイズ row_count+1）。
+    if (tl.row_cum_y.size() == row_count + 1) {
+        const float local_y = dip_y - entry.y_position;
+        const auto it = std::ranges::upper_bound(tl.row_cum_y, local_y);
+        if (it == tl.row_cum_y.begin()) {
+            return { -1, 0.0f };
+        }
+        const auto idx = std::ranges::distance(tl.row_cum_y.begin(), it) - 1;
+        if (static_cast<size_t>(idx) >= row_count) {
+            return { -1, 0.0f };
+        }
+        return { static_cast<int>(idx), entry.y_position + tl.row_cum_y[static_cast<size_t>(idx)] };
+    }
+
+    // フォールバック: 線形走査
     const float border = TABLE_BORDER_WIDTH;
     float ry = entry.y_position;
-    const auto row_count = node.table_rows().size();
     for (size_t r = 0; r < row_count; r++) {
         const float row_h = (r < tl.row_heights.size()) ? tl.row_heights[r] : (theme.font_size_body * TABLE_ROW_HEIGHT_FACTOR);
         const float row_bottom = ry + row_h + border;
@@ -51,10 +71,28 @@ TableRowHit FindTableRow(const Node& node, const NodeLayoutEntry& entry,
 int FindTableCol(const TableLayoutData& tl, float base_x, float dip_x,
     float& cell_left_x) noexcept
 {
+    const auto col_count = tl.col_widths.size();
+
+    // 事前計算された累積X配列で二分探索。
+    // col_cum_x[c] = base_x からの列 c の左端までの累積幅（サイズ col_count+1）。
+    if (col_count > 0 && tl.col_cum_x.size() == col_count + 1) {
+        const float local_x = dip_x - base_x;
+        auto it = std::ranges::upper_bound(tl.col_cum_x, local_x);
+        if (it == tl.col_cum_x.begin()) {
+            ++it; // base_x + border より左の場合は最初の列にクランプ
+        }
+        size_t idx = static_cast<size_t>(std::ranges::distance(tl.col_cum_x.begin(), it) - 1);
+        if (idx >= col_count) {
+            idx = col_count - 1; // 最終列にクランプ
+        }
+        cell_left_x = base_x + tl.col_cum_x[idx];
+        return static_cast<int>(idx);
+    }
+
+    // フォールバック: 線形走査
     const float cell_padding = TABLE_CELL_PADDING;
     const float border = TABLE_BORDER_WIDTH;
     float cx = base_x + border;
-    const auto col_count = tl.col_widths.size();
     for (size_t c = 0; c < col_count; c++) {
         const float col_right = cx + tl.col_widths[c] + cell_padding * 2.0f;
         if (dip_x < col_right) {
@@ -63,9 +101,7 @@ int FindTableCol(const TableLayoutData& tl, float base_x, float dip_x,
         }
         cx += tl.col_widths[c] + cell_padding * 2.0f + border;
     }
-    // 最終列にフォールバック
     if (col_count > 0) {
-        // cx は最終列の右端を過ぎているので巻き戻す
         cell_left_x = cx - tl.col_widths[col_count - 1] - cell_padding * 2.0f - border;
         return static_cast<int>(col_count - 1);
     }

--- a/src/io/file_explorer.cpp
+++ b/src/io/file_explorer.cpp
@@ -49,6 +49,9 @@ void FileExplorer::Refresh()
     }
 
     struct SortSlot {
+        // ASCII A-Z のみ小文字化した比較キー。_wcsicmp は Unicode 大小無視だったが
+        // ローカルファイル名の実用上の並びは ASCII 大小無視で十分なため、
+        // ソート前処理コストを削減する Schwartzian transform を優先する。
         std::pmr::wstring sort_key;
         FileEntry entry;
     };

--- a/src/io/file_explorer.cpp
+++ b/src/io/file_explorer.cpp
@@ -48,8 +48,12 @@ void FileExplorer::Refresh()
         return;
     }
 
-    std::pmr::vector<FileEntry> dirs;
-    std::pmr::vector<FileEntry> files;
+    struct SortSlot {
+        std::pmr::wstring sort_key;
+        FileEntry entry;
+    };
+    std::pmr::vector<SortSlot> dirs;
+    std::pmr::vector<SortSlot> files;
     static constexpr size_t MAX_ENTRIES = 4096;
 
     do {
@@ -67,30 +71,30 @@ void FileExplorer::Refresh()
         }
 
         if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-            FileEntry entry;
-            entry.full_path.assign((dir_base / fd.cFileName).native());
-            entry.is_directory = true;
-            dirs.emplace_back(std::move(entry));
+            SortSlot slot;
+            slot.sort_key = ToLowerAscii(fd.cFileName);
+            slot.entry.full_path.assign((dir_base / fd.cFileName).native());
+            slot.entry.is_directory = true;
+            dirs.emplace_back(std::move(slot));
         }
         else if (IsMarkdownFile(fd.cFileName)) {
-            FileEntry entry;
-            entry.full_path.assign((dir_base / fd.cFileName).native());
-            files.emplace_back(std::move(entry));
+            SortSlot slot;
+            slot.sort_key = ToLowerAscii(fd.cFileName);
+            slot.entry.full_path.assign((dir_base / fd.cFileName).native());
+            files.emplace_back(std::move(slot));
         }
     } while (FindNextFileW(hFind.get(), &fd));
 
-    // ディレクトリとファイルをそれぞれ大文字小文字無視でソート
-    std::ranges::sort(dirs, [](const FileEntry& a, const FileEntry& b) static noexcept {
-        return _wcsicmp(a.GetDisplayName(), b.GetDisplayName()) < 0;
-    });
-    std::ranges::sort(files, [](const FileEntry& a, const FileEntry& b) static noexcept {
-        return _wcsicmp(a.GetDisplayName(), b.GetDisplayName()) < 0;
-    });
+    auto by_key = [](const SortSlot& a, const SortSlot& b) static noexcept {
+        return a.sort_key < b.sort_key;
+    };
+    std::ranges::sort(dirs, by_key);
+    std::ranges::sort(files, by_key);
 
     // 追加: ディレクトリを先に、次にファイル
     entries_.reserve(entries_.size() + dirs.size() + files.size());
-    std::ranges::move(dirs, std::back_inserter(entries_));
-    std::ranges::move(files, std::back_inserter(entries_));
+    for (auto& s : dirs) entries_.emplace_back(std::move(s.entry));
+    for (auto& s : files) entries_.emplace_back(std::move(s.entry));
 }
 
 int FileExplorer::HitTest(float local_y, float item_height) const noexcept

--- a/src/io/file_explorer.cpp
+++ b/src/io/file_explorer.cpp
@@ -96,8 +96,12 @@ void FileExplorer::Refresh()
 
     // 追加: ディレクトリを先に、次にファイル
     entries_.reserve(entries_.size() + dirs.size() + files.size());
-    for (auto& s : dirs) entries_.emplace_back(std::move(s.entry));
-    for (auto& s : files) entries_.emplace_back(std::move(s.entry));
+    for (auto& s : dirs) {
+        entries_.emplace_back(std::move(s.entry));
+    }
+    for (auto& s : files) {
+        entries_.emplace_back(std::move(s.entry));
+    }
 }
 
 int FileExplorer::HitTest(float local_y, float item_height) const noexcept

--- a/src/io/file_watcher.h
+++ b/src/io/file_watcher.h
@@ -40,7 +40,7 @@ private:
     UniqueHandle dir_handle_;
     UniqueEventHandle event_;          // overlapped_.hEvent のオーナー（StartWatching で同期）
     OVERLAPPED overlapped_{};
-    alignas(DWORD) char change_buf_[4096]{};
+    alignas(DWORD) char change_buf_[32768]{};
     bool read_pending_ = false;
     bool paused_ = false;
     bool pending_change_ = false;

--- a/src/io/image_loader.cpp
+++ b/src/io/image_loader.cpp
@@ -150,13 +150,6 @@ bool ImageLoader::GetCachedImage(const std::wstring& abs_path, DiagramEntry& out
 
 void ImageLoader::RequestLoadAsync(const std::wstring& abs_path, Callback on_complete)
 {
-    if (cache_.Contains(abs_path)) {
-        if (on_complete) {
-            on_complete();
-        }
-        return;
-    }
-
     {
         const std::lock_guard lock(pending_mutex_);
         if (!pending_paths_.insert(abs_path).second) {

--- a/src/io/image_loader.cpp
+++ b/src/io/image_loader.cpp
@@ -150,6 +150,13 @@ bool ImageLoader::GetCachedImage(const std::wstring& abs_path, DiagramEntry& out
 
 void ImageLoader::RequestLoadAsync(const std::wstring& abs_path, Callback on_complete)
 {
+    if (cache_.Contains(abs_path)) {
+        if (on_complete) {
+            on_complete();
+        }
+        return;
+    }
+
     {
         const std::lock_guard lock(pending_mutex_);
         if (!pending_paths_.insert(abs_path).second) {

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -289,6 +289,26 @@ void DWriteTextMeasurer::FinalizeTableLayout(Node& node, NodeLayoutEntry& entry,
         node.SetText(BuildLinearizedTableText(node.table_rows()));
     }
 
+    // ヒットテスト高速化: 行Y累積と列X累積を事前計算
+    tl.row_cum_y.resize(row_count + 1);
+    {
+        float ry = 0.0f;
+        for (size_t r = 0; r < row_count; r++) {
+            tl.row_cum_y[r] = ry;
+            ry += tl.row_heights[r] + border_width;
+        }
+        tl.row_cum_y[row_count] = ry;
+    }
+    tl.col_cum_x.resize(col_count + 1);
+    {
+        float cx = border_width;
+        for (size_t c = 0; c < col_count; c++) {
+            tl.col_cum_x[c] = cx;
+            cx += tl.col_widths[c] + cell_padding * 2.0f + border_width;
+        }
+        tl.col_cum_x[col_count] = cx;
+    }
+
     // 行ごとのフラットテキストオフセットをプリコンピュート（ヒットテスト高速化用）
     tl.row_flat_offsets.resize(row_count);
     uint32_t flat_offset = 0;

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -22,6 +22,11 @@ struct TableLayoutData {
     std::pmr::vector<float> natural_col_widths; // リサイズ高速パス用キャッシュ
     std::pmr::vector<uint32_t> row_flat_offsets; // 各行の線形化テキスト先頭オフセット（ヒットテスト高速化用）
     std::pmr::vector<uint8_t> row_bgs_computed; // 各行のインラインコード背景計算済みフラグ
+    // ヒットテスト高速化用の累積オフセット。
+    // row_cum_y[r] = エントリ上端からの行 r の上端までの累積高さ。サイズは row_count+1。
+    // col_cum_x[c] = base_x からの列 c の左端までの累積幅。サイズは col_count+1。
+    std::pmr::vector<float> row_cum_y;
+    std::pmr::vector<float> col_cum_x;
 
     // フラットインデックスへの変換
     constexpr size_t CellIndex(size_t row, size_t col) const noexcept { return row * col_count + col; }
@@ -156,6 +161,13 @@ public:
     void InvalidateAllWithDiagrams(const std::pmr::vector<Node>& nodes) noexcept
     {
         InvalidateAllLayouts(); // effects_generation_ は InvalidateAllLayouts 内で更新済み
+        InvalidateMermaidBitmaps(nodes);
+    }
+
+    // Mermaid ノードのビットマップのみを無効化する。
+    // ダークモード切替時に text_layout とエフェクトを保持したまま図だけ再描画したい場合に使う。
+    void InvalidateMermaidBitmaps(const std::pmr::vector<Node>& nodes) noexcept
+    {
         const auto count = std::min(nodes.size(), diagrams_.size());
         for (size_t i = 0; i < count; ++i) {
             if (nodes[i].code_language == SyntaxLanguage::Mermaid) {

--- a/src/nav/nav_history.cpp
+++ b/src/nav/nav_history.cpp
@@ -6,8 +6,8 @@ uint32_t NavHistory::InternPath(std::wstring_view path)
         return it->second;
     }
     const auto idx = static_cast<uint32_t>(path_pool_.size());
-    path_pool_.emplace_back(path);
-    path_index_.emplace(path_pool_.back(), idx);
+    auto& stored = path_pool_.emplace_back(path);
+    path_index_.emplace(std::wstring_view{ stored.data(), stored.size() }, idx);
     return idx;
 }
 

--- a/src/nav/nav_history.cpp
+++ b/src/nav/nav_history.cpp
@@ -2,11 +2,13 @@
 
 uint32_t NavHistory::InternPath(std::wstring_view path)
 {
-    if (const auto iter = std::ranges::find(path_pool_, path); iter != path_pool_.end()) {
-        return static_cast<uint32_t>(std::ranges::distance(path_pool_.begin(), iter));
+    if (const auto it = path_index_.find(path); it != path_index_.end()) {
+        return it->second;
     }
+    const auto idx = static_cast<uint32_t>(path_pool_.size());
     path_pool_.emplace_back(path);
-    return static_cast<uint32_t>(path_pool_.size() - 1);
+    path_index_.emplace(path_pool_.back(), idx);
+    return idx;
 }
 
 NavEntry NavHistory::ToExternal(const InternalEntry& e) const
@@ -57,4 +59,5 @@ void NavHistory::Clear() noexcept
     back_stack_.clear();
     forward_stack_.clear();
     path_pool_.clear();
+    path_index_.clear();
 }

--- a/src/nav/nav_history.h
+++ b/src/nav/nav_history.h
@@ -61,11 +61,12 @@ private:
     struct WStringHash {
         using is_transparent = void;
         size_t operator()(std::wstring_view sv) const noexcept { return std::hash<std::wstring_view>{}(sv); }
-        size_t operator()(const std::pmr::wstring& s) const noexcept { return std::hash<std::wstring_view>{}(std::wstring_view{ s.data(), s.size() }); }
     };
 
-    std::pmr::vector<std::pmr::wstring> path_pool_;
-    std::pmr::unordered_map<std::pmr::wstring, uint32_t, WStringHash, std::equal_to<>> path_index_;
+    // path_pool_ は deque にして emplace_back での参照安定性を保証し、
+    // path_index_ のキー (std::wstring_view) が pool 内の文字列を指し続けるようにする。
+    std::pmr::deque<std::pmr::wstring> path_pool_;
+    std::pmr::unordered_map<std::wstring_view, uint32_t, WStringHash, std::equal_to<>> path_index_;
     std::pmr::deque<InternalEntry> back_stack_;
     std::pmr::deque<InternalEntry> forward_stack_;
 };

--- a/src/nav/nav_history.h
+++ b/src/nav/nav_history.h
@@ -3,6 +3,7 @@
 #include <string_view>
 #include <deque>
 #include <memory_resource>
+#include <unordered_map>
 
 // 単一のナビゲーション履歴エントリ: ファイルパス + スクロール位置。
 struct NavEntry {
@@ -57,7 +58,14 @@ private:
     InternalEntry ToInternal(const NavEntry& e) { return { InternPath(e.file_path), e.scroll_y }; }
     NavEntry ToExternal(const InternalEntry& e) const;
 
+    struct WStringHash {
+        using is_transparent = void;
+        size_t operator()(std::wstring_view sv) const noexcept { return std::hash<std::wstring_view>{}(sv); }
+        size_t operator()(const std::pmr::wstring& s) const noexcept { return std::hash<std::wstring_view>{}(std::wstring_view{ s.data(), s.size() }); }
+    };
+
     std::pmr::vector<std::pmr::wstring> path_pool_;
+    std::pmr::unordered_map<std::pmr::wstring, uint32_t, WStringHash, std::equal_to<>> path_index_;
     std::pmr::deque<InternalEntry> back_stack_;
     std::pmr::deque<InternalEntry> forward_stack_;
 };

--- a/src/render/command_gen_table.cpp
+++ b/src/render/command_gen_table.cpp
@@ -113,33 +113,39 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
             D2D1::Point2F(offset_x, y), D2D1::Point2F(offset_x + table_width, y),
             theme_->hr_color, border });
 
-        // セルを描画
+        // セルを描画（可視列のみコマンド生成、画面外は flat_offset のみ進める）
+        const float cull_left = offset_x + frame_viewport_left_;
+        const float cull_right = offset_x + frame_viewport_right_;
         float cx = offset_x + border;
         const size_t drawn_cols = std::min(row.cells.size(), tl.col_widths.size());
         for (size_t c = 0; c < drawn_cols; c++) {
             const auto& cell = row.cells[c];
             const float cw = tl.col_widths[c];
+            const float col_right = cx + cw + cell_padding * 2.0f;
+            const bool col_visible = (col_right >= cull_left) && (cx - border <= cull_right);
 
-            // 垂直の罫線
-            cmds.emplace_back(DrawLineCmd{
-                D2D1::Point2F(cx - border, y), D2D1::Point2F(cx - border, y + row_h + border),
-                theme_->hr_color, border });
+            if (col_visible) {
+                // 垂直の罫線
+                cmds.emplace_back(DrawLineCmd{
+                    D2D1::Point2F(cx - border, y), D2D1::Point2F(cx - border, y + row_h + border),
+                    theme_->hr_color, border });
 
-            const float text_x = cx + cell_padding;
-            const float text_y = y + cell_padding;
+                const float text_x = cx + cell_padding;
+                const float text_y = y + cell_padding;
 
-            IDWriteTextLayout* cell_layout = tl.GetCellLayout(r, c);
+                IDWriteTextLayout* cell_layout = tl.GetCellLayout(r, c);
 
-            // セルのインラインコード背景
-            if (const size_t ci = tl.CellIndex(r, c); ci < tl.cell_inline_code_bgs.size()) {
-                GenInlineCodeBgs(cmds, tl.cell_inline_code_bgs[ci], text_x, text_y, theme_->code_bg_color);
+                // セルのインラインコード背景
+                if (const size_t ci = tl.CellIndex(r, c); ci < tl.cell_inline_code_bgs.size()) {
+                    GenInlineCodeBgs(cmds, tl.cell_inline_code_bgs[ci], text_x, text_y, theme_->code_bg_color);
+                }
+
+                // 検索マッチのハイライト（テーブルセル）
+                GenSearchHighlights(cmds, cell_layout, node_index, text_x, text_y,
+                    static_cast<int>(r), static_cast<int>(c));
+
+                GenTableCellContent(cmds, cell, cell_layout, text_x, text_y, has_selection, sel_start, sel_end, flat_offset);
             }
-
-            // 検索マッチのハイライト（テーブルセル）
-            GenSearchHighlights(cmds, cell_layout, node_index, text_x, text_y,
-                static_cast<int>(r), static_cast<int>(c));
-
-            GenTableCellContent(cmds, cell, cell_layout, text_x, text_y, has_selection, sel_start, sel_end, flat_offset);
 
             flat_offset += static_cast<uint32_t>(cell.text.size());
             if (c + 1 < row.cells.size()) {

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -49,6 +49,9 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     frame_offset_x_ = theme_->margin_left;
     frame_viewport_top_ = scroll_y;
     frame_viewport_bottom_ = scroll_y + md_pane_rect.height;
+    // 水平カリング範囲: ペイン内ローカル座標で margin_left を起点とした相対値
+    frame_viewport_left_ = -theme_->margin_left;
+    frame_viewport_right_ = md_pane_rect.width - theme_->margin_left;
     frame_content_width_ = theme_->ContentWidth(md_pane_rect.width);
     frame_selection_ = &selection;
     frame_hovered_copy_node_ = hovered_copy_node;

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -152,6 +152,8 @@ private:
     float frame_offset_x_ = 0.0f;
     float frame_viewport_top_ = 0.0f;
     float frame_viewport_bottom_ = 0.0f;
+    float frame_viewport_left_ = 0.0f;   // offset_x 相対の左端（= 0）
+    float frame_viewport_right_ = 0.0f;  // offset_x 相対の右端
     float frame_content_width_ = 0.0f;
     const TextSelection* frame_selection_ = nullptr;
     int frame_hovered_copy_node_ = -1;

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -152,8 +152,11 @@ private:
     float frame_offset_x_ = 0.0f;
     float frame_viewport_top_ = 0.0f;
     float frame_viewport_bottom_ = 0.0f;
-    float frame_viewport_left_ = 0.0f;   // offset_x 相対の左端（= 0）
-    float frame_viewport_right_ = 0.0f;  // offset_x 相対の右端
+    // フレーム座標系でのビューポート左右端。各セル x を frame_offset_x_ と
+    // 合成したあとカリング判定に使う。GenerateMdPane で
+    // -theme_->margin_left / md_pane_rect.width - theme_->margin_left を設定。
+    float frame_viewport_left_ = 0.0f;
+    float frame_viewport_right_ = 0.0f;
     float frame_content_width_ = 0.0f;
     const TextSelection* frame_selection_ = nullptr;
     int frame_hovered_copy_node_ = -1;

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -81,10 +81,6 @@ void Renderer::RecreateBrushes()
         return;
     }
 
-    for (auto& b : brushes_) {
-        b.Reset();
-    }
-
     const bool is_dark = theme_.IsDark();
 
     const float stripe_alpha = is_dark ? TABLE_STRIPE_ALPHA_DARK : TABLE_STRIPE_ALPHA_LIGHT;
@@ -137,8 +133,23 @@ void Renderer::RecreateBrushes()
         {BrushId::SearchNoMatchBg,  theme_.search_no_match_bg_color},
     };
 
+    // 既存ブラシには SetColor のみ、未生成のものだけ CreateSolidColorBrush。
+    // テーマ切替時の 40+ 個の COM オブジェクト再生成を回避する。
     for (const auto& s : specs) {
-        render_target_->CreateSolidColorBrush(s.color, &brushes_[static_cast<size_t>(s.id)]);
+        auto& brush = brushes_[static_cast<size_t>(s.id)];
+        if (brush) {
+            brush->SetColor(s.color);
+        }
+        else {
+            render_target_->CreateSolidColorBrush(s.color, &brush);
+        }
+    }
+}
+
+void Renderer::InvalidateBrushes() noexcept
+{
+    for (auto& b : brushes_) {
+        b.Reset();
     }
 }
 
@@ -265,6 +276,11 @@ void Renderer::RecreatePaneFormats()
     gesture_forward_layout_.Reset();
     cached_toast_layout_.Reset();
     cached_toast_text_.clear();
+    cached_search_layout_.Reset();
+    cached_search_text_.clear();
+    cached_search_width_ = -1.0f;
+    cached_search_height_ = -1.0f;
+    cached_search_has_underline_ = false;
     if (fmt_.nav_button) {
         auto* dw = backend_.GetDWriteFactory();
         if (dw) {
@@ -642,6 +658,8 @@ bool Renderer::RecreateRenderTarget()
         return false;
     }
 
+    // 旧レンダーターゲットに紐付いたブラシは全て無効化し、RecreateBrushes で再生成する
+    InvalidateBrushes();
     RecreateBrushes();
     LoadAppIconBitmap();
     file_pane_cache_.Reset();

--- a/src/render/renderer.h
+++ b/src/render/renderer.h
@@ -111,6 +111,7 @@ private:
     void ApplyTableEffects(Node& node, NodeLayoutEntry& entry, float viewport_top, float viewport_bottom);
     void ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float viewport_top = -1.0f, float viewport_bottom = -1.0f);
     void RecreateBrushes();
+    void InvalidateBrushes() noexcept;
     void RecreatePaneFormats();
     Microsoft::WRL::ComPtr<IDWriteTextFormat> CreatePaneFormat(const wchar_t* family, DWRITE_FONT_WEIGHT weight, float size, const wchar_t* locale);
     bool CheckEndDraw();
@@ -145,6 +146,15 @@ private:
     Microsoft::WRL::ComPtr<IDWriteTextLayout> gesture_forward_layout_;  // "→ 進む" のキャッシュ済みレイアウト
     Microsoft::WRL::ComPtr<IDWriteTextLayout> cached_toast_layout_;
     std::pmr::wstring cached_toast_text_;
+
+    // 検索バーの入力テキストレイアウトキャッシュ。display_text/width/height が
+    // 一致すれば使い回す。キャレット点滅や同一入力継続中の毎フレーム
+    // CreateTextLayout を抑止する。
+    mutable Microsoft::WRL::ComPtr<IDWriteTextLayout> cached_search_layout_;
+    mutable std::pmr::wstring cached_search_text_;
+    mutable float cached_search_width_ = -1.0f;
+    mutable float cached_search_height_ = -1.0f;
+    mutable bool cached_search_has_underline_ = false;
     Microsoft::WRL::ComPtr<ID2D1Bitmap> app_icon_bitmap_;
     void LoadAppIconBitmap();
     Microsoft::WRL::ComPtr<ID2D1StrokeStyle> gesture_stroke_style_;

--- a/src/render/renderer_search.cpp
+++ b/src/render/renderer_search.cpp
@@ -102,9 +102,9 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
             && std::equal(cached_search_text_.begin(), cached_search_text_.end(), display_text.begin());
         if (cache_hit) {
             text_layout = cached_search_layout_;
-            // 前フレームで IME 合成下線を付けた場合のみクリアする
-            // （IME 非アクティブ継続時は毎フレーム SetUnderline を発行しない）
-            if (cached_search_has_underline_ && !has_comp) {
+            // 前フレームの下線範囲と異なる可能性があるため、キャッシュ上に下線が残っていれば
+            // 常に全体をクリアする。IME 非アクティブ継続時はクリアも発行されない。
+            if (cached_search_has_underline_) {
                 text_layout->SetUnderline(FALSE, DWRITE_TEXT_RANGE{ 0, static_cast<UINT32>(cached_search_text_.size()) });
                 cached_search_has_underline_ = false;
             }

--- a/src/render/renderer_search.cpp
+++ b/src/render/renderer_search.cpp
@@ -91,23 +91,49 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
     if (fmt_.search_input && !display_text.empty() && backend_.GetDWriteFactory()) {
         const float input_w = sbl.input_rect.right - SEARCH_INPUT_TEXT_PAD_RIGHT - text_left;
         const float input_h = sbl.input_rect.bottom - sbl.input_rect.top;
+
+        // 同一テキスト・同一サイズなら前回のレイアウトを使い回す。
+        // キャレット点滅で毎フレーム再描画されても CreateTextLayout を避ける。
         Microsoft::WRL::ComPtr<IDWriteTextLayout> text_layout;
-        backend_.GetDWriteFactory()->CreateTextLayout(
-            display_text.data(),
-            static_cast<UINT32>(display_text.size()),
-            fmt_.search_input.Get(),
-            input_w,
-            input_h,
-            &text_layout
-        );
+        const bool cache_hit = cached_search_layout_
+            && cached_search_width_ == input_w
+            && cached_search_height_ == input_h
+            && cached_search_text_.size() == display_text.size()
+            && std::equal(cached_search_text_.begin(), cached_search_text_.end(), display_text.begin());
+        if (cache_hit) {
+            text_layout = cached_search_layout_;
+            // 前フレームで IME 合成下線を付けた場合のみクリアする
+            // （IME 非アクティブ継続時は毎フレーム SetUnderline を発行しない）
+            if (cached_search_has_underline_ && !has_comp) {
+                text_layout->SetUnderline(FALSE, DWRITE_TEXT_RANGE{ 0, static_cast<UINT32>(cached_search_text_.size()) });
+                cached_search_has_underline_ = false;
+            }
+        }
+        else {
+            backend_.GetDWriteFactory()->CreateTextLayout(
+                display_text.data(),
+                static_cast<UINT32>(display_text.size()),
+                fmt_.search_input.Get(),
+                input_w,
+                input_h,
+                &text_layout
+            );
+            if (text_layout) {
+                cached_search_layout_ = text_layout;
+                cached_search_text_.assign(display_text);
+                cached_search_width_ = input_w;
+                cached_search_height_ = input_h;
+                cached_search_has_underline_ = false;
+            }
+        }
         if (text_layout) {
-            // コンポジション文字列に下線を付与
             if (has_comp) {
                 const DWRITE_TEXT_RANGE range = {
                     static_cast<UINT32>(comp_start),
                     static_cast<UINT32>(comp_len)
                 };
                 text_layout->SetUnderline(TRUE, range);
+                cached_search_has_underline_ = true;
             }
 
             // 選択範囲のハイライト描画（テキストの背面に描画）
@@ -241,14 +267,25 @@ int Renderer::HitTestSearchInput(std::wstring_view query, float local_x, float m
         return 0;
     }
     Microsoft::WRL::ComPtr<IDWriteTextLayout> layout;
-    backend_.GetDWriteFactory()->CreateTextLayout(
-        query.data(),
-        static_cast<UINT32>(query.size()),
-        fmt_.search_input.Get(),
-        max_width,
-        SEARCH_INPUT_HEIGHT,
-        &layout
-    );
+    // DrawSearchBar が直前に作成した cached_search_layout_ を再利用できるケース
+    // （IME コンポジションが無く、query と表示テキストが一致）を高速パスに。
+    const bool cache_hit = cached_search_layout_
+        && cached_search_width_ == max_width
+        && cached_search_text_.size() == query.size()
+        && std::equal(cached_search_text_.begin(), cached_search_text_.end(), query.begin());
+    if (cache_hit) {
+        layout = cached_search_layout_;
+    }
+    else {
+        backend_.GetDWriteFactory()->CreateTextLayout(
+            query.data(),
+            static_cast<UINT32>(query.size()),
+            fmt_.search_input.Get(),
+            max_width,
+            SEARCH_INPUT_HEIGHT,
+            &layout
+        );
+    }
     if (!layout) {
         return 0;
     }

--- a/src/ui/hover_throttle.h
+++ b/src/ui/hover_throttle.h
@@ -9,11 +9,26 @@ struct HoverThrottle {
     bool last_md_cursor_hand = false;
     POINT last_copy_hit_pos = { LONG_MIN, LONG_MIN };
     POINT last_save_hit_pos = { LONG_MIN, LONG_MIN };
+    POINT last_hover_dispatch_pos = { LONG_MIN, LONG_MIN };
 
     void Reset() noexcept
     {
         last_md_hit_pos = { LONG_MIN, LONG_MIN };
         last_copy_hit_pos = { LONG_MIN, LONG_MIN };
         last_save_hit_pos = { LONG_MIN, LONG_MIN };
+        last_hover_dispatch_pos = { LONG_MIN, LONG_MIN };
+    }
+
+    // OS の MOUSEMOVE が同一座標で繰り返し届くことがあるため、
+    // 完全同一座標の連続ディスパッチを抑止する。
+    // 最低限の前段フィルタであり、通常のスロットリングは
+    // last_md_hit_pos 等の距離比較で行う。
+    bool ShouldSkipSameDispatch(int px, int py) noexcept
+    {
+        if (last_hover_dispatch_pos.x == px && last_hover_dispatch_pos.y == py) {
+            return true;
+        }
+        last_hover_dispatch_pos = { px, py };
+        return false;
     }
 };


### PR DESCRIPTION
## Summary

アプリ全体のパフォーマンスレビューで特定した 13 項目を実装。レンダリング・入力処理・パース・キャッシュ・I/O の各ホットパスを最適化。

## 主な変更

### 🔴 高影響
- **検索バーのレイアウトキャッシュ化** (`renderer_search.cpp`) — display_text / width / height をキーに `IDWriteTextLayout` を再利用。キャレット点滅による毎フレーム `CreateTextLayout` を解消。`HitTestSearchInput` でも同キャッシュを共有。
- **HoverThrottle 距離しきい値** (`hover_throttle.h`, `app_mouse_hover.cpp`) — `ShouldSkipSameDispatch` で OS から重複発火される同一座標 `WM_MOUSEMOVE` を前段で弾く。
- **parser.cpp の link_urls 重複検出** — 末尾逆走査を直近 8 件に制限。異種 URL 混在時の O(n²) 退化を回避。
- **テーマ切替のブラシ差分更新** (`renderer.cpp`) — `CreateSolidColorBrush` は未生成時のみ、既存ブラシは `SetColor`。`SetDrawingEffect` で attach 済みのブラシも自動的に新色を反映。

### 🟡 中影響
- **テーブルヒットテスト二分探索化** (`hit_test_service.cpp`, `dwrite_measurer.cpp`, `layout_cache.h`) — `row_cum_y` / `col_cum_x` をレイアウト時に事前計算し `upper_bound` で O(log n)。
- **テーブル列方向カリング** (`command_gen_table.cpp`, `command_generator.cpp/.h`) — `frame_viewport_left_/right_` を導入して画面外列のコマンド生成をスキップ。
- **ImageLoader 非同期リクエストの早期 return** — `RequestLoadAsync` 冒頭で `cache_.Contains` を確認。
- **FileWatcher バッファ拡大** — `ReadDirectoryChangesW` の change_buf を 4KB → 32KB。
- **string_convert 参照版への統一** (`parser.cpp`) — `link_urls` / `pending_image_src` を `Utf8ToWide(sv, out)` 参照版に切り替え。

### 🟢 低影響
- **NavHistory::InternPath の O(1) 化** — 線形 `find` → `pmr::unordered_map` + transparent lookup。
- **FileExplorer ソート最適化** — Schwartzian transform + `ToLowerAscii` 済みキーで比較コスト削減。
- **LayoutCache::InvalidateMermaidBitmaps** — 将来の部分的無効化に備えて Mermaid ビットマップ無効化を分離。

## Test plan

- [x] `cmake --build build --config Release` でビルド成功
- [x] `build/tests/Release/mendo_tests.exe` で 1617 tests すべて PASS
- [x] 手動で検索バー（キャレット点滅・IME 合成）、大きなテーブル、ダークモード切替、画像多数のドキュメント、広いリポジトリのファイル一覧、ナビゲーション履歴の挙動を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)