### PR TITLE
コードブロック背景の左端を通常コンテンツと揃える

### DIFF
--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -1,4 +1,5 @@
 #include "hit_test_service.h"
+#include "layout.h"
 #include "ui_constants.h"
 #include <cassert>
 #include <ranges>
@@ -183,7 +184,7 @@ HitTestService::HitResult HitTestService::HitTest(
 
         if (entry.text_layout) {
             const float indent = NodeIndent(node, ctx.theme);
-            const float local_x = dip_x - ctx.theme.margin_left - indent;
+            const float local_x = dip_x - ctx.theme.margin_left - indent - NodeTextXOffset(node, ctx.theme);
             const float local_y = dip_y - entry.y_position;
 
             BOOL is_trailing = FALSE;

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -6,6 +6,14 @@
 #include <dwrite.h>
 #include <memory_resource>
 
+// コードブロック本文の左端を背景内側にオフセットする量（段落は 0）。
+// 描画側（command_generator）と入力側（hit_test_service）で座標空間がずれないよう
+// 単一のソースに集約する。
+[[nodiscard]] inline float NodeTextXOffset(const Node& node, const Theme& theme) noexcept
+{
+    return (node.type == NodeType::CodeBlock) ? theme.code_block_padding : 0.0f;
+}
+
 // テーブルの自然幅（実測値）と利用可能な幅から列幅を計算する。
 // 最終的な列幅のベクターを返す。
 [[nodiscard]] std::pmr::vector<float> ComputeColumnWidths(const std::pmr::vector<float>& natural_widths,

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -1,5 +1,6 @@
 #include "command_generator.h"
 #include "i18n.h"
+#include "layout.h"
 #include "ui_constants.h"
 #include <algorithm>
 #include <format>
@@ -97,6 +98,7 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
     const float indent = node.indent_level * theme_->indent_width;
     const float x = frame_offset_x_ + indent;
     const float cw = frame_content_width_ - indent;
+    const float text_x = x + NodeTextXOffset(node, *theme_);
 
     switch (node.type) {
     case NodeType::HorizontalRule:
@@ -178,10 +180,10 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
     }
 
     // インラインコードの背景
-    GenInlineCodeBgs(cmds, entry.inline_code_bgs, x, entry.y_position, theme_->code_bg_color);
+    GenInlineCodeBgs(cmds, entry.inline_code_bgs, text_x, entry.y_position, theme_->code_bg_color);
 
     // 検索マッチのハイライト（選択より先に描画し、選択が最前面になるようにする）
-    GenSearchHighlights(cmds, entry.text_layout.Get(), node_index, x, entry.y_position);
+    GenSearchHighlights(cmds, entry.text_layout.Get(), node_index, text_x, entry.y_position);
 
     // 選択範囲のハイライト
     const auto& selection = *frame_selection_;
@@ -196,12 +198,12 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
         }
         if (sel_end > sel_start) {
             GenSelectionHighlight(cmds, entry.text_layout.Get(),
-                sel_start, sel_end - sel_start, x, entry.y_position);
+                sel_start, sel_end - sel_start, text_x, entry.y_position);
         }
     }
 
     // メインテキスト
-    cmds.emplace_back(DrawTextLayoutCmd{ D2D1::Point2F(x, entry.y_position), entry.text_layout.Get(), base_color });
+    cmds.emplace_back(DrawTextLayoutCmd{ D2D1::Point2F(text_x, entry.y_position), entry.text_layout.Get(), base_color });
 
     // タスクリストのチェックボックス
     if (node.type == NodeType::TaskListItem && formats_.icon_font) {
@@ -233,7 +235,7 @@ void CommandGenerator::GenCodeBlockBg(DrawCommandList& cmds,
 {
     const float pad = theme_->code_block_padding;
     const D2D1_RECT_F bg_rect = D2D1::RectF(
-        x - pad,
+        x,
         entry.y_position - pad,
         x + w,
         entry.y_position + entry.height + pad


### PR DESCRIPTION
## Summary

- コードブロック背景の左端が段落等の通常コンテンツよりも左側に突き出していた問題を修正
- 背景矩形の左端を `x`（通常コンテンツ左端）に揃え、コード本文を `code_block_padding` 分だけ右にオフセットして内側パディングを確保
- 描画側（`command_generator.cpp`）とヒットテスト側（`hit_test_service.cpp`）の両方で同じオフセット計算が必要なため、`NodeTextXOffset(node, theme)` を `layout.h` に共通ヘルパーとして追加

## Test plan

- [x] 既存テスト 1617 件すべて通過（`mendo_tests.exe --gtest_brief=1`）
- [x] コードブロックを含む Markdown を表示し、背景左端が段落と揃っていることを目視確認
- [x] コードブロック内のテキスト選択・検索ハイライトが文字位置と整合していることを確認
- [ ] コードブロック内クリック時のヒットテスト（キャレット位置）が正しい文字にヒットすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)