### PR TITLE
7モジュールのユニットテストを追加

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(mendo_tests
     test_mermaid_file_cache.cpp
     test_mermaid_renderer.cpp
     ../src/mermaid/mermaid.cpp
+    ../src/app/render_composer.cpp
     test_ini_parser.cpp
     test_config_store.cpp
     test_viewport_manager.cpp
@@ -49,6 +50,15 @@ add_executable(mendo_tests
     test_reducer.cpp
     test_flat_map.cpp
     test_string_convert.cpp
+    test_render_composer.cpp
+    test_file_io.cpp
+    test_utility.cpp
+    test_tooltip_target.cpp
+    test_task_scheduler.cpp
+    test_side_effect_executor.cpp
+    test_command_generator_frame.cpp
+    ../src/app/side_effect_executor.cpp
+    ../src/app/resource_manager.cpp
 )
 
 target_include_directories(mendo_tests PRIVATE ${WEBVIEW2_INCLUDE} ${WIL_INCLUDE})

--- a/tests/test_command_generator_frame.cpp
+++ b/tests/test_command_generator_frame.cpp
@@ -1,0 +1,253 @@
+#include <gtest/gtest.h>
+#include "command_generator.h"
+#include "layout.h"
+#include "mock_text_measurer.h"
+#include "parser.h"
+#include "search_state.h"
+#include <optional>
+#include <variant>
+
+namespace {
+
+class CmdGenFrameTest : public ::testing::Test {
+protected:
+    MockTextMeasurer mock_;
+    LayoutEngine engine_;
+    CommandGenerator gen_;
+    Theme theme_;
+    LayoutCache cache_;
+    std::pmr::vector<Node> nodes_;
+
+    void SetUp() override
+    {
+        theme_ = GetLightTheme();
+        ASSERT_TRUE(engine_.Init(&mock_, theme_));
+        gen_.SetTheme(&theme_);
+        gen_.SetFormats({ nullptr, nullptr, nullptr, nullptr });
+    }
+
+    void Parse(const std::string& md, float viewport_w = 800.0f)
+    {
+        nodes_ = ParseMarkdown(md).nodes;
+        cache_.Resize(nodes_.size());
+        engine_.ComputeLayout(nodes_, cache_, viewport_w);
+    }
+
+    int CountCmd(const DrawCommandList& cmds, auto predicate)
+    {
+        int n = 0;
+        for (const auto& c : cmds) {
+            if (predicate(c)) n++;
+        }
+        return n;
+    }
+};
+
+template <typename T>
+const T* FindFirst(const DrawCommandList& cmds)
+{
+    for (const auto& c : cmds) {
+        if (auto* p = std::get_if<T>(&c)) return p;
+    }
+    return nullptr;
+}
+
+} // namespace
+
+// ═══════════════════════════════════════════════
+// クリップ矩形とペイン原点
+// ═══════════════════════════════════════════════
+
+TEST_F(CmdGenFrameTest, PushClipMatchesPaneRect)
+{
+    Parse("Hello");
+    const PaneRect pane{ 100.0f, 50.0f, 600.0f, 400.0f };
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
+
+    const auto* clip = FindFirst<PushClipCmd>(cmds);
+    ASSERT_NE(clip, nullptr);
+    EXPECT_FLOAT_EQ(clip->rect.left,   100.0f);
+    EXPECT_FLOAT_EQ(clip->rect.top,     50.0f);
+    EXPECT_FLOAT_EQ(clip->rect.right,  700.0f);
+    EXPECT_FLOAT_EQ(clip->rect.bottom, 450.0f);
+}
+
+TEST_F(CmdGenFrameTest, TransformTranslatesByPaneOriginAndScroll)
+{
+    Parse("Hello");
+    constexpr float origin_x = 120.0f;
+    constexpr float scroll_y = 40.0f;
+    const PaneRect pane{ origin_x, 0.0f, 600.0f, 400.0f };
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, scroll_y, TextSelection{});
+
+    const auto* first_xform = FindFirst<SetTransformCmd>(cmds);
+    ASSERT_NE(first_xform, nullptr);
+    EXPECT_FLOAT_EQ(first_xform->transform._31, origin_x);
+    EXPECT_FLOAT_EQ(first_xform->transform._32, -scroll_y);
+}
+
+TEST_F(CmdGenFrameTest, TransformSnapsScrollToPixelWithDpi)
+{
+    // DPI=2.0 → round(scroll_y * 2) / 2 で 0.5px 境界にスナップ
+    Parse("Hello");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 400.0f };
+    const float scroll_y = 0.3f;
+    const float dpi = 2.0f;
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, scroll_y, TextSelection{}, -1, -1, -1, dpi);
+
+    const auto* xform = FindFirst<SetTransformCmd>(cmds);
+    ASSERT_NE(xform, nullptr);
+    EXPECT_FLOAT_EQ(xform->transform._32, -0.5f);
+}
+
+// ═══════════════════════════════════════════════
+// ビューポートカリング
+// ═══════════════════════════════════════════════
+
+TEST_F(CmdGenFrameTest, ScrolledBeyondBottomProducesOnlyFrameCommands)
+{
+    // 数個の水平線を生成し、ビューポートより大きく下にスクロールする
+    Parse("---\n\n---\n\n---");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 100.0f };
+    // 全ノードより下にスクロール → DrawLineCmd なし
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 10000.0f, TextSelection{});
+
+    int draw_lines = CountCmd(cmds, [](const auto& c) {
+        return std::holds_alternative<DrawLineCmd>(c);
+    });
+    EXPECT_EQ(draw_lines, 0) << "すべてのノードがビューポート下ならDrawLineCmdは生成されない";
+    // PushClip + SetTransform×2 + PopClip のみ
+    EXPECT_EQ(cmds.size(), 4u);
+}
+
+TEST_F(CmdGenFrameTest, EmptyNodesListEmitsOnlyFrameScaffolding)
+{
+    nodes_.clear();
+    cache_.Resize(0);
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
+
+    ASSERT_EQ(cmds.size(), 4u);
+    EXPECT_TRUE(std::holds_alternative<PushClipCmd>(cmds[0]));
+    EXPECT_TRUE(std::holds_alternative<SetTransformCmd>(cmds[1]));
+    EXPECT_TRUE(std::holds_alternative<SetTransformCmd>(cmds[2]));
+    EXPECT_TRUE(std::holds_alternative<PopClipCmd>(cmds[3]));
+}
+
+// ═══════════════════════════════════════════════
+// first_visible の明示指定と自動探索
+// ═══════════════════════════════════════════════
+
+TEST_F(CmdGenFrameTest, ExplicitFirstVisibleMatchesAutoDiscovery)
+{
+    Parse("---\n\n---\n\n---\n\n---\n\n---");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 500.0f };
+
+    // first_visible=-1 (自動) と first_visible=0 (明示) は 0 からスクロール時に同じ結果
+    auto cmds_auto_saved = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{}, -1).size();
+    auto cmds_explicit_saved = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{}, 0).size();
+    EXPECT_EQ(cmds_auto_saved, cmds_explicit_saved);
+}
+
+TEST_F(CmdGenFrameTest, FirstVisibleBeyondEndProducesNoContent)
+{
+    Parse("---\n\n---\n\n---");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 500.0f };
+
+    // first_visible がノード数以上 → 本体ループに入らない
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{}, 999);
+    int draw_lines = CountCmd(cmds, [](const auto& c) {
+        return std::holds_alternative<DrawLineCmd>(c);
+    });
+    EXPECT_EQ(draw_lines, 0);
+}
+
+// ═══════════════════════════════════════════════
+// ShrinkBuffers / SetSharedHitTestBuffer / SetSearchMatches
+// ═══════════════════════════════════════════════
+
+TEST_F(CmdGenFrameTest, ShrinkBuffersIsSafeWithoutSharedBuffer)
+{
+    Parse("Hello");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 400.0f };
+    const auto baseline_size = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{}).size();
+    gen_.ShrinkBuffers();
+    // ShrinkBuffers 後も同じ入力で同じコマンド列が再生成される
+    const auto after_size = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{}).size();
+    EXPECT_EQ(after_size, baseline_size);
+}
+
+TEST_F(CmdGenFrameTest, SetSharedHitTestBufferPreventsShrink)
+{
+    Parse("Hello");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 400.0f };
+    std::pmr::vector<DWRITE_HIT_TEST_METRICS> shared;
+    shared.reserve(32);
+    const auto capacity_before = shared.capacity();
+    gen_.SetSharedHitTestBuffer(&shared);
+    (void)gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
+    gen_.ShrinkBuffers(); // shared 設定時は内部バッファを触らない
+    // shared バッファ自体の容量は ShrinkBuffers では影響されない
+    EXPECT_EQ(shared.capacity(), capacity_before);
+}
+
+TEST_F(CmdGenFrameTest, SetSearchMatchesWithNullIsSafe)
+{
+    Parse("Hello world");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 400.0f };
+    gen_.SetSearchMatches(nullptr, -1);
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
+    EXPECT_FALSE(cmds.empty());
+}
+
+TEST_F(CmdGenFrameTest, SetSearchMatchesWithEmptyProducesNoHighlight)
+{
+    Parse("Hello world");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 400.0f };
+    std::pmr::vector<SearchMatch> matches;
+    gen_.SetSearchMatches(&matches, -1);
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
+    // マッチ空のため FillRectCmd は選択ハイライト経路以外は生成されない
+    // (paragraph text_layout=null なので選択経路も走らない)
+    int fill_rects = CountCmd(cmds, [](const auto& c) {
+        return std::holds_alternative<FillRectCmd>(c);
+    });
+    EXPECT_EQ(fill_rects, 0);
+}
+
+// ═══════════════════════════════════════════════
+// テーマ変更の反映
+// ═══════════════════════════════════════════════
+
+TEST_F(CmdGenFrameTest, DarkThemeSelectionUsesDifferentStripeCache)
+{
+    auto light = GetLightTheme();
+    auto dark = GetDarkTheme();
+    Parse("| A | B |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 400.0f };
+
+    auto find_stripe = [](const DrawCommandList& cmds) -> std::optional<D2D1_COLOR_F> {
+        for (const auto& c : cmds) {
+            if (auto* fr = std::get_if<FillRectCmd>(&c)) {
+                if (fr->color.a > 0.0f && fr->color.a < 1.0f) {
+                    return fr->color;
+                }
+            }
+        }
+        return std::nullopt;
+    };
+
+    gen_.SetTheme(&light);
+    auto light_stripe = find_stripe(gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{}));
+    ASSERT_TRUE(light_stripe.has_value());
+    EXPECT_FLOAT_EQ(light_stripe->r, 0.0f);
+    EXPECT_FLOAT_EQ(light_stripe->g, 0.0f);
+    EXPECT_FLOAT_EQ(light_stripe->b, 0.0f);
+
+    gen_.SetTheme(&dark);
+    auto dark_stripe = find_stripe(gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{}));
+    ASSERT_TRUE(dark_stripe.has_value());
+    EXPECT_FLOAT_EQ(dark_stripe->r, 1.0f);
+    EXPECT_FLOAT_EQ(dark_stripe->g, 1.0f);
+    EXPECT_FLOAT_EQ(dark_stripe->b, 1.0f);
+}

--- a/tests/test_file_io.cpp
+++ b/tests/test_file_io.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "file_io.h"
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <string>

--- a/tests/test_file_io.cpp
+++ b/tests/test_file_io.cpp
@@ -1,0 +1,139 @@
+#include <gtest/gtest.h>
+#include "file_io.h"
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+class FileIoTest : public ::testing::Test {
+protected:
+    fs::path temp_dir_;
+
+    void SetUp() override
+    {
+        wchar_t tmp[MAX_PATH];
+        GetTempPathW(MAX_PATH, tmp);
+        temp_dir_ = fs::path(tmp) / (L"mendo_file_io_test_" + std::to_wstring(GetCurrentProcessId()));
+        fs::create_directories(temp_dir_);
+    }
+
+    void TearDown() override
+    {
+        std::error_code ec;
+        fs::remove_all(temp_dir_, ec);
+    }
+};
+
+// ═══════════════════════════════════════════════
+// WriteAllBytes + ReadAllBytes ラウンドトリップ
+// ═══════════════════════════════════════════════
+
+TEST_F(FileIoTest, RoundTripAscii)
+{
+    const auto path = temp_dir_ / L"ascii.bin";
+    const std::string payload = "Hello, mendo!";
+
+    ASSERT_TRUE(WriteAllBytes(path, payload.data(), payload.size()));
+
+    auto [buf, size] = ReadAllBytes(path);
+    ASSERT_NE(buf.get(), nullptr);
+    ASSERT_EQ(size, payload.size());
+    EXPECT_EQ(std::string(reinterpret_cast<const char*>(buf.get()), size), payload);
+}
+
+TEST_F(FileIoTest, RoundTripBinary)
+{
+    const auto path = temp_dir_ / L"binary.bin";
+    std::vector<uint8_t> payload;
+    for (int i = 0; i < 256; ++i) {
+        payload.push_back(static_cast<uint8_t>(i));
+    }
+
+    ASSERT_TRUE(WriteAllBytes(path, payload.data(), payload.size()));
+
+    auto [buf, size] = ReadAllBytes(path);
+    ASSERT_EQ(size, payload.size());
+    EXPECT_EQ(std::memcmp(buf.get(), payload.data(), size), 0);
+}
+
+TEST_F(FileIoTest, WriteOverwritesExistingFile)
+{
+    const auto path = temp_dir_ / L"overwrite.bin";
+    const std::string first = "first-content-longer";
+    const std::string second = "short";
+
+    ASSERT_TRUE(WriteAllBytes(path, first.data(), first.size()));
+    ASSERT_TRUE(WriteAllBytes(path, second.data(), second.size()));
+
+    auto [buf, size] = ReadAllBytes(path);
+    ASSERT_EQ(size, second.size());
+    EXPECT_EQ(std::string(reinterpret_cast<const char*>(buf.get()), size), second);
+}
+
+// ═══════════════════════════════════════════════
+// エラーケース
+// ═══════════════════════════════════════════════
+
+TEST_F(FileIoTest, ReadMissingFileReturnsEmpty)
+{
+    const auto path = temp_dir_ / L"does_not_exist.bin";
+    DWORD err = 0xDEADBEEF;
+    auto [buf, size] = ReadAllBytes(path, &err);
+    EXPECT_EQ(buf.get(), nullptr);
+    EXPECT_EQ(size, 0u);
+    EXPECT_EQ(err, static_cast<DWORD>(ERROR_FILE_NOT_FOUND));
+}
+
+TEST_F(FileIoTest, ReadMissingFileWithoutErrorPointer)
+{
+    const auto path = temp_dir_ / L"does_not_exist.bin";
+    auto [buf, size] = ReadAllBytes(path);
+    EXPECT_EQ(buf.get(), nullptr);
+    EXPECT_EQ(size, 0u);
+}
+
+TEST_F(FileIoTest, ReadEmptyFileReturnsEmpty)
+{
+    const auto path = temp_dir_ / L"empty.bin";
+    std::ofstream(path, std::ios::binary).close();
+
+    DWORD err = 0xDEADBEEF;
+    auto [buf, size] = ReadAllBytes(path, &err);
+    EXPECT_EQ(buf.get(), nullptr);
+    EXPECT_EQ(size, 0u);
+    // 成功時 (CreateFileW OK) の err はクリアされる契約
+    EXPECT_EQ(err, 0u);
+}
+
+TEST_F(FileIoTest, WriteToInvalidPathFails)
+{
+    // 存在しないディレクトリ配下のパス（親ディレクトリがない）
+    const auto path = temp_dir_ / L"no_such_dir" / L"file.bin";
+    const std::string payload = "data";
+    EXPECT_FALSE(WriteAllBytes(path, payload.data(), payload.size()));
+}
+
+TEST_F(FileIoTest, ErrorPointerResetOnSuccess)
+{
+    const auto path = temp_dir_ / L"reset.bin";
+    const std::string payload = "x";
+    ASSERT_TRUE(WriteAllBytes(path, payload.data(), payload.size()));
+
+    DWORD err = 0xDEADBEEF;
+    auto [buf, size] = ReadAllBytes(path, &err);
+    EXPECT_EQ(err, 0u);
+    EXPECT_EQ(size, 1u);
+}
+
+TEST_F(FileIoTest, WriteZeroBytesProducesEmptyFile)
+{
+    const auto path = temp_dir_ / L"zero.bin";
+    ASSERT_TRUE(WriteAllBytes(path, "", 0));
+
+    auto [buf, size] = ReadAllBytes(path);
+    EXPECT_EQ(size, 0u);
+    EXPECT_TRUE(fs::exists(path));
+    EXPECT_EQ(fs::file_size(path), 0u);
+}

--- a/tests/test_render_composer.cpp
+++ b/tests/test_render_composer.cpp
@@ -1,0 +1,196 @@
+#include <gtest/gtest.h>
+#include "render_composer.h"
+#include "app_state.h"
+
+// SearchBarController は Init が必要なので BuildSearchBarState はテスト対象外。
+
+TEST(RenderComposer, GestureState_Idle)
+{
+    AppState state;
+    auto gs = render_composer::BuildGestureState(state);
+    EXPECT_FALSE(gs.trail_active);
+    EXPECT_FALSE(gs.overlay_visible);
+    EXPECT_EQ(gs.direction, 0);
+    EXPECT_FLOAT_EQ(gs.overlay_alpha, 0.0f);
+    ASSERT_NE(gs.trail_points, nullptr);
+    EXPECT_TRUE(gs.trail_points->empty());
+}
+
+TEST(RenderComposer, GestureState_TrackingLeft)
+{
+    AppState state;
+    state.interaction.gesture.OnRButtonDown(100.0f, 100.0f);
+    state.interaction.gesture.OnMouseMove(20.0f, 100.0f); // 左に80px移動
+
+    auto gs = render_composer::BuildGestureState(state);
+    EXPECT_TRUE(gs.trail_active);
+    EXPECT_TRUE(gs.overlay_visible);
+    EXPECT_EQ(gs.direction, -1);
+    EXPECT_GT(gs.overlay_alpha, 0.0f);
+}
+
+TEST(RenderComposer, GestureState_TrackingRight)
+{
+    AppState state;
+    state.interaction.gesture.OnRButtonDown(100.0f, 100.0f);
+    state.interaction.gesture.OnMouseMove(200.0f, 100.0f);
+
+    auto gs = render_composer::BuildGestureState(state);
+    EXPECT_EQ(gs.direction, 1);
+}
+
+TEST(RenderComposer, GestureState_SwipeFallback_WhenGestureIdle)
+{
+    AppState state;
+    // ジェスチャーは非アクティブのまま、スワイプ検出器のみアクティブにする
+    state.interaction.swipe_detector.OnHWheel(500, 1000);
+
+    auto gs = render_composer::BuildGestureState(state);
+    EXPECT_FALSE(gs.trail_active);     // gesture 側は非アクティブ
+    EXPECT_TRUE(gs.overlay_visible);   // swipe 側のオーバーレイが表示
+    EXPECT_EQ(gs.direction, -1);       // 右スワイプ→戻る
+    EXPECT_FLOAT_EQ(gs.overlay_alpha, 1.0f);
+}
+
+TEST(RenderComposer, GestureState_GestureTakesPrecedenceOverSwipe)
+{
+    AppState state;
+    state.interaction.gesture.OnRButtonDown(100.0f, 100.0f);
+    state.interaction.gesture.OnMouseMove(200.0f, 100.0f);
+    state.interaction.swipe_detector.OnHWheel(-500, 1000);
+
+    auto gs = render_composer::BuildGestureState(state);
+    EXPECT_TRUE(gs.overlay_visible);
+    EXPECT_EQ(gs.direction, 1);
+}
+
+// ============================================================
+// BuildToastState
+// ============================================================
+
+TEST(RenderComposer, ToastState_HiddenByDefault)
+{
+    AppState state;
+    auto ts = render_composer::BuildToastState(state);
+    EXPECT_FALSE(ts.visible);
+    EXPECT_FLOAT_EQ(ts.alpha, 0.0f);
+    EXPECT_TRUE(ts.message.empty());
+}
+
+TEST(RenderComposer, ToastState_VisibleAfterShow)
+{
+    AppState state;
+    state.interaction.toast.Show(L"Copied");
+
+    auto ts = render_composer::BuildToastState(state);
+    EXPECT_TRUE(ts.visible);
+    // ホールド中は内部 alpha=2.5 を 1.0 にクランプ
+    EXPECT_FLOAT_EQ(ts.alpha, 1.0f);
+    EXPECT_EQ(ts.message, L"Copied");
+}
+
+TEST(RenderComposer, ToastState_AfterReset)
+{
+    AppState state;
+    state.interaction.toast.Show(L"Hello");
+    state.interaction.toast.Reset();
+
+    auto ts = render_composer::BuildToastState(state);
+    EXPECT_FALSE(ts.visible);
+    EXPECT_TRUE(ts.message.empty());
+}
+
+// ============================================================
+// BuildTitleBarState
+// ============================================================
+
+TEST(RenderComposer, TitleBarState_CopiesFlags)
+{
+    AppState state;
+    state.window.titlebar.UpdateLayout(1024.0f);
+    state.cached_title_text = L"example.md";
+
+    auto tb = render_composer::BuildTitleBarState(state, 1024.0f, /*is_dark=*/true, /*is_max=*/false);
+
+    EXPECT_FLOAT_EQ(tb.window_width, 1024.0f);
+    EXPECT_TRUE(tb.is_dark_mode);
+    EXPECT_FALSE(tb.is_maximized);
+    EXPECT_EQ(tb.title_text, std::wstring_view(L"example.md"));
+    EXPECT_FLOAT_EQ(tb.height, state.window.titlebar.GetHeight());
+}
+
+TEST(RenderComposer, TitleBarState_WindowActiveDefault)
+{
+    AppState state;
+    auto tb = render_composer::BuildTitleBarState(state, 800.0f, false, true);
+    EXPECT_TRUE(tb.window_active);
+    EXPECT_TRUE(tb.is_maximized);
+    EXPECT_FALSE(tb.is_dark_mode);
+}
+
+TEST(RenderComposer, TitleBarState_ButtonsComeFromTitleBar)
+{
+    AppState state;
+    state.window.titlebar.UpdateLayout(1024.0f);
+    state.window.titlebar.SetHovered(TitleBarHitZone::Close);
+
+    auto tb = render_composer::BuildTitleBarState(state, 1024.0f, false, false);
+    EXPECT_TRUE(tb.close.hovered);
+    EXPECT_FALSE(tb.minimize.hovered);
+    EXPECT_FALSE(tb.maximize.hovered);
+}
+
+TEST(RenderComposer, TitleBarState_PaneVisibilityMirrorsState)
+{
+    AppState state;
+    state.view.panes.SetFilePaneVisible(false);
+    state.view.panes.SetTocPaneVisible(true);
+
+    auto tb = render_composer::BuildTitleBarState(state, 800.0f, false, false);
+    EXPECT_FALSE(tb.file_pane_visible);
+    EXPECT_TRUE(tb.toc_pane_visible);
+}
+
+// ============================================================
+// BuildSidePaneState
+// ============================================================
+
+TEST(RenderComposer, SidePaneState_ReferencesDocumentAndPanes)
+{
+    AppState state;
+    state.view.panes.SetFilePaneVisible(true);
+    state.view.panes.SetTocPaneVisible(false);
+    state.active_toc_index = 3;
+
+    PaneLayout layout{};
+    layout.file_rect = { 0.0f, 0.0f, 200.0f, 600.0f };
+    layout.toc_rect  = { 200.0f, 0.0f, 200.0f, 600.0f };
+
+    auto sp = render_composer::BuildSidePaneState(state, layout);
+
+    EXPECT_TRUE(sp.show_file_pane);
+    EXPECT_FALSE(sp.show_toc_pane);
+    EXPECT_EQ(sp.active_toc_index, 3);
+    EXPECT_FLOAT_EQ(sp.file_pane_rect.width, 200.0f);
+    EXPECT_FLOAT_EQ(sp.toc_pane_rect.x, 200.0f);
+    EXPECT_EQ(&sp.file_entries, &state.file_explorer.GetEntries());
+    EXPECT_EQ(&sp.nodes, &state.document.doc.GetNodes());
+}
+
+TEST(RenderComposer, SidePaneState_HoverAndHeaderFlags)
+{
+    AppState state;
+    state.view.panes.SetHoveredFileIndex(2);
+    state.view.panes.SetHoveredTocIndex(5);
+    state.view.panes.SetFileCloseHovered(true);
+    state.view.panes.SetFileRefreshHovered(true);
+    state.view.panes.SetTocCloseHovered(true);
+
+    PaneLayout layout{};
+    auto sp = render_composer::BuildSidePaneState(state, layout);
+    EXPECT_EQ(sp.hovered_file_index, 2);
+    EXPECT_EQ(sp.hovered_toc_index, 5);
+    EXPECT_TRUE(sp.file_close_hovered);
+    EXPECT_TRUE(sp.file_refresh_hovered);
+    EXPECT_TRUE(sp.toc_close_hovered);
+}

--- a/tests/test_side_effect_executor.cpp
+++ b/tests/test_side_effect_executor.cpp
@@ -1,0 +1,321 @@
+#include <gtest/gtest.h>
+#include "side_effect_executor.h"
+#include "app_state.h"
+#include "resource_manager.h"
+#include "cursor_manager.h"
+#include "document_service.h"
+#include "config_service.h"
+#include "layout_service.h"
+#include "layout.h"
+#include "file_watcher.h"
+
+// side_effect_executor.cpp が extern 参照するシンボルのダミー。本体は app.cpp。
+// ApplyDarkMode 副作用はテストで発火しないが、LTCG が効かない場合のリンク保険。
+void ApplyDarkModeToWindow(HWND, bool) {}
+
+class SideEffectExecutorTest : public ::testing::Test {
+protected:
+    // --- 依存クラスの実体（default-construct） ---
+    FileWatcher watcher_;
+    DocumentService doc_service_{watcher_};
+    ConfigService config_;
+    ResourceManager resource_manager_;
+    CursorManager cursors_;
+    AppState state_;
+    LayoutEngine engine_;
+    LayoutService layout_service_{engine_, state_.view.viewport};
+    SideEffectExecutor exec_;
+
+    // --- スパイ記録 ---
+    std::vector<std::pmr::wstring> load_file_paths_;
+    int reload_file_count_ = 0;
+    int open_file_dialog_count_ = 0;
+    std::vector<PaneZone> invalidate_pane_cache_calls_;
+    int refresh_pane_layout_count_ = 0;
+    std::pair<UINT, UINT> last_renderer_resize_{0, 0};
+    int renderer_resize_count_ = 0;
+    float last_renderer_dpi_ = 0.0f;
+    int renderer_set_dpi_count_ = 0;
+    int clear_file_cache_count_ = 0;
+    int perform_resize_end_count_ = 0;
+    int perform_sizing_update_count_ = 0;
+    effect::ApplyThemeChange last_theme_change_{};
+    int apply_theme_change_count_ = 0;
+    int process_deferred_layout_count_ = 0;
+    int tick_loading_animation_count_ = 0;
+    int process_mermaid_batch_timer_count_ = 0;
+    int process_bitmap_manage_count_ = 0;
+    int mermaid_init_retry_count_ = 0;
+    int destroy_count_ = 0;
+    int handle_parse_complete_count_ = 0;
+    struct MouseEventRecord { effect::MouseEventType type; int px; int py; };
+    std::vector<MouseEventRecord> mouse_events_;
+    std::pair<int, int> last_context_menu_{0, 0};
+    int context_menu_count_ = 0;
+
+    SideEffectExecutor::Callbacks MakeCallbacks()
+    {
+        return {
+            .load_file = [this](std::wstring_view p) {
+                load_file_paths_.emplace_back(std::pmr::wstring{p});
+            },
+            .reload_file = [this] { reload_file_count_++; },
+            .open_file_dialog = [this] { open_file_dialog_count_++; },
+            .invalidate_pane_cache = [this](PaneZone p) {
+                invalidate_pane_cache_calls_.push_back(p);
+            },
+            .refresh_pane_layout = [this] { refresh_pane_layout_count_++; },
+            .renderer_resize = [this](UINT w, UINT h) {
+                last_renderer_resize_ = {w, h};
+                renderer_resize_count_++;
+            },
+            .renderer_set_dpi = [this](float dpi) {
+                last_renderer_dpi_ = dpi;
+                renderer_set_dpi_count_++;
+            },
+            .clear_file_cache = [this] { clear_file_cache_count_++; },
+            .perform_resize_end = [this] { perform_resize_end_count_++; },
+            .perform_sizing_update = [this] { perform_sizing_update_count_++; },
+            .apply_theme_change = [this](const effect::ApplyThemeChange& e) {
+                last_theme_change_ = e;
+                apply_theme_change_count_++;
+            },
+            .process_deferred_layout = [this] { process_deferred_layout_count_++; },
+            .tick_loading_animation = [this] { tick_loading_animation_count_++; },
+            .process_mermaid_batch_timer = [this] { process_mermaid_batch_timer_count_++; },
+            .process_bitmap_manage = [this] { process_bitmap_manage_count_++; },
+            .mermaid_init_retry = [this] { mermaid_init_retry_count_++; },
+            .destroy = [this] { destroy_count_++; },
+            .handle_parse_complete = [this] { handle_parse_complete_count_++; },
+            .handle_mouse_event = [this](effect::MouseEventType t, int px, int py) {
+                mouse_events_.push_back({t, px, py});
+            },
+            .handle_context_menu = [this](int x, int y) {
+                last_context_menu_ = {x, y};
+                context_menu_count_++;
+            },
+        };
+    }
+
+    void SetUp() override
+    {
+        exec_.Init(/*hwnd=*/nullptr, resource_manager_, cursors_, doc_service_,
+                   config_, state_, layout_service_, MakeCallbacks());
+    }
+};
+
+// ═══════════════════════════════════════════════
+// Callback 委譲型副作用
+// ═══════════════════════════════════════════════
+
+TEST_F(SideEffectExecutorTest, LoadFileDispatchesToCallback)
+{
+    exec_.ExecuteOne(effect::LoadFile{std::pmr::wstring{L"C:/doc.md"}});
+    ASSERT_EQ(load_file_paths_.size(), 1u);
+    EXPECT_EQ(load_file_paths_[0], L"C:/doc.md");
+}
+
+TEST_F(SideEffectExecutorTest, ReloadFileDispatchesToCallback)
+{
+    exec_.ExecuteOne(effect::ReloadFile{});
+    EXPECT_EQ(reload_file_count_, 1);
+}
+
+TEST_F(SideEffectExecutorTest, OpenFileDialogDispatchesToCallback)
+{
+    exec_.ExecuteOne(effect::OpenFileDialog{});
+    EXPECT_EQ(open_file_dialog_count_, 1);
+}
+
+TEST_F(SideEffectExecutorTest, InvalidatePaneCacheForwardsPaneZone)
+{
+    exec_.ExecuteOne(effect::InvalidatePaneCache{PaneZone::MdPane});
+    exec_.ExecuteOne(effect::InvalidatePaneCache{PaneZone::FilePane});
+    ASSERT_EQ(invalidate_pane_cache_calls_.size(), 2u);
+    EXPECT_EQ(invalidate_pane_cache_calls_[0], PaneZone::MdPane);
+    EXPECT_EQ(invalidate_pane_cache_calls_[1], PaneZone::FilePane);
+}
+
+TEST_F(SideEffectExecutorTest, RefreshPaneLayoutDispatchesToCallback)
+{
+    exec_.ExecuteOne(effect::RefreshPaneLayout{});
+    EXPECT_EQ(refresh_pane_layout_count_, 1);
+}
+
+TEST_F(SideEffectExecutorTest, RendererResizeForwardsDimensions)
+{
+    exec_.ExecuteOne(effect::RendererResize{1920, 1080});
+    EXPECT_EQ(renderer_resize_count_, 1);
+    EXPECT_EQ(last_renderer_resize_, std::make_pair(UINT{1920}, UINT{1080}));
+}
+
+TEST_F(SideEffectExecutorTest, RendererSetDpiForwardsDpiValue)
+{
+    exec_.ExecuteOne(effect::RendererSetDpi{144.0f});
+    EXPECT_EQ(renderer_set_dpi_count_, 1);
+    EXPECT_FLOAT_EQ(last_renderer_dpi_, 144.0f);
+}
+
+TEST_F(SideEffectExecutorTest, ClearFileCacheDispatchesToCallback)
+{
+    exec_.ExecuteOne(effect::ClearFileCache{});
+    EXPECT_EQ(clear_file_cache_count_, 1);
+}
+
+TEST_F(SideEffectExecutorTest, PerformResizeEndDispatchesToCallback)
+{
+    exec_.ExecuteOne(effect::PerformResizeEnd{});
+    EXPECT_EQ(perform_resize_end_count_, 1);
+}
+
+TEST_F(SideEffectExecutorTest, PerformSizingUpdateDispatchesToCallback)
+{
+    exec_.ExecuteOne(effect::PerformSizingUpdate{});
+    EXPECT_EQ(perform_sizing_update_count_, 1);
+}
+
+TEST_F(SideEffectExecutorTest, ApplyThemeChangeForwardsStruct)
+{
+    effect::ApplyThemeChange in{};
+    in.type = effect::ApplyThemeChange::Type::Zoom;
+    in.anchor_idx = 5;
+    in.anchor_y_before = 100.0f;
+    in.anchor_offset = 10.0f;
+    in.offset_scale = 1.25f;
+    in.new_zoom = 1.25f;
+    in.zoom_index = 4;
+    exec_.ExecuteOne(in);
+    EXPECT_EQ(apply_theme_change_count_, 1);
+    EXPECT_EQ(last_theme_change_.type, effect::ApplyThemeChange::Type::Zoom);
+    EXPECT_EQ(last_theme_change_.anchor_idx, 5);
+    EXPECT_FLOAT_EQ(last_theme_change_.anchor_y_before, 100.0f);
+    EXPECT_FLOAT_EQ(last_theme_change_.offset_scale, 1.25f);
+    EXPECT_EQ(last_theme_change_.zoom_index, 4);
+}
+
+TEST_F(SideEffectExecutorTest, ProcessDeferredLayoutDispatchesToCallback)
+{
+    exec_.ExecuteOne(effect::ProcessDeferredLayout{});
+    EXPECT_EQ(process_deferred_layout_count_, 1);
+}
+
+TEST_F(SideEffectExecutorTest, TickLoadingAnimationDispatchesToCallback)
+{
+    exec_.ExecuteOne(effect::TickLoadingAnimation{});
+    EXPECT_EQ(tick_loading_animation_count_, 1);
+}
+
+TEST_F(SideEffectExecutorTest, ProcessMermaidBatchTimerDispatchesToCallback)
+{
+    exec_.ExecuteOne(effect::ProcessMermaidBatchTimer{});
+    EXPECT_EQ(process_mermaid_batch_timer_count_, 1);
+}
+
+TEST_F(SideEffectExecutorTest, ProcessBitmapManageDispatchesToCallback)
+{
+    exec_.ExecuteOne(effect::ProcessBitmapManage{});
+    EXPECT_EQ(process_bitmap_manage_count_, 1);
+}
+
+TEST_F(SideEffectExecutorTest, MermaidInitRetryDispatchesToCallback)
+{
+    exec_.ExecuteOne(effect::MermaidInitRetry{});
+    EXPECT_EQ(mermaid_init_retry_count_, 1);
+}
+
+TEST_F(SideEffectExecutorTest, DestroyDispatchesToCallback)
+{
+    exec_.ExecuteOne(effect::Destroy{});
+    EXPECT_EQ(destroy_count_, 1);
+}
+
+TEST_F(SideEffectExecutorTest, HandleParseCompleteDispatchesToCallback)
+{
+    exec_.ExecuteOne(effect::HandleParseComplete{});
+    EXPECT_EQ(handle_parse_complete_count_, 1);
+}
+
+TEST_F(SideEffectExecutorTest, HandleMouseEventForwardsAllFields)
+{
+    exec_.ExecuteOne(effect::HandleMouseEvent{effect::MouseEventType::LButtonDown, 100, 200});
+    exec_.ExecuteOne(effect::HandleMouseEvent{effect::MouseEventType::MouseMove, 150, 250});
+    ASSERT_EQ(mouse_events_.size(), 2u);
+    EXPECT_EQ(mouse_events_[0].type, effect::MouseEventType::LButtonDown);
+    EXPECT_EQ(mouse_events_[0].px, 100);
+    EXPECT_EQ(mouse_events_[0].py, 200);
+    EXPECT_EQ(mouse_events_[1].type, effect::MouseEventType::MouseMove);
+    EXPECT_EQ(mouse_events_[1].px, 150);
+}
+
+TEST_F(SideEffectExecutorTest, HandleContextMenuForwardsScreenCoords)
+{
+    exec_.ExecuteOne(effect::HandleContextMenu{800, 600});
+    EXPECT_EQ(context_menu_count_, 1);
+    EXPECT_EQ(last_context_menu_, std::make_pair(800, 600));
+}
+
+// ═══════════════════════════════════════════════
+// AppState を変更する副作用
+// ═══════════════════════════════════════════════
+
+TEST_F(SideEffectExecutorTest, ShowToastUpdatesToastState)
+{
+    exec_.ExecuteOne(effect::ShowToast{L"Copied"});
+    EXPECT_TRUE(state_.interaction.toast.IsVisible());
+    EXPECT_EQ(state_.interaction.toast.GetMessage(), L"Copied");
+}
+
+TEST_F(SideEffectExecutorTest, ShowToastOverwritesPreviousMessage)
+{
+    exec_.ExecuteOne(effect::ShowToast{L"First"});
+    exec_.ExecuteOne(effect::ShowToast{L"Second"});
+    EXPECT_EQ(state_.interaction.toast.GetMessage(), L"Second");
+}
+
+// ═══════════════════════════════════════════════
+// Execute: 副作用リストを順番に実行する
+// ═══════════════════════════════════════════════
+
+TEST_F(SideEffectExecutorTest, ExecuteRunsAllEffectsInOrder)
+{
+    std::pmr::vector<SideEffect> list;
+    list.emplace_back(effect::ReloadFile{});
+    list.emplace_back(effect::LoadFile{std::pmr::wstring{L"A"}});
+    list.emplace_back(effect::LoadFile{std::pmr::wstring{L"B"}});
+    list.emplace_back(effect::Destroy{});
+
+    exec_.Execute(list);
+
+    EXPECT_EQ(reload_file_count_, 1);
+    EXPECT_EQ(destroy_count_, 1);
+    ASSERT_EQ(load_file_paths_.size(), 2u);
+    EXPECT_EQ(load_file_paths_[0], L"A");
+    EXPECT_EQ(load_file_paths_[1], L"B");
+}
+
+TEST_F(SideEffectExecutorTest, ExecuteEmptyListIsNoop)
+{
+    std::pmr::vector<SideEffect> list;
+    exec_.Execute(list);
+    EXPECT_EQ(reload_file_count_, 0);
+    EXPECT_EQ(destroy_count_, 0);
+}
+
+// HWND=nullptr で Win32 API 呼び出し分岐（InvalidateRect/ShowWindow/PostMessage/
+// SetWindowText/SetWindowPos）が内部で失敗終了することの確認。
+// メッセージ定数は傍受されにくい WM_USER+α を使う（WM_CLOSE 等はテストハーネスの
+// メッセージポンプと干渉しうるため避ける）。
+// CursorManager 未初期化ルートの SetCursor もここでまとめて走らせる。
+TEST_F(SideEffectExecutorTest, Win32EffectsWithNullHwndDoNotCrash)
+{
+    exec_.ExecuteOne(effect::InvalidateWindow{});
+    exec_.ExecuteOne(effect::InvalidateTitleBar{});
+    exec_.ExecuteOne(effect::ShowWindowCmd{1});
+    exec_.ExecuteOne(effect::PostMessage{WM_USER + 42, 0, 0});
+    exec_.ExecuteOne(effect::SetWindowTitle{std::pmr::wstring{L"hello"}});
+    exec_.ExecuteOne(effect::SetWindowPosition{10, 20, 800, 600});
+    exec_.ExecuteOne(effect::SetCursor{effect::CursorType::Arrow});
+    exec_.ExecuteOne(effect::SetCursor{effect::CursorType::Hand});
+    exec_.ExecuteOne(effect::SetCursor{effect::CursorType::IBeam});
+    exec_.ExecuteOne(effect::SetCursor{effect::CursorType::SizeWE});
+}

--- a/tests/test_side_effect_executor.cpp
+++ b/tests/test_side_effect_executor.cpp
@@ -301,19 +301,14 @@ TEST_F(SideEffectExecutorTest, ExecuteEmptyListIsNoop)
     EXPECT_EQ(destroy_count_, 0);
 }
 
-// HWND=nullptr で Win32 API 呼び出し分岐（InvalidateRect/ShowWindow/PostMessage/
-// SetWindowText/SetWindowPos）が内部で失敗終了することの確認。
-// メッセージ定数は傍受されにくい WM_USER+α を使う（WM_CLOSE 等はテストハーネスの
-// メッセージポンプと干渉しうるため避ける）。
-// CursorManager 未初期化ルートの SetCursor もここでまとめて走らせる。
-TEST_F(SideEffectExecutorTest, Win32EffectsWithNullHwndDoNotCrash)
+// HWND=nullptr の executor に対して、ウィンドウ対象の Win32 API を発火させる
+// 副作用はここでは実行しない。nullptr は API によって特別扱いされ（例:
+// InvalidateRect(nullptr, ...) は全ウィンドウを再描画、PostMessageW(nullptr, ...)
+// はスレッドメッセージ投稿）、画面全体の invalidation などグローバル副作用や
+// 他テストとの干渉を招きうるため。
+// ここでは HWND に依存しない CursorManager 未初期化ルートの SetCursor のみ確認する。
+TEST_F(SideEffectExecutorTest, SetCursorEffectsWithNullHwndDoNotCrash)
 {
-    exec_.ExecuteOne(effect::InvalidateWindow{});
-    exec_.ExecuteOne(effect::InvalidateTitleBar{});
-    exec_.ExecuteOne(effect::ShowWindowCmd{1});
-    exec_.ExecuteOne(effect::PostMessage{WM_USER + 42, 0, 0});
-    exec_.ExecuteOne(effect::SetWindowTitle{std::pmr::wstring{L"hello"}});
-    exec_.ExecuteOne(effect::SetWindowPosition{10, 20, 800, 600});
     exec_.ExecuteOne(effect::SetCursor{effect::CursorType::Arrow});
     exec_.ExecuteOne(effect::SetCursor{effect::CursorType::Hand});
     exec_.ExecuteOne(effect::SetCursor{effect::CursorType::IBeam});

--- a/tests/test_task_scheduler.cpp
+++ b/tests/test_task_scheduler.cpp
@@ -1,0 +1,209 @@
+#include <gtest/gtest.h>
+#include "task_scheduler.h"
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <condition_variable>
+#include <functional>
+#include <set>
+#include <thread>
+
+namespace {
+
+bool WaitFor(std::function<bool()> cond, int timeout_ms = 2000)
+{
+    const auto start = std::chrono::steady_clock::now();
+    while (!cond()) {
+        if (std::chrono::steady_clock::now() - start >
+            std::chrono::milliseconds(timeout_ms)) {
+            return false;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return true;
+}
+
+} // namespace
+
+// ═══════════════════════════════════════════════
+// 基本的な Post → 実行
+// ═══════════════════════════════════════════════
+
+TEST(TaskScheduler, SingleTaskExecutes)
+{
+    TaskScheduler sch;
+    sch.Init(1);
+    std::atomic<bool> ran{false};
+    sch.Post([&] { ran.store(true); });
+    EXPECT_TRUE(WaitFor([&] { return ran.load(); }));
+    sch.Shutdown();
+}
+
+TEST(TaskScheduler, MultipleTasksAllExecute)
+{
+    TaskScheduler sch;
+    sch.Init(2);
+    constexpr int N = 100;
+    std::atomic<int> count{0};
+    for (int i = 0; i < N; ++i) {
+        sch.Post([&] { count.fetch_add(1); });
+    }
+    EXPECT_TRUE(WaitFor([&] { return count.load() == N; }));
+    sch.Shutdown();
+    EXPECT_EQ(count.load(), N);
+}
+
+TEST(TaskScheduler, TasksRunOnWorkerThreadsNotCaller)
+{
+    TaskScheduler sch;
+    sch.Init(2);
+    const auto caller_id = std::this_thread::get_id();
+    std::atomic<bool> ran{false};
+    std::atomic<bool> different_thread{false};
+    sch.Post([&] {
+        different_thread.store(std::this_thread::get_id() != caller_id);
+        ran.store(true);
+    });
+    EXPECT_TRUE(WaitFor([&] { return ran.load(); }));
+    EXPECT_TRUE(different_thread.load());
+    sch.Shutdown();
+}
+
+// ═══════════════════════════════════════════════
+// 並行性
+// ═══════════════════════════════════════════════
+
+TEST(TaskScheduler, TasksDistributedAcrossWorkers)
+{
+    // 複数ワーカーで並行処理されることを観測する。
+    // 各タスクがワーカーをブロックしている間に他のワーカーが別タスクを拾うはず。
+    constexpr int WORKERS = 4;
+    TaskScheduler sch;
+    sch.Init(WORKERS);
+
+    std::mutex m;
+    std::set<std::thread::id> observed_threads;
+    std::atomic<int> running{0};
+    std::atomic<int> finished{0};
+
+    for (int i = 0; i < WORKERS; ++i) {
+        sch.Post([&] {
+            running.fetch_add(1);
+            {
+                std::lock_guard lock(m);
+                observed_threads.insert(std::this_thread::get_id());
+            }
+            // 他のワーカーも到達するまで少し待つ
+            WaitFor([&] { return running.load() >= 2; }, 500);
+            finished.fetch_add(1);
+        });
+    }
+
+    EXPECT_TRUE(WaitFor([&] { return finished.load() == WORKERS; }));
+    sch.Shutdown();
+
+    // 最低でも2つ以上の異なるスレッドで処理されているはず
+    std::lock_guard lock(m);
+    EXPECT_GE(observed_threads.size(), 2u);
+}
+
+// ═══════════════════════════════════════════════
+// Shutdown の挙動
+// ═══════════════════════════════════════════════
+
+TEST(TaskScheduler, ShutdownProcessesRemainingQueuedTasks)
+{
+    // ドキュメント: 「キューに残っているタスクをすべて処理してから終了」
+    TaskScheduler sch;
+    sch.Init(1);
+
+    std::atomic<int> count{0};
+    std::atomic<bool> first_entered{false};
+    std::atomic<bool> gate_open{false};
+    sch.Post([&] {
+        first_entered.store(true);
+        WaitFor([&] { return gate_open.load(); }, 2000);
+        count.fetch_add(1);
+    });
+    // 先頭タスクがワーカーを掴んだことを確定させてから残りを投入する
+    ASSERT_TRUE(WaitFor([&] { return first_entered.load(); }));
+    for (int i = 0; i < 20; ++i) {
+        sch.Post([&] { count.fetch_add(1); });
+    }
+    gate_open.store(true);
+
+    sch.Shutdown();
+
+    EXPECT_EQ(count.load(), 21);
+}
+
+TEST(TaskScheduler, ShutdownWithoutPostCompletes)
+{
+    TaskScheduler sch;
+    sch.Init(4);
+    sch.Shutdown(); // タスクがなくても正常終了する
+    SUCCEED();
+}
+
+TEST(TaskScheduler, ShutdownTwiceIsSafe)
+{
+    TaskScheduler sch;
+    sch.Init(2);
+    std::atomic<int> count{0};
+    sch.Post([&] { count.fetch_add(1); });
+    EXPECT_TRUE(WaitFor([&] { return count.load() == 1; }));
+    sch.Shutdown();
+    sch.Shutdown(); // 2回目は no-op
+    SUCCEED();
+}
+
+TEST(TaskScheduler, DestructorJoinsWorkersEvenIfShutdownNotCalled)
+{
+    std::atomic<int> count{0};
+    {
+        TaskScheduler sch;
+        sch.Init(2);
+        for (int i = 0; i < 10; ++i) {
+            sch.Post([&] { count.fetch_add(1); });
+        }
+        // Shutdown を呼ばずスコープを抜ける → デストラクタで join される
+    }
+    EXPECT_EQ(count.load(), 10);
+}
+
+// ═══════════════════════════════════════════════
+// タスクの型（move-only）
+// ═══════════════════════════════════════════════
+
+TEST(TaskScheduler, AcceptsMoveOnlyCallable)
+{
+    TaskScheduler sch;
+    sch.Init(1);
+    auto ptr = std::make_unique<std::atomic<int>>(0);
+    auto* raw = ptr.get();
+    sch.Post([p = std::move(ptr)]() mutable { p->fetch_add(42); });
+    EXPECT_TRUE(WaitFor([&] { return raw->load() == 42; }));
+    sch.Shutdown();
+}
+
+// ═══════════════════════════════════════════════
+// 初期化なしで Post → Shutdown してもクラッシュしない
+// ═══════════════════════════════════════════════
+
+TEST(TaskScheduler, PostWithoutInitThenInitProcessesQueued)
+{
+    TaskScheduler sch;
+    std::atomic<bool> ran{false};
+    sch.Post([&] { ran.store(true); }); // Init 前に Post
+    sch.Init(1); // ワーカー起動後にキュー消化
+    EXPECT_TRUE(WaitFor([&] { return ran.load(); }));
+    sch.Shutdown();
+}
+
+TEST(TaskScheduler, ZeroThreadsInitThenShutdownIsSafe)
+{
+    TaskScheduler sch;
+    sch.Init(0); // ワーカーなし
+    sch.Shutdown();
+    SUCCEED();
+}

--- a/tests/test_tooltip_target.cpp
+++ b/tests/test_tooltip_target.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+#include "tooltip.h"
+
+// Tooltip クラス本体は Win32 HWND 依存のためテスト対象外。
+// ここでは値型 TooltipTarget の等価性と IsEmpty のみを検証する。
+
+TEST(TooltipTarget, DefaultConstructedIsEmpty)
+{
+    TooltipTarget t;
+    EXPECT_EQ(t.zone, TooltipTarget::Zone::None);
+    EXPECT_TRUE(t.text.empty());
+    EXPECT_TRUE(t.IsEmpty());
+}
+
+TEST(TooltipTarget, ConstructedWithZoneAndTextIsNotEmpty)
+{
+    TooltipTarget t{ TooltipTarget::Zone::MdLink, L"https://example.com" };
+    EXPECT_EQ(t.zone, TooltipTarget::Zone::MdLink);
+    EXPECT_EQ(t.text, L"https://example.com");
+    EXPECT_FALSE(t.IsEmpty());
+}
+
+TEST(TooltipTarget, IsEmptyIgnoresText)
+{
+    TooltipTarget t{ TooltipTarget::Zone::None, L"still empty" };
+    EXPECT_TRUE(t.IsEmpty());
+}
+
+TEST(TooltipTarget, IsEmptyFalseForNonNoneZoneWithEmptyText)
+{
+    TooltipTarget t{ TooltipTarget::Zone::CopyButton, L"" };
+    EXPECT_FALSE(t.IsEmpty());
+}
+
+TEST(TooltipTarget, EqualityDefault)
+{
+    TooltipTarget a;
+    TooltipTarget b;
+    EXPECT_TRUE(a == b);
+}
+
+TEST(TooltipTarget, EqualitySameZoneAndText)
+{
+    TooltipTarget a{ TooltipTarget::Zone::FilePaneItem, L"README.md" };
+    TooltipTarget b{ TooltipTarget::Zone::FilePaneItem, L"README.md" };
+    EXPECT_TRUE(a == b);
+}
+
+TEST(TooltipTarget, InequalityDifferentZone)
+{
+    TooltipTarget a{ TooltipTarget::Zone::MdLink, L"same" };
+    TooltipTarget b{ TooltipTarget::Zone::MdImage, L"same" };
+    EXPECT_FALSE(a == b);
+}
+
+TEST(TooltipTarget, InequalityDifferentText)
+{
+    TooltipTarget a{ TooltipTarget::Zone::TitleBarButton, L"Close" };
+    TooltipTarget b{ TooltipTarget::Zone::TitleBarButton, L"Minimize" };
+    EXPECT_FALSE(a == b);
+}
+
+TEST(TooltipTarget, AssignmentPreservesEquality)
+{
+    TooltipTarget a{ TooltipTarget::Zone::SaveButton, L"save.png" };
+    TooltipTarget b;
+    b = a;
+    EXPECT_TRUE(a == b);
+    EXPECT_EQ(b.zone, TooltipTarget::Zone::SaveButton);
+    EXPECT_EQ(b.text, L"save.png");
+}

--- a/tests/test_utility.cpp
+++ b/tests/test_utility.cpp
@@ -1,0 +1,87 @@
+#include <gtest/gtest.h>
+#include "utility.h"
+#include <memory_resource>
+#include <variant>
+#include <string>
+
+// ═══════════════════════════════════════════════
+// PmrFormat
+// ═══════════════════════════════════════════════
+
+TEST(Utility, PmrFormatPlainText)
+{
+    auto s = PmrFormat(L"hello");
+    EXPECT_EQ(s, L"hello");
+}
+
+TEST(Utility, PmrFormatIntegerFormatting)
+{
+    auto s = PmrFormat(L"count={}", 42);
+    EXPECT_EQ(s, L"count=42");
+}
+
+TEST(Utility, PmrFormatMultipleArgs)
+{
+    auto s = PmrFormat(L"{}+{}={}", 1, 2, 3);
+    EXPECT_EQ(s, L"1+2=3");
+}
+
+TEST(Utility, PmrFormatWideStringArgument)
+{
+    std::wstring name = L"mendo";
+    auto s = PmrFormat(L"hi {}!", name);
+    EXPECT_EQ(s, L"hi mendo!");
+}
+
+TEST(Utility, PmrFormatReturnsPmrString)
+{
+    auto s = PmrFormat(L"x={}", 5);
+    static_assert(std::is_same_v<decltype(s), std::pmr::wstring>,
+        "PmrFormat must return std::pmr::wstring");
+    EXPECT_EQ(s.size(), 3u); // "x=5"
+}
+
+TEST(Utility, PmrFormatEmptyFormatString)
+{
+    auto s = PmrFormat(L"");
+    EXPECT_TRUE(s.empty());
+}
+
+TEST(Utility, PmrFormatFloatingPoint)
+{
+    auto s = PmrFormat(L"pi={:.2f}", 3.14159);
+    EXPECT_EQ(s, L"pi=3.14");
+}
+
+// ═══════════════════════════════════════════════
+// overloaded (std::visit 用ヘルパー)
+// ═══════════════════════════════════════════════
+
+TEST(Utility, OverloadedDispatchesByType)
+{
+    std::variant<int, double, std::wstring> v;
+
+    v = 42;
+    int tag = std::visit(overloaded{
+        [](int)           { return 1; },
+        [](double)        { return 2; },
+        [](const std::wstring&) { return 3; },
+    }, v);
+    EXPECT_EQ(tag, 1);
+
+    v = 1.5;
+    tag = std::visit(overloaded{
+        [](int)           { return 1; },
+        [](double)        { return 2; },
+        [](const std::wstring&) { return 3; },
+    }, v);
+    EXPECT_EQ(tag, 2);
+
+    v = std::wstring(L"hi");
+    tag = std::visit(overloaded{
+        [](int)           { return 1; },
+        [](double)        { return 2; },
+        [](const std::wstring&) { return 3; },
+    }, v);
+    EXPECT_EQ(tag, 3);
+}


### PR DESCRIPTION
## Summary
- `CommandGenerator` / `render_composer` / `SideEffectExecutor` / `TaskScheduler` / `file_io` / `TooltipTarget` / `PmrFormat (utility)` の7モジュールに対するユニットテストを追加
- 追加テストをビルド対象にするため `tests/CMakeLists.txt` に `side_effect_executor.cpp` / `resource_manager.cpp` / `render_composer.cpp` をリンクするよう更新
- 既存 1706 テストはすべてパス（Release ビルド）

## Test plan
- [x] `cmake --build build --config Release --target mendo_tests` がエラーなく完了
- [x] `build/tests/Release/mendo_tests.exe --gtest_brief=1` が PASSED で終了
- [ ] CI（もし設定されていれば）でも同様にパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)