### PR TITLE
std::ranges / std::views によるアルゴリズムのモダン化

### DIFF
--- a/src/core/document_utils.cpp
+++ b/src/core/document_utils.cpp
@@ -46,34 +46,34 @@ std::pmr::wstring ExtractSelectedText(const std::pmr::vector<Node>& nodes, const
 
 static std::optional<std::pmr::wstring> FindLinkInRuns(const std::pmr::vector<TextRun>& runs, const std::pmr::vector<std::pmr::wstring>& link_urls, uint32_t pos)
 {
-    for (const auto& run : runs) {
-        if (run.has_link() && (pos >= run.start) && (pos < run.start + run.length)) {
-            return link_urls[static_cast<size_t>(run.link_url_index)];
-        }
+    const auto it = std::ranges::find_if(runs, [pos](const TextRun& run) noexcept {
+        return run.has_link() && (pos >= run.start) && (pos < run.start + run.length);
+    });
+    if (it == runs.end()) {
+        return std::nullopt;
     }
-    return std::nullopt;
+    return link_urls[static_cast<size_t>(it->link_url_index)];
 }
 
 static const std::pmr::vector<TextRun>* FindTableCellRuns(const Node& node, uint32_t text_pos, uint32_t& local_pos)
 {
     uint32_t offset = 0;
     const auto& rows = node.table_rows();
-    const auto row_count = rows.size();
-    for (size_t r = 0; r < row_count; r++) {
-        const auto& row = rows[r];
-        const auto col_count = row.cells.size();
-        for (size_t c = 0; c < col_count; c++) {
-            const uint32_t cell_len = static_cast<uint32_t>(row.cells[c].text.size());
+    const auto last_row = static_cast<ptrdiff_t>(rows.size()) - 1;
+    for (const auto& [r, row] : rows | std::views::enumerate) {
+        const auto last_col = static_cast<ptrdiff_t>(row.cells.size()) - 1;
+        for (const auto& [c, cell] : row.cells | std::views::enumerate) {
+            const uint32_t cell_len = static_cast<uint32_t>(cell.text.size());
             if (text_pos >= offset && text_pos < offset + cell_len) {
                 local_pos = text_pos - offset;
-                return &row.cells[c].runs;
+                return &cell.runs;
             }
             offset += cell_len;
-            if (c + 1 < col_count) {
+            if (c < last_col) {
                 offset++; // タブ区切り
             }
         }
-        if (r + 1 < row_count) {
+        if (r < last_row) {
             offset++; // 改行区切り
         }
     }

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -56,14 +56,14 @@ std::pmr::vector<float> ComputeColumnWidths(const std::pmr::vector<float>& natur
     );
 
     if (total_natural > 0 && total_natural > available_width) {
-        for (size_t c = 0; c < col_count; c++) {
-            widths[c] = std::max(MIN_COLUMN_WIDTH, available_width * natural_widths[c] / total_natural);
+        for (auto [w, nw] : std::views::zip(widths, natural_widths) | std::views::take(col_count)) {
+            w = std::max(MIN_COLUMN_WIDTH, available_width * nw / total_natural);
         }
     }
     else {
         const float even = available_width / static_cast<float>(col_count);
-        for (size_t c = 0; c < col_count; c++) {
-            widths[c] = std::max(natural_widths[c] + COLUMN_WIDTH_PADDING, even);
+        for (auto [w, nw] : std::views::zip(widths, natural_widths) | std::views::take(col_count)) {
+            w = std::max(nw + COLUMN_WIDTH_PADDING, even);
         }
     }
     return widths;
@@ -75,16 +75,15 @@ std::pmr::wstring BuildLinearizedTableText(const std::pmr::vector<TableRow>& row
     // 概算でreserveし、1パスで構築する（二重走査を回避）
     std::pmr::wstring text;
     text.reserve(row_count * 64); // 行あたり平均64文字の概算
-    for (size_t r = 0; r < row_count; r++) {
-        const auto& row = rows[r];
-        const auto col_count = row.cells.size();
-        for (size_t c = 0; c < col_count; c++) {
+    const auto last_row = static_cast<ptrdiff_t>(row_count) - 1;
+    for (const auto& [r, row] : rows | std::views::enumerate) {
+        for (const auto& [c, cell] : row.cells | std::views::enumerate) {
             if (c > 0) {
                 text += L'\t';
             }
-            text += row.cells[c].text;
+            text += cell.text;
         }
-        if (r + 1 < row_count) {
+        if (r < last_row) {
             text += L'\n';
         }
     }

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -7,6 +7,7 @@
 #include <dwrite.h>
 #include <algorithm>
 #include <cassert>
+#include <ranges>
 
 
 // インラインコードの背景矩形（レイアウト原点からの相対座標、パディング適用済み）
@@ -169,9 +170,9 @@ public:
     void InvalidateMermaidBitmaps(const std::pmr::vector<Node>& nodes) noexcept
     {
         const auto count = std::min(nodes.size(), diagrams_.size());
-        for (size_t i = 0; i < count; ++i) {
-            if (nodes[i].code_language == SyntaxLanguage::Mermaid) {
-                diagrams_[i].bitmap.Reset();
+        for (const auto& [idx, node] : nodes | std::views::take(count) | std::views::enumerate) {
+            if (node.code_language == SyntaxLanguage::Mermaid) {
+                diagrams_[static_cast<size_t>(idx)].bitmap.Reset();
             }
         }
     }

--- a/src/mermaid/mermaid_util.cpp
+++ b/src/mermaid/mermaid_util.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <format>
 #include <iterator>
+#include <ranges>
 
 std::pmr::wstring mermaid_util::JsEscape(std::wstring_view input)
 {
@@ -35,22 +36,16 @@ std::pmr::wstring mermaid_util::JsEscape(std::wstring_view input)
 
 uint64_t mermaid_util::HashRaw(std::wstring_view input) noexcept
 {
-    uint64_t hash = 14695981039346656037ULL;
-    for (wchar_t c : input) {
-        hash ^= static_cast<uint64_t>(c);
-        hash *= 1099511628211ULL;
-    }
-    return hash;
+    return std::ranges::fold_left(input, 14695981039346656037ULL, [](uint64_t h, wchar_t c) static noexcept {
+        return (h ^ static_cast<uint64_t>(c)) * 1099511628211ULL;
+    });
 }
 
 uint64_t mermaid_util::HashRaw(std::string_view input) noexcept
 {
-    uint64_t hash = 14695981039346656037ULL;
-    for (char c : input) {
-        hash ^= static_cast<uint64_t>(static_cast<unsigned char>(c));
-        hash *= 1099511628211ULL;
-    }
-    return hash;
+    return std::ranges::fold_left(input, 14695981039346656037ULL, [](uint64_t h, char c) static noexcept {
+        return (h ^ static_cast<uint64_t>(static_cast<unsigned char>(c))) * 1099511628211ULL;
+    });
 }
 
 std::pmr::wstring mermaid_util::SimpleHash(std::wstring_view input)

--- a/src/nav/nav_history.h
+++ b/src/nav/nav_history.h
@@ -3,7 +3,7 @@
 #include <string_view>
 #include <deque>
 #include <memory_resource>
-#include <unordered_map>
+#include <map>
 
 // 単一のナビゲーション履歴エントリ: ファイルパス + スクロール位置。
 struct NavEntry {
@@ -58,15 +58,12 @@ private:
     InternalEntry ToInternal(const NavEntry& e) { return { InternPath(e.file_path), e.scroll_y }; }
     NavEntry ToExternal(const InternalEntry& e) const;
 
-    struct WStringHash {
-        using is_transparent = void;
-        size_t operator()(std::wstring_view sv) const noexcept { return std::hash<std::wstring_view>{}(sv); }
-    };
-
     // path_pool_ は deque にして emplace_back での参照安定性を保証し、
     // path_index_ のキー (std::wstring_view) が pool 内の文字列を指し続けるようにする。
+    // 典型的なセッションのエントリ数は数十〜数百で、文字列ハッシュの計算コストと
+    // バケット配列のキャッシュミスを避けられる std::pmr::map のほうが優位。
     std::pmr::deque<std::pmr::wstring> path_pool_;
-    std::pmr::unordered_map<std::wstring_view, uint32_t, WStringHash, std::equal_to<>> path_index_;
+    std::pmr::map<std::wstring_view, uint32_t> path_index_;
     std::pmr::deque<InternalEntry> back_stack_;
     std::pmr::deque<InternalEntry> forward_stack_;
 };

--- a/src/nav/navigation_service.cpp
+++ b/src/nav/navigation_service.cpp
@@ -1,24 +1,17 @@
 #include "navigation_service.h"
+#include <algorithm>
+#include <ranges>
 
 // ShellExecuteWに渡しても安全なURLスキームかどうかを判定する。
 // file:// やその他の危険なスキームをブロックし、http/https/mailto のみ許可する。
 static bool IsSafeUrlScheme(std::wstring_view url) noexcept
 {
-    const auto starts_with_i = [](std::wstring_view s, std::wstring_view prefix) static noexcept {
-        if (s.size() < prefix.size()) {
-            return false;
-        }
-        const auto prefix_len = prefix.size();
-        for (size_t i = 0; i < prefix_len; i++) {
-            wchar_t a = s[i], b = prefix[i];
-            if (a >= L'A' && a <= L'Z') {
-                a += L'a' - L'A';
-            }
-            if (a != b) {
-                return false;
-            }
-        }
-        return true;
+    const auto to_lower = [](wchar_t c) static noexcept {
+        return (c >= L'A' && c <= L'Z') ? static_cast<wchar_t>(c + (L'a' - L'A')) : c;
+    };
+    const auto starts_with_i = [&](std::wstring_view s, std::wstring_view prefix) noexcept {
+        return s.size() >= prefix.size()
+            && std::ranges::equal(s | std::views::take(prefix.size()), prefix, {}, to_lower, to_lower);
     };
     return starts_with_i(url, L"http://") || starts_with_i(url, L"https://") || starts_with_i(url, L"mailto:");
 }

--- a/src/render/renderer_search.cpp
+++ b/src/render/renderer_search.cpp
@@ -1,6 +1,7 @@
 #include "renderer.h"
 #include "ui_constants.h"
 #include <algorithm>
+#include <ranges>
 #include <wrl/client.h>
 
 void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_pane_rect)
@@ -98,8 +99,7 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
         const bool cache_hit = cached_search_layout_
             && cached_search_width_ == input_w
             && cached_search_height_ == input_h
-            && cached_search_text_.size() == display_text.size()
-            && std::equal(cached_search_text_.begin(), cached_search_text_.end(), display_text.begin());
+            && std::ranges::equal(cached_search_text_, display_text);
         if (cache_hit) {
             text_layout = cached_search_layout_;
             // 前フレームの下線範囲と異なる可能性があるため、キャッシュ上に下線が残っていれば
@@ -271,8 +271,7 @@ int Renderer::HitTestSearchInput(std::wstring_view query, float local_x, float m
     // （IME コンポジションが無く、query と表示テキストが一致）を高速パスに。
     const bool cache_hit = cached_search_layout_
         && cached_search_width_ == max_width
-        && cached_search_text_.size() == query.size()
-        && std::equal(cached_search_text_.begin(), cached_search_text_.end(), query.begin());
+        && std::ranges::equal(cached_search_text_, query);
     if (cache_hit) {
         layout = cached_search_layout_;
     }

--- a/src/util/lru_cache.h
+++ b/src/util/lru_cache.h
@@ -37,9 +37,10 @@ public:
     }
 
     // キーが存在するかチェック（アクセス世代は更新しない）。
+    // 有効エントリは [0, size_) の範囲に限定する（他メソッドと同じ論理サイズ）。
     bool Contains(const Key& key) const
     {
-        return std::ranges::contains(keys_, key);
+        return std::ranges::contains(keys_ | std::views::take(size_), key);
     }
 
     // エントリを挿入する。既存キーの場合は値を上書きしてアクセス世代を更新する。

--- a/src/util/lru_cache.h
+++ b/src/util/lru_cache.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <ranges>
 
 // 固定サイズの LRU (Least Recently Used) キャッシュ。
 // キーと値を連続メモリ上に保持し、CPU キャッシュの局所性を最大化する。
@@ -38,12 +39,7 @@ public:
     // キーが存在するかチェック（アクセス世代は更新しない）。
     bool Contains(const Key& key) const
     {
-        for (size_t i = 0; i < size_; i++) {
-            if (keys_[i] == key) {
-                return true;
-            }
-        }
-        return false;
+        return std::ranges::contains(keys_, key);
     }
 
     // エントリを挿入する。既存キーの場合は値を上書きしてアクセス世代を更新する。


### PR DESCRIPTION
## Summary

C++23 の `std::ranges` / `std::views` / `std::ranges::fold_left` / `std::ranges::contains` を活用し、`src/` 全体の手書きループを現代的なアルゴリズム呼び出しに書き直しました。あわせて、キーが文字列・要素数が小さい場面では連想コンテナを `std::pmr::unordered_map` → `std::pmr::map` に変更しています。

## 主な変更

- **document_utils** — `FindLinkInRuns` を `std::ranges::find_if` に、`FindTableCellRuns` のネストループを `std::views::enumerate` + `ptrdiff_t` の `last_col` / `last_row` 変数で整理
- **layout** — `ComputeColumnWidths` を `std::views::zip` + `std::views::take` に、`BuildLinearizedTableText` を `std::views::enumerate` + `last_row` に
- **layout_cache** — `InvalidateMermaidBitmaps` を `std::views::take` + `std::views::enumerate` に
- **mermaid_util** — FNV-1a ハッシュの手動ループ 2 箇所を `std::ranges::fold_left` に置換
- **navigation_service** — URL スキームの case-insensitive prefix 比較を `std::ranges::equal` + projection に（手書きの for ループを削除）
- **renderer_search** — `begin/end` ペアの `std::equal` を `std::ranges::equal` に（サイズ事前チェックも内部で行われるため削除）
- **lru_cache** — `Contains` の線形探索を `std::ranges::contains` に
- **nav_history** — `std::pmr::unordered_map<std::wstring_view, uint32_t, WStringHash, std::equal_to<>>` を `std::pmr::map<std::wstring_view, uint32_t>` に変更（要素数が小さく文字列ハッシュのコストが相対的に大きいため。不要になった `WStringHash` と `<functional>` / `<unordered_map>` も削除）

## 意図的に却下した候補

- **case-insensitive 比較ユーティリティの抽出**: 呼び出し箇所が 1 つだけで、スコープ拡大するメリットが薄いため
- **prefix sum 系の累積配列構築**（`dwrite_measurer`）: C++23 標準に `ranges::scan` 相当がなく、手書きが自然
- **テーブルセルの条件付き累積**（`hit_test_service`）: タブ/改行区切り判定を fold に載せると可読性が低下
- **`mermaid_file_cache.h` の `unordered_map<uint64_t, IndexEntry>`**: キーが uint64_t（ハッシュが恒等レベルに安価）、上限が 4096 エントリで `map` への変更は非推奨
- **`ini_parser.h` の `std::less<>`**: `config_store.cpp` で `find(std::string_view)` による heterogeneous lookup を行っているため維持

## Test plan

- [x] `cmake --build build --config Release` が警告なしで通る
- [x] `mendo_tests.exe` 1617 件全通過（92 スイート）
- [x] 実バイナリでのスモーク確認（Markdown を開き、リンククリック・検索・ナビゲーション履歴が動くこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)