### PR TITLE
MermaidホストHTMLをRCDATAリソースとして分離

### DIFF
--- a/res/mendo.rc
+++ b/res/mendo.rc
@@ -39,6 +39,9 @@ END
 // Embedded mermaid.js (gzip compressed) for offline rendering
 IDR_MERMAID_JS_GZ RCDATA "..\\third_party\\mermaid\\mermaid.min.js.gz"
 
+// Embedded HTML template for mermaid rendering host
+IDR_MERMAID_HTML RCDATA "mermaid.html"
+
 // Embedded help documents (UTF-8 Markdown)
 IDR_HELP_MD    RCDATA "help_ja.md"
 IDR_HELP_EN_MD RCDATA "help_en.md"

--- a/res/mermaid.html
+++ b/res/mermaid.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  html, body { margin: 0; padding: 0; overflow: hidden; }
+  body { background: white; }
+  body.dark { background: #1e1e1e; }
+  #container { display: block; }
+</style>
+<script>
+  let currentTheme = null;
+  let renderCount = 0;
+
+  function mermaidReady() {
+    return typeof mermaid !== 'undefined' && typeof mermaid.render === 'function';
+  }
+
+  async function renderMermaid(code, isDark, maxWidth) {
+    try {
+      if (!mermaidReady()) {
+        return JSON.stringify({ ok: false, error: 'mermaid not loaded' });
+      }
+      const wantTheme = isDark ? 'dark' : 'default';
+      document.body.className = isDark ? 'dark' : '';
+      if (currentTheme !== wantTheme) {
+        mermaid.initialize({
+          startOnLoad: false,
+          theme: wantTheme,
+          securityLevel: 'strict'
+        });
+        currentTheme = wantTheme;
+      }
+      const container = document.getElementById('container');
+      container.innerHTML = '';
+      document.body.style.width = '';
+      container.style.maxWidth = '';
+      renderCount++;
+      const id = 'mmd-' + renderCount;
+      const { svg } = await mermaid.render(id, code);
+      container.innerHTML = svg;
+      await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+      const svgEl = container.querySelector('svg');
+      if (svgEl) {
+        const rect = svgEl.getBoundingClientRect();
+        return JSON.stringify({
+          width: Math.ceil(rect.width),
+          height: Math.ceil(rect.height),
+          dpr: window.devicePixelRatio || 1,
+          ok: true
+        });
+      }
+      return JSON.stringify({ ok: false, error: 'SVG not found' });
+    } catch (e) {
+      return JSON.stringify({ ok: false, error: e.message || String(e) });
+    }
+  }
+
+  (async function() {
+    try {
+      const resp = await fetch('https://app.local/mermaid.min.js.gz');
+      const ds = new DecompressionStream('gzip');
+      const text = await new Response(resp.body.pipeThrough(ds)).text();
+      const blob = new Blob([text], {type: 'application/javascript'});
+      const url = URL.createObjectURL(blob);
+      await new Promise((resolve, reject) => {
+        const s = document.createElement('script');
+        s.src = url;
+        s.onload = resolve;
+        s.onerror = reject;
+        document.head.appendChild(s);
+      });
+      URL.revokeObjectURL(url);
+      var dpr = window.devicePixelRatio || 1;
+      window.chrome.webview.postMessage(
+        mermaidReady() ? ('mermaid-ready:' + dpr) : 'mermaid-failed');
+    } catch(e) {
+      window.chrome.webview.postMessage('mermaid-failed');
+    }
+  })();
+</script>
+</head>
+<body>
+<div id="container"></div>
+</body>
+</html>

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -11,104 +11,6 @@
 
 #pragma comment(lib, "windowscodecs.lib")
 
-static std::span<const std::byte> LoadMermaidJsGzFromResource()
-{
-    return LoadRcData(IDR_MERMAID_JS_GZ);
-}
-
-// 仮想ホスト経由で配信される小さなHTMLテンプレート。mermaid.jsは別の
-// <script src>として読み込まれるため、HTMLは2MBのNavigateToString制限を
-// 十分に下回る。両リソースはWebResourceRequestedによりインプロセスで配信される。
-static const char MERMAID_HTML[] = R"HTML(<!DOCTYPE html>
-<html>
-<head>
-<meta charset="utf-8">
-<style>
-  html, body { margin: 0; padding: 0; overflow: hidden; }
-  body { background: white; }
-  body.dark { background: #1e1e1e; }
-  #container { display: block; }
-</style>
-<script>
-  let currentTheme = null;
-  let renderCount = 0;
-
-  function mermaidReady() {
-    return typeof mermaid !== 'undefined' && typeof mermaid.render === 'function';
-  }
-
-  async function renderMermaid(code, isDark, maxWidth) {
-    try {
-      if (!mermaidReady()) {
-        return JSON.stringify({ ok: false, error: 'mermaid not loaded' });
-      }
-      const wantTheme = isDark ? 'dark' : 'default';
-      document.body.className = isDark ? 'dark' : '';
-      if (currentTheme !== wantTheme) {
-        mermaid.initialize({
-          startOnLoad: false,
-          theme: wantTheme,
-          securityLevel: 'strict'
-        });
-        currentTheme = wantTheme;
-      }
-      const container = document.getElementById('container');
-      container.innerHTML = '';
-      // 以前の幅制約をリセット
-      document.body.style.width = '';
-      container.style.maxWidth = '';
-      renderCount++;
-      const id = 'mmd-' + renderCount;
-      const { svg } = await mermaid.render(id, code);
-      container.innerHTML = svg;
-      await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
-      const svgEl = container.querySelector('svg');
-      if (svgEl) {
-        const rect = svgEl.getBoundingClientRect();
-        return JSON.stringify({
-          width: Math.ceil(rect.width),
-          height: Math.ceil(rect.height),
-          dpr: window.devicePixelRatio || 1,
-          ok: true
-        });
-      }
-      return JSON.stringify({ ok: false, error: 'SVG not found' });
-    } catch (e) {
-      return JSON.stringify({ ok: false, error: e.message || String(e) });
-    }
-  }
-
-  // DecompressionStream APIを使ってgzip圧縮されたmermaid.jsを読み込む
-  (async function() {
-    try {
-      const resp = await fetch('https://app.local/mermaid.min.js.gz');
-      const ds = new DecompressionStream('gzip');
-      const text = await new Response(resp.body.pipeThrough(ds)).text();
-      const blob = new Blob([text], {type: 'application/javascript'});
-      const url = URL.createObjectURL(blob);
-      await new Promise((resolve, reject) => {
-        const s = document.createElement('script');
-        s.src = url;
-        s.onload = resolve;
-        s.onerror = reject;
-        document.head.appendChild(s);
-      });
-      URL.revokeObjectURL(url);
-      var dpr = window.devicePixelRatio || 1;
-      window.chrome.webview.postMessage(
-        mermaidReady() ? ('mermaid-ready:' + dpr) : 'mermaid-failed');
-    } catch(e) {
-      window.chrome.webview.postMessage('mermaid-failed');
-    }
-  })();
-</script>
-</head>
-<body>
-<div id="container"></div>
-</body>
-</html>
-)HTML";
-
 // IStreamから全バイトを読み出す（ファイルキャッシュ保存用）。
 static std::vector<uint8_t> ReadAllStreamBytes(IStream* stream)
 {
@@ -208,8 +110,7 @@ void MermaidRenderer::Shutdown()
     initialized_ = false;
 }
 
-void MermaidRenderer::Init(HWND hwnd, ID2D1RenderTarget* render_target, IWICImagingFactory* wic,
-    std::move_only_function<void()> on_ready)
+void MermaidRenderer::Init(HWND hwnd, ID2D1RenderTarget* render_target, IWICImagingFactory* wic, std::move_only_function<void()> on_ready)
 {
     hwnd_ = hwnd;
     render_target_ = render_target;
@@ -218,7 +119,8 @@ void MermaidRenderer::Init(HWND hwnd, ID2D1RenderTarget* render_target, IWICImag
     // PNGデコード用のWICファクトリ（D2DRenderBackendから共有）
     if (wic) {
         wic_factory_ = wic;
-    } else {
+    }
+    else {
         CoCreateInstance(
             CLSID_WICImagingFactory,
             nullptr,
@@ -406,8 +308,7 @@ void MermaidRenderer::SetupWorker(int index)
                 CoTaskMemFree(msg);
             }
             return S_OK;
-        }).Get(),
-            nullptr);
+        }).Get(), nullptr);
 
         // ナビゲーションを制限: app.local以外へのナビゲーションをブロック
         w.webview->add_NavigationStarting(
@@ -422,8 +323,7 @@ void MermaidRenderer::SetupWorker(int index)
                 CoTaskMemFree(uri);
             }
             return S_OK;
