### PR TITLE
fix: セッション復元のスクロール位置がずれる不具合を修正 (#118)

### DIFF
--- a/src/app/app.h
+++ b/src/app/app.h
@@ -89,9 +89,9 @@ public:
     RECT GetSearchEditRect();
 
     // 前回セッションのスクロール位置復元用（LoadMarkdownFileの前に呼ぶ）
-    void SetPendingRestoreNode(int node, int offset, float scroll_y = -1.0f) noexcept
+    void SetPendingRestoreNode(int node, int offset) noexcept
     {
-        state_.view.scroll_restore.SetNodeRestore(node, offset, scroll_y);
+        state_.view.scroll_restore.SetNodeRestore(node, offset);
     }
 
     // サイズ変更状態 — Reducer経由で状態変更

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -252,13 +252,6 @@ void App::FinishLoadMarkdownFile(bool heights_estimated)
     }
     else if (state_.view.scroll_restore.HasNavScroll()) {
         scroll_y = state_.view.scroll_restore.ConsumeNavScroll();
-        // 残留 pending_restore_scroll_y が遅延レイアウト完了時に適用され、
-        // ナビゲーション復帰スクロールを上書きするのを防ぐ。
-        state_.view.scroll_restore.pending_restore_scroll_y = -1.0f;
-    }
-    else {
-        // 新規ファイルオープン: 前回ナビゲーションの残留値をクリア
-        state_.view.scroll_restore.pending_restore_scroll_y = -1;
     }
 
     MENDO_TRACEF("FinishLoad: scroll_y=%.1f (0=top of file)", scroll_y);

--- a/src/app/app_scroll.cpp
+++ b/src/app/app_scroll.cpp
@@ -24,7 +24,6 @@ void App::InvalidateHitPositions() noexcept
 
 void App::ScrollTo(float position)
 {
-    state_.view.scroll_restore.pending_restore_scroll_y = -1;
     state_.view.viewport.ScrollTo(position);
     InvalidateHitPositions();
 }
@@ -167,12 +166,6 @@ void App::OnDeferredLayout()
         // 時間予算付きバッチで処理する。同期ディスクI/O + PNGデコードが
         // UIスレッドを長時間ブロックするのを防ぐ。
         resource_manager_.ScheduleMermaidBatch();
