### PR TITLE
検索ヒット移動時にmermaid図/画像が描画されない問題を修正

### DIFF
--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -226,6 +226,8 @@ SearchBarController::Callbacks App::BuildSearchBarCallbacks()
         .on_scroll_changed = [this](float visible_h) {
             SyncMaxScroll(visible_h);
             InvalidateHitPositions();
+            // Why: 検索ヒット移動で可視化されたmermaid/画像の描画要求を出す (issue #102)
+            resource_manager_.ScheduleBitmapManage();
         },
     };
 }


### PR DESCRIPTION
## Summary
- 検索でページ内移動したとき mermaid 図（および画像）が描画されない問題（#102）を修正
- `on_scroll_changed` コールバックに `resource_manager_.ScheduleBitmapManage()` を追加し、内部リンク移動時の `NavigateToAnchor` と同じ挙動に統一

## 原因
通常のホイール/キースクロール経路は reducer の `EmitScrollEffects` 経由で `effect::BitmapManage` を発行して mermaid/画像の遅延レンダリングをトリガするが、検索ヒット時の `ScrollToCurrentMatch` は viewport を直接更新する経路で `on_scroll_changed` を呼ぶのみで、`ScheduleBitmapManage` が発行されていなかった。

## Test plan
- [x] `cmake --build build --config Release` でビルドが通る
- [x] `mendo_tests.exe` 全 1618 テストがパス
- [ ] 手動確認：mermaid 図を含む Markdown で Ctrl+F → 検索ヒットまでスクロールしたとき図が即座に描画される
- [ ] 手動確認：画像を含むページでも同様に描画される
- [ ] 回帰確認：通常のホイール/キースクロール、内部リンク移動の挙動が変わっていない

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)