-        }).Get(),
-            nullptr);
+        }).Get(), nullptr);
 
         // 新規ウィンドウの要求を全てブロック
         w.webview->add_NewWindowRequested(
@@ -463,17 +363,15 @@ void MermaidRenderer::SetupWorker(int index)
             const wchar_t* headers = nullptr;
 
             if (url.find(L"/mermaid.min.js.gz") != std::pmr::wstring::npos) {
-                // gzip圧縮されたmermaid.js（キャッシュ済み）を配信する。JSがDecompressionStreamで展開する
-                if (cached_mermaid_gz_.empty()) {
-                    cached_mermaid_gz_ = LoadMermaidJsGzFromResource();
-                }
-                const auto& gz = cached_mermaid_gz_;
+                // gzip圧縮されたmermaid.jsを配信する。JSがDecompressionStreamで展開する
+                const auto gz = LoadRcData(IDR_MERMAID_JS_GZ);
                 stream = CreateMemoryStream(gz.data(), gz.size());
                 headers = L"Content-Type: application/gzip";
             }
             else {
-                // その他のパスにはHTMLテンプレートを配信する
-                stream = CreateMemoryStream(MERMAID_HTML, sizeof(MERMAID_HTML) - 1);
+                // その他のパスにはHTMLテンプレート（res/mermaid.html）を配信する
+                const auto html = LoadRcData(IDR_MERMAID_HTML);
+                stream = CreateMemoryStream(html.data(), html.size());
                 headers = L"Content-Type: text/html; charset=utf-8";
             }
 
@@ -675,8 +573,7 @@ void MermaidRenderer::RenderInWorker(Worker& worker)
     const int h_phys = static_cast<int>(4096 * worker.dpr);
     const RECT bounds = { 0, 0, vp_phys, h_phys };
     worker.controller->put_Bounds(bounds);
-    SetWindowPos(worker.hwnd, nullptr, -32000, -32000, vp_phys, h_phys,
-        SWP_NOZORDER | SWP_NOACTIVATE);
+    SetWindowPos(worker.hwnd, nullptr, -32000, -32000, vp_phys, h_phys, SWP_NOZORDER | SWP_NOACTIVATE);
 
     // Mermaidをレンダリングする（maxWidth=0はCSS制約なし、ビューポートが制約する）
     // リクエストIDをpostMessageに含め、C++側でコールバックとリクエストを照合する
@@ -747,8 +644,7 @@ void MermaidRenderer::OnRenderResult(int worker_idx, std::wstring_view json)
     w.controller->put_Bounds(capBounds);
 
     // ホストポップアップウィンドウも同じサイズにリサイズする
-    SetWindowPos(w.hwnd, nullptr, -32000, -32000, cw, ch,
-        SWP_NOZORDER | SWP_NOACTIVATE);
+    SetWindowPos(w.hwnd, nullptr, -32000, -32000, cw, ch, SWP_NOZORDER | SWP_NOACTIVATE);
 
     // rAFを使ってWebViewが新しいサイズで再レンダリングするのを待ち、
     // postMessageでシグナルを送る（Promise-awaitの問題を回避する）。

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -351,31 +351,40 @@ void MermaidRenderer::SetupWorker(int index)
             const std::pmr::wstring url(uri ? uri : L"");
             CoTaskMemFree(uri);
 
-            // app.local以外へのリクエストをブロック（fetch/XHR等）
-            if (url.find(L"app.local") == std::pmr::wstring::npos) {
+            // https://app.local/ 以外へのリクエストをブロックする。
+            // NavigationStartingと判定ロジックを揃え、app.local.evil.comのような
+            // 部分一致によるサブドメイン経由の経路を塞ぐ。
+            if (url.compare(0, 18, L"https://app.local/") != 0) {
                 Microsoft::WRL::ComPtr<ICoreWebView2WebResourceResponse> response;
                 webview_env_->CreateWebResourceResponse(nullptr, 403, L"Blocked", L"", &response);
                 args->put_Response(response.Get());
                 return S_OK;
             }
 
-            Microsoft::WRL::ComPtr<IStream> stream;
+            std::span<const std::byte> payload;
             const wchar_t* headers = nullptr;
 
             if (url.find(L"/mermaid.min.js.gz") != std::pmr::wstring::npos) {
                 // gzip圧縮されたmermaid.jsを配信する。JSがDecompressionStreamで展開する
-                const auto gz = LoadRcData(IDR_MERMAID_JS_GZ);
-                stream = CreateMemoryStream(gz.data(), gz.size());
+                payload = LoadRcData(IDR_MERMAID_JS_GZ);
                 headers = L"Content-Type: application/gzip";
             }
             else {
                 // その他のパスにはHTMLテンプレート（res/mermaid.html）を配信する
-                const auto html = LoadRcData(IDR_MERMAID_HTML);
-                stream = CreateMemoryStream(html.data(), html.size());
+                payload = LoadRcData(IDR_MERMAID_HTML);
                 headers = L"Content-Type: text/html; charset=utf-8";
             }
 
-            if (stream && headers) {
+            // リソースが見つからない場合は空ボディを200で返さず500を返して失敗を明示する
+            if (payload.empty()) {
+                Microsoft::WRL::ComPtr<ICoreWebView2WebResourceResponse> response;
+                webview_env_->CreateWebResourceResponse(nullptr, 500, L"Resource missing", L"", &response);
+                args->put_Response(response.Get());
+                return S_OK;
+            }
+
+            const auto stream = CreateMemoryStream(payload.data(), payload.size());
+            if (stream) {
                 Microsoft::WRL::ComPtr<ICoreWebView2WebResourceResponse> response;
                 webview_env_->CreateWebResourceResponse(stream.Get(), 200, L"OK", headers, &response);
                 args->put_Response(response.Get());

--- a/src/mermaid/mermaid.h
+++ b/src/mermaid/mermaid.h
@@ -12,7 +12,6 @@
 #include <functional>
 #include "lru_cache.h"
 #include <queue>
-#include <span>
 #include <memory_resource>
 
 
@@ -123,7 +122,6 @@ private:
     ID2D1RenderTarget* render_target_ = nullptr;
     Microsoft::WRL::ComPtr<IWICImagingFactory> wic_factory_;
     Microsoft::WRL::ComPtr<ICoreWebView2Environment> webview_env_;
-    std::span<const std::byte> cached_mermaid_gz_; // Win32リソースから直接参照するgzip圧縮済みmermaid.js
 
     Worker workers_[MAX_WORKERS];
     int worker_count_ = 0;

--- a/src/ui/resource.h
+++ b/src/ui/resource.h
@@ -15,3 +15,4 @@
 #define IDR_MERMAID_JS_GZ 301
 #define IDR_HELP_MD       302
 #define IDR_HELP_EN_MD    303
+#define IDR_MERMAID_HTML  304


### PR DESCRIPTION
## Summary
- Mermaidレンダリングホスト用の HTML テンプレートを `src/mermaid/mermaid.cpp` 内のインラインRaw文字列リテラルから `res/mermaid.html` に切り出し、`IDR_MERMAID_HTML` として RCDATA 埋め込み。`WebResourceRequested` ハンドラから `LoadRcData` 経由で配信する。
- HTML/JS がエディタのシンタックスハイライトとフォーマッタの対象になり、C++ Raw 文字列リテラルの制約から解放される。バイナリサイズは同等（リソースはマップ、コピー無し）。
- 併せて、`LoadRcData` はマップ済みポインタを返すだけでキャッシュする意味が無いため、既存の `cached_mermaid_gz_` も含めてキャッシュメンバとワンライナーラッパー (`LoadMermaidJsGzFromResource` / `LoadMermaidHtmlFromResource`) を削除し、呼び出し側で直呼びする形に整理（`src/app/app_file.cpp` のヘルプドキュメントロードと同じパターン）。
- 旧コメントの `NavigateToString の 2MB 制限` への言及は `WebResourceRequested` 配信に切り替え済みの現実装では不要なため削除。

## Test plan
- [x] `cmake --build build --config Release` が成功
- [x] `mendo_tests.exe` — 全 1706 テストパス
- [x] 実アプリ起動で Mermaid ダイアグラムがライト/ダーク両テーマでレンダリングされることを確認
- [x] `mermaid.min.js.gz` のgzip配信が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)