### PR TITLE
TOCクリック・ナビゲーション時の推定高さズレを補償

### DIFF
--- a/src/app/app.h
+++ b/src/app/app.h
@@ -215,6 +215,10 @@ private:
     // テーマ/ズーム変更後の共通後処理（ViewportLayout→スクロール復元→再描画）
     void FinishThemeOrZoomChange(const AnchorState& anchor, float offset_scale);
 
+    // ノード指定ジャンプ後の推定→実測誤差補償（TOCクリック・戻る/進む同一ファイル等）
+    void HandleCompensateScrollAfterLayout(const effect::CompensateScrollAfterLayout& e);
+    void ViewportLayoutAndCompensate(int anchor_idx, float anchor_y_before);
+
 private:
     // Win32ハンドル
     HWND hwnd_ = nullptr;

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -76,6 +76,9 @@ bool App::Init(HWND hwnd)
             .apply_theme_change = [this](const effect::ApplyThemeChange& e) {
                 HandleApplyThemeChange(e);
             },
+            .compensate_scroll_after_layout = [this](const effect::CompensateScrollAfterLayout& e) {
+                HandleCompensateScrollAfterLayout(e);
+            },
             .process_deferred_layout = [this]() {
                 OnDeferredLayout();
             },

--- a/src/app/app_navigate.cpp
+++ b/src/app/app_navigate.cpp
@@ -93,8 +93,9 @@ void App::ViewportLayoutAndCompensate(int anchor_idx, float anchor_y_before)
 
 void App::HandleCompensateScrollAfterLayout(const effect::CompensateScrollAfterLayout& e)
 {
+    // 発行元 Reducer が直後に effect::InvalidateWindow を発行するため
+    // ここで UpdateScrollBar 経由の部分無効化は冗長
     ViewportLayoutAndCompensate(e.anchor_idx, e.anchor_y_before);
-    UpdateScrollBar();
 }
 
 void App::HandleApplyThemeChange(const effect::ApplyThemeChange& e)

--- a/src/app/app_navigate.cpp
+++ b/src/app/app_navigate.cpp
@@ -37,9 +37,11 @@ void App::NavigateToAnchor(std::wstring_view anchor)
     }
 
     const auto layout = GetPaneLayout();
-    float target_y = state_.document.layout_cache[idx].y_position - renderer_.GetTheme().heading_spacing_above - layout.md_rect.y;
+    const float anchor_y_before = state_.document.layout_cache[idx].y_position;
+    float target_y = anchor_y_before - renderer_.GetTheme().heading_spacing_above - layout.md_rect.y;
     target_y = std::max(0.0f, target_y);
     ScrollTo(target_y);
+    ViewportLayoutAndCompensate(idx, anchor_y_before);
     UpdateScrollBar();
     InvalidateMdPane(layout.md_rect);
     resource_manager_.ScheduleBitmapManage();
@@ -77,6 +79,22 @@ void App::FinishThemeOrZoomChange(const AnchorState& anchor, float offset_scale)
     ScheduleDeferredLayoutIfNeeded();
     UpdateScrollBar();
     Invalidate();
+}
+
+void App::ViewportLayoutAndCompensate(int anchor_idx, float anchor_y_before)
+{
+    const auto layout = GetPaneLayout();
+    const float md_width = layout.md_rect.width;
+    const float md_height = layout.md_rect.height;
+    layout_service_->ViewportLayout(state_.document.doc, state_.document.layout_cache, md_width, md_height);
+    state_.view.viewport.AnchorCompensateScroll(anchor_idx, anchor_y_before, state_.document.layout_cache);
+    SyncMaxScroll(md_height);
+}
+
+void App::HandleCompensateScrollAfterLayout(const effect::CompensateScrollAfterLayout& e)
+{
+    ViewportLayoutAndCompensate(e.anchor_idx, e.anchor_y_before);
+    UpdateScrollBar();
 }
 
 void App::HandleApplyThemeChange(const effect::ApplyThemeChange& e)

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -75,9 +75,17 @@ void ApplyNavResult(AppState& state, SideEffectList& effects, NavEntry&& entry)
         effects.emplace_back(effect::LoadFile{ std::move(entry.file_path) });
     }
     else {
-        state.view.viewport.ScrollTo(NodeOffsetToScrollY(state.document.layout_cache, entry.node, entry.offset));
+        const auto& cache = state.document.layout_cache;
+        const bool valid = cache.size() > 0 && entry.node >= 0;
+        const int idx = valid ? std::min(entry.node, static_cast<int>(cache.size()) - 1) : -1;
+        const float anchor_y_before = valid ? cache[idx].y_position : 0.0f;
+
+        state.view.viewport.ScrollTo(NodeOffsetToScrollY(cache, entry.node, entry.offset));
         state.interaction.hover_throttle.Reset();
         ClearTooltip(state, effects);
+        if (valid) {
+            effects.emplace_back(effect::CompensateScrollAfterLayout{ idx, anchor_y_before });
+        }
         effects.emplace_back(effect::InvalidateWindow{});
         effects.emplace_back(effect::BitmapManage{});
     }
@@ -690,11 +698,13 @@ void ReduceTocItemClicked(AppState& state, SideEffectList& effects, const TocIte
     if (idx < 0) {
         return;
     }
+    const float anchor_y_before = state.document.layout_cache[idx].y_position;
     const float target_y = std::max(0.0f,
-        state.document.layout_cache[idx].y_position
+        anchor_y_before
         - state.window.cached_theme.heading_spacing_above
         - state.cached_pane_layout.md_rect.y);
     state.view.viewport.ScrollTo(target_y);
+    effects.emplace_back(effect::CompensateScrollAfterLayout{ idx, anchor_y_before });
     effects.emplace_back(effect::InvalidateWindow{});
     effects.emplace_back(effect::BitmapManage{});
 }

--- a/src/app/side_effect.h
+++ b/src/app/side_effect.h
@@ -94,6 +94,14 @@ struct ApplyThemeChange {
     int zoom_index;       // Zoom 用: ズームインデックス（設定保存用）
 };
 
+// ノード指定ジャンプ（TOCクリック・戻る/進む同一ファイル）後に発行する補償副作用。
+// Reducer で推定 y_position を基準に ScrollTo した後、executor が ViewportLayout で
+// 目的地周辺を本計測し、推定と実測の差を AnchorCompensateScroll で吸収する。
+struct CompensateScrollAfterLayout {
+    int anchor_idx;
+    float anchor_y_before;
+};
+
 // ---- ファイル監視・リソース ----
 struct CheckFileChanges {};
 struct NotifyImageLoaded {};
@@ -167,6 +175,7 @@ using SideEffect = std::variant<
     effect::PerformResizeEnd,
     effect::PerformSizingUpdate,
     effect::ApplyThemeChange,
+    effect::CompensateScrollAfterLayout,
     effect::ProcessDeferredLayout,
     effect::TickLoadingAnimation,
     effect::ProcessMermaidBatchTimer,

--- a/src/app/side_effect_executor.cpp
+++ b/src/app/side_effect_executor.cpp
@@ -199,6 +199,9 @@ void SideEffectExecutor::ExecuteOne(const SideEffect& e)
         [this](const effect::ApplyThemeChange& e) {
             cb_.apply_theme_change(e);
         },
+        [this](const effect::CompensateScrollAfterLayout& e) {
+            cb_.compensate_scroll_after_layout(e);
+        },
         [this](const effect::ProcessDeferredLayout&) {
             cb_.process_deferred_layout();
         },

--- a/src/app/side_effect_executor.h
+++ b/src/app/side_effect_executor.h
@@ -28,6 +28,7 @@ public:
         std::move_only_function<void()> perform_resize_end;
         std::move_only_function<void()> perform_sizing_update;
         std::move_only_function<void(const effect::ApplyThemeChange&)> apply_theme_change;
+        std::move_only_function<void(const effect::CompensateScrollAfterLayout&)> compensate_scroll_after_layout;
         std::move_only_function<void()> process_deferred_layout;
         std::move_only_function<void()> tick_loading_animation;
         std::move_only_function<void()> process_mermaid_batch_timer;


### PR DESCRIPTION
## 概要

TOCペインのリンクや戻る/進むで大きなファイルの遠い未計測位置へジャンプした際、実際の位置より少し下（ホイール1回分未満）にズレる問題を修正する。同じリンクを2回目にクリックすると正しい位置に着地していたのは、初回ジャンプで目的地周辺がDirectWrite本計測され、`y_position`が推定値から実測値に更新されるため。

## 原因

`ReduceTocItemClicked` / `ApplyNavResult` 同一ファイル分岐 / `App::NavigateToAnchor` は、スクロール目標を `layout_cache[idx].y_position` から算出している。この値は、中間ノードがまだDirectWrite本計測されていない場合 `EstimateNodeHeights` の推定値の累積に基づき、やや過大な方向にズレる傾向がある。

結果、計算された `target_y` は実際の位置より下になり、スクロール後のViewportLayoutで実測が入って `y_position` が縮んでも、スクロール値は補償されないまま残る。

## 修正方針

既存の `SaveAnchor` / `AnchorCompensateScroll` 機構（ズーム・ダークモード等で使用）と同じ補償パターンをノード指定ジャンプにも適用する。

- **新副作用** `effect::CompensateScrollAfterLayout { anchor_idx, anchor_y_before }` を追加
- Reducer が推定 `y_position` で `ScrollTo` した直後、この副作用を発行
- Executor 側で `ViewportLayoutAndCompensate` を実行:
  - `ViewportLayout` で目的地周辺を本計測
  - `AnchorCompensateScroll` で推定→実測の差を `scroll_y` に反映
  - `SyncMaxScroll` で最大スクロール値を同期

## 修正対象経路

- `ReduceTocItemClicked` (src/app/reducer.cpp) — TOCペインのリンククリック
- `ApplyNavResult` 同一ファイル分岐 (src/app/reducer.cpp) — 戻る/進むナビゲーション
- `App::NavigateToAnchor` (src/app/app_navigate.cpp) — 文書内アンカーリンク（App直接呼びのため `ViewportLayoutAndCompensate` を直接使用）

## Test plan

- [x] 大きなMarkdownファイル（例: README長編）を開き、TOCペインで遠い見出しをクリックして一発で正確に着地することを確認
- [x] 同じ操作で戻る/進むが正確に着地することを確認
- [x] 文書内 \`[...](#anchor)\` リンクで同様に確認
- [x] 既存テスト (1852件) が全てPASS
- [x] ズーム・ダークモード切替時のスクロール保持が壊れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)