### PR TITLE
テーブル内検索ヒット時に該当行までスクロール (fix #97)

### DIFF
--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -59,11 +59,12 @@ struct NodeLayoutEntry {
     bool has_table_layout() const noexcept { return table_layout != nullptr; }
 
     // table_row に対応する絶対 Y。行情報が無ければ y_position にフォールバックする。
+    // row_cum_y は row_count+1 要素（末尾は合計高さ）なので、行として有効なのは [0, row_heights.size()) のみ。
     float GetTableRowY(int table_row) const noexcept
     {
         if (table_row >= 0 && has_table_layout()) {
             const auto row = static_cast<size_t>(table_row);
-            if (row < table_layout->row_cum_y.size()) {
+            if (row < table_layout->row_heights.size() && row < table_layout->row_cum_y.size()) {
                 return y_position + table_layout->row_cum_y[row];
             }
         }

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -57,6 +57,30 @@ struct NodeLayoutEntry {
         return *table_layout;
     }
     bool has_table_layout() const noexcept { return table_layout != nullptr; }
+
+    // table_row に対応する絶対 Y。行情報が無ければ y_position にフォールバックする。
+    float GetTableRowY(int table_row) const noexcept
+    {
+        if (table_row >= 0 && has_table_layout()) {
+            const auto row = static_cast<size_t>(table_row);
+            if (row < table_layout->row_cum_y.size()) {
+                return y_position + table_layout->row_cum_y[row];
+            }
+        }
+        return y_position;
+    }
+
+    // table_row の高さ。行情報が無ければエントリ全体の高さにフォールバックする。
+    float GetTableRowHeight(int table_row) const noexcept
+    {
+        if (table_row >= 0 && has_table_layout()) {
+            const auto row = static_cast<size_t>(table_row);
+            if (row < table_layout->row_heights.size()) {
+                return table_layout->row_heights[row];
+            }
+        }
+        return height;
+    }
 };
 
 struct DiagramEntry {

--- a/src/ui/search_bar_controller.cpp
+++ b/src/ui/search_bar_controller.cpp
@@ -181,7 +181,9 @@ void SearchBarController::ScrollToCurrentMatch()
     }
 
     const auto& entry = (*cache_)[match.node_index];
-    const float match_y = entry.y_position;
+    // Why: 長いテーブルがウィンドウより縦長の場合、ブロック先頭に合わせるとヒット行が画面外になる (issue #97)
+    const float match_y = entry.GetTableRowY(match.table_row);
+    const float match_h = entry.GetTableRowHeight(match.table_row);
     const float md_pane_height = cb_.get_md_pane_height();
     const float visible_height = md_pane_height
         - (state_->IsVisible() ? SEARCH_BAR_HEIGHT : 0.0f);
@@ -189,7 +191,7 @@ void SearchBarController::ScrollToCurrentMatch()
     const float effective_bottom = scroll_y + visible_height;
 
     // マッチが可視範囲外の場合のみスクロール
-    if (match_y < scroll_y || match_y + entry.height > effective_bottom) {
+    if (match_y < scroll_y || match_y + match_h > effective_bottom) {
         const float target = std::max(0.0f, match_y - visible_height / 3.0f);
         viewport_->SetScrollY(target);
         cb_.on_scroll_changed(visible_height);

--- a/src/ui/search_state.cpp
+++ b/src/ui/search_state.cpp
@@ -120,9 +120,11 @@ void SearchState::SetCurrentMatchNear(float scroll_y, const LayoutCache& cache) 
         return;
     }
 
-    // matches_ は node_index 昇順 → cache[ni].y_position も単調増加のため二分探索を使用
+    // matches_ は node_index 昇順、同一テーブル内では (row, col) 昇順で追加されるため
+    // GetTableRowY(m.table_row) も単調非減少となり二分探索が使える (issue #97)。
     const auto it = std::ranges::partition_point(matches_, [&](const SearchMatch& m) noexcept {
-        return m.node_index >= static_cast<int>(cache.size()) || cache[m.node_index].y_position < scroll_y;
+        return m.node_index >= static_cast<int>(cache.size())
+            || cache[m.node_index].GetTableRowY(m.table_row) < scroll_y;
     });
     current_match_ = (it != matches_.end()) ? static_cast<int>(it - matches_.begin()) : 0;
 }

--- a/tests/test_search_state.cpp
+++ b/tests/test_search_state.cpp
@@ -406,6 +406,52 @@ TEST(SearchStateTest, SetCurrentMatchNearNoMatches)
     EXPECT_EQ(s.GetCurrentMatchIndex(), -1);
 }
 
+// issue #97: 縦長テーブル内で下方にスクロール中にマッチを確定する際、
+// ブロック先頭 Y ではなく該当行の Y を評価してマッチを選択する。
+TEST(SearchStateTest, SetCurrentMatchNearUsesTableRowY)
+{
+    // 3 行 1 列のテーブル。各行に "hit" が 1 件ずつ含まれる。
+    Node table;
+    table.type = NodeType::Table;
+    table.ensure_table();
+    for (int r = 0; r < 3; r++) {
+        TableRow row;
+        TableCell c;
+        c.text.assign(L"hit");
+        row.cells.push_back(std::move(c));
+        table.table_data->rows.push_back(std::move(row));
+    }
+    std::pmr::vector<Node> nodes;
+    nodes.push_back(std::move(table));
+
+    SearchState s;
+    s.SetQuery(L"hit");
+    s.ExecuteSearch(nodes);
+    ASSERT_EQ(s.GetMatchCount(), 3);
+
+    // ブロックは y=0, 各行は高さ 100 → 行Y = 0, 100, 200
+    LayoutCache cache;
+    cache.Resize(1);
+    cache[0].y_position = 0.0f;
+    cache[0].height = 300.0f;
+    auto& tl = cache[0].ensure_table_layout();
+    tl.row_heights = {100.0f, 100.0f, 100.0f};
+    tl.row_cum_y = {0.0f, 100.0f, 200.0f, 300.0f};
+
+    // scroll_y=150 → 行2(y=200) の先頭マッチを選ぶ。
+    // ブロック先頭 Y (=0) だけを見る旧実装だと 3 件目以降を探して 0 にフォールバックしていた。
+    s.SetCurrentMatchNear(150.0f, cache);
+    EXPECT_EQ(s.GetCurrentMatchIndex(), 2);
+
+    // scroll_y=50 → 行1(y=100) のマッチ。
+    s.SetCurrentMatchNear(50.0f, cache);
+    EXPECT_EQ(s.GetCurrentMatchIndex(), 1);
+
+    // テーブル全体より下にスクロールしても必ずどこかにフォールバック。
+    s.SetCurrentMatchNear(1000.0f, cache);
+    EXPECT_EQ(s.GetCurrentMatchIndex(), 0);
+}
+
 // ═══════════════════════════════════════════════
 // 再検索（クエリ変更後の再実行）
 // ═══════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- 縦長テーブル内のセルが検索にヒットした際、ブロック先頭ではなく該当行の Y までスクロールするよう修正 (issue #97)
- `NodeLayoutEntry::GetTableRowY` / `GetTableRowHeight` ヘルパーを追加し、検索スクロールとカレントマッチ推定の両方で行単位の Y を参照
- 回帰テスト `SearchStateTest.SetCurrentMatchNearUsesTableRowY` を追加

## Test plan
- [x] `cmake --build build --config Release` でビルド成功
- [x] `build/tests/Release/mendo_tests.exe --gtest_brief=1` で全 1618 テストパス
- [ ] 実アプリで縦長テーブル内の文字列を検索し、ヒット行が可視範囲に入ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)