### PR TITLE
パフォーマンス最適化: ホットパスのアロケーション削減とキャッシュ強化

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -94,8 +94,7 @@ const PaneLayout& App::GetPaneLayout()
         const auto size = rt->GetSize();
         state_.cached_window_width_for_layout = size.width;
         const float tb_h = state_.window.titlebar.GetHeight();
-        state_.cached_pane_layout = state_.view.panes.ComputeLayout(size.width, size.height,
-            renderer_.GetTheme().splitter_width, tb_h);
+        state_.cached_pane_layout = state_.view.panes.ComputeLayout(size.width, size.height, renderer_.GetTheme().splitter_width, tb_h);
         state_.pane_layout_valid = true;
     }
     return state_.cached_pane_layout;

--- a/src/app/app_mouse_hover.cpp
+++ b/src/app/app_mouse_hover.cpp
@@ -316,7 +316,9 @@ void App::OnMouseHover(int px, int py)
             [](bool) { return false; },
             [this](float y, float h) { return state_.document.doc.GetToc().HitTest(y, h); },
             [&](bool close_hit, bool, int idx) -> TooltipTarget {
-            if (close_hit) { return { TooltipTarget::Zone::TocPaneButton, i18n::S().tooltip_pane_close }; }
+            if (close_hit) {
+                return { TooltipTarget::Zone::TocPaneButton, i18n::S().tooltip_pane_close };
+            }
             if (idx >= 0 && idx < static_cast<int>(toc_entries.size())) {
                 return { TooltipTarget::Zone::TocPaneItem, state_.document.doc.GetNodes()[toc_entries[idx].node_index].GetText() };
             }

--- a/src/app/resource_manager.cpp
+++ b/src/app/resource_manager.cpp
@@ -366,6 +366,9 @@ void ResourceManager::FlushPendingResources()
         return;
     }
     pending_flush_ = false;
+    // last_flush_time_ は ScheduleBitmapManage 以外の経路（OnBitmapManageTimer 等）
+    // からのフラッシュでも一元的に更新する
+    last_flush_time_ = std::chrono::steady_clock::now();
 
     bool changed = (ApplyCachedImages() > 0);
 
@@ -388,7 +391,6 @@ void ResourceManager::ScheduleBitmapManage()
     pending_flush_ = true;
     if (since_last >= 50) {
         FlushPendingResources();
-        last_flush_time_ = now;
     }
     cb_.set_timer(TIMER_BITMAP_MANAGE, 150);
 }

--- a/src/app/resource_manager.cpp
+++ b/src/app/resource_manager.cpp
@@ -380,8 +380,16 @@ void ResourceManager::FlushPendingResources()
 
 void ResourceManager::ScheduleBitmapManage()
 {
-    pending_flush_ = true;  // スクロールで新たに可視になったノードをスキャンする
-    FlushPendingResources();
+    // 直近 50ms 以内に既に flush していれば再実行を抑止する。
+    // 細かいスクロールで FlushPendingResources が毎フレーム走るのを防ぎ、
+    // タイマー (150ms) 側で集約的に処理する。
+    const auto now = std::chrono::steady_clock::now();
+    const auto since_last = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_flush_time_).count();
+    pending_flush_ = true;
+    if (since_last >= 50) {
+        FlushPendingResources();
+        last_flush_time_ = now;
+    }
     cb_.set_timer(TIMER_BITMAP_MANAGE, 150);
 }
 

--- a/src/app/resource_manager.h
+++ b/src/app/resource_manager.h
@@ -2,6 +2,7 @@
 #include "flat_map.h"
 #include <string>
 #include <functional>
+#include <chrono>
 #include <windows.h>
 
 class Document;
@@ -82,4 +83,5 @@ private:
     size_t mermaid_batch_next_ = 0;
     FlatMap<size_t, std::wstring> resolved_image_paths_;
     bool pending_flush_ = false;
+    std::chrono::steady_clock::time_point last_flush_time_{};
 };

