### PR TITLE
テーマのカラーコードを theme_palette.h に一元化 (#115)

### DIFF
--- a/src/core/document_utils.cpp
+++ b/src/core/document_utils.cpp
@@ -2,6 +2,7 @@
 #include "layout_cache.h"
 #include "navigation_service.h"
 #include "syntax.h"
+#include "theme_palette.h"
 #include <windows.h>
 #include <cwctype>
 #include <filesystem>
@@ -209,31 +210,45 @@ void AppendNodeInlineHtml(std::pmr::wstring& out, const Node& node, uint32_t sta
     AppendInlineHtml(out, node.GetText(), node.runs, node.link_urls, start, end);
 }
 
-// シンタックスハイライト用 span の prefix を、ライト / ダークテーマで切り替えて返す。
-// ライト: VS Code Light 風、ダーク: VS Code Dark+ 風。Plain は空で「色付けなし」。
-constexpr std::wstring_view SyntaxSpanPrefix(SyntaxTokenType type, bool dark) noexcept
+constexpr void AppendHexColor(std::pmr::wstring& out, uint32_t rgb)
+{
+    constexpr wchar_t kDigits[] = L"0123456789abcdef";
+    out.push_back(L'#');
+    out.push_back(kDigits[(rgb >> 20) & 0xF]);
+    out.push_back(kDigits[(rgb >> 16) & 0xF]);
+    out.push_back(kDigits[(rgb >> 12) & 0xF]);
+    out.push_back(kDigits[(rgb >> 8) & 0xF]);
+    out.push_back(kDigits[(rgb >> 4) & 0xF]);
+    out.push_back(kDigits[rgb & 0xF]);
+}
+
+constexpr std::optional<uint32_t> SyntaxTokenColor(SyntaxTokenType type,
+    const theme_palette::SharedColors& palette) noexcept
 {
     switch (type) {
-    case SyntaxTokenType::Keyword:      return dark ? L"<span style=\"color:#C586C0\">" : L"<span style=\"color:#AF00DB\">";
-    case SyntaxTokenType::Type:         return dark ? L"<span style=\"color:#4EC9B0\">" : L"<span style=\"color:#267F99\">";
-    case SyntaxTokenType::String:       return dark ? L"<span style=\"color:#CE9178\">" : L"<span style=\"color:#A31515\">";
-    case SyntaxTokenType::Number:       return dark ? L"<span style=\"color:#B5CEA8\">" : L"<span style=\"color:#098658\">";
-    case SyntaxTokenType::Comment:      return dark ? L"<span style=\"color:#6A9955\">" : L"<span style=\"color:#008000\">";
-    case SyntaxTokenType::Preprocessor: return dark ? L"<span style=\"color:#DCDCAA\">" : L"<span style=\"color:#795E26\">";
-    case SyntaxTokenType::Function:     return dark ? L"<span style=\"color:#DCDCAA\">" : L"<span style=\"color:#795E26\">";
-    default:                            return {};
+    case SyntaxTokenType::Keyword:      return palette.syntax_keyword;
+    case SyntaxTokenType::Type:         return palette.syntax_type;
+    case SyntaxTokenType::String:       return palette.syntax_string;
+    case SyntaxTokenType::Number:       return palette.syntax_number;
+    case SyntaxTokenType::Comment:      return palette.syntax_comment;
+    case SyntaxTokenType::Preprocessor: return palette.syntax_preprocessor;
+    case SyntaxTokenType::Function:     return palette.syntax_function;
+    default:                            return std::nullopt;
     }
 }
 
 constexpr void AppendSyntaxHighlightedSpan(std::pmr::wstring& out, std::wstring_view chunk,
     SyntaxTokenType type, bool dark_mode)
 {
-    const auto prefix = SyntaxSpanPrefix(type, dark_mode);
-    if (prefix.empty()) {
+    const auto& palette = dark_mode ? theme_palette::kDark : theme_palette::kLight;
+    const auto color = SyntaxTokenColor(type, palette);
+    if (!color) {
         AppendHtmlEscaped(out, chunk);
         return;
     }
-    out.append(prefix);
+    out.append(L"<span style=\"color:");
+    AppendHexColor(out, *color);
+    out.append(L"\">");
     AppendHtmlEscaped(out, chunk);
     out.append(L"</span>");
 }
@@ -241,13 +256,19 @@ constexpr void AppendSyntaxHighlightedSpan(std::pmr::wstring& out, std::wstring_
 void AppendCodeBlockHtml(std::pmr::wstring& out, const Node& node, uint32_t start, uint32_t end,
     bool dark_mode)
 {
-    constexpr std::wstring_view kOpenLight =
-        LR"(<pre style="background-color:#f6f8fa;padding:12px;border-radius:4px;overflow:auto;font-family:Consolas,'Courier New',monospace;font-size:13px;line-height:1.45;"><code>)";
-    constexpr std::wstring_view kOpenDark =
-        LR"(<pre style="background-color:#2d2d2d;color:#d4d4d4;padding:12px;border-radius:4px;overflow:auto;font-family:Consolas,'Courier New',monospace;font-size:13px;line-height:1.45;"><code>)";
+    constexpr std::wstring_view kStyleTail =
+        LR"(;padding:12px;border-radius:4px;overflow:auto;font-family:Consolas,'Courier New',monospace;font-size:13px;line-height:1.45;"><code>)";
     constexpr std::wstring_view kClose = L"</code></pre>";
 
-    out.append(dark_mode ? kOpenDark : kOpenLight);
+    const auto& palette = dark_mode ? theme_palette::kDark : theme_palette::kLight;
+    out.append(L"<pre style=\"background-color:");
+    AppendHexColor(out, palette.code_bg);
+    // ダーク時のみテキスト色を明示する（ライトは呼び出し側の親要素の色を継承）。
+    if (dark_mode) {
+        out.append(L";color:");
+        AppendHexColor(out, palette.code_text);
+    }
+    out.append(kStyleTail);
     const auto& text = node.GetText();
     if (end > text.size()) {
         end = static_cast<uint32_t>(text.size());
@@ -337,9 +358,10 @@ private:
 constexpr void AppendTableCellStyle(std::pmr::wstring& out, const TableCell& cell, bool dark_mode)
 {
     // 共通の border+padding を先に出し、align 指定があれば追加して閉じる。
-    constexpr std::wstring_view kOpenLight = LR"( style="border:1px solid #d0d7de;padding:6px 13px)";
-    constexpr std::wstring_view kOpenDark  = LR"( style="border:1px solid #3c3c3c;padding:6px 13px)";
-    out.append(dark_mode ? kOpenDark : kOpenLight);
+    const auto& palette = dark_mode ? theme_palette::kDark : theme_palette::kLight;
+    out.append(LR"( style="border:1px solid )");
+    AppendHexColor(out, palette.table_border);
+    out.append(L";padding:6px 13px");
     switch (cell.align) {
     case TableAlign::Center: out.append(L";text-align:center"); break;
     case TableAlign::Right:  out.append(L";text-align:right"); break;

--- a/src/theme/theme.cpp
+++ b/src/theme/theme.cpp
@@ -1,4 +1,5 @@
 #include "theme.h"
+#include "theme_palette.h"
 
 static D2D1_COLOR_F Color(uint32_t rgb, float a = 1.0f) noexcept
 {
@@ -114,8 +115,8 @@ Theme GetLightTheme()
     t.bg_color = Color(0xFFFFFF);
     t.text_color = Color(0x24292e);
     t.heading_color = Color(0x1a1a1a);
-    t.code_bg_color = Color(0xf6f8fa);
-    t.code_text_color = Color(0x24292e);
+    t.code_bg_color = Color(theme_palette::kLight.code_bg);
+    t.code_text_color = Color(theme_palette::kLight.code_text);
     t.link_color = Color(0x0366d6);
     t.hr_color = Color(0xd0d0d0);
     t.blockquote_bar_color = Color(0xdfe2e5);
@@ -134,13 +135,13 @@ Theme GetLightTheme()
     t.alert_bg_color[4] = Color(0xffebe9, 0.4f); // Caution bg
 
     // シンタックスハイライト
-    t.syntax_keyword = Color(0xAF00DB);  // 紫
-    t.syntax_type = Color(0x267F99);  // ティール
-    t.syntax_string = Color(0xA31515);  // 暗い赤
-    t.syntax_number = Color(0x098658);  // 緑
-    t.syntax_comment = Color(0x008000);  // 緑
-    t.syntax_preprocessor = Color(0x795E26);  // 茶
-    t.syntax_function = Color(0x795E26);  // 茶
+    t.syntax_keyword = Color(theme_palette::kLight.syntax_keyword);
+    t.syntax_type = Color(theme_palette::kLight.syntax_type);
+    t.syntax_string = Color(theme_palette::kLight.syntax_string);
+    t.syntax_number = Color(theme_palette::kLight.syntax_number);
+    t.syntax_comment = Color(theme_palette::kLight.syntax_comment);
+    t.syntax_preprocessor = Color(theme_palette::kLight.syntax_preprocessor);
+    t.syntax_function = Color(theme_palette::kLight.syntax_function);
 
     ApplyCommonLayout(t);
 
@@ -175,8 +176,8 @@ Theme GetDarkTheme()
     t.bg_color = Color(0x1e1e1e);
     t.text_color = Color(0xd4d4d4);
     t.heading_color = Color(0xe0e0e0);
-    t.code_bg_color = Color(0x2d2d2d);
-    t.code_text_color = Color(0xd4d4d4);
+    t.code_bg_color = Color(theme_palette::kDark.code_bg);
+    t.code_text_color = Color(theme_palette::kDark.code_text);
     t.link_color = Color(0x569cd6);
     t.hr_color = Color(0x404040);
     t.blockquote_bar_color = Color(0x505050);
@@ -195,13 +196,13 @@ Theme GetDarkTheme()
     t.alert_bg_color[4] = Color(0x2e0b0d, 0.5f); // Caution bg
 
     // シンタックスハイライト（VS Code Dark+風）
-    t.syntax_keyword = Color(0xC586C0);
-    t.syntax_type = Color(0x4EC9B0);
-    t.syntax_string = Color(0xCE9178);
-    t.syntax_number = Color(0xB5CEA8);
-    t.syntax_comment = Color(0x6A9955);
-    t.syntax_preprocessor = Color(0xDCDCAA);
-    t.syntax_function = Color(0xDCDCAA);
+    t.syntax_keyword = Color(theme_palette::kDark.syntax_keyword);
+    t.syntax_type = Color(theme_palette::kDark.syntax_type);
+    t.syntax_string = Color(theme_palette::kDark.syntax_string);
+    t.syntax_number = Color(theme_palette::kDark.syntax_number);
+    t.syntax_comment = Color(theme_palette::kDark.syntax_comment);
+    t.syntax_preprocessor = Color(theme_palette::kDark.syntax_preprocessor);
+    t.syntax_function = Color(theme_palette::kDark.syntax_function);
 
     ApplyCommonLayout(t);
 

--- a/src/theme/theme_palette.h
+++ b/src/theme/theme_palette.h
@@ -1,9 +1,10 @@
 #pragma once
 #include <cstdint>
 
-// 描画（Direct2D）とHTMLクリップボードコピーの両方で参照される色を一元定義する。
-// 0xRRGGBB 形式の uint32_t で保持し、D2D1_COLOR_F と L"#rrggbb" のどちらの形式にも変換できる。
-// theme.cpp は D2D1_COLOR_F へ、document_utils.cpp は hex 文字列へ、同じ値を参照する。
+// 描画（Direct2D）と HTML クリップボードコピーで利用する色を一元定義する。
+// 0xRRGGBB 形式の uint32_t で保持し、D2D1_COLOR_F や L"#rrggbb" 文字列へ変換して参照する。
+// すべての色が両方から参照されるとは限らない（例: table_border は現状 HTML のみ）が、
+// 将来的な共有を見越して同じ palette に集約する。
 namespace theme_palette {
 
 struct SharedColors {

--- a/src/theme/theme_palette.h
+++ b/src/theme/theme_palette.h
@@ -1,0 +1,50 @@
+#pragma once
+#include <cstdint>
+
+// 描画（Direct2D）とHTMLクリップボードコピーの両方で参照される色を一元定義する。
+// 0xRRGGBB 形式の uint32_t で保持し、D2D1_COLOR_F と L"#rrggbb" のどちらの形式にも変換できる。
+// theme.cpp は D2D1_COLOR_F へ、document_utils.cpp は hex 文字列へ、同じ値を参照する。
+namespace theme_palette {
+
+struct SharedColors {
+    uint32_t code_bg;
+    uint32_t code_text;
+    uint32_t table_border;
+
+    // シンタックスハイライト色（ライトは VS Code Light 風、ダークは VS Code Dark+ 風）
+    uint32_t syntax_keyword;
+    uint32_t syntax_type;
+    uint32_t syntax_string;
+    uint32_t syntax_number;
+    uint32_t syntax_comment;
+    uint32_t syntax_preprocessor;
+    uint32_t syntax_function;
+};
+
+inline constexpr SharedColors kLight = {
+    .code_bg             = 0xf6f8fa,
+    .code_text           = 0x24292e,
+    .table_border        = 0xd0d7de,
+    .syntax_keyword      = 0xaf00db,
+    .syntax_type         = 0x267f99,
+    .syntax_string       = 0xa31515,
+    .syntax_number       = 0x098658,
+    .syntax_comment      = 0x008000,
+    .syntax_preprocessor = 0x795e26,
+    .syntax_function     = 0x795e26,
+};
+
+inline constexpr SharedColors kDark = {
+    .code_bg             = 0x2d2d2d,
+    .code_text           = 0xd4d4d4,
+    .table_border        = 0x3c3c3c,
+    .syntax_keyword      = 0xc586c0,
+    .syntax_type         = 0x4ec9b0,
+    .syntax_string       = 0xce9178,
+    .syntax_number       = 0xb5cea8,
+    .syntax_comment      = 0x6a9955,
+    .syntax_preprocessor = 0xdcdcaa,
+    .syntax_function     = 0xdcdcaa,
+};
+
+} // namespace theme_palette

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -207,7 +207,7 @@ TEST(ExtractSelectedTextAsHtml, CodeBlockWithSyntaxTokensWrapsInSpans)
 
     auto sel = TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(text.size()));
     auto html = ExtractSelectedTextAsHtml(nodes, sel);
-    EXPECT_NE(html.find(L"<span style=\"color:#AF00DB\">int</span>"), std::wstring::npos);
+    EXPECT_NE(html.find(L"<span style=\"color:#af00db\">int</span>"), std::wstring::npos);
     EXPECT_NE(html.find(L"<span style=\"color:#098658\">42</span>"), std::wstring::npos);
     // その他の Plain 区間は素のテキスト
     EXPECT_NE(html.find(L" x = "), std::wstring::npos);
@@ -246,10 +246,10 @@ TEST(ExtractSelectedTextAsHtml, CodeBlockDarkModeUsesDarkColors)
     auto sel = TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(text.size()));
     auto html = ExtractSelectedTextAsHtml(nodes, sel, /*dark_mode=*/true);
     // ダーク用の色（VS Code Dark+ 相当）が使われる
-    EXPECT_NE(html.find(L"<span style=\"color:#C586C0\">int</span>"), std::wstring::npos);
-    EXPECT_NE(html.find(L"<span style=\"color:#B5CEA8\">42</span>"), std::wstring::npos);
+    EXPECT_NE(html.find(L"<span style=\"color:#c586c0\">int</span>"), std::wstring::npos);
+    EXPECT_NE(html.find(L"<span style=\"color:#b5cea8\">42</span>"), std::wstring::npos);
     // ライト用の色は混ざらない
-    EXPECT_EQ(html.find(L"#AF00DB"), std::wstring::npos);
+    EXPECT_EQ(html.find(L"#af00db"), std::wstring::npos);
     EXPECT_EQ(html.find(L"#098658"), std::wstring::npos);
     // コードブロック背景がダーク色
     EXPECT_NE(html.find(L"background-color:#2d2d2d"), std::wstring::npos);


### PR DESCRIPTION
## Summary
- Issue #115 対応。描画 (Direct2D) と書式付きコピー (HTML) で重複していたカラーコードを `src/theme/theme_palette.h` に `0xRRGGBB` の `uint32_t` として一元定義。
- `theme.cpp` は `D2D1_COLOR_F` を、`document_utils.cpp` は `L"#rrggbb"` を、同じ palette フィールドから構築するようにした。
- 対象色: コードブロック背景・テキスト、シンタックスハイライト 7 種 × 2 テーマ、テーブル境界。HTML 出力 hex 文字列は小文字に統一。

## Test plan
- [x] `cmake --build build --config Release` でビルド成功
- [x] `mendo_tests.exe` 全 1739 テストパス
- [ ] 書式付きコピー (Ctrl+Shift+C) で Light / Dark テーマ両方の出力 HTML を目視確認
- [ ] コードブロック背景色、シンタックスハイライト色、テーブル境界色が従来と視覚的に同一

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)