### PR TITLE
リロード時のスクロール位置取得を同期/非同期経路で統一

### DIFF
--- a/src/app/app.h
+++ b/src/app/app.h
@@ -185,12 +185,12 @@ private:
     void FinishLoadMarkdownFile(bool heights_estimated = false);
     // ロード失敗時のフォールバック: 初回起動で空画面になるのを避けるためヘルプを表示する
     void HandleLoadFailureFallback();
-    float CalcScrollForDiff(size_t diff_pos, float viewport_height, float fallback_scroll) const;
+    float CalcScrollForDiff(size_t diff_pos, float viewport_height) const;
     void ApplyMermaidCacheHeights(float md_width);
     void UpdateTitleBar();
 
     // リロード共通処理: 差分分析後のレイアウト更新・スクロール復元・検索再実行
-    void FinishReload(bool is_prefix_only, size_t diff_pos, float old_scroll);
+    void FinishReload(bool is_prefix_only, size_t diff_pos);
 
     // ファイル読み込み/リロード共通ヘルパー
     void CancelPendingResources();

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -164,7 +164,7 @@ void App::OnParseComplete()
             // 末尾伸張のみ。FinishReload が ResizePreservingPrefix で旧キャッシュの実測高さを保持する。
             resource_manager_.CancelMermaidBatch();
             state_.document.doc = std::move(result->doc);
-            FinishReload(true, decision.diff_pos, state_.reload_old_scroll);
+            FinishReload(true, decision.diff_pos);
             return;
         case ReloadOp::FullReload:
             state_.reload_diff_pos = decision.diff_pos;
@@ -231,7 +231,7 @@ void App::FinishLoadMarkdownFile(bool heights_estimated)
     }
 
     if (has_reload_diff) {
-        scroll_y = CalcScrollForDiff(state_.reload_diff_pos, md_height, state_.reload_old_scroll);
+        scroll_y = CalcScrollForDiff(state_.reload_diff_pos, md_height);
         state_.reload_diff_pos = std::string_view::npos;
     }
     else if (state_.view.scroll_restore.HasNodeRestore()) {
@@ -291,7 +291,6 @@ void App::ReloadCurrentFile()
 
     if (DocumentService::NeedsAsyncLoad(path)) {
         MENDO_TRACE("ReloadCurrentFile: async path");
-        state_.reload_old_scroll = state_.view.viewport.GetScrollY();
         BeginAsyncLoad(path);
     }
     else {
@@ -312,8 +311,6 @@ void App::DoReloadCurrentFile()
         return;
     }
 
-    const float old_scroll = state_.view.viewport.GetScrollY();
-
     CancelPendingResources();
 
     // ファイルを読み込み、旧コンテンツとの差分位置をコピーなしで計算
@@ -331,8 +328,8 @@ void App::DoReloadCurrentFile()
     const auto decision = AnalyzeReloadDiff(old_view, new_view);
     state_.pending_prefix_shrink = (decision.op == ReloadOp::DeferPrefixShrink);
 
-    MENDO_TRACEF("DoReload: diff_pos=%zu old_size=%zu new_size=%zu old_scroll=%.1f op=%d",
-        decision.diff_pos, old_view.size(), new_view.size(), old_scroll,
+    MENDO_TRACEF("DoReload: diff_pos=%zu old_size=%zu new_size=%zu op=%d",
+        decision.diff_pos, old_view.size(), new_view.size(),
         static_cast<int>(decision.op));
 
     switch (decision.op) {
@@ -350,7 +347,7 @@ void App::DoReloadCurrentFile()
     case ReloadOp::FullReload: {
         MENDO_PROFILE("Reload::ReplaceFromMarkdown");
         state_.document.doc.ReplaceFromMarkdown(std::move(new_utf8));
-        FinishReload(decision.op == ReloadOp::PrefixGrowth, decision.diff_pos, old_scroll);
+        FinishReload(decision.op == ReloadOp::PrefixGrowth, decision.diff_pos);
         return;
     }
     }
@@ -358,11 +355,10 @@ void App::DoReloadCurrentFile()
 
 // DoReloadCurrentFile / OnParseComplete 共通のリロード後処理。
 // ドキュメントは更新済みの状態で呼ばれる。
-// is_prefix_only: ファイル末尾の伸縮のみか
-// diff_pos: 差分開始位置 (prefix-only の場合は使用しない)
-// old_scroll: リロード前のスクロール位置
-void App::FinishReload(bool is_prefix_only, size_t diff_pos, float old_scroll)
+void App::FinishReload(bool is_prefix_only, size_t diff_pos)
 {
+    const float old_scroll = state_.view.viewport.GetScrollY();
+
     if (is_prefix_only) {
         state_.document.layout_cache.ResizePreservingPrefix(state_.document.doc.GetNodes().size());
     }
@@ -385,7 +381,7 @@ void App::FinishReload(bool is_prefix_only, size_t diff_pos, float old_scroll)
 
     const float desired_scroll = is_prefix_only
         ? old_scroll
-        : CalcScrollForDiff(diff_pos, md_height, old_scroll);
+        : CalcScrollForDiff(diff_pos, md_height);
 
     MENDO_TRACEF("FinishReload: desired_scroll=%.1f old_scroll=%.1f is_prefix_only=%d",
         desired_scroll, old_scroll, is_prefix_only ? 1 : 0);
@@ -412,13 +408,13 @@ void App::FinishReload(bool is_prefix_only, size_t diff_pos, float old_scroll)
 // ファイル読み込みヘルパー
 // ============================================================
 
-float App::CalcScrollForDiff(size_t diff_pos, float viewport_height, float fallback_scroll) const
+float App::CalcScrollForDiff(size_t diff_pos, float viewport_height) const
 {
     MENDO_TRACEF("CalcScrollForDiff: diff_pos=%zu node_count=%zu", diff_pos, state_.document.doc.GetNodes().size());
     return CalcScrollYForDiff(
         state_.document.doc.GetNodes(), state_.document.layout_cache,
         std::string_view(state_.document.doc.GetRawUtf8()),
-        diff_pos, viewport_height, fallback_scroll);
+        diff_pos, viewport_height, state_.view.viewport.GetScrollY());
 }
 
 void App::ApplyMermaidCacheHeights(float md_width)

--- a/src/app/app_state.h
+++ b/src/app/app_state.h
@@ -91,7 +91,6 @@ struct AppState {
 
     // ---- リロード管理 ----
     size_t reload_diff_pos = std::string_view::npos;
-    float reload_old_scroll = 0.0f;
     bool pending_prefix_shrink = false;
 
     // ---- ペインレイアウトキャッシュ ----


### PR DESCRIPTION
## Summary

- `AppState::reload_old_scroll` フィールドを廃止し、`FinishReload` / `CalcScrollForDiff` の内部で `viewport.GetScrollY()` を直接呼ぶ形に集約
- これにより同期 (`DoReloadCurrentFile`) と非同期 (`OnParseComplete`) のスクロール位置推定ロジックが同一シグネチャで対称化
- 呼び出し元ローカル変数 / 関数引数 / 状態フィールドの三重保持を解消し、`FinishReload(bool, size_t)` / `CalcScrollForDiff(size_t, float)` にシグネチャが簡素化

## 背景

従来、非同期リロード経路ではロード開始時のスクロール位置を `state_.reload_old_scroll` に退避し、`OnParseComplete` で消費していた。これは「非同期ロード中にユーザー操作（検索ジャンプ、戻る/進む、マウスホイール等）でスクロール位置が変わる可能性がある」ため、完了時に `GetScrollY()` を呼ぶとロード開始時と異なる値になる、という懸念への対応だった。

しかし、ロード中に位置が変わる場合は**移動後の位置**を「ユーザーが見たい位置」とみなすほうが自然で、入力ブロック等の複雑な手当ても不要。そこで `FinishReload` が完了直後に自身で `GetScrollY()` を呼ぶ設計に統一した。

同期経路ではそもそもロード中の入力は挟まらないため、「読み込み直前に取得」と「完了直後に取得」で結果は同じ。両経路とも同じタイミング（= レイアウト更新直前）でスクロール値を取る形になる。

## 変更内容

- `src/app/app_state.h`: `reload_old_scroll` フィールド削除
- `src/app/app.h`:
  - `FinishReload(bool, size_t, float)` → `FinishReload(bool, size_t)`
  - `CalcScrollForDiff(size_t, float, float)` → `CalcScrollForDiff(size_t, float)`
- `src/app/app_file.cpp`:
  - `FinishReload` 冒頭で `viewport.GetScrollY()` を取得
  - `CalcScrollForDiff` 内部で `viewport.GetScrollY()` を fallback_scroll として渡す
  - `OnParseComplete` / `DoReloadCurrentFile` から `old_scroll` ローカル変数・引数を削除
  - `ReloadCurrentFile` から `state_.reload_old_scroll` への事前退避を削除
  - 不要になったコメントを整理

**統計**: 3 files changed, 13 insertions(+), 18 deletions(-)

## Test plan

- [x] `cmake --build build --config Release` でビルド成功
- [x] `mendo_tests.exe` で 1855 tests 全通過
- [ ] ファイルをエディタで編集→保存したとき、リロード後のスクロール位置が編集箇所付近に保たれる（同期・非同期両ケース）
- [ ] 16MB 超の大きなファイルをリロード中に検索ジャンプしても、完了後に移動先へスクロールが保たれる
- [ ] 末尾追記 (PrefixGrowth) 時、既存の見えている範囲が動かない
- [ ] エディタ truncate→rewrite 保存プロトコル (DeferPrefixShrink) の 2 段階リロードで、先頭へ飛ばされない

🤖 Generated with [Claude Code](https://claude.com/claude-code)