-
-        // 全レイアウト確定後に前回セッションの生のscroll_yを適用する
-        if (state_.view.scroll_restore.pending_restore_scroll_y >= 0.0f) {
-            state_.view.viewport.SetScrollY(state_.view.scroll_restore.pending_restore_scroll_y);
-            state_.view.scroll_restore.pending_restore_scroll_y = -1.0f;
-        }
 
         SyncMaxScroll(md_height);
 

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -61,7 +61,6 @@ void ApplyNavResult(AppState& state, SideEffectList& effects, NavEntry&& entry)
         effects.emplace_back(effect::LoadFile{ std::move(entry.file_path) });
     }
     else {
-        state.view.scroll_restore.pending_restore_scroll_y = -1;
         state.view.viewport.ScrollTo(entry.scroll_y);
         state.interaction.hover_throttle.Reset();
         ClearTooltip(state, effects);
@@ -92,7 +91,6 @@ void ReduceNavigateForward(AppState& state, SideEffectList& effects)
 
 void ReduceKeyScroll(AppState& state, SideEffectList& effects, const KeyScrollAction& a)
 {
-    state.view.scroll_restore.pending_restore_scroll_y = -1;
     const float old_scroll = state.view.viewport.GetScrollY();
     const float page_size = state.cached_pane_layout.md_rect.height;
     switch (a.type) {
@@ -122,7 +120,6 @@ void ReduceKeyScroll(AppState& state, SideEffectList& effects, const KeyScrollAc
 
 void ReduceDirectScrollBy(AppState& state, SideEffectList& effects, const DirectScrollByAction& a)
 {
-    state.view.scroll_restore.pending_restore_scroll_y = -1;
     const float old_scroll = state.view.viewport.GetScrollY();
     state.view.viewport.DirectScrollBy(a.delta);
     EmitScrollEffects(state, effects, old_scroll);

--- a/src/io/session_service.cpp
+++ b/src/io/session_service.cpp
@@ -64,8 +64,6 @@ void SessionService::SaveScrollPosition(int node, float scroll_y, float node_y)
     const int offset = static_cast<int>(std::lround(scroll_y - node_y));
     config_.SaveInt("Session", "ScrollNode", node);
     config_.SaveInt("Session", "ScrollOffset", offset);
-    // 遅延レイアウト完了後に正確な位置を復元するための生のscroll_y
-    config_.SaveInt("Session", "ScrollY", static_cast<int>(std::lround(scroll_y)));
 }
 
 SessionService::ScrollPosition SessionService::LoadScrollPosition() const
@@ -73,6 +71,5 @@ SessionService::ScrollPosition SessionService::LoadScrollPosition() const
     return {
         .node = config_.LoadInt("Session", "ScrollNode", -1, -1, 1000000),
         .offset = config_.LoadInt("Session", "ScrollOffset", 0, -1000000, 1000000),
-        .raw_y = config_.LoadInt("Session", "ScrollY", 0, 0, 10000000),
     };
 }

--- a/src/io/session_service.h
+++ b/src/io/session_service.h
@@ -18,7 +18,6 @@ public:
     struct ScrollPosition {
         int node = -1;
         int offset = 0;
-        int raw_y = 0;
     };
     void SaveScrollPosition(int node, float scroll_y, float node_y);
     ScrollPosition LoadScrollPosition() const;

--- a/src/ui/scroll_restoration.h
+++ b/src/ui/scroll_restoration.h
@@ -7,7 +7,6 @@ struct ScrollRestoration {
     float pending_nav_scroll_y = -1.0f;
     int pending_restore_node = -1;
     int pending_restore_offset = 0;
-    float pending_restore_scroll_y = -1.0f;  // 遅延レイアウト完了後に適用する生のscroll_y
 
     bool HasNavScroll() const noexcept { return pending_nav_scroll_y >= 0.0f; }
     bool HasNodeRestore() const noexcept { return pending_restore_node >= 0; }
@@ -19,11 +18,10 @@ struct ScrollRestoration {
         return v;
     }
 
-    void SetNodeRestore(int node, int offset, float scroll_y = -1.0f) noexcept
+    void SetNodeRestore(int node, int offset) noexcept
     {
         pending_restore_node = node;
         pending_restore_offset = offset;
-        pending_restore_scroll_y = scroll_y;
     }
 
     void ClearNodeRestore() noexcept
@@ -37,6 +35,5 @@ struct ScrollRestoration {
         pending_nav_scroll_y = -1.0f;
         pending_restore_node = -1;
         pending_restore_offset = 0;
-        pending_restore_scroll_y = -1.0f;
     }
 };

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -703,8 +703,7 @@ void Win32Window::RestoreScrollPosition()
         return;
     }
     const int offset = config::GetInt("Session", "ScrollOffset", 0, -100000, 100000);
-    const int scroll_y = config::GetInt("Session", "ScrollY", -1, -1, 100000000);
-    app_->SetPendingRestoreNode(node, offset, static_cast<float>(scroll_y));
+    app_->SetPendingRestoreNode(node, offset);
 }
 
 // ============================================================

--- a/tests/test_scroll_restoration.cpp
+++ b/tests/test_scroll_restoration.cpp
@@ -10,7 +10,6 @@ TEST(ScrollRestoration, InitialState)
     EXPECT_FLOAT_EQ(sr.pending_nav_scroll_y, -1.0f);
     EXPECT_EQ(sr.pending_restore_node, -1);
     EXPECT_EQ(sr.pending_restore_offset, 0);
-    EXPECT_EQ(sr.pending_restore_scroll_y, -1);
 }
 
 TEST(ScrollRestoration, HasNavScroll)
@@ -55,66 +54,23 @@ TEST(ScrollRestoration, SetNodeRestore)
     sr.SetNodeRestore(10, 50);
     EXPECT_EQ(sr.pending_restore_node, 10);
     EXPECT_EQ(sr.pending_restore_offset, 50);
-    EXPECT_EQ(sr.pending_restore_scroll_y, -1);
-}
-
-TEST(ScrollRestoration, SetNodeRestoreWithScrollY)
-{
-    ScrollRestoration sr;
-    sr.SetNodeRestore(5, 30, 1200);
-    EXPECT_EQ(sr.pending_restore_node, 5);
-    EXPECT_EQ(sr.pending_restore_offset, 30);
-    EXPECT_EQ(sr.pending_restore_scroll_y, 1200);
 }
 
 TEST(ScrollRestoration, ClearNodeRestore)
 {
     ScrollRestoration sr;
-    sr.SetNodeRestore(10, 50, 800);
+    sr.SetNodeRestore(10, 50);
     sr.ClearNodeRestore();
     EXPECT_FALSE(sr.HasNodeRestore());
     EXPECT_EQ(sr.pending_restore_node, -1);
     EXPECT_EQ(sr.pending_restore_offset, 0);
-    // ClearNodeRestoreはpending_restore_scroll_yを保持する
-    // （遅延レイアウト完了後の最終補正に必要なため）
-    EXPECT_EQ(sr.pending_restore_scroll_y, 800);
-}
-
-// ConsumeNavScrollはpending_restore_scroll_yに影響しない。
-// ナビゲーション復帰ではアンカー補償に任せるため、Appは設定しない。
-TEST(ScrollRestoration, ConsumeNavScrollDoesNotAffectPendingRestoreScrollY)
-{
-    ScrollRestoration sr;
-    sr.pending_nav_scroll_y = 500.3f;
-    sr.pending_restore_scroll_y = 1200;
-
-    sr.ConsumeNavScroll();
-    EXPECT_EQ(sr.pending_restore_scroll_y, 1200);
-}
-
-// ScrollRestoration APIテスト:
-// ConsumeNavScroll後にpending_restore_scroll_yを手動設定できることを確認。
-// 注: ナビゲーション復帰時はAppが設定しない（アンカー補償に委ねる）。
-// セッション復元時のみ SetNodeRestore 経由で設定される。
-TEST(ScrollRestoration, NavRestoreThenSetPendingScrollY)
-{
-    ScrollRestoration sr;
-    sr.pending_nav_scroll_y = 500.3f;
-
-    const float scroll_y = sr.ConsumeNavScroll();
-    EXPECT_FLOAT_EQ(scroll_y, 500.3f);
-    EXPECT_FALSE(sr.HasNavScroll());
-
-    // API上は手動設定可能（セッション復元で使用）
-    sr.pending_restore_scroll_y = scroll_y;
-    EXPECT_FLOAT_EQ(sr.pending_restore_scroll_y, 500.3f);
 }
 
 TEST(ScrollRestoration, Reset)
 {
     ScrollRestoration sr;
     sr.pending_nav_scroll_y = 100.0f;
-    sr.SetNodeRestore(10, 50, 800);
+    sr.SetNodeRestore(10, 50);
 
     sr.Reset();
     EXPECT_FALSE(sr.HasNavScroll());
@@ -122,5 +78,4 @@ TEST(ScrollRestoration, Reset)
     EXPECT_FLOAT_EQ(sr.pending_nav_scroll_y, -1.0f);
     EXPECT_EQ(sr.pending_restore_node, -1);
     EXPECT_EQ(sr.pending_restore_offset, 0);
-    EXPECT_EQ(sr.pending_restore_scroll_y, -1);
 }

--- a/tests/test_session_service.cpp
+++ b/tests/test_session_service.cpp
@@ -59,7 +59,6 @@ TEST_F(SessionServiceTest, SaveAndLoadScrollPosition)
     const auto pos = session_.LoadScrollPosition();
     EXPECT_EQ(pos.node, 5);
     EXPECT_EQ(pos.offset, 50);       // lround(350 - 300)
-    EXPECT_EQ(pos.raw_y, 350);       // lround(350)
 }
 
 // ---- SaveLastFilePath / LoadLastFilePath ----


### PR DESCRIPTION
## Summary
- 再起動時にファイルのスクロール位置が大きくずれる不具合 (#118) を修正。原因は `OnDeferredLayout` で保存時の生 `scroll_y` をそのまま再適用していたこと。`ProcessDirtyBatch` はビューポート付近のみ計測するため、遠方ノードは推定高さのままで累積高さが変わり、同じ `scroll_y` が全く違うノードを指してしまう。
- ナビゲーション復帰で既に同じ問題を解決済み (035456d) のアンカー補償方式へ統一。
- 生 `scroll_y` 経路が完全に死に体となったため、`pending_restore_scroll_y` フィールド／`Session/ScrollY` 設定キー／`raw_y` メンバ／関連する引数連鎖を一括削除し、次の実装者による再発を防止。

## 変更ファイル (+6 / -77)
- `src/app/app_scroll.cpp`: `OnDeferredLayout` の生 `scroll_y` 適用ブロックと、`ScrollTo` の防御的クリアを削除
- `src/ui/scroll_restoration.h`: `pending_restore_scroll_y` と `SetNodeRestore` の `scroll_y` 引数を削除
- `src/io/session_service.{h,cpp}`: `Session/ScrollY` の保存・読込と `ScrollPosition::raw_y` を削除
- `src/window/window.cpp`, `src/app/app.h`: `SetPendingRestoreNode` の `scroll_y` 引数連鎖を削除
- `src/app/{app_file,reducer}.cpp`: 読み出しを伴わない防御的クリアを削除
- `tests/`: 死んだフィールドを参照するテストを整理

## Test plan
- [x] `cmake --build build --config Release` 成功
- [x] `build/tests/Release/mendo_tests.exe` — 1750 tests passed
- [x] 手動確認: 再現手順どおり「別ファイルをファイルペインから開く→スクロール→終了→再起動」で前回位置が復元されること
- [x] 手動確認: ナビゲーション (戻る/進む) の位置復元が退行していないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)