### PR TITLE
戻る/進むナビゲーションをノード+オフセット形式に統一

### DIFF
--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -211,18 +211,22 @@ void App::FinishLoadMarkdownFile(bool heights_estimated)
 
     const bool has_reload_diff = (state_.reload_diff_pos != std::string_view::npos);
 
-    MENDO_TRACEF("FinishLoad: has_reload_diff=%d HasNodeRestore=%d HasNavScroll=%d nav_scroll_y=%.1f heights_estimated=%d",
-        has_reload_diff ? 1 : 0,
-        state_.view.scroll_restore.HasNodeRestore() ? 1 : 0,
-        state_.view.scroll_restore.HasNavScroll() ? 1 : 0,
-        state_.view.scroll_restore.HasNavScroll() ? state_.view.scroll_restore.pending_nav_scroll_y : -1.0f,
-        heights_estimated ? 1 : 0);
+    if (state_.view.scroll_restore.HasNodeRestore()) {
+        MENDO_TRACEF("FinishLoad: has_reload_diff=%d node=%d offset=%d heights_estimated=%d",
+            has_reload_diff ? 1 : 0,
+            state_.view.scroll_restore.pending_restore_node,
+            state_.view.scroll_restore.pending_restore_offset,
+            heights_estimated ? 1 : 0);
+    }
+    else {
+        MENDO_TRACEF("FinishLoad: has_reload_diff=%d (no node restore) heights_estimated=%d",
+            has_reload_diff ? 1 : 0,
+            heights_estimated ? 1 : 0);
+    }
 
     // cache.Reset()直後は全ノードの高さが0のため、スクロール復元前に
     // ノード高さを推定し、Mermaidキャッシュの実測値で補正する
-    if (has_reload_diff
-        || state_.view.scroll_restore.HasNodeRestore()
-        || (state_.view.scroll_restore.HasNavScroll() && state_.view.scroll_restore.pending_nav_scroll_y > 0.0f)) {
+    if (has_reload_diff || state_.view.scroll_restore.HasNodeRestore()) {
         if (!heights_estimated) {
             MENDO_PROFILE("EstimateNodeHeights");
             EstimateNodeHeights(state_.document.doc.GetNodes(), state_.document.layout_cache, renderer_.GetTheme());
@@ -235,16 +239,10 @@ void App::FinishLoadMarkdownFile(bool heights_estimated)
         state_.reload_diff_pos = std::string_view::npos;
     }
     else if (state_.view.scroll_restore.HasNodeRestore()) {
-        const int node = std::min(state_.view.scroll_restore.pending_restore_node,
-            static_cast<int>(state_.document.layout_cache.size()) - 1);
-        if (node >= 0) {
-            scroll_y = std::max(0.0f,
-                state_.document.layout_cache[node].y_position + static_cast<float>(state_.view.scroll_restore.pending_restore_offset));
-        }
+        scroll_y = NodeOffsetToScrollY(state_.document.layout_cache,
+            state_.view.scroll_restore.pending_restore_node,
+            static_cast<float>(state_.view.scroll_restore.pending_restore_offset));
         state_.view.scroll_restore.ClearNodeRestore();
-    }
-    else if (state_.view.scroll_restore.HasNavScroll()) {
-        scroll_y = state_.view.scroll_restore.ConsumeNavScroll();
     }
 
     MENDO_TRACEF("FinishLoad: scroll_y=%.1f (0=top of file)", scroll_y);

--- a/src/app/app_state.cpp
+++ b/src/app/app_state.cpp
@@ -2,14 +2,21 @@
 
 AnchorState SaveAnchorFromState(const AppState& state) noexcept
 {
+    const auto& cache = state.document.layout_cache;
     AnchorState a;
-    a.idx = state.view.viewport.FindFirstVisibleNode(state.document.layout_cache, state.document.doc.GetNodes().size());
-    a.y_before = (a.idx >= 0) ? state.document.layout_cache[a.idx].y_position : 0.0f;
+    a.idx = state.view.viewport.FindFirstVisibleNode(cache, cache.size());
+    a.y_before = (a.idx >= 0) ? cache[a.idx].y_position : 0.0f;
     a.offset = state.view.viewport.GetScrollY() - a.y_before;
     return a;
 }
 
+NavEntry CurrentNavEntry(const AppState& state)
+{
+    const AnchorState a = SaveAnchorFromState(state);
+    return NavEntry{ state.document.doc.GetFilePath(), a.idx, a.offset };
+}
+
 void PushCurrentNavEntry(AppState& state)
 {
-    state.view.nav_history.Push(NavEntry{ state.document.doc.GetFilePath(), state.view.viewport.GetScrollY() });
+    state.view.nav_history.Push(CurrentNavEntry(state));
 }

--- a/src/app/app_state.h
+++ b/src/app/app_state.h
@@ -105,3 +105,6 @@ AnchorState SaveAnchorFromState(const AppState& state) noexcept;
 
 // 現在のファイル/スクロール位置をナビゲーション履歴に Push する。
 void PushCurrentNavEntry(AppState& state);
+
+// 現在のファイル/スクロール位置を NavEntry として返す（Push せず）。
+NavEntry CurrentNavEntry(const AppState& state);

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -70,11 +70,11 @@ SidePaneContext GetSidePaneContext(AppState& state, PaneTarget pane)
 void ApplyNavResult(AppState& state, SideEffectList& effects, NavEntry&& entry)
 {
     if (entry.file_path != state.document.doc.GetFilePath() && !entry.file_path.empty()) {
-        state.view.scroll_restore.pending_nav_scroll_y = entry.scroll_y;
+        state.view.scroll_restore.SetNodeRestore(entry.node, static_cast<int>(entry.offset));
         effects.emplace_back(effect::LoadFile{ std::move(entry.file_path) });
     }
     else {
-        state.view.viewport.ScrollTo(entry.scroll_y);
+        state.view.viewport.ScrollTo(NodeOffsetToScrollY(state.document.layout_cache, entry.node, entry.offset));
         state.interaction.hover_throttle.Reset();
         ClearTooltip(state, effects);
         effects.emplace_back(effect::InvalidateWindow{});
@@ -85,7 +85,7 @@ void ApplyNavResult(AppState& state, SideEffectList& effects, NavEntry&& entry)
 void ReduceNavigateBack(AppState& state, SideEffectList& effects)
 {
     NavEntry out;
-    if (state.view.nav_history.GoBack(NavEntry{ state.document.doc.GetFilePath(), state.view.viewport.GetScrollY() }, out)) {
+    if (state.view.nav_history.GoBack(CurrentNavEntry(state), out)) {
         ApplyNavResult(state, effects, std::move(out));
     }
 }
@@ -93,7 +93,7 @@ void ReduceNavigateBack(AppState& state, SideEffectList& effects)
 void ReduceNavigateForward(AppState& state, SideEffectList& effects)
 {
     NavEntry out;
-    if (state.view.nav_history.GoForward(NavEntry{ state.document.doc.GetFilePath(), state.view.viewport.GetScrollY() }, out)) {
+    if (state.view.nav_history.GoForward(CurrentNavEntry(state), out)) {
         ApplyNavResult(state, effects, std::move(out));
     }
 }

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -4,6 +4,7 @@
 #include "document_utils.h"
 #include "ui_constants.h"
 #include "utility.h"
+#include <cmath>
 
 // ============================================================
 // 共通ヘルパー
@@ -70,7 +71,7 @@ SidePaneContext GetSidePaneContext(AppState& state, PaneTarget pane)
 void ApplyNavResult(AppState& state, SideEffectList& effects, NavEntry&& entry)
 {
     if (entry.file_path != state.document.doc.GetFilePath() && !entry.file_path.empty()) {
-        state.view.scroll_restore.SetNodeRestore(entry.node, static_cast<int>(entry.offset));
+        state.view.scroll_restore.SetNodeRestore(entry.node, static_cast<int>(std::lround(entry.offset)));
         effects.emplace_back(effect::LoadFile{ std::move(entry.file_path) });
     }
     else {

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -264,3 +264,12 @@ constexpr int FindFirstVisibleNodeIndex(const LayoutCache& cache, size_t node_co
     });
     return static_cast<int>(it - first);
 }
+
+// (node, offset) → 絶対スクロール位置。範囲外/未定義の場合 0 を返す。
+constexpr float NodeOffsetToScrollY(const LayoutCache& cache, int node, float offset) noexcept
+{
+    if (node < 0 || node >= static_cast<int>(cache.size())) {
+        return 0.0f;
+    }
+    return std::max(0.0f, cache[node].y_position + offset);
+}

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -265,11 +265,14 @@ constexpr int FindFirstVisibleNodeIndex(const LayoutCache& cache, size_t node_co
     return static_cast<int>(it - first);
 }
 
-// (node, offset) → 絶対スクロール位置。範囲外/未定義の場合 0 を返す。
+// (node, offset) → 絶対スクロール位置。
+// 負の node や空キャッシュは 0 を返し、末尾を超える node は最後の要素へクランプする
+// （ドキュメントが縮んでいた場合にトップではなく末尾近くへ復帰する）。
 constexpr float NodeOffsetToScrollY(const LayoutCache& cache, int node, float offset) noexcept
 {
-    if (node < 0 || node >= static_cast<int>(cache.size())) {
+    if (cache.size() == 0 || node < 0) {
         return 0.0f;
     }
-    return std::max(0.0f, cache[node].y_position + offset);
+    const int clamped = std::min(node, static_cast<int>(cache.size()) - 1);
+    return std::max(0.0f, cache[clamped].y_position + offset);
 }

--- a/src/nav/nav_history.cpp
+++ b/src/nav/nav_history.cpp
@@ -20,7 +20,7 @@ uint32_t NavHistory::InternPath(std::wstring_view path)
 
 NavEntry NavHistory::ToExternal(const InternalEntry& e) const
 {
-    return NavEntry(path_pool_[e.path_index], e.scroll_y);
+    return NavEntry(path_pool_[e.path_index], e.node, e.offset);
 }
 
 void NavHistory::Push(const NavEntry& current)

--- a/src/nav/nav_history.h
+++ b/src/nav/nav_history.h
@@ -5,14 +5,17 @@
 #include <memory_resource>
 #include <map>
 
-// 単一のナビゲーション履歴エントリ: ファイルパス + スクロール位置。
+// 単一のナビゲーション履歴エントリ: ファイルパス + スクロール位置（ノード単位）。
+// ノードインデックスと、そのノードの y_position からのオフセットで位置を表現する。
+// ファイルが編集されて絶対 y 座標が変わっても、同じノードの相対位置に戻れる。
 struct NavEntry {
     std::pmr::wstring file_path;
-    float scroll_y = 0.0f;
+    int node = -1;
+    float offset = 0.0f;
 
     NavEntry() = default;
-    NavEntry(std::wstring_view fp, float sy = 0.0f)
-        : file_path(fp), scroll_y(sy)
+    NavEntry(std::wstring_view fp, int n = -1, float off = 0.0f)
+        : file_path(fp), node(n), offset(off)
     {
     }
 };
@@ -45,17 +48,18 @@ public:
     static constexpr size_t MAX_HISTORY = 1024;
 
 private:
-    // 内部エントリ: パスインデックス + スクロール位置（8バイト）
+    // 内部エントリ: パスインデックス + ノードインデックス + オフセット（12バイト）
     struct InternalEntry {
         uint32_t path_index = 0;
-        float scroll_y = 0.0f;
+        int node = -1;
+        float offset = 0.0f;
     };
 
     // パスをインターン化し、インデックスを返す
     uint32_t InternPath(std::wstring_view path);
 
     // NavEntry ↔ InternalEntry 変換
-    InternalEntry ToInternal(const NavEntry& e) { return { InternPath(e.file_path), e.scroll_y }; }
+    InternalEntry ToInternal(const NavEntry& e) { return { InternPath(e.file_path), e.node, e.offset }; }
     NavEntry ToExternal(const InternalEntry& e) const;
 
     // path_pool_ は deque にして emplace_back での参照安定性を保証し、

--- a/src/ui/scroll_restoration.h
+++ b/src/ui/scroll_restoration.h
@@ -1,22 +1,13 @@
 #pragma once
 
 // スクロール位置の復元状態を管理する値型。
-// ナビゲーション時の遅延スクロールとセッション復元時のノードベース復元を統合する。
+// セッション復元とナビゲーション履歴（戻る/進む）の両方をノードベースで統合する。
 // 各フィールドは App の複数箇所から直接読み書きされるため public にしている。
 struct ScrollRestoration {
-    float pending_nav_scroll_y = -1.0f;
     int pending_restore_node = -1;
     int pending_restore_offset = 0;
 
-    bool HasNavScroll() const noexcept { return pending_nav_scroll_y >= 0.0f; }
     bool HasNodeRestore() const noexcept { return pending_restore_node >= 0; }
-
-    float ConsumeNavScroll() noexcept
-    {
-        const float v = pending_nav_scroll_y;
-        pending_nav_scroll_y = -1.0f;
-        return v;
-    }
 
     void SetNodeRestore(int node, int offset) noexcept
     {
@@ -32,7 +23,6 @@ struct ScrollRestoration {
 
     void Reset() noexcept
     {
-        pending_nav_scroll_y = -1.0f;
         pending_restore_node = -1;
         pending_restore_offset = 0;
     }

--- a/tests/test_help.cpp
+++ b/tests/test_help.cpp
@@ -68,39 +68,41 @@ protected:
 
 TEST_F(HelpNavigationTest, GoBackFromHelpToFile)
 {
-    history_.Push(NavEntry{ L"C:\\file.md", 50.0f });
+    history_.Push(NavEntry{ L"C:\\file.md", 5, 10.0f });
 
     NavEntry out;
-    ASSERT_TRUE(history_.GoBack(NavEntry{ HELP_PATH, 0.0f }, out));
+    ASSERT_TRUE(history_.GoBack(NavEntry{ HELP_PATH, 0, 0.0f }, out));
     EXPECT_EQ(out.file_path, L"C:\\file.md");
-    EXPECT_FLOAT_EQ(out.scroll_y, 50.0f);
+    EXPECT_EQ(out.node, 5);
+    EXPECT_FLOAT_EQ(out.offset, 10.0f);
 }
 
 TEST_F(HelpNavigationTest, GoForwardFromFileToHelp)
 {
-    history_.Push(NavEntry{ L"C:\\file.md", 50.0f });
+    history_.Push(NavEntry{ L"C:\\file.md", 5, 10.0f });
 
     NavEntry back_out;
-    history_.GoBack(NavEntry{ HELP_PATH, 0.0f }, back_out);
+    history_.GoBack(NavEntry{ HELP_PATH, 0, 0.0f }, back_out);
 
     NavEntry fwd_out;
-    ASSERT_TRUE(history_.GoForward(NavEntry{ L"C:\\file.md", 50.0f }, fwd_out));
+    ASSERT_TRUE(history_.GoForward(NavEntry{ L"C:\\file.md", 5, 10.0f }, fwd_out));
     EXPECT_EQ(std::wstring_view(fwd_out.file_path), HELP_PATH);
-    EXPECT_FLOAT_EQ(fwd_out.scroll_y, 0.0f);
+    EXPECT_EQ(fwd_out.node, 0);
+    EXPECT_FLOAT_EQ(fwd_out.offset, 0.0f);
 }
 
 TEST_F(HelpNavigationTest, PushHelpThenGoBack)
 {
-    history_.Push(NavEntry{ HELP_PATH, 0.0f });
+    history_.Push(NavEntry{ HELP_PATH, 0, 0.0f });
 
     NavEntry out;
-    ASSERT_TRUE(history_.GoBack(NavEntry{ L"C:\\file.md", 100.0f }, out));
+    ASSERT_TRUE(history_.GoBack(NavEntry{ L"C:\\file.md", 3, 40.0f }, out));
     EXPECT_EQ(std::wstring_view(out.file_path), HELP_PATH);
 }
 
 TEST_F(HelpNavigationTest, HelpPathInHistoryCanGoBack)
 {
-    history_.Push(NavEntry{ HELP_PATH, 0.0f });
+    history_.Push(NavEntry{ HELP_PATH, 0, 0.0f });
     EXPECT_TRUE(history_.CanGoBack());
 }
 

--- a/tests/test_nav_history.cpp
+++ b/tests/test_nav_history.cpp
@@ -19,27 +19,28 @@ TEST_F(NavHistoryTest, InitiallyEmpty)
 TEST_F(NavHistoryTest, GoBackOnEmptyReturnsFalse)
 {
     NavEntry out;
-    EXPECT_FALSE(hist_.GoBack({ L"a.md", 0.0f }, out));
+    EXPECT_FALSE(hist_.GoBack({ L"a.md", 0, 0.0f }, out));
 }
 
 TEST_F(NavHistoryTest, GoForwardOnEmptyReturnsFalse)
 {
     NavEntry out;
-    EXPECT_FALSE(hist_.GoForward({ L"a.md", 0.0f }, out));
+    EXPECT_FALSE(hist_.GoForward({ L"a.md", 0, 0.0f }, out));
 }
 
 // ─── Push / GoBack（プッシュ / 戻る） ───
 
 TEST_F(NavHistoryTest, PushThenGoBack)
 {
-    hist_.Push({ L"a.md", 100.0f });
+    hist_.Push({ L"a.md", 3, 25.0f });
     EXPECT_TRUE(hist_.CanGoBack());
     EXPECT_FALSE(hist_.CanGoForward());
 
     NavEntry out;
-    EXPECT_TRUE(hist_.GoBack({ L"b.md", 200.0f }, out));
+    EXPECT_TRUE(hist_.GoBack({ L"b.md", 7, 12.0f }, out));
     EXPECT_EQ(out.file_path, L"a.md");
-    EXPECT_FLOAT_EQ(out.scroll_y, 100.0f);
+    EXPECT_EQ(out.node, 3);
+    EXPECT_FLOAT_EQ(out.offset, 25.0f);
 
     // 戻った後は、進むが利用可能になるべき
     EXPECT_TRUE(hist_.CanGoForward());
@@ -50,28 +51,29 @@ TEST_F(NavHistoryTest, PushThenGoBack)
 
 TEST_F(NavHistoryTest, GoBackThenGoForward)
 {
-    hist_.Push({ L"a.md", 0.0f });
+    hist_.Push({ L"a.md", 0, 0.0f });
 
     NavEntry out;
-    hist_.GoBack({ L"b.md", 50.0f }, out);
+    hist_.GoBack({ L"b.md", 2, 10.0f }, out);
 
-    EXPECT_TRUE(hist_.GoForward({ L"a.md", 0.0f }, out));
+    EXPECT_TRUE(hist_.GoForward({ L"a.md", 0, 0.0f }, out));
     EXPECT_EQ(out.file_path, L"b.md");
-    EXPECT_FLOAT_EQ(out.scroll_y, 50.0f);
+    EXPECT_EQ(out.node, 2);
+    EXPECT_FLOAT_EQ(out.offset, 10.0f);
 }
 
 // ─── 新規ナビゲーションで進むスタックをクリア ───
 
 TEST_F(NavHistoryTest, PushClearsForwardStack)
 {
-    hist_.Push({ L"a.md", 0.0f });
+    hist_.Push({ L"a.md", 0, 0.0f });
 
     NavEntry out;
-    hist_.GoBack({ L"b.md", 0.0f }, out);
+    hist_.GoBack({ L"b.md", 0, 0.0f }, out);
     EXPECT_TRUE(hist_.CanGoForward());
 
     // 新規ナビゲーションは進むスタックをクリアすべき
-    hist_.Push({ L"a.md", 0.0f });
+    hist_.Push({ L"a.md", 0, 0.0f });
     EXPECT_FALSE(hist_.CanGoForward());
 }
 
@@ -80,33 +82,36 @@ TEST_F(NavHistoryTest, PushClearsForwardStack)
 TEST_F(NavHistoryTest, MultipleBackForward)
 {
     // シミュレーション: A を開く -> B を開く -> C を開く
-    hist_.Push({ L"a.md", 10.0f });  // B を開く前
-    hist_.Push({ L"b.md", 20.0f });  // C を開く前
+    hist_.Push({ L"a.md", 1, 2.0f });   // B を開く前
+    hist_.Push({ L"b.md", 3, 4.0f });   // C を開く前
 
     EXPECT_EQ(hist_.BackSize(), 2u);
 
     NavEntry out;
     // CからBへ戻る
-    EXPECT_TRUE(hist_.GoBack({ L"c.md", 30.0f }, out));
+    EXPECT_TRUE(hist_.GoBack({ L"c.md", 5, 6.0f }, out));
     EXPECT_EQ(out.file_path, L"b.md");
-    EXPECT_FLOAT_EQ(out.scroll_y, 20.0f);
+    EXPECT_EQ(out.node, 3);
+    EXPECT_FLOAT_EQ(out.offset, 4.0f);
 
     // BからAへ戻る
-    EXPECT_TRUE(hist_.GoBack({ L"b.md", 20.0f }, out));
+    EXPECT_TRUE(hist_.GoBack({ L"b.md", 3, 4.0f }, out));
     EXPECT_EQ(out.file_path, L"a.md");
-    EXPECT_FLOAT_EQ(out.scroll_y, 10.0f);
+    EXPECT_EQ(out.node, 1);
+    EXPECT_FLOAT_EQ(out.offset, 2.0f);
 
     EXPECT_FALSE(hist_.CanGoBack());
     EXPECT_EQ(hist_.ForwardSize(), 2u);
 
     // AからBへ進む
-    EXPECT_TRUE(hist_.GoForward({ L"a.md", 10.0f }, out));
+    EXPECT_TRUE(hist_.GoForward({ L"a.md", 1, 2.0f }, out));
     EXPECT_EQ(out.file_path, L"b.md");
 
     // BからCへ進む
-    EXPECT_TRUE(hist_.GoForward({ L"b.md", 20.0f }, out));
+    EXPECT_TRUE(hist_.GoForward({ L"b.md", 3, 4.0f }, out));
     EXPECT_EQ(out.file_path, L"c.md");
-    EXPECT_FLOAT_EQ(out.scroll_y, 30.0f);
+    EXPECT_EQ(out.node, 5);
+    EXPECT_FLOAT_EQ(out.offset, 6.0f);
 
     EXPECT_FALSE(hist_.CanGoForward());
 }
@@ -115,24 +120,25 @@ TEST_F(NavHistoryTest, MultipleBackForward)
 
 TEST_F(NavHistoryTest, SameFileAnchorNavigation)
 {
-    hist_.Push({ L"readme.md", 0.0f });   // アンカーへジャンプする前
-    hist_.Push({ L"readme.md", 500.0f }); // 別のアンカーへジャンプする前
+    hist_.Push({ L"readme.md", 0, 0.0f });    // アンカーへジャンプする前
+    hist_.Push({ L"readme.md", 12, 30.0f });  // 別のアンカーへジャンプする前
 
     NavEntry out;
-    EXPECT_TRUE(hist_.GoBack({ L"readme.md", 1200.0f }, out));
+    EXPECT_TRUE(hist_.GoBack({ L"readme.md", 25, 0.0f }, out));
     EXPECT_EQ(out.file_path, L"readme.md");
-    EXPECT_FLOAT_EQ(out.scroll_y, 500.0f);
+    EXPECT_EQ(out.node, 12);
+    EXPECT_FLOAT_EQ(out.offset, 30.0f);
 }
 
 // ─── クリア ───
 
 TEST_F(NavHistoryTest, ClearRemovesAll)
 {
-    hist_.Push({ L"a.md", 0.0f });
-    hist_.Push({ L"b.md", 0.0f });
+    hist_.Push({ L"a.md", 0, 0.0f });
+    hist_.Push({ L"b.md", 0, 0.0f });
 
     NavEntry out;
-    hist_.GoBack({ L"c.md", 0.0f }, out);
+    hist_.GoBack({ L"c.md", 0, 0.0f }, out);
 
     hist_.Clear();
     EXPECT_FALSE(hist_.CanGoBack());
@@ -144,7 +150,7 @@ TEST_F(NavHistoryTest, ClearRemovesAll)
 TEST_F(NavHistoryTest, MaxHistoryCapsBackStack)
 {
     for (size_t i = 0; i < NavHistory::MAX_HISTORY + 10; ++i) {
-        hist_.Push({ L"file" + std::to_wstring(i) + L".md", static_cast<float>(i) });
+        hist_.Push({ L"file" + std::to_wstring(i) + L".md", static_cast<int>(i), 0.0f });
     }
     EXPECT_EQ(hist_.BackSize(), NavHistory::MAX_HISTORY);
 }
@@ -153,12 +159,12 @@ TEST_F(NavHistoryTest, MaxHistoryCapsForwardStack)
 {
     // 戻るスタックにMAX_HISTORY+10件を積む
     for (size_t i = 0; i < NavHistory::MAX_HISTORY + 10; ++i) {
-        hist_.Push({ L"file" + std::to_wstring(i) + L".md", static_cast<float>(i) });
+        hist_.Push({ L"file" + std::to_wstring(i) + L".md", static_cast<int>(i), 0.0f });
     }
     // 全件GoBackして進むスタックに移す
     NavEntry out;
     for (size_t i = 0; i < NavHistory::MAX_HISTORY; ++i) {
-        if (!hist_.GoBack({ L"cur.md", 0.0f }, out)) break;
+        if (!hist_.GoBack({ L"cur.md", 0, 0.0f }, out)) break;
     }
     EXPECT_LE(hist_.ForwardSize(), NavHistory::MAX_HISTORY);
 }
@@ -175,24 +181,26 @@ TEST_F(NavHistoryTest, OpenDialogSecondFileCanGoBack)
     // （ユーザーはa.mdを閲覧中）
 
     // 2番目のロード: current_file_ == "a.md" → b.mdをロードする前にpush
-    hist_.Push({ L"a.md", 42.0f });
+    hist_.Push({ L"a.md", 2, 8.0f });
 
     NavEntry out;
-    EXPECT_TRUE(hist_.GoBack({ L"b.md", 0.0f }, out));
+    EXPECT_TRUE(hist_.GoBack({ L"b.md", 0, 0.0f }, out));
     EXPECT_EQ(out.file_path, L"a.md");
-    EXPECT_FLOAT_EQ(out.scroll_y, 42.0f);
+    EXPECT_EQ(out.node, 2);
+    EXPECT_FLOAT_EQ(out.offset, 8.0f);
 }
 
 TEST_F(NavHistoryTest, DropFileSecondFileCanGoBack)
 {
     // シミュレーション: 最初のファイルを開く、次にドラッグ＆ドロップで2番目のファイル
     // current_file_ == "readme.md" → dropped.mdをロードする前にpush
-    hist_.Push({ L"readme.md", 300.0f });
+    hist_.Push({ L"readme.md", 8, 40.0f });
 
     NavEntry out;
-    EXPECT_TRUE(hist_.GoBack({ L"dropped.md", 0.0f }, out));
+    EXPECT_TRUE(hist_.GoBack({ L"dropped.md", 0, 0.0f }, out));
     EXPECT_EQ(out.file_path, L"readme.md");
-    EXPECT_FLOAT_EQ(out.scroll_y, 300.0f);
+    EXPECT_EQ(out.node, 8);
+    EXPECT_FLOAT_EQ(out.offset, 40.0f);
 }
 
 TEST_F(NavHistoryTest, FirstLoadNoPushKeepsHistoryEmpty)
@@ -211,40 +219,40 @@ TEST_F(NavHistoryTest, MixedEntryPointsProduceConsistentHistory)
     //         → ファイルペインからBを開く（Aをpush）
     //         → ドラッグ＆ドロップでCを開く（Bをpush）
     //         → Ctrl+OでDを開く（Cをpush）
-    hist_.Push({ L"a.md", 10.0f });  // ファイルペインからBを開く前
-    hist_.Push({ L"b.md", 20.0f });  // ドラッグ＆ドロップでCを開く前
-    hist_.Push({ L"c.md", 30.0f });  // Ctrl+OでDを開く前
+    hist_.Push({ L"a.md", 1, 0.0f });   // ファイルペインからBを開く前
+    hist_.Push({ L"b.md", 2, 0.0f });   // ドラッグ＆ドロップでCを開く前
+    hist_.Push({ L"c.md", 3, 0.0f });   // Ctrl+OでDを開く前
 
     EXPECT_EQ(hist_.BackSize(), 3u);
 
     NavEntry out;
     // DからCへ戻る
-    EXPECT_TRUE(hist_.GoBack({ L"d.md", 40.0f }, out));
+    EXPECT_TRUE(hist_.GoBack({ L"d.md", 4, 0.0f }, out));
     EXPECT_EQ(out.file_path, L"c.md");
-    EXPECT_FLOAT_EQ(out.scroll_y, 30.0f);
+    EXPECT_EQ(out.node, 3);
 
     // CからBへ戻る
-    EXPECT_TRUE(hist_.GoBack({ L"c.md", 30.0f }, out));
+    EXPECT_TRUE(hist_.GoBack({ L"c.md", 3, 0.0f }, out));
     EXPECT_EQ(out.file_path, L"b.md");
-    EXPECT_FLOAT_EQ(out.scroll_y, 20.0f);
+    EXPECT_EQ(out.node, 2);
 
     // BからAへ戻る
-    EXPECT_TRUE(hist_.GoBack({ L"b.md", 20.0f }, out));
+    EXPECT_TRUE(hist_.GoBack({ L"b.md", 2, 0.0f }, out));
     EXPECT_EQ(out.file_path, L"a.md");
-    EXPECT_FLOAT_EQ(out.scroll_y, 10.0f);
+    EXPECT_EQ(out.node, 1);
 
     EXPECT_FALSE(hist_.CanGoBack());
 
     // Dまで全て進む
-    EXPECT_TRUE(hist_.GoForward({ L"a.md", 10.0f }, out));
+    EXPECT_TRUE(hist_.GoForward({ L"a.md", 1, 0.0f }, out));
     EXPECT_EQ(out.file_path, L"b.md");
 
-    EXPECT_TRUE(hist_.GoForward({ L"b.md", 20.0f }, out));
+    EXPECT_TRUE(hist_.GoForward({ L"b.md", 2, 0.0f }, out));
     EXPECT_EQ(out.file_path, L"c.md");
 
-    EXPECT_TRUE(hist_.GoForward({ L"c.md", 30.0f }, out));
+    EXPECT_TRUE(hist_.GoForward({ L"c.md", 3, 0.0f }, out));
     EXPECT_EQ(out.file_path, L"d.md");
-    EXPECT_FLOAT_EQ(out.scroll_y, 40.0f);
+    EXPECT_EQ(out.node, 4);
 
     EXPECT_FALSE(hist_.CanGoForward());
 }

--- a/tests/test_reducer.cpp
+++ b/tests/test_reducer.cpp
@@ -226,7 +226,7 @@ TEST_F(ReducerTest, NavigateBack_NoHistory_NoEffects) {
 
 TEST_F(ReducerTest, NavigateBack_DifferentFile_EmitsLoadFile) {
     state.document.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\current.md");
-    state.view.nav_history.Push(NavEntry{ L"C:\\prev.md", 50.0f });
+    state.view.nav_history.Push(NavEntry{ L"C:\\prev.md", 0, 50.0f });
 
     auto effects = Reduce(state, NavigateBackAction{});
     EXPECT_TRUE(HasEffect<effect::LoadFile>(effects));
@@ -234,7 +234,9 @@ TEST_F(ReducerTest, NavigateBack_DifferentFile_EmitsLoadFile) {
 
 TEST_F(ReducerTest, NavigateBack_SameFile_ScrollsAndInvalidates) {
     state.document.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\file.md");
-    state.view.nav_history.Push(NavEntry{ L"C:\\file.md", 50.0f });
+    // ノード 0 に対してオフセット 50 → y_position(0) + 50 = 50.0f
+    state.document.layout_cache.Resize(state.document.doc.GetNodes().size());
+    state.view.nav_history.Push(NavEntry{ L"C:\\file.md", 0, 50.0f });
     state.view.viewport.ScrollTo(200.0f);
 
     auto effects = Reduce(state, NavigateBackAction{});
@@ -865,7 +867,7 @@ TEST_F(ReducerTest, RightClickGestureCompleted_Pressed_ShowsContextMenu) {
 TEST_F(ReducerTest, RightClickGestureCompleted_TrackingLeft_NavigatesBack) {
     // 戻り先履歴を用意
     state.document.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\current.md");
-    state.view.nav_history.Push(NavEntry{ L"C:\\prev.md", 0.0f });
+    state.view.nav_history.Push(NavEntry{ L"C:\\prev.md", 0, 0.0f });
 
     state.interaction.gesture.OnRButtonDown(200.0f, 200.0f);
     state.interaction.gesture.OnMouseMove(100.0f, 200.0f); // 左に 100px = 閾値越え
@@ -880,9 +882,9 @@ TEST_F(ReducerTest, RightClickGestureCompleted_TrackingLeft_NavigatesBack) {
 
 TEST_F(ReducerTest, RightClickGestureCompleted_TrackingRight_NavigatesForward) {
     // 前進履歴を用意: page2 からスタート → Push(page1) → GoBack → 前進スタックに page2
-    state.view.nav_history.Push(NavEntry{ L"C:\\page1.md", 0.0f });
+    state.view.nav_history.Push(NavEntry{ L"C:\\page1.md", 0, 0.0f });
     NavEntry tmp;
-    state.view.nav_history.GoBack(NavEntry{ L"C:\\page2.md", 0.0f }, tmp);
+    state.view.nav_history.GoBack(NavEntry{ L"C:\\page2.md", 0, 0.0f }, tmp);
     // 現在ドキュメントを page1（後進結果）に合わせる
     state.document.doc = Document::FromMarkdown(std::pmr::string("test"), L"C:\\page1.md");
     ASSERT_TRUE(state.view.nav_history.CanGoForward());

--- a/tests/test_scroll_restoration.cpp
+++ b/tests/test_scroll_restoration.cpp
@@ -5,35 +5,9 @@
 TEST(ScrollRestoration, InitialState)
 {
     ScrollRestoration sr;
-    EXPECT_FALSE(sr.HasNavScroll());
     EXPECT_FALSE(sr.HasNodeRestore());
-    EXPECT_FLOAT_EQ(sr.pending_nav_scroll_y, -1.0f);
     EXPECT_EQ(sr.pending_restore_node, -1);
     EXPECT_EQ(sr.pending_restore_offset, 0);
-}
-
-TEST(ScrollRestoration, HasNavScroll)
-{
-    ScrollRestoration sr;
-    EXPECT_FALSE(sr.HasNavScroll());
-
-    sr.pending_nav_scroll_y = 0.0f;
-    EXPECT_TRUE(sr.HasNavScroll());
-
-    sr.pending_nav_scroll_y = 500.0f;
-    EXPECT_TRUE(sr.HasNavScroll());
-}
-
-TEST(ScrollRestoration, ConsumeNavScroll)
-{
-    ScrollRestoration sr;
-    sr.pending_nav_scroll_y = 250.0f;
-    EXPECT_TRUE(sr.HasNavScroll());
-
-    const float v = sr.ConsumeNavScroll();
-    EXPECT_FLOAT_EQ(v, 250.0f);
-    EXPECT_FALSE(sr.HasNavScroll());
-    EXPECT_FLOAT_EQ(sr.pending_nav_scroll_y, -1.0f);
 }
 
 TEST(ScrollRestoration, HasNodeRestore)
@@ -69,13 +43,10 @@ TEST(ScrollRestoration, ClearNodeRestore)
 TEST(ScrollRestoration, Reset)
 {
     ScrollRestoration sr;
-    sr.pending_nav_scroll_y = 100.0f;
     sr.SetNodeRestore(10, 50);
 
     sr.Reset();
-    EXPECT_FALSE(sr.HasNavScroll());
     EXPECT_FALSE(sr.HasNodeRestore());
-    EXPECT_FLOAT_EQ(sr.pending_nav_scroll_y, -1.0f);
     EXPECT_EQ(sr.pending_restore_node, -1);
     EXPECT_EQ(sr.pending_restore_offset, 0);
 }


### PR DESCRIPTION
## Summary

- `NavEntry` のスクロール位置を `scroll_y (float)` から `{node, offset}` 形式に変更し、ファイル編集時もノード相対位置で戻れるようにする
- `ScrollRestoration` の `pending_nav_scroll_y` 系 API を廃止し、セッション復元の `pending_restore_node/offset` に一本化
- `FinishLoadMarkdownFile` の復元分岐が 3 段（リロード差分 > セッション復元 > ナビ復帰）→ 2 段（リロード差分 > ノード復元）に簡略化

## 背景

セッション復元は node+offset でファイル編集耐性があったが、戻る/進むは絶対 y 座標で保持していたため、別ファイルが編集されると復帰位置がずれる問題があった。両者をノードベースに統一。

## 主な変更

- `src/nav/nav_history.{h,cpp}`: `NavEntry` / `InternalEntry` を `{path, node, offset}` に変更
- `src/ui/scroll_restoration.h`: `pending_nav_scroll_y` / `HasNavScroll` / `ConsumeNavScroll` を廃止
- `src/app/reducer.cpp` `ApplyNavResult`:
  - 同一ファイル: `NodeOffsetToScrollY()` で即時 `ScrollTo`
  - 別ファイル: `SetNodeRestore()` でセッション復元と同じ合流点へ
- `src/app/app_state.{h,cpp}`: `CurrentNavEntry()` ヘルパー追加、`SaveAnchorFromState` の `FindFirstVisibleNode` を `cache.size()` に統一
- `src/layout/layout_cache.h`: `NodeOffsetToScrollY()` 共通ヘルパー追加
- `src/app/app_file.cpp` `FinishLoadMarkdownFile`: 復元分岐を簡略化、トレースログを条件付き出力に

## コード削減

12 files changed, 132 insertions(+), **138 deletions(-)** — 正味 -6 行。

## Test plan

- [x] 既存のユニットテスト 1853 件が全通過
- [x] `test_nav_history.cpp`: 全テストを新フィールド (`node`/`offset`) で書き換え
- [x] `test_scroll_restoration.cpp`: 廃止した `HasNavScroll`/`ConsumeNavScroll` テストを削除
- [x] `test_help.cpp`: ヘルプナビゲーション 4 件を新形式に更新
- [x] `test_reducer.cpp`: `NavigateBack_SameFile_ScrollsAndInvalidates` に `layout_cache.Resize()` を追加して node アクセスを有効化
- [ ] 実機確認: アプリを起動して (a) リンククリックで別ファイルへ移動→戻る、(b) 同一ファイル内の TOC ジャンプ→戻る、(c) アプリ再起動後のセッション復元、がいずれも期待位置に戻ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)