--- a/src/app/side_effect_executor.cpp
+++ b/src/app/side_effect_executor.cpp
@@ -37,7 +37,11 @@ void SideEffectExecutor::ExecuteOne(const SideEffect& e)
             InvalidateRect(hwnd_, nullptr, FALSE);
         },
         [this](const effect::InvalidateTitleBar&) {
-            InvalidateRect(hwnd_, nullptr, FALSE);
+            RECT client;
+            GetClientRect(hwnd_, &client);
+            const float dpi_scale = state_ ? state_->window.cached_dpi_scale : 1.0f;
+            RECT tb_rect{ 0, 0, client.right, static_cast<LONG>(state_->window.titlebar.GetHeight() * dpi_scale + 0.5f) };
+            InvalidateRect(hwnd_, &tb_rect, FALSE);
         },
         [this](const effect::SetTimer& e) {
             ::SetTimer(hwnd_, e.id, e.ms, nullptr);
@@ -105,7 +109,7 @@ void SideEffectExecutor::ExecuteOne(const SideEffect& e)
             config_->Flush();
         },
         [this](const effect::ShowTooltip& e) {
-            POINT screen_pos = { e.px, e.py };
+            POINT screen_pos{ e.px, e.py };
             ClientToScreen(hwnd_, &screen_pos);
             if (state_->interaction.tooltip.Update(e.target, screen_pos)) {
                 ::SetTimer(hwnd_, app_timer::TOOLTIP, TOOLTIP_DELAY_MS, nullptr);

--- a/src/app/side_effect_executor.cpp
+++ b/src/app/side_effect_executor.cpp
@@ -37,10 +37,15 @@ void SideEffectExecutor::ExecuteOne(const SideEffect& e)
             InvalidateRect(hwnd_, nullptr, FALSE);
         },
         [this](const effect::InvalidateTitleBar&) {
+            if (!state_) {
+                InvalidateRect(hwnd_, nullptr, FALSE);
+                return;
+            }
             RECT client;
             GetClientRect(hwnd_, &client);
-            const float dpi_scale = state_ ? state_->window.cached_dpi_scale : 1.0f;
-            RECT tb_rect{ 0, 0, client.right, static_cast<LONG>(state_->window.titlebar.GetHeight() * dpi_scale + 0.5f) };
+            const float dpi_scale = state_->window.cached_dpi_scale;
+            RECT tb_rect{ 0, 0, client.right,
+                static_cast<LONG>(state_->window.titlebar.GetHeight() * dpi_scale + 0.5f) };
             InvalidateRect(hwnd_, &tb_rect, FALSE);
         },
         [this](const effect::SetTimer& e) {

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
-#include <map>
+#include <unordered_map>
 #include <memory_resource>
 
 class Document {
@@ -49,7 +49,7 @@ private:
     std::pmr::wstring file_path_;
     std::pmr::string raw_utf8_;
     TableOfContents toc_;
-    std::pmr::map<std::pmr::wstring, int> anchor_index_;
+    std::pmr::unordered_map<std::pmr::wstring, int> anchor_index_;
     std::pmr::vector<size_t> image_node_indices_;
     std::pmr::vector<size_t> diagram_node_indices_;
 };

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -5,6 +5,7 @@
 #include "md4c.h"
 #include <stack>
 #include <map>
+#include <unordered_map>
 #include <charconv>
 #include <format>
 #include <iterator>
@@ -110,6 +111,9 @@ struct ParseContext {
     // リンクURL格納: SpanStateではインデックスのみ保持し、push/popでの文字列コピーを回避
     std::pmr::vector<std::pmr::wstring> link_urls{ parse_resource.resource() };
 
+    // BeginNode 毎にクリア。MakeRun から O(1) で重複 URL を検出する
+    std::pmr::unordered_map<std::pmr::wstring, int16_t> current_node_url_map{ parse_resource.resource() };
+
     // アンカーIDの一意性追跡: スラグ -> 出現回数
     std::pmr::map<std::pmr::wstring, int> anchor_counts{ parse_resource.resource() };
 
@@ -141,9 +145,10 @@ struct ParseContext {
         if (blockquote_depth > 0 && !blockquote_group_stack.empty()) {
             current_node->blockquote_group = blockquote_group_stack.top();
         }
+        current_node_url_map.clear();
     }
 
-    TextRun MakeRun(uint32_t start, uint32_t length) const
+    TextRun MakeRun(uint32_t start, uint32_t length)
     {
         TextRun run;
         run.start = start;
@@ -154,24 +159,14 @@ struct ParseContext {
         run.set_strikethrough(current_span.strikethrough);
         if (current_span.link_url_index >= 0 && current_node) {
             const auto& url = link_urls[static_cast<size_t>(current_span.link_url_index)];
-            // ノードのURLプール内で重複を検索し、なければ追加。
-            // 同一リンク内のテキストは連続呼び出しされるため末尾一致が最多だが、
-            // 異種URLが混在すると末尾逆走査は O(n²) に退化する。
-            // 直近数件のみ比較する制限付き逆走査に切り替え、閾値超過時は重複追加を許容する
-            // （link_url_index は int16_t で十分な余裕があり、機能上は同値）。
-            constexpr size_t LINEAR_SCAN_LIMIT = 8;
-            int16_t node_idx = -1;
-            const auto url_count = current_node->link_urls.size();
-            const auto scan_start = url_count > LINEAR_SCAN_LIMIT ? url_count - LINEAR_SCAN_LIMIT : 0;
-            for (size_t i = url_count; i > scan_start; i--) {
-                if (current_node->link_urls[i - 1] == url) {
-                    node_idx = static_cast<int16_t>(i - 1);
-                    break;
-                }
+            int16_t node_idx;
+            if (const auto it = current_node_url_map.find(url); it != current_node_url_map.end()) {
+                node_idx = it->second;
             }
-            if (node_idx < 0) {
+            else {
                 node_idx = static_cast<int16_t>(current_node->link_urls.size());
                 current_node->link_urls.emplace_back(url);
+                current_node_url_map.emplace(url, node_idx);
             }
             run.link_url_index = node_idx;
         }
@@ -199,11 +194,12 @@ struct ParseContext {
             return;
         }
         const uint32_t start = node_wide_offset;
-        const int utf8_len = WideCharToMultiByte(CP_UTF8, 0, text.data(), static_cast<int>(text.size()), nullptr, 0, nullptr, nullptr);
-        if (utf8_len > 0) {
+        if (!text.empty()) {
             const size_t old_size = current_node->text_utf8.size();
-            current_node->text_utf8.resize_and_overwrite(old_size + static_cast<size_t>(utf8_len), [&](char* buf, size_t count) -> size_t {
-                return old_size + static_cast<size_t>(WideCharToMultiByte(CP_UTF8, 0, text.data(), static_cast<int>(text.size()), buf + old_size, static_cast<int>(count - old_size), nullptr, nullptr));
+            const size_t max_bytes = text.size() * 3;
+            current_node->text_utf8.resize_and_overwrite(old_size + max_bytes, [&](char* buf, size_t count) -> size_t {
+                const int n = WideCharToMultiByte(CP_UTF8, 0, text.data(), static_cast<int>(text.size()), buf + old_size, static_cast<int>(count - old_size), nullptr, nullptr);
+                return old_size + (n > 0 ? static_cast<size_t>(n) : 0);
             });
         }
         node_wide_offset += static_cast<uint32_t>(text.size());
@@ -732,6 +728,9 @@ ParseResult ParseMarkdown(std::string_view markdown_text)
     ctx.markdown_base = markdown_text.data();
     ctx.utf8_accum.reserve(4096);
     ctx.nodes.reserve(std::clamp(markdown_text.size() / 64, size_t{ 64 }, size_t{ 8192 }));
+    ctx.heading_indices.reserve(std::clamp(markdown_text.size() / 256, size_t{ 8 }, size_t{ 512 }));
+    ctx.image_indices.reserve(std::clamp(markdown_text.size() / 512, size_t{ 4 }, size_t{ 256 }));
+    ctx.diagram_indices.reserve(std::clamp(markdown_text.size() / 1024, size_t{ 4 }, size_t{ 128 }));
 
     MD_PARSER parser{};
     parser.abi_version = 0;

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -7,6 +7,7 @@
 #include <map>
 #include <unordered_map>
 #include <charconv>
+#include <climits>
 #include <format>
 #include <iterator>
 #include <algorithm>
@@ -194,7 +195,8 @@ struct ParseContext {
             return;
         }
         const uint32_t start = node_wide_offset;
-        if (!text.empty()) {
+        // AppendText は BR/SOFTBR/Entity 用で短い入力前提。INT_MAX/3 超は安全のためスキップ
+        if (!text.empty() && text.size() <= static_cast<size_t>(INT_MAX) / 3) {
             const size_t old_size = current_node->text_utf8.size();
             const size_t max_bytes = text.size() * 3;
             current_node->text_utf8.resize_and_overwrite(old_size + max_bytes, [&](char* buf, size_t count) -> size_t {

--- a/src/core/syntax.cpp
+++ b/src/core/syntax.cpp
@@ -244,6 +244,10 @@ std::pmr::vector<SyntaxToken> TokenizeGeneric(
     uint32_t plain_start = 0;
     bool in_plain = false;
     std::wstring ci_buf; // case_insensitive用の再利用バッファ
+    if (cfg.case_insensitive) {
+        // 典型的なキーワード最長（PowerShell の `ForEach-Object` 等）を事前確保
+        ci_buf.reserve(64);
+    }
 
     const auto flush_plain = [&]() {
         if (in_plain && static_cast<uint32_t>(i) > plain_start) {
@@ -422,22 +426,24 @@ std::pmr::vector<SyntaxToken> TokenizeGeneric(
             const std::wstring_view word(text.data() + start, i - start);
             std::wstring_view lookup_word = word;
             if (cfg.case_insensitive) {
-                // 再利用バッファで小文字化（毎回のメモリ確保を回避）
-                ci_buf.clear();
-                if (ci_buf.capacity() < word.size()) {
-                    ci_buf.reserve(word.size());
-                }
+                // 大文字有無を先行判定し、無ければ word をそのまま使用（ci_buf への書き込み回避）
                 bool has_upper = false;
                 for (wchar_t ch : word) {
                     if (ch >= L'A' && ch <= L'Z') {
                         has_upper = true;
-                        ci_buf += static_cast<wchar_t>(ch - L'A' + L'a');
-                    }
-                    else {
-                        ci_buf += ch;
+                        break;
                     }
                 }
                 if (has_upper) {
+                    ci_buf.clear();
+                    if (ci_buf.capacity() < word.size()) {
+                        ci_buf.reserve(word.size());
+                    }
+                    for (wchar_t ch : word) {
+                        ci_buf += (ch >= L'A' && ch <= L'Z')
+                            ? static_cast<wchar_t>(ch - L'A' + L'a')
+                            : ch;
+                    }
                     lookup_word = ci_buf;
                 }
             }

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -164,6 +164,11 @@ HitTestService::HitResult HitTestService::HitTest(
         return result;
     }
 
+    const uint32_t gen = ctx.cache.GetEffectsGeneration();
+    if (last_md_hit_.Matches(ctx, gen)) {
+        return last_md_hit_.result;
+    }
+
     const auto [dip_x, dip_y] = ScreenToPaneDip(ctx.screen_x, ctx.screen_y, ctx.dpi_scale, ctx.md_pane_left, ctx.scroll_y);
 
     // dip_yを含むノードを検索
@@ -179,7 +184,9 @@ HitTestService::HitResult HitTestService::HitTest(
         const auto& entry = ctx.cache[candidate];
 
         if (node.type == NodeType::Table) {
-            return HitTestTable(node, entry, candidate, ctx.theme, dip_x, dip_y);
+            result = HitTestTable(node, entry, candidate, ctx.theme, dip_x, dip_y);
+            last_md_hit_.Store(ctx, gen, result);
+            return result;
         }
 
         if (entry.text_layout) {
@@ -195,6 +202,7 @@ HitTestService::HitResult HitTestService::HitTest(
 
             result.node_index = candidate;
             result.text_pos = metrics.textPosition + (is_trailing ? 1 : 0);
+            last_md_hit_.Store(ctx, gen, result);
             return result;
         }
     }
@@ -204,9 +212,10 @@ HitTestService::HitResult HitTestService::HitTest(
         if (const auto& text = node.GetText(); !text.empty()) {
             result.node_index = static_cast<int>(i);
             result.text_pos = static_cast<uint32_t>(text.size());
-            return result;
+            break;
         }
     }
+    last_md_hit_.Store(ctx, gen, result);
     return result;
 }
 
@@ -274,11 +283,17 @@ int HitTestService::CopyButtonHitTest(const MdPaneHitContext& ctx) const noexcep
         return -1;
     }
 
+    const uint32_t gen = ctx.cache.GetEffectsGeneration();
+    if (last_copy_hit_.Matches(ctx, gen)) {
+        return last_copy_hit_.result;
+    }
+
     const auto [dip_x, dip_y] = ScreenToPaneDip(ctx.screen_x, ctx.screen_y, ctx.dpi_scale, ctx.md_pane_left, ctx.scroll_y);
 
     // コピーボタンはコンテンツ右端にあるため、X座標で大半のマウス位置を早期棄却
     const float btn_left_bound = ctx.theme.margin_left + ctx.content_width - COPY_BTN_MARGIN - COPY_BTN_SIZE;
     if (dip_x < btn_left_bound) {
+        last_copy_hit_.Store(ctx, gen, -1);
         return -1;
     }
 
@@ -312,9 +327,11 @@ int HitTestService::CopyButtonHitTest(const MdPaneHitContext& ctx) const noexcep
 
         const D2D1_RECT_F btn = OverlayButtonRect(block_right, block_top);
         if (dip_x >= btn.left && dip_x <= btn.right && dip_y >= btn.top && dip_y <= btn.bottom) {
+            last_copy_hit_.Store(ctx, gen, i);
             return i;
         }
     }
+    last_copy_hit_.Store(ctx, gen, -1);
     return -1;
 }
 
@@ -324,6 +341,11 @@ int HitTestService::SaveButtonHitTest(const MdPaneHitContext& ctx) const noexcep
     assert(ctx.md_pane_height > 0.0f && "md_pane_height must be set for button hit test");
     if (ctx.nodes.empty()) {
         return -1;
+    }
+
+    const uint32_t gen = ctx.cache.GetEffectsGeneration();
+    if (last_save_hit_.Matches(ctx, gen)) {
+        return last_save_hit_.result;
     }
 
     const auto [dip_x, dip_y] = ScreenToPaneDip(ctx.screen_x, ctx.screen_y, ctx.dpi_scale, ctx.md_pane_left, ctx.scroll_y);
@@ -355,9 +377,11 @@ int HitTestService::SaveButtonHitTest(const MdPaneHitContext& ctx) const noexcep
         const auto bmp = MermaidBitmapRect(diagram.width, diagram.height, x, cw, ctx.cache[i].y_position);
         const D2D1_RECT_F btn = OverlayButtonRect(bmp.right, bmp.top);
         if (dip_x >= btn.left && dip_x <= btn.right && dip_y >= btn.top && dip_y <= btn.bottom) {
+            last_save_hit_.Store(ctx, gen, i);
             return i;
         }
     }
+    last_save_hit_.Store(ctx, gen, -1);
     return -1;
 }
 

--- a/src/input/hit_test_service.h
+++ b/src/input/hit_test_service.h
@@ -51,4 +51,32 @@ public:
     // Mermaidダイアグラムの保存ボタンのヒットテスト。
     // ヒットしたダイアグラムのノードインデックスを返す（-1=なし）。
     int SaveButtonHitTest(const MdPaneHitContext& ctx) const noexcept;
+
+private:
+    // 同一座標の連続ヒットテストを高速化する結果キャッシュ。
+    // effects_generation が変わると自動で無効化される。
+    template <typename T>
+    struct HitCache {
+        int screen_x = INT_MIN, screen_y = INT_MIN;
+        float scroll_y = 0.0f;
+        uint32_t effects_gen = UINT32_MAX;
+        T result{};
+
+        bool Matches(const MdPaneHitContext& ctx, uint32_t gen) const noexcept
+        {
+            return ctx.screen_x == screen_x && ctx.screen_y == screen_y
+                && ctx.scroll_y == scroll_y && gen == effects_gen;
+        }
+        void Store(const MdPaneHitContext& ctx, uint32_t gen, const T& r) noexcept
+        {
+            screen_x = ctx.screen_x;
+            screen_y = ctx.screen_y;
+            scroll_y = ctx.scroll_y;
+            effects_gen = gen;
+            result = r;
+        }
+    };
+    mutable HitCache<HitResult> last_md_hit_{};
+    mutable HitCache<int> last_copy_hit_{ .result = -1 };
+    mutable HitCache<int> last_save_hit_{ .result = -1 };
 };

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -12,6 +12,8 @@ static constexpr float CODE_BLOCK_NO_WRAP_WIDTH = 10000.0f;
 static constexpr float LAYOUT_MAX_HEIGHT = 100000.0f;
 static constexpr float DEFAULT_COLUMN_WIDTH = 60.0f;
 static constexpr float MIN_DIAGRAM_PLACEHOLDER_HEIGHT = 60.0f;
+// セル幅がこれ以下の差分なら前回の計測高さを再利用する
+static constexpr float CELL_WIDTH_EPSILON = 0.5f;
 
 static HRESULT CreateFormat(IDWriteFactory* factory, const wchar_t* family,
     float size, DWRITE_FONT_WEIGHT weight,
@@ -83,35 +85,75 @@ IDWriteTextFormat* DWriteTextMeasurer::GetTextFormat(const Node& node) noexcept
     return fmt_body_.Get();
 }
 
+namespace {
+
+// 隣接する同属性ランを連続 range にマージして emit に渡す。
+// ラン配列は start 昇順で、直前ランの直後に始まる前提。
+template <typename Pred, typename Emit>
+void ForEachAttrRange(const std::pmr::vector<TextRun>& runs, Pred predicate, Emit emit)
+{
+    const size_t n = runs.size();
+    for (size_t i = 0; i < n; ) {
+        if (!predicate(runs[i])) { i++; continue; }
+        const uint32_t range_start = runs[i].start;
+        uint32_t range_end = runs[i].start + runs[i].length;
+        size_t j = i + 1;
+        while (j < n && predicate(runs[j]) && runs[j].start == range_end) {
+            range_end += runs[j].length;
+            j++;
+        }
+        emit(DWRITE_TEXT_RANGE{ range_start, range_end - range_start });
+        i = j;
+    }
+}
+
+} // namespace
+
 void DWriteTextMeasurer::ApplyRunFormatting(IDWriteTextLayout* layout,
     const std::pmr::vector<TextRun>& runs, std::optional<NodeType> node_type)
 {
-    for (const auto& run : runs) {
-        const DWRITE_TEXT_RANGE range{ run.start, run.length };
-        if (run.bold()) {
-            layout->SetFontWeight(DWRITE_FONT_WEIGHT_EXTRA_BOLD, range);
-        }
-        if (run.italic()) {
-            layout->SetFontStyle(DWRITE_FONT_STYLE_ITALIC, range);
-        }
-        if (run.code()) {
-            // CodeBlock 内ではインラインコードフォーマットを適用しない
-            if (!node_type || *node_type != NodeType::CodeBlock) {
-                layout->SetFontFamilyName(theme_->monospace_font.c_str(), range);
-                // Heading 内ではコードフォントサイズを変更しない（見出しサイズを維持）
-                if (!node_type || *node_type != NodeType::Heading) {
-                    layout->SetFontSize(theme_->font_size_code, range);
-                }
+    if (runs.empty()) {
+        return;
+    }
+    const bool apply_code = (!node_type || *node_type != NodeType::CodeBlock);
+    const bool apply_code_size = apply_code && (!node_type || *node_type != NodeType::Heading);
+    const bool apply_link = !node_type;
+
+    ForEachAttrRange(
+        runs,
+        [](const TextRun& r) static noexcept { return r.bold(); },
+        [&](DWRITE_TEXT_RANGE r) { layout->SetFontWeight(DWRITE_FONT_WEIGHT_EXTRA_BOLD, r); }
+    );
+    ForEachAttrRange(
+        runs,
+        [](const TextRun& r) static noexcept { return r.italic(); },
+        [&](DWRITE_TEXT_RANGE r) { layout->SetFontStyle(DWRITE_FONT_STYLE_ITALIC, r); }
+    );
+
+    if (apply_code) {
+        ForEachAttrRange(
+            runs,
+            [](const TextRun& r) static noexcept { return r.code(); },
+            [&](DWRITE_TEXT_RANGE r) {
+            layout->SetFontFamilyName(theme_->monospace_font.c_str(), r);
+            if (apply_code_size) {
+                layout->SetFontSize(theme_->font_size_code, r);
             }
-        }
-        if (run.strikethrough()) {
-            layout->SetStrikethrough(TRUE, range);
-        }
-        // テーブルセル（node_type なし）ではリンクの下線を適用する。
-        // 通常ノードではApplyNodeEffects（描画パス）で下線＋色を一括適用するため、ここではスキップ。
-        if (!node_type && run.has_link()) {
-            layout->SetUnderline(TRUE, range);
-        }
+        });
+    }
+
+    ForEachAttrRange(
+        runs,
+        [](const TextRun& r) static noexcept { return r.strikethrough(); },
+        [&](DWRITE_TEXT_RANGE r) { layout->SetStrikethrough(TRUE, r); }
+    );
+
+    if (apply_link) {
+        ForEachAttrRange(
+            runs,
+            [](const TextRun& r) static noexcept { return r.has_link(); },
+            [&](DWRITE_TEXT_RANGE r) { layout->SetUnderline(TRUE, r); }
+        );
     }
 }
 
@@ -174,8 +216,13 @@ void DWriteTextMeasurer::MeasureNode(Node& node, NodeLayoutEntry& entry, float m
 
     ComPtr<IDWriteTextLayout> layout;
     const HRESULT hr = dwrite_->CreateTextLayout(
-        text.c_str(), static_cast<UINT32>(text.size()),
-        fmt, layout_width, LAYOUT_MAX_HEIGHT, &layout);
+        text.c_str(),
+        static_cast<UINT32>(text.size()),
+        fmt,
+        layout_width,
+        LAYOUT_MAX_HEIGHT,
+        &layout
+    );
     if (FAILED(hr)) {
         return;
     }
@@ -209,8 +256,7 @@ void DWriteTextMeasurer::MeasureNode(Node& node, NodeLayoutEntry& entry, float m
     entry.inline_code_bgs.clear();
 }
 
-void DWriteTextMeasurer::MeasureTableCells(Node& node, NodeLayoutEntry& entry,
-    std::pmr::vector<float>& natural_widths)
+void DWriteTextMeasurer::MeasureTableCells(Node& node, NodeLayoutEntry& entry, std::pmr::vector<float>& natural_widths)
 {
     IDWriteTextFormat* const fmt = fmt_body_.Get();
     IDWriteTextFormat* const fmt_bold = fmt_h_[3].Get();
@@ -251,9 +297,17 @@ void DWriteTextMeasurer::FinalizeTableLayout(Node& node, NodeLayoutEntry& entry,
     const float border_width = TABLE_BORDER_WIDTH;
     auto& tl = *entry.table_layout;
 
-    const float available = max_width - (static_cast<float>(col_count) + 1.0f) * border_width
-        - static_cast<float>(col_count) * cell_padding * 2.0f;
+    const float available = max_width - (static_cast<float>(col_count) + 1.0f) * border_width - static_cast<float>(col_count) * cell_padding * 2.0f;
     tl.col_widths = ComputeColumnWidths(natural_widths, available, col_count);
+
+    // セル毎の適用幅/高さキャッシュを確保（幅不変なら GetMetrics を省略）
+    const size_t cell_total = tl.cell_layouts.size();
+    if (tl.cell_heights.size() != cell_total) {
+        tl.cell_heights.assign(cell_total, 0.0f);
+    }
+    if (tl.cell_applied_widths.size() != cell_total) {
+        tl.cell_applied_widths.assign(cell_total, -1.0f);
+    }
 
     float total_height = border_width;
     auto& rows = node.table_rows();
@@ -268,17 +322,21 @@ void DWriteTextMeasurer::FinalizeTableLayout(Node& node, NodeLayoutEntry& entry,
 
             const size_t ci = tl.CellIndex(r, c);
             if (tl.cell_layouts[ci]) {
-                tl.cell_layouts[ci]->SetMaxWidth(cw);
-                if (cell.align == TableAlign::Center) {
-                    tl.cell_layouts[ci]->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+                const bool width_unchanged = std::abs(tl.cell_applied_widths[ci] - cw) < CELL_WIDTH_EPSILON && tl.cell_heights[ci] > 0.0f;
+                if (!width_unchanged) {
+                    tl.cell_layouts[ci]->SetMaxWidth(cw);
+                    if (cell.align == TableAlign::Center) {
+                        tl.cell_layouts[ci]->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+                    }
+                    else if (cell.align == TableAlign::Right) {
+                        tl.cell_layouts[ci]->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_TRAILING);
+                    }
+                    DWRITE_TEXT_METRICS metrics{};
+                    tl.cell_layouts[ci]->GetMetrics(&metrics);
+                    tl.cell_heights[ci] = metrics.height;
+                    tl.cell_applied_widths[ci] = cw;
                 }
-                else if (cell.align == TableAlign::Right) {
-                    tl.cell_layouts[ci]->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_TRAILING);
-                }
-
-                DWRITE_TEXT_METRICS metrics{};
-                tl.cell_layouts[ci]->GetMetrics(&metrics);
-                row_height = std::max(row_height, metrics.height + cell_padding * 2.0f);
+                row_height = std::max(row_height, tl.cell_heights[ci] + cell_padding * 2.0f);
             }
         }
         tl.row_heights[r] = row_height;

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -224,7 +224,9 @@ void LayoutEngine::ComputeLayout(std::pmr::vector<Node>& nodes, LayoutCache& cac
     const auto node_count = nodes.size();
     cache.Resize(node_count);
 
-    const bool width_changed = std::abs(viewport_width - last_viewport_width_) > 0.5f;
+    // 小刻みな WM_SIZE で全ノード再レイアウトが頻発するのを防ぐ
+    static constexpr float WIDTH_CHANGE_THRESHOLD = 2.0f;
+    const bool width_changed = std::abs(viewport_width - last_viewport_width_) > WIDTH_CHANGE_THRESHOLD;
     const bool partial = (viewport_top >= 0.0f);
 
     if (width_changed) {
@@ -306,9 +308,7 @@ void LayoutEngine::LayoutNodes(std::pmr::vector<Node>& nodes, LayoutCache& cache
     ComputeLayout(nodes, cache, viewport_width + theme_->margin_left + theme_->margin_right); // 逆変換: content→viewport
 }
 
-bool LayoutEngine::EnsureVisibleLayout(std::pmr::vector<Node>& nodes, LayoutCache& cache,
-    float viewport_width,
-    float viewport_top, float viewport_bottom)
+bool LayoutEngine::EnsureVisibleLayout(std::pmr::vector<Node>& nodes, LayoutCache& cache, float viewport_width, float viewport_top, float viewport_bottom)
 {
     const float content_width = theme_->ContentWidth(viewport_width);
     bool any_updated = false;

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -21,6 +21,8 @@ struct TableLayoutData {
     std::pmr::vector<float> col_widths;
     std::pmr::vector<float> row_heights;
     std::pmr::vector<float> natural_col_widths; // リサイズ高速パス用キャッシュ
+    std::pmr::vector<float> cell_heights;        // 各セルに最後に適用した幅での計測高さ
+    std::pmr::vector<float> cell_applied_widths; // 各セルに最後に適用した max_width（変更判定用）
     std::pmr::vector<uint32_t> row_flat_offsets; // 各行の線形化テキスト先頭オフセット（ヒットテスト高速化用）
     std::pmr::vector<uint8_t> row_bgs_computed; // 各行のインラインコード背景計算済みフラグ
     // ヒットテスト高速化用の累積オフセット。
@@ -176,6 +178,8 @@ public:
                 e.table_layout->cell_inline_code_bgs.clear();
                 e.table_layout->row_bgs_computed.clear();
                 e.table_layout->natural_col_widths.clear();
+                e.table_layout->cell_heights.clear();
+                e.table_layout->cell_applied_widths.clear();
                 e.table_layout->col_count = 0;
             }
         }
@@ -212,6 +216,8 @@ public:
                 e.table_layout->cell_layouts.clear();
                 e.table_layout->row_bgs_computed.clear();
                 e.table_layout->natural_col_widths.clear();
+                e.table_layout->cell_heights.clear();
+                e.table_layout->cell_applied_widths.clear();
                 e.table_layout->col_count = 0;
             }
         }

--- a/src/mermaid/mermaid_file_cache.cpp
+++ b/src/mermaid/mermaid_file_cache.cpp
@@ -90,17 +90,6 @@ int64_t MermaidFileCache::Now() noexcept
     return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
-void MermaidFileCache::RemoveLruEntry(int64_t timestamp, uint64_t key)
-{
-    const auto [lo, hi] = lru_order_.equal_range(timestamp);
-    for (auto iter = lo; iter != hi; ++iter) {
-        if (iter->second == key) {
-            lru_order_.erase(iter);
-            return;
-        }
-    }
-}
-
 void MermaidFileCache::Init(float current_dpr, TaskScheduler& scheduler)
 {
     scheduler_ = &scheduler;
@@ -174,13 +163,12 @@ void MermaidFileCache::LoadIndex()
             continue;
         }
 
-        index_[record.key] = IndexEntry{
-            record.css_width,
-            record.css_height,
-            record.png_size,
-            record.last_used
-        };
-        lru_order_.emplace(record.last_used, record.key);
+        auto& entry_ref = index_[record.key];
+        entry_ref.css_width = record.css_width;
+        entry_ref.css_height = record.css_height;
+        entry_ref.png_size = record.png_size;
+        entry_ref.last_used = record.last_used;
+        entry_ref.lru_iter = lru_order_.emplace(record.last_used, record.key);
         total_size_ += record.png_size;
     }
 }
@@ -247,7 +235,7 @@ bool MermaidFileCache::Lookup(uint64_t key, CacheEntry& entry, PngBlob& png)
             else {
                 total_size_ = 0;
             }
-            RemoveLruEntry(it->second.last_used, key);
+            lru_order_.erase(it->second.lru_iter);
             index_.erase(it);
         }
         return false;
@@ -258,12 +246,11 @@ bool MermaidFileCache::Lookup(uint64_t key, CacheEntry& entry, PngBlob& png)
     entry.css_width = it->second.css_width;
     entry.css_height = it->second.css_height;
 
-    // last_usedを更新し、LRU順序を再配置
-    const int64_t old_time = it->second.last_used;
+    // last_usedを更新し、LRU順序を再配置（O(1) で erase/insert）
     const int64_t new_time = Now();
+    lru_order_.erase(it->second.lru_iter);
     it->second.last_used = new_time;
-    RemoveLruEntry(old_time, key);
-    lru_order_.emplace(new_time, key);
+    it->second.lru_iter = lru_order_.emplace(new_time, key);
 
     return true;
 }
@@ -292,16 +279,21 @@ void MermaidFileCache::StoreAsync(uint64_t key, float css_width, float css_heigh
 
     // インデックスエントリを即座に追加・更新
     auto& entry = index_[key];
-    if (entry.png_size > 0 && total_size_ >= entry.png_size) {
-        total_size_ -= entry.png_size;
-        RemoveLruEntry(entry.last_used, key);
+    if (entry.png_size > 0) {
+        if (total_size_ >= entry.png_size) {
+            total_size_ -= entry.png_size;
+        }
+        else {
+            total_size_ = 0;
+        }
+        lru_order_.erase(entry.lru_iter);
     }
     entry.css_width = css_width;
     entry.css_height = css_height;
     entry.png_size = png_size;
     entry.last_used = Now();
     total_size_ += png_size;
-    lru_order_.emplace(entry.last_used, key);
+    entry.lru_iter = lru_order_.emplace(entry.last_used, key);
 
     if (!scheduler_) {
         return;

--- a/src/mermaid/mermaid_file_cache.h
+++ b/src/mermaid/mermaid_file_cache.h
@@ -75,11 +75,14 @@ private:
     static constexpr size_t DEFAULT_MAX_ENTRIES = 4096;
     static constexpr uint64_t DEFAULT_MAX_TOTAL_SIZE = 1ULL * 1024 * 1024 * 1024; // 1GB
 
+    using LruOrder = std::multimap<int64_t, uint64_t>;
+
     struct IndexEntry {
         float css_width = 0.0f;
         float css_height = 0.0f;
         uint32_t png_size = 0;
         int64_t last_used = 0;
+        LruOrder::iterator lru_iter{}; // png_size > 0 なら lru_order_ 内の該当エントリを指す
     };
 
     std::filesystem::path GetCacheDir() const;
@@ -88,7 +91,6 @@ private:
     std::filesystem::path GetIndexPath() const;
     void LoadIndex();
     void EvictIfNeeded(uint32_t new_png_size);
-    void RemoveLruEntry(int64_t timestamp, uint64_t key);
     static int64_t Now() noexcept;
 
     std::filesystem::path cache_dir_override_;
@@ -97,8 +99,8 @@ private:
 
     // インデックス: key → エントリメタデータ（最大4096エントリ）
     std::unordered_map<uint64_t, IndexEntry> index_;
-    // LRU順序: last_used → keys（O(log n) での最古エントリ特定用）
-    std::multimap<int64_t, uint64_t> lru_order_;
+    // LRU順序: last_used → keys（最古エントリは begin() で O(1)）
+    LruOrder lru_order_;
     uint64_t total_size_ = 0;
 
     size_t max_entries_ = DEFAULT_MAX_ENTRIES;

--- a/src/nav/nav_history.cpp
+++ b/src/nav/nav_history.cpp
@@ -2,12 +2,19 @@
 
 uint32_t NavHistory::InternPath(std::wstring_view path)
 {
+    if (last_interned_index_ != UINT32_MAX && last_interned_view_ == path) {
+        return last_interned_index_;
+    }
     if (const auto it = path_index_.find(path); it != path_index_.end()) {
+        last_interned_view_ = it->first;
+        last_interned_index_ = it->second;
         return it->second;
     }
     const auto idx = static_cast<uint32_t>(path_pool_.size());
     auto& stored = path_pool_.emplace_back(path);
     path_index_.emplace(stored, idx);
+    last_interned_view_ = stored;
+    last_interned_index_ = idx;
     return idx;
 }
 
@@ -60,4 +67,6 @@ void NavHistory::Clear() noexcept
     forward_stack_.clear();
     path_pool_.clear();
     path_index_.clear();
+    last_interned_view_ = {};
+    last_interned_index_ = UINT32_MAX;
 }

--- a/src/nav/nav_history.h
+++ b/src/nav/nav_history.h
@@ -66,4 +66,8 @@ private:
     std::pmr::map<std::wstring_view, uint32_t> path_index_;
     std::pmr::deque<InternalEntry> back_stack_;
     std::pmr::deque<InternalEntry> forward_stack_;
+
+    // Back→Forward→Back の連続操作で path_index_::find を回避する直前値キャッシュ
+    std::wstring_view last_interned_view_;
+    uint32_t last_interned_index_ = UINT32_MAX;
 };

--- a/src/render/command_executor.cpp
+++ b/src/render/command_executor.cpp
@@ -39,7 +39,10 @@ ID2D1SolidColorBrush* CommandExecutor::GetBrush(ID2D1RenderTarget* rt, D2D1_COLO
         return last_brush_;
     }
     if (brush_pool_.size() >= MAX_POOLED_BRUSHES) {
+        // clear で既存ブラシを破棄するので、直近キャッシュもダングリング防止に無効化
         brush_pool_.clear();
+        last_key_ = 0xFFFFFFFFu;
+        last_brush_ = nullptr;
     }
     Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush;
     if (FAILED(rt->CreateSolidColorBrush(color, &brush)) || !brush) {

--- a/src/render/command_executor.cpp
+++ b/src/render/command_executor.cpp
@@ -1,23 +1,54 @@
 #include "command_executor.h"
 #include "utility.h"
 
+namespace {
+
+// D2D1_COLOR_F を 8bit RGBA にパックしたキー。テーマ色は 8bit 精度で作られているため十分。
+constexpr uint32_t PackColor(D2D1_COLOR_F c) noexcept
+{
+    const auto quant = [](float v) noexcept -> uint32_t {
+        if (v <= 0.0f) {
+            return 0;
+        }
+        if (v >= 1.0f) {
+            return 255;
+        }
+        return static_cast<uint32_t>(v * 255.0f + 0.5f);
+    };
+    return (quant(c.r) << 24) | (quant(c.g) << 16) | (quant(c.b) << 8) | quant(c.a);
+}
+
+} // namespace
+
 ID2D1SolidColorBrush* CommandExecutor::GetBrush(ID2D1RenderTarget* rt, D2D1_COLOR_F color)
 {
     if (rt != bound_rt_) {
-        brush_.Reset();
+        // ブラシは RT 付随リソースなので、RT 切替・デバイス再作成では破棄する
+        brush_pool_.clear();
         bound_rt_ = rt;
-        last_color_ = { -1.0f, -1.0f, -1.0f, -1.0f };
+        last_key_ = 0xFFFFFFFFu;
+        last_brush_ = nullptr;
     }
-    if (!brush_) {
-        rt->CreateSolidColorBrush(color, &brush_);
-        last_color_ = color;
+    const uint32_t key = PackColor(color);
+    if (key == last_key_ && last_brush_) {
+        return last_brush_;
     }
-    else if (color.r != last_color_.r || color.g != last_color_.g ||
-        color.b != last_color_.b || color.a != last_color_.a) {
-        brush_->SetColor(color);
-        last_color_ = color;
+    if (const auto it = brush_pool_.find(key); it != brush_pool_.end()) {
+        last_key_ = key;
+        last_brush_ = it->second.Get();
+        return last_brush_;
     }
-    return brush_.Get();
+    if (brush_pool_.size() >= MAX_POOLED_BRUSHES) {
+        brush_pool_.clear();
+    }
+    Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush;
+    if (FAILED(rt->CreateSolidColorBrush(color, &brush)) || !brush) {
+        return nullptr;
+    }
+    auto [it, _] = brush_pool_.emplace(key, std::move(brush));
+    last_key_ = key;
+    last_brush_ = it->second.Get();
+    return last_brush_;
 }
 
 void CommandExecutor::Execute(const DrawCommandList& cmds, ID2D1RenderTarget* rt)
@@ -68,7 +99,7 @@ void CommandExecutor::Execute(const DrawCommandList& cmds, ID2D1RenderTarget* rt
             },
             [&](const DrawBitmapCmd& c) {
                 if (c.bitmap) {
-                    rt->DrawBitmap(c.bitmap, c.dest, c.opacity);
+                    rt->DrawBitmap(c.bitmap, c.dest, c.opacity, c.interpolation_mode);
                 }
             },
             [&](const FillEllipseCmd& c) {
@@ -86,7 +117,7 @@ void CommandExecutor::Execute(const DrawCommandList& cmds, ID2D1RenderTarget* rt
                 }
             },
             [&](const PushClipCmd& c) {
-                rt->PushAxisAlignedClip(c.rect, D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);
+                rt->PushAxisAlignedClip(c.rect, D2D1_ANTIALIAS_MODE_ALIASED);
             },
             [&](const PopClipCmd&) {
                 rt->PopAxisAlignedClip();

--- a/src/render/command_executor.h
+++ b/src/render/command_executor.h
@@ -2,9 +2,10 @@
 #include "draw_command.h"
 #include <d2d1.h>
 #include <wrl/client.h>
+#include <unordered_map>
 
 // DrawCommandList を Direct2D レンダーターゲット上で実行する。
-// すべての単色描画操作に対して再利用可能な単一ブラシを使用する。
+// 色ごとに ID2D1SolidColorBrush をプールし、SetColor 呼び出しも削減する。
 class CommandExecutor {
 public:
     void Execute(const DrawCommandList& cmds, ID2D1RenderTarget* rt);
@@ -12,7 +13,12 @@ public:
 private:
     ID2D1SolidColorBrush* GetBrush(ID2D1RenderTarget* rt, D2D1_COLOR_F color);
 
-    Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush_;
+    // ブラシ数が超過したらプールを一掃し、肥大化を防ぐ。
+    // テーマ + UI アクセント色は通常 ~50 個以内に収まる。
+    static constexpr size_t MAX_POOLED_BRUSHES = 256;
+
+    std::unordered_map<uint32_t, Microsoft::WRL::ComPtr<ID2D1SolidColorBrush>> brush_pool_;
     ID2D1RenderTarget* bound_rt_ = nullptr;
-    D2D1_COLOR_F last_color_{ -1.0f, -1.0f, -1.0f, -1.0f };
+    uint32_t last_key_ = 0xFFFFFFFFu;
+    ID2D1SolidColorBrush* last_brush_ = nullptr;
 };

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -32,13 +32,10 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     int hovered_save_node,
     float dpi_scale)
 {
-    // 古いコマンドリストを破棄し、monotonic リソースをリセットして再利用する。
-    // clear() で要素を破棄してから Reset() を呼び、新しいリストを作成する。
-    // monotonic_buffer_resource::deallocate は no-op のため、
-    // clear() 後のバッファポインタが残っていても安全。
+    active_buffer_ = 1 - active_buffer_;
     cmds_.clear();
-    frame_resource_.Reset();
-    cmds_ = DrawCommandList{ frame_resource_.resource() };
+    frame_resource().Reset();
+    cmds_ = DrawCommandList{ frame_resource().resource() };
     auto& cmds = cmds_;
 
     // MDペインの境界でクリップ
@@ -202,8 +199,7 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
             sel_end = selection.end_pos;
         }
         if (sel_end > sel_start) {
-            GenSelectionHighlight(cmds, entry.text_layout.Get(),
-                sel_start, sel_end - sel_start, text_x, entry.y_position);
+            GenSelectionHighlight(cmds, entry.text_layout.Get(), sel_start, sel_end - sel_start, text_x, entry.y_position);
         }
     }
 
@@ -419,8 +415,7 @@ void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds,
     }
 }
 
-void CommandGenerator::GenDiagramPlaceholder(DrawCommandList& cmds,
-    float x, float y, float w, float h)
+void CommandGenerator::GenDiagramPlaceholder(DrawCommandList& cmds, float x, float y, float w, float h)
 {
     const D2D1_RECT_F bg = D2D1::RectF(x, y, x + w, y + h);
     cmds.emplace_back(FillRoundedRectCmd{ bg, CODE_BLOCK_CORNER, CODE_BLOCK_CORNER, theme_->code_bg_color });
@@ -450,16 +445,12 @@ void CommandGenerator::EmitHighlightRects(DrawCommandList& cmds,
     }
 }
 
-void CommandGenerator::GenSelectionHighlight(DrawCommandList& cmds,
-    IDWriteTextLayout* layout, uint32_t start, uint32_t length,
-    float origin_x, float origin_y)
+void CommandGenerator::GenSelectionHighlight(DrawCommandList& cmds, IDWriteTextLayout* layout, uint32_t start, uint32_t length, float origin_x, float origin_y)
 {
     EmitHighlightRects(cmds, layout, start, length, origin_x, origin_y, SELECTION_COLOR);
 }
 
-void CommandGenerator::GenSearchHighlights(DrawCommandList& cmds, IDWriteTextLayout* layout,
-    int node_index, float origin_x, float origin_y,
-    int table_row, int table_col)
+void CommandGenerator::GenSearchHighlights(DrawCommandList& cmds, IDWriteTextLayout* layout, int node_index, float origin_x, float origin_y, int table_row, int table_col)
 {
     if (!layout || !search_matches_ || search_matches_->empty()) {
         return;
@@ -488,8 +479,7 @@ void CommandGenerator::GenSearchHighlights(DrawCommandList& cmds, IDWriteTextLay
 
 // ---- Table generator ----
 
-void CommandGenerator::GenTableRowBg(DrawCommandList& cmds, bool is_header, bool is_even_row,
-    float x, float y, float table_width, float row_h, float border)
+void CommandGenerator::GenTableRowBg(DrawCommandList& cmds, bool is_header, bool is_even_row, float x, float y, float table_width, float row_h, float border)
 {
     if (is_header) {
         cmds.emplace_back(FillRectCmd{
@@ -580,7 +570,8 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
             // プリコンピュート済みの行オフセットを使い、O(cells) の走査を O(1) に削減
             if (r + 1 < node.table_rows().size() && r + 1 < tl.row_flat_offsets.size()) {
                 flat_offset = tl.row_flat_offsets[r + 1];
-            } else {
+            }
+            else {
                 advance_flat_offset(flat_offset, row, 0, row.cells.size());
                 if (r + 1 < node.table_rows().size()) {
                     flat_offset++;
@@ -626,8 +617,7 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
                 }
 
                 // 検索マッチのハイライト（テーブルセル）
-                GenSearchHighlights(cmds, cell_layout, node_index, text_x, text_y,
-                    static_cast<int>(r), static_cast<int>(c));
+                GenSearchHighlights(cmds, cell_layout, node_index, text_x, text_y, static_cast<int>(r), static_cast<int>(c));
 
                 GenTableCellContent(cmds, cell, cell_layout, text_x, text_y, has_selection, sel_start, sel_end, flat_offset);
             }

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -113,9 +113,16 @@ private:
     const Theme* theme_ = nullptr;
     Formats formats_;
 
-    // フレーム毎にリセットする monotonic リソースで描画コマンドを管理
+    // 偶数/奇数フレームで交互に使うダブルバッファ monotonic リソース。
+    // 前フレームのコマンドリストが次フレーム開始時点まで有効に保たれる。
     MonotonicResource frame_resource_{ 128 * 1024 };
+    MonotonicResource frame_resource_alt_{ 128 * 1024 };
     DrawCommandList cmds_{ frame_resource_.resource() };
+    int active_buffer_ = 0;
+    MonotonicResource& frame_resource() noexcept
+    {
+        return active_buffer_ == 0 ? frame_resource_ : frame_resource_alt_;
+    }
 
     const std::pmr::vector<SearchMatch>* search_matches_ = nullptr;
     int current_match_index_ = -1;
@@ -133,8 +140,7 @@ private:
         DrawTextCmd c{};
         c.text_len = static_cast<uint8_t>((std::min)(len, size_t(255)));
         if (c.text_len > 0) {
-            auto* buf = static_cast<wchar_t*>(frame_resource_.resource()->allocate(
-                c.text_len * sizeof(wchar_t), alignof(wchar_t)));
+            auto* buf = static_cast<wchar_t*>(frame_resource().resource()->allocate(c.text_len * sizeof(wchar_t), alignof(wchar_t)));
             std::char_traits<wchar_t>::copy(buf, src, c.text_len);
             c.text = buf;
         }

--- a/src/render/draw_command.h
+++ b/src/render/draw_command.h
@@ -47,6 +47,7 @@ struct DrawBitmapCmd {
     ID2D1Bitmap* bitmap; // 非所有; ライフタイムはLayoutCache::DiagramEntryが管理。
     D2D1_RECT_F dest;
     float opacity = 1.0f;
+    D2D1_BITMAP_INTERPOLATION_MODE interpolation_mode = D2D1_BITMAP_INTERPOLATION_MODE_LINEAR;
 };
 
 struct FillEllipseCmd {

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -22,11 +22,7 @@ bool Renderer::Init(HWND hwnd)
     RecreatePaneFormats();
     LoadAppIconBitmap();
 
-    // 滑らかなジェスチャー軌跡のための丸型キャップと結合
-    const D2D1_STROKE_STYLE_PROPERTIES ssp = D2D1::StrokeStyleProperties(
-        D2D1_CAP_STYLE_ROUND, D2D1_CAP_STYLE_ROUND,
-        D2D1_CAP_STYLE_ROUND, D2D1_LINE_JOIN_ROUND);
-    backend_.GetD2DFactory()->CreateStrokeStyle(ssp, nullptr, 0, &gesture_stroke_style_);
+    // gesture_stroke_style_ は DrawGestureTrail 初回呼び出し時に lazy 生成
 
     measurer_.SetFactory(backend_.GetDWriteFactory());
     if (!layout_.Init(&measurer_, theme_)) {

--- a/src/render/renderer_overlay.cpp
+++ b/src/render/renderer_overlay.cpp
@@ -104,6 +104,13 @@ void Renderer::DrawGestureTrail(const std::pmr::deque<GesturePoint>& points)
     }
 
     Brush(BrushId::Overlay)->SetColor(D2D1::ColorF(0.9f, 0.2f, 0.2f, 0.5f));
+    if (!gesture_stroke_style_) {
+        // 滑らかなジェスチャー軌跡のための丸型キャップと結合（初回のみ生成）
+        const D2D1_STROKE_STYLE_PROPERTIES ssp = D2D1::StrokeStyleProperties(
+            D2D1_CAP_STYLE_ROUND, D2D1_CAP_STYLE_ROUND,
+            D2D1_CAP_STYLE_ROUND, D2D1_LINE_JOIN_ROUND);
+        d2d()->CreateStrokeStyle(ssp, nullptr, 0, &gesture_stroke_style_);
+    }
     rt()->DrawGeometry(path.Get(), Brush(BrushId::Overlay), GESTURE_TRAIL_STROKE_WIDTH, gesture_stroke_style_.Get());
 }
 

--- a/src/render/renderer_pane.cpp
+++ b/src/render/renderer_pane.cpp
@@ -128,7 +128,7 @@ static void DrawSidePaneImpl(
         const float content_top = theme.pane_header_height;
         const float content_height = rect.height - content_top;
         const D2D1_RECT_F clip = D2D1::RectF(0, content_top, rect.width, rect.height);
-        rt->PushAxisAlignedClip(clip, D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);
+        rt->PushAxisAlignedClip(clip, D2D1_ANTIALIAS_MODE_ALIASED);
         rt->SetTransform(D2D1::Matrix3x2F::Translation(0, -scroll.scroll_y));
 
         // ビューポートカリング

--- a/src/theme/theme.cpp
+++ b/src/theme/theme.cpp
@@ -108,7 +108,7 @@ static void ApplyCommonLayout(Theme& t)
     t.pane_font_size = 13.0f;
 }
 
-Theme GetLightTheme()
+static Theme BuildLightTheme()
 {
     Theme t{};
 
@@ -169,7 +169,7 @@ Theme GetLightTheme()
     return t;
 }
 
-Theme GetDarkTheme()
+static Theme BuildDarkTheme()
 {
     Theme t{};
 
@@ -228,4 +228,16 @@ Theme GetDarkTheme()
     t.search_no_match_bg_color = D2D1::ColorF(0.5f, 0.15f, 0.15f, 1.0f);
 
     return t;
+}
+
+Theme GetLightTheme()
+{
+    static const Theme kLight = BuildLightTheme();
+    return kLight;
+}
+
+Theme GetDarkTheme()
+{
+    static const Theme kDark = BuildDarkTheme();
+    return kDark;
 }

--- a/src/util/string_convert.h
+++ b/src/util/string_convert.h
@@ -12,13 +12,10 @@ inline void Utf8ToWide(std::string_view utf8, std::pmr::wstring& out)
         out.clear();
         return;
     }
-    const int wlen = MultiByteToWideChar(CP_UTF8, 0, utf8.data(), static_cast<int>(utf8.size()), nullptr, 0);
-    if (wlen <= 0) {
-        out.clear();
-        return;
-    }
-    out.resize_and_overwrite(static_cast<size_t>(wlen), [utf8](wchar_t* buf, size_t count) -> size_t {
-        return static_cast<size_t>(MultiByteToWideChar(CP_UTF8, 0, utf8.data(), static_cast<int>(utf8.size()), buf, static_cast<int>(count)));
+    // wchar 数 <= UTF-8 byte 数 が常に成立するため、上限確保で API 1 回呼び出し
+    out.resize_and_overwrite(utf8.size(), [utf8](wchar_t* buf, size_t count) -> size_t {
+        const int n = MultiByteToWideChar(CP_UTF8, 0, utf8.data(), static_cast<int>(utf8.size()), buf, static_cast<int>(count));
+        return n > 0 ? static_cast<size_t>(n) : 0;
     });
 }
 
@@ -35,13 +32,10 @@ inline void WideToUtf8(std::wstring_view wide, std::string& out)
         out.clear();
         return;
     }
-    const int len = WideCharToMultiByte(CP_UTF8, 0, wide.data(), static_cast<int>(wide.size()), nullptr, 0, nullptr, nullptr);
-    if (len <= 0) {
-        out.clear();
-        return;
-    }
-    out.resize_and_overwrite(static_cast<size_t>(len), [wide](char* buf, size_t count) -> size_t {
-        return static_cast<size_t>(WideCharToMultiByte(CP_UTF8, 0, wide.data(), static_cast<int>(wide.size()), buf, static_cast<int>(count), nullptr, nullptr));
+    // UTF-8 byte 数 <= UTF-16 wchar 数 * 3 が常に成立するため、上限確保で API 1 回呼び出し
+    out.resize_and_overwrite(wide.size() * 3, [wide](char* buf, size_t count) -> size_t {
+        const int n = WideCharToMultiByte(CP_UTF8, 0, wide.data(), static_cast<int>(wide.size()), buf, static_cast<int>(count), nullptr, nullptr);
+        return n > 0 ? static_cast<size_t>(n) : 0;
     });
 }
 

--- a/src/util/string_convert.h
+++ b/src/util/string_convert.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <climits>
 #include <string>
 #include <string_view>
 #include <memory_resource>
@@ -9,6 +10,11 @@ namespace string_convert {
 inline void Utf8ToWide(std::string_view utf8, std::pmr::wstring& out)
 {
     if (utf8.empty()) {
+        out.clear();
+        return;
+    }
+    // Windows API の cb*Char は int なので INT_MAX を超える入力は拒否する
+    if (utf8.size() > static_cast<size_t>(INT_MAX)) {
         out.clear();
         return;
     }
@@ -29,6 +35,11 @@ inline std::pmr::wstring Utf8ToWide(std::string_view utf8)
 inline void WideToUtf8(std::wstring_view wide, std::string& out)
 {
     if (wide.empty()) {
+        out.clear();
+        return;
+    }
+    // wide.size() * 3 のオーバーフローと cb*Char の int 制限を同時にガード
+    if (wide.size() > static_cast<size_t>(INT_MAX) / 3) {
         out.clear();
         return;
     }

--- a/src/util/task_scheduler.cpp
+++ b/src/util/task_scheduler.cpp
@@ -51,11 +51,9 @@ void TaskScheduler::WorkerLoop()
             cv_.wait(lock, [this] {
                 return !queue_.empty() || shutdown_.load();
             });
+            // predicate から戻った時点で queue に残りがあれば shutdown 中でも処理する
             if (queue_.empty()) {
-                if (shutdown_.load()) {
-                    break;
-                }
-                continue;
+                break;
             }
             task = std::move(queue_.front());
             queue_.pop();


### PR DESCRIPTION
## Summary

20 件のパフォーマンス最適化をまとめて適用。描画・レイアウト・パース・入力処理のホットパスでアロケーションと API 呼び出しを削減し、キャッシュを追加。

既存の 1832 テストはすべて pass。

## 主な変更

### 🎨 描画パス
- `CommandExecutor` に色キーのブラシプール（上限 256）を導入。毎フレームの `SetColor` を削減
- `DrawCommandList` を monotonic リソース 2 枚のダブルバッファ化
- `PushAxisAlignedClip` を `D2D1_ANTIALIAS_MODE_ALIASED` に変更
- `DrawBitmapCmd` に `interpolation_mode` を追加し LINEAR を明示
- `gesture_stroke_style` を初回呼び出し時に lazy 生成

### 📐 レイアウト
- `ApplyRunFormatting` を属性毎の連続 range マージに変更し Set* 呼び出しを削減
- テーブルセルに `cell_heights` / `cell_applied_widths` キャッシュを追加。幅不変時の `SetMaxWidth`/`GetMetrics` をスキップ
- 幅変更再レイアウト閾値を 0.5 → 2.0 DIP に緩和（小刻みな WM_SIZE で再計算が頻発するのを抑止）

### 📄 コア / パース
- UTF-8↔UTF-16 変換を 1 回呼び出しに統合（上限バッファ確保）
- parser の heading/image/diagram indices を事前 reserve
- syntax case_insensitive トークナイズで大文字判定を先行化し無駄な小文字化を回避
- `link_urls` 重複検出を O(n²) 逆走査 → `unordered_map` で O(1) 化
- document の `anchor_index_` を `std::pmr::map` → `unordered_map`

### 🖱️ ヒットテスト / 入力
- `HitTestService` に `HitCache<T>` テンプレートを追加。座標・scroll_y・effects_generation が同一なら前回結果を返す（Md/Copy/Save の 3 系統）

### 💾 キャッシュ / リソース
- `MermaidFileCache` の LRU 管理で `multimap::iterator` を `IndexEntry` に保持し O(1) erase 化
- `NavHistory` に直前 intern パスの direct index キャッシュを追加
- Theme を Meyers singleton で 1 度だけ構築

### 🔧 その他
- `InvalidateTitleBar` を titlebar 領域限定の `InvalidateRect` に
- `task_scheduler` の wait 後の冗長な `continue` を除去
- `ScheduleBitmapManage` に 50ms スロットルを追加し連続スクロール時の `FlushPendingResources` を間引き

### 🧹 品質改善（simplify 適用後）
- ヒットテストキャッシュを `HitCache<T>::Matches() / Store()` ヘルパーに集約
- `ApplyRunFormatting` の `apply_attr` ラムダをファイル内テンプレート関数 `ForEachAttrRange` に昇格
- マジックナンバー（2.0f, 0.5f）を名前付き定数化
- 冗長な WHAT コメントを削除
- `PackColor` を anonymous namespace に隠蔽

## Test plan

- [x] Release ビルド成功を確認
- [x] `mendo_tests.exe` の 1832 テスト全 pass
- [x] 実際のアプリでスクロール・リサイズ・テーマ切替・検索の動作確認
- [x] 大規模ドキュメント（example/test.md）での体感速度確認
- [x] マウスホバー連打時の CPU 使用率確認（ヒットテストキャッシュの効果）

🤖 Generated with [Claude Code](https://claude.com/claude-code)