### PR TITLE
スクロール位置保持を ScrollTarget ベースに一本化

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -165,7 +165,7 @@ void App::OnPaint()
         resource_manager_.FlushPendingResources();
 
         // 現在表示中のダーティなノードを現在の幅でレイアウトする
-        const auto anchor = SaveAnchor();
+        EnsureScrollTarget();
 
         bool updated;
         {
@@ -175,7 +175,7 @@ void App::OnPaint()
         }
 
         if (updated) {
-            RestoreAnchor(anchor, layout.md_rect.height);
+            SyncMaxScroll(layout.md_rect.height);
         }
     }
     // 目次ペインの同期: mdペインのスクロール位置からアクティブ見出しを判定し、

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -128,10 +128,9 @@ private:
     ResourceManager::Callbacks BuildResourceManagerCallbacks();
     SearchBarController::Callbacks BuildSearchBarCallbacks();
 
-    // アンカーベースのスクロール位置保存/復元 (AnchorState は app_state.h で定義)
-    AnchorState SaveAnchor() const;
-    void RestoreAnchor(const AnchorState& anchor, float md_pane_height);
-    void RestoreAnchorWithScale(const AnchorState& anchor, float offset_scale);
+    // 現在可視アンカーから scroll_target を合成（未設定時のみ）。
+    // レイアウト操作の直前に呼び、直後のフックで補償を掛ける。
+    void EnsureScrollTarget();
 
     // DIP変換
     struct DipPoint { float x, y; };
@@ -212,12 +211,8 @@ private:
     // ダークモード / ズーム (theme_service_に委譲)
     void HandleApplyThemeChange(const effect::ApplyThemeChange& e);
 
-    // テーマ/ズーム変更後の共通後処理（ViewportLayout→スクロール復元→再描画）
-    void FinishThemeOrZoomChange(const AnchorState& anchor, float offset_scale);
-
-    // ノード指定ジャンプ後の推定→実測誤差補償（TOCクリック・戻る/進む同一ファイル等）
-    void HandleCompensateScrollAfterLayout(const effect::CompensateScrollAfterLayout& e);
-    void ViewportLayoutAndCompensate(int anchor_idx, float anchor_y_before);
+    // テーマ/ズーム変更後の共通後処理（ViewportLayout→scroll_target フックで復元→再描画）
+    void FinishThemeOrZoomChange();
 
 private:
     // Win32ハンドル

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -234,32 +234,30 @@ void App::FinishLoadMarkdownFile(bool heights_estimated)
         ApplyMermaidCacheHeights(md_width);
     }
 
+    state_.view.viewport.ClearScrollTarget();
+
     if (has_reload_diff) {
         scroll_y = CalcScrollForDiff(state_.reload_diff_pos, md_height);
         state_.reload_diff_pos = std::string_view::npos;
+        state_.view.viewport.SetScrollY(scroll_y);
     }
     else if (state_.view.scroll_restore.HasNodeRestore()) {
-        scroll_y = NodeOffsetToScrollY(state_.document.layout_cache,
+        state_.view.viewport.SetScrollTarget(
             state_.view.scroll_restore.pending_restore_node,
             static_cast<float>(state_.view.scroll_restore.pending_restore_offset));
+        state_.view.viewport.ApplyScrollTarget(state_.document.layout_cache);
+        scroll_y = state_.view.viewport.GetScrollY();
         state_.view.scroll_restore.ClearNodeRestore();
+    }
+    else {
+        state_.view.viewport.SetScrollY(0.0f);
     }
 
     MENDO_TRACEF("FinishLoad: scroll_y=%.1f (0=top of file)", scroll_y);
 
-    state_.view.viewport.SetScrollY(scroll_y);
-
-    // 推定→計測の高さ差をアンカー補償
-    const bool need_anchor = (scroll_y > 0.0f);
-    const auto anchor = need_anchor ? SaveAnchor() : AnchorState{};
-
     {
         MENDO_PROFILE("ViewportLayout(Initial)");
         layout_service_->ViewportLayout(state_.document.doc, state_.document.layout_cache, md_width, md_height);
-    }
-
-    if (need_anchor) {
-        state_.view.viewport.AnchorCompensateScroll(anchor.idx, anchor.y_before, state_.document.layout_cache);
     }
 
     FinalizeLayout(md_height);
@@ -385,7 +383,9 @@ void App::FinishReload(bool is_prefix_only, size_t diff_pos)
         desired_scroll, old_scroll, is_prefix_only ? 1 : 0);
 
     // スクロール位置を設定してからViewportLayoutを呼ぶことで、
-    // 変更箇所周辺の可視ノードが優先的に計測される
+    // 変更箇所周辺の可視ノードが優先的に計測される。
+    // リロード時は直前の navigation target を破棄し、ピクセル位置で固定する。
+    state_.view.viewport.ClearScrollTarget();
     state_.view.viewport.SetScrollY(desired_scroll);
 
     {

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -76,9 +76,6 @@ bool App::Init(HWND hwnd)
             .apply_theme_change = [this](const effect::ApplyThemeChange& e) {
                 HandleApplyThemeChange(e);
             },
-            .compensate_scroll_after_layout = [this](const effect::CompensateScrollAfterLayout& e) {
-                HandleCompensateScrollAfterLayout(e);
-            },
             .process_deferred_layout = [this]() {
                 OnDeferredLayout();
             },
@@ -178,10 +175,10 @@ ResourceManager::Callbacks App::BuildResourceManagerCallbacks()
             layout_service_->RecomputeAfterDiagram(state_.document.doc, state_.document.layout_cache, renderer_.GetTheme());
         },
         .recompute_layout_anchored = [this]() {
-            const auto anchor = SaveAnchor();
+            EnsureScrollTarget();
             layout_service_->RecomputeAfterDiagram(state_.document.doc, state_.document.layout_cache, renderer_.GetTheme());
             const auto layout = GetPaneLayout();
-            RestoreAnchor(anchor, layout.md_rect.height);
+            SyncMaxScroll(layout.md_rect.height);
             Invalidate();
         },
     };

--- a/src/app/app_navigate.cpp
+++ b/src/app/app_navigate.cpp
@@ -37,11 +37,15 @@ void App::NavigateToAnchor(std::wstring_view anchor)
     }
 
     const auto layout = GetPaneLayout();
-    const float anchor_y_before = state_.document.layout_cache[idx].y_position;
-    float target_y = anchor_y_before - renderer_.GetTheme().heading_spacing_above - layout.md_rect.y;
-    target_y = std::max(0.0f, target_y);
-    ScrollTo(target_y);
-    ViewportLayoutAndCompensate(idx, anchor_y_before);
+    const auto target = MakeHeadingTopTarget(idx, renderer_.GetTheme().heading_spacing_above, layout.md_rect.y);
+    state_.view.viewport.SetScrollTarget(target.node, target.offset);
+
+    const float md_width = layout.md_rect.width;
+    const float md_height = layout.md_rect.height;
+    state_.view.viewport.ApplyScrollTarget(state_.document.layout_cache);
+    layout_service_->ViewportLayout(state_.document.doc, state_.document.layout_cache, md_width, md_height);
+    SyncMaxScroll(md_height);
+
     UpdateScrollBar();
     InvalidateMdPane(layout.md_rect);
     resource_manager_.ScheduleBitmapManage();
@@ -61,7 +65,7 @@ void App::SyncPaneThemeCache()
     state_.window.cached_theme = renderer_.GetTheme().ToReducerConstants();
 }
 
-void App::FinishThemeOrZoomChange(const AnchorState& anchor, float offset_scale)
+void App::FinishThemeOrZoomChange()
 {
     SyncPaneThemeCache();
 
@@ -72,8 +76,6 @@ void App::FinishThemeOrZoomChange(const AnchorState& anchor, float offset_scale)
     // 表示領域を優先的にレイアウトし、残りは遅延処理に委ねる
     layout_service_->ViewportLayout(state_.document.doc, state_.document.layout_cache, md_width, md_height);
 
-    RestoreAnchorWithScale(anchor, offset_scale);
-
     SyncMaxScroll(md_height);
     resource_manager_.RequestMermaidRenders();
     ScheduleDeferredLayoutIfNeeded();
@@ -81,31 +83,12 @@ void App::FinishThemeOrZoomChange(const AnchorState& anchor, float offset_scale)
     Invalidate();
 }
 
-void App::ViewportLayoutAndCompensate(int anchor_idx, float anchor_y_before)
-{
-    const auto layout = GetPaneLayout();
-    const float md_width = layout.md_rect.width;
-    const float md_height = layout.md_rect.height;
-    layout_service_->ViewportLayout(state_.document.doc, state_.document.layout_cache, md_width, md_height);
-    state_.view.viewport.AnchorCompensateScroll(anchor_idx, anchor_y_before, state_.document.layout_cache);
-    SyncMaxScroll(md_height);
-}
-
-void App::HandleCompensateScrollAfterLayout(const effect::CompensateScrollAfterLayout& e)
-{
-    // 発行元 Reducer が直後に effect::InvalidateWindow を発行するため
-    // ここで UpdateScrollBar 経由の部分無効化は冗長
-    ViewportLayoutAndCompensate(e.anchor_idx, e.anchor_y_before);
-}
-
 void App::HandleApplyThemeChange(const effect::ApplyThemeChange& e)
 {
-    const AnchorState anchor{ e.anchor_idx, e.anchor_y_before, e.anchor_offset };
-
     if (e.type == effect::ApplyThemeChange::Type::Zoom) {
         const Theme base = theme_service_.CreateTheme();
         renderer_.ApplyZoomFromBase(base, e.new_zoom);
-        FinishThemeOrZoomChange(anchor, e.offset_scale);
+        FinishThemeOrZoomChange();
         UpdateTitleBar();
         theme_service_.SaveZoomLevel(e.zoom_index);
     }
@@ -118,7 +101,7 @@ void App::HandleApplyThemeChange(const effect::ApplyThemeChange& e)
         state_.interaction.tooltip.ApplyDarkMode(dark);
         mermaid_renderer_.CancelPending();
         mermaid_renderer_.ClearCache();
-        FinishThemeOrZoomChange(anchor, e.offset_scale);
+        FinishThemeOrZoomChange();
         theme_service_.SaveDarkMode();
     }
 }

--- a/src/app/app_scroll.cpp
+++ b/src/app/app_scroll.cpp
@@ -51,23 +51,10 @@ int App::FindFirstVisibleNode() const noexcept
     return state_.view.viewport.FindFirstVisibleNode(state_.document.layout_cache, state_.document.doc.GetNodes().size());
 }
 
-AnchorState App::SaveAnchor() const
+void App::EnsureScrollTarget()
 {
-    return SaveAnchorFromState(state_);
-}
-
-void App::RestoreAnchor(const AnchorState& anchor, float md_pane_height)
-{
-    state_.view.viewport.AnchorCompensateScroll(anchor.idx, anchor.y_before, state_.document.layout_cache);
-    SyncMaxScroll(md_pane_height);
-}
-
-void App::RestoreAnchorWithScale(const AnchorState& anchor, float offset_scale)
-{
-    if (anchor.idx >= 0 && anchor.idx < static_cast<int>(state_.document.doc.GetNodes().size())) {
-        float anchor_y_after = state_.document.layout_cache[anchor.idx].y_position;
-        state_.view.viewport.SetScrollY(anchor_y_after + anchor.offset * offset_scale);
-    }
+    state_.view.viewport.EnsureScrollTarget(
+        state_.document.layout_cache, state_.document.doc.GetNodes().size());
 }
 
 // ============================================================
@@ -90,6 +77,8 @@ void App::OnResizeEnd()
     const auto pane_layout = GetPaneLayout();
     const float md_width = pane_layout.md_rect.width;
     const float md_height = pane_layout.md_rect.height;
+
+    EnsureScrollTarget();
 
     {
         MENDO_PROFILE("ViewportLayout(Resize)");
@@ -117,7 +106,7 @@ void App::OnDeferredLayout()
 {
     MENDO_PROFILE("OnDeferredLayout");
 
-    const auto anchor = SaveAnchor();
+    EnsureScrollTarget();
 
     const auto pane_layout = GetPaneLayout();
     const float md_width = pane_layout.md_rect.width;
@@ -137,14 +126,11 @@ void App::OnDeferredLayout()
     }
 #endif
 
-    if (!state_.view.viewport.IsScrollbarTracking()) {
-        // 中間バッチではアンカー補償のみ行い、SyncMaxScrollのクランプを遅延させる。
-        // ビューポート後のノードが計測されるとtotal_heightが縮小し、中間的な
-        // max_scrollに基づくクランプでscroll_yが不当に引き下げられるのを防ぐ。
-        // 最終バッチでもMermaidレンダリング後までクランプを遅延させる（後述）。
-        state_.view.viewport.AnchorCompensateScroll(anchor.idx, anchor.y_before, state_.document.layout_cache);
-    }
-    else {
+    // 中間バッチでは SyncMaxScroll のクランプを遅延させる。
+    // ビューポート後のノードが計測されると total_height が縮小し、中間的な
+    // max_scroll に基づくクランプで scroll_y が不当に引き下げられるのを防ぐ。
+    // スクロールバートラッキング中はユーザー操作を優先してクランプを反映する。
+    if (state_.view.viewport.IsScrollbarTracking()) {
         SyncMaxScroll(md_height);
     }
 

--- a/src/app/app_state.cpp
+++ b/src/app/app_state.cpp
@@ -1,19 +1,17 @@
 #include "app_state.h"
 
-AnchorState SaveAnchorFromState(const AppState& state) noexcept
+ScrollTarget SnapshotVisibleTarget(const AppState& state) noexcept
 {
     const auto& cache = state.document.layout_cache;
-    AnchorState a;
-    a.idx = state.view.viewport.FindFirstVisibleNode(cache, cache.size());
-    a.y_before = (a.idx >= 0) ? cache[a.idx].y_position : 0.0f;
-    a.offset = state.view.viewport.GetScrollY() - a.y_before;
-    return a;
+    const int node = state.view.viewport.FindFirstVisibleNode(cache, cache.size());
+    const float y_before = (node >= 0) ? cache[node].y_position : 0.0f;
+    return { node, state.view.viewport.GetScrollY() - y_before };
 }
 
 NavEntry CurrentNavEntry(const AppState& state)
 {
-    const AnchorState a = SaveAnchorFromState(state);
-    return NavEntry{ state.document.doc.GetFilePath(), a.idx, a.offset };
+    const ScrollTarget t = SnapshotVisibleTarget(state);
+    return NavEntry{ state.document.doc.GetFilePath(), t.node, t.offset };
 }
 
 void PushCurrentNavEntry(AppState& state)

--- a/src/app/app_state.h
+++ b/src/app/app_state.h
@@ -22,13 +22,6 @@
 #include <string_view>
 #include <memory_resource>
 
-// スクロール位置のアンカー。レイアウト無効化の前に保存し、復元に使用する。
-struct AnchorState {
-    int idx = -1;
-    float y_before = 0.0f;
-    float offset = 0.0f;
-};
-
 // ---- ドメイン状態: ドキュメントとレイアウトキャッシュ ----
 struct DocumentState {
     Document doc;
@@ -100,8 +93,8 @@ struct AppState {
     bool pane_layout_valid = false;
 };
 
-// 現在のスクロール位置からアンカーを保存する。Reducer と App の共通ヘルパー。
-AnchorState SaveAnchorFromState(const AppState& state) noexcept;
+// 現在の可視先頭ノードから ScrollTarget を合成する。Reducer と App の共通ヘルパー。
+ScrollTarget SnapshotVisibleTarget(const AppState& state) noexcept;
 
 // 現在のファイル/スクロール位置をナビゲーション履歴に Push する。
 void PushCurrentNavEntry(AppState& state);

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -75,17 +75,11 @@ void ApplyNavResult(AppState& state, SideEffectList& effects, NavEntry&& entry)
         effects.emplace_back(effect::LoadFile{ std::move(entry.file_path) });
     }
     else {
-        const auto& cache = state.document.layout_cache;
-        const bool valid = cache.size() > 0 && entry.node >= 0;
-        const int idx = valid ? std::min(entry.node, static_cast<int>(cache.size()) - 1) : -1;
-        const float anchor_y_before = valid ? cache[idx].y_position : 0.0f;
-
-        state.view.viewport.ScrollTo(NodeOffsetToScrollY(cache, entry.node, entry.offset));
+        auto& cache = state.document.layout_cache;
+        state.view.viewport.SetScrollTarget(entry.node, entry.offset);
+        state.view.viewport.ApplyScrollTarget(cache);
         state.interaction.hover_throttle.Reset();
         ClearTooltip(state, effects);
-        if (valid) {
-            effects.emplace_back(effect::CompensateScrollAfterLayout{ idx, anchor_y_before });
-        }
         effects.emplace_back(effect::InvalidateWindow{});
         effects.emplace_back(effect::BitmapManage{});
     }
@@ -129,9 +123,11 @@ void ReduceKeyScroll(AppState& state, SideEffectList& effects, const KeyScrollAc
         state.view.viewport.DirectScrollBy(page_size * SCROLL_PAGE_FACTOR);
         break;
     case ScrollType::Home:
-        state.view.viewport.ScrollTo(0.0f);
+        state.view.viewport.SetScrollTarget(0, 0.0f);
+        state.view.viewport.ApplyScrollTarget(state.document.layout_cache);
         break;
     case ScrollType::End:
+        // 末尾は max_scroll に依存するためピクセル指定。target は無効化される
         state.view.viewport.ScrollTo(state.view.viewport.GetMaxScroll());
         break;
     default:
@@ -242,17 +238,17 @@ void ReduceZoom(AppState& state, SideEffectList& effects, const ZoomAction& a)
     if (new_zoom <= 0.0f) {
         return;
     }
-    const auto anchor = SaveAnchorFromState(state);
+    const auto anchor = SnapshotVisibleTarget(state);
     state.pane_layout_valid = false;
     const float zoom_ratio = new_zoom / state.window.cached_theme.zoom;
     state.view.panes.ApplyZoom(zoom_ratio);
     state.document.layout_cache.InvalidateAllLayouts();
+    if (anchor.IsValid()) {
+        // offset もズーム比でスケールし、ノード内の同じ位置が可視先頭に留まるようにする
+        state.view.viewport.SetScrollTarget(anchor.node, anchor.offset * zoom_ratio);
+    }
     effects.emplace_back(effect::ApplyThemeChange{
         .type = effect::ApplyThemeChange::Type::Zoom,
-        .anchor_idx = anchor.idx,
-        .anchor_y_before = anchor.y_before,
-        .anchor_offset = anchor.offset,
-        .offset_scale = zoom_ratio,
         .new_zoom = new_zoom,
         .zoom_index = state.view.viewport.GetZoomIndex(),
         });
@@ -260,15 +256,15 @@ void ReduceZoom(AppState& state, SideEffectList& effects, const ZoomAction& a)
 
 void ReduceToggleDarkMode(AppState& state, SideEffectList& effects)
 {
-    const auto anchor = SaveAnchorFromState(state);
+    const auto anchor = SnapshotVisibleTarget(state);
     state.pane_layout_valid = false;
     state.document.layout_cache.InvalidateAllWithDiagrams(state.document.doc.GetNodes());
+    if (anchor.IsValid()) {
+        // Mermaid 再レンダリングで微小な高さ変化が起きるので target で追従する
+        state.view.viewport.SetScrollTarget(anchor.node, anchor.offset);
+    }
     effects.emplace_back(effect::ApplyThemeChange{
         .type = effect::ApplyThemeChange::Type::DarkMode,
-        .anchor_idx = anchor.idx,
-        .anchor_y_before = anchor.y_before,
-        .anchor_offset = anchor.offset,
-        .offset_scale = 1.0f,
         .new_zoom = 0.0f,
         .zoom_index = state.view.viewport.GetZoomIndex(),
         });
@@ -698,13 +694,11 @@ void ReduceTocItemClicked(AppState& state, SideEffectList& effects, const TocIte
     if (idx < 0) {
         return;
     }
-    const float anchor_y_before = state.document.layout_cache[idx].y_position;
-    const float target_y = std::max(0.0f,
-        anchor_y_before
-        - state.window.cached_theme.heading_spacing_above
-        - state.cached_pane_layout.md_rect.y);
-    state.view.viewport.ScrollTo(target_y);
-    effects.emplace_back(effect::CompensateScrollAfterLayout{ idx, anchor_y_before });
+    const auto target = MakeHeadingTopTarget(idx,
+        state.window.cached_theme.heading_spacing_above,
+        state.cached_pane_layout.md_rect.y);
+    state.view.viewport.SetScrollTarget(target.node, target.offset);
+    state.view.viewport.ApplyScrollTarget(state.document.layout_cache);
     effects.emplace_back(effect::InvalidateWindow{});
     effects.emplace_back(effect::BitmapManage{});
 }

--- a/src/app/side_effect.h
+++ b/src/app/side_effect.h
@@ -81,25 +81,13 @@ struct RefreshPaneLayout {};
 // ---- テーマ・ダークモード ----
 struct ApplyDarkMode { bool dark; };
 
-// テーマ/ズーム変更の複合副作用。
-// Reducer が SaveAnchor + 状態変更を行った後、executor がレンダラー適用 + レイアウトを実行する。
+// テーマ/ズーム変更の複合副作用。executor がレンダラー適用 + レイアウトを実行する。
+// スクロール位置保持は scroll_target を介して行うのでアンカー情報は含めない。
 struct ApplyThemeChange {
     enum class Type { Zoom, DarkMode };
     Type type;
-    int anchor_idx;
-    float anchor_y_before;
-    float anchor_offset;
-    float offset_scale;   // Zoom: zoom_ratio, DarkMode: 1.0f
     float new_zoom;       // Zoom 用: 新しいズーム値
     int zoom_index;       // Zoom 用: ズームインデックス（設定保存用）
-};
-
-// ノード指定ジャンプ（TOCクリック・戻る/進む同一ファイル）後に発行する補償副作用。
-// Reducer で推定 y_position を基準に ScrollTo した後、executor が ViewportLayout で
-// 目的地周辺を本計測し、推定と実測の差を AnchorCompensateScroll で吸収する。
-struct CompensateScrollAfterLayout {
-    int anchor_idx;
-    float anchor_y_before;
 };
 
 // ---- ファイル監視・リソース ----
@@ -175,7 +163,6 @@ using SideEffect = std::variant<
     effect::PerformResizeEnd,
     effect::PerformSizingUpdate,
     effect::ApplyThemeChange,
-    effect::CompensateScrollAfterLayout,
     effect::ProcessDeferredLayout,
     effect::TickLoadingAnimation,
     effect::ProcessMermaidBatchTimer,

--- a/src/app/side_effect_executor.cpp
+++ b/src/app/side_effect_executor.cpp
@@ -199,9 +199,6 @@ void SideEffectExecutor::ExecuteOne(const SideEffect& e)
         [this](const effect::ApplyThemeChange& e) {
             cb_.apply_theme_change(e);
         },
-        [this](const effect::CompensateScrollAfterLayout& e) {
-            cb_.compensate_scroll_after_layout(e);
-        },
         [this](const effect::ProcessDeferredLayout&) {
             cb_.process_deferred_layout();
         },

--- a/src/app/side_effect_executor.h
+++ b/src/app/side_effect_executor.h
@@ -28,7 +28,6 @@ public:
         std::move_only_function<void()> perform_resize_end;
         std::move_only_function<void()> perform_sizing_update;
         std::move_only_function<void(const effect::ApplyThemeChange&)> apply_theme_change;
-        std::move_only_function<void(const effect::CompensateScrollAfterLayout&)> compensate_scroll_after_layout;
         std::move_only_function<void()> process_deferred_layout;
         std::move_only_function<void()> tick_loading_animation;
         std::move_only_function<void()> process_mermaid_batch_timer;

--- a/src/layout/layout_service.cpp
+++ b/src/layout/layout_service.cpp
@@ -26,9 +26,9 @@ bool LayoutService::EnsureVisibleLayout(Document& doc, LayoutCache& cache, float
 {
     const float scroll_y = viewport_.GetScrollY();
     const bool updated = engine_.EnsureVisibleLayout(doc.GetNodesMut(), cache, width, scroll_y, scroll_y + height);
-    if (updated) {
-        viewport_.ApplyScrollTarget(cache);
-    }
+    // updated=false でもレイアウト操作の一貫した契約として target を再適用する
+    // （target 無効時は ApplyScrollTarget 側で早期 return）
+    viewport_.ApplyScrollTarget(cache);
     return updated;
 }
 

--- a/src/layout/layout_service.cpp
+++ b/src/layout/layout_service.cpp
@@ -4,26 +4,37 @@ void LayoutService::ViewportLayout(Document& doc, LayoutCache& cache, float widt
 {
     const float scroll_y = viewport_.GetScrollY();
     engine_.ComputeLayout(doc.GetNodesMut(), cache, width, scroll_y, scroll_y + height);
+    viewport_.ApplyScrollTarget(cache);
 }
 
 bool LayoutService::ProcessDirtyBatch(Document& doc, LayoutCache& cache, float width, int batch_size, int time_budget_us,
     float viewport_height, float buffer_screens)
 {
+    bool more;
     if (viewport_height > 0.0f) {
         const float vp_top = viewport_.GetScrollY();
-        return engine_.ProcessDirtyBatch(doc.GetNodesMut(), cache, width, batch_size, time_budget_us, vp_top, viewport_height, buffer_screens);
+        more = engine_.ProcessDirtyBatch(doc.GetNodesMut(), cache, width, batch_size, time_budget_us, vp_top, viewport_height, buffer_screens);
     }
-    return engine_.ProcessDirtyBatch(doc.GetNodesMut(), cache, width, batch_size, time_budget_us);
+    else {
+        more = engine_.ProcessDirtyBatch(doc.GetNodesMut(), cache, width, batch_size, time_budget_us);
+    }
+    viewport_.ApplyScrollTarget(cache);
+    return more;
 }
 
 bool LayoutService::EnsureVisibleLayout(Document& doc, LayoutCache& cache, float width, float height)
 {
     const float scroll_y = viewport_.GetScrollY();
-    return engine_.EnsureVisibleLayout(doc.GetNodesMut(), cache, width, scroll_y, scroll_y + height);
+    const bool updated = engine_.EnsureVisibleLayout(doc.GetNodesMut(), cache, width, scroll_y, scroll_y + height);
+    if (updated) {
+        viewport_.ApplyScrollTarget(cache);
+    }
+    return updated;
 }
 
 void LayoutService::RecomputeAfterDiagram(Document& doc, LayoutCache& cache, const Theme& theme) noexcept
 {
     const auto result = RecomputeYPositions(doc.GetNodesMut(), cache, theme);
     engine_.SetTotalHeight(result.total_height);
+    viewport_.ApplyScrollTarget(cache);
 }

--- a/src/ui/viewport_manager.h
+++ b/src/ui/viewport_manager.h
@@ -72,7 +72,8 @@ public:
     constexpr const ScrollTarget& GetScrollTarget() const noexcept { return scroll_target_; }
 
     // scroll_target が有効な場合、現在のレイアウトキャッシュから scroll_y を再評価する。
-    // クランプは行わない（SyncMaxScroll がクランプを担当する）。
+    // max_scroll によるクランプは行わない（SyncMaxScroll が担当する）。
+    // 負値は NodeOffsetToScrollY 側で 0 に、node はキャッシュ末尾にクランプされる。
     constexpr void ApplyScrollTarget(const LayoutCache& cache) noexcept
     {
         if (!scroll_target_.IsValid()) {
@@ -89,8 +90,13 @@ public:
         if (scroll_target_.IsValid()) {
             return;
         }
-        const int idx = FindFirstVisibleNodeIndex(cache, node_count, scroll_y_);
-        if (idx < static_cast<int>(node_count)) {
+        // 呼び出し側の node_count が過渡状態で cache.size() を超える可能性に備えてクランプ
+        const size_t effective = std::min(node_count, cache.size());
+        if (effective == 0) {
+            return;
+        }
+        const int idx = FindFirstVisibleNodeIndex(cache, effective, scroll_y_);
+        if (idx < static_cast<int>(effective)) {
             scroll_target_ = { idx, scroll_y_ - cache[idx].y_position };
         }
     }

--- a/src/ui/viewport_manager.h
+++ b/src/ui/viewport_manager.h
@@ -5,6 +5,23 @@
 #include <algorithm>
 #include <memory_resource>
 
+// スクロール位置の「目的地」を表す値型。
+// node が有効な間、レイアウトが変化するたびに scroll_y = y_position[node] + offset として再評価される。
+// ユーザー発のピクセルスクロールや ClearScrollTarget で無効化される。
+struct ScrollTarget {
+    int node = -1;          // -1 = 無効
+    float offset = 0.0f;    // ノード先頭からのピクセル距離
+
+    constexpr bool IsValid() const noexcept { return node >= 0; }
+};
+
+// 見出しノードを md ペイン上端の heading_spacing_above 分だけ下に配置する ScrollTarget を作る。
+// TOCクリック・#anchor ナビゲーションで共通して使う。
+constexpr ScrollTarget MakeHeadingTopTarget(int node, float heading_spacing_above, float md_pane_top) noexcept
+{
+    return { node, -(heading_spacing_above + md_pane_top) };
+}
+
 // スクロール、選択、ズームの純粋な状態管理。
 // Win32 API依存なし — 完全にテスト可能。
 class ViewportManager {
@@ -14,14 +31,18 @@ public:
     constexpr float GetScrollY() const noexcept { return scroll_y_; }
     constexpr float GetMaxScroll() const noexcept { return max_scroll_; }
 
+    // ピクセル絶対スクロール。scroll_target を無効化する。
     constexpr void ScrollTo(float position) noexcept
     {
         scroll_y_ = std::clamp(position, 0.0f, max_scroll_);
+        scroll_target_ = {};
     }
 
+    // ユーザー発のピクセルスクロール。scroll_target を無効化する。
     constexpr void DirectScrollBy(float delta) noexcept
     {
         scroll_y_ = std::clamp(scroll_y_ + delta, 0.0f, max_scroll_);
+        scroll_target_ = {};
     }
 
     constexpr void SyncMaxScroll(float total_height, float viewport_height) noexcept
@@ -38,16 +59,44 @@ public:
         return idx < static_cast<int>(node_count) ? idx : -1;
     }
 
-    constexpr void AnchorCompensateScroll(int anchor_idx, float anchor_y_before, const LayoutCache& cache) noexcept
+    // scroll_target を明示設定する。内部の scroll_y は更新しないので、
+    // 呼び出し側は直後に ApplyScrollTarget を呼ぶか、レイアウト操作経由のフック
+    // で再評価されるのを待つ必要がある。
+    constexpr void SetScrollTarget(int node, float offset) noexcept
     {
-        if (anchor_idx < 0) {
-            return;
-        }
-        const float shift = cache[anchor_idx].y_position - anchor_y_before;
-        scroll_y_ = std::max(0.0f, scroll_y_ + shift);
-        // 注意: 呼び出し側はこの後SyncMaxScroll()を呼ぶ必要がある
+        scroll_target_ = { node, offset };
     }
 
+    constexpr void ClearScrollTarget() noexcept { scroll_target_ = {}; }
+    constexpr bool HasScrollTarget() const noexcept { return scroll_target_.IsValid(); }
+    constexpr const ScrollTarget& GetScrollTarget() const noexcept { return scroll_target_; }
+
+    // scroll_target が有効な場合、現在のレイアウトキャッシュから scroll_y を再評価する。
+    // クランプは行わない（SyncMaxScroll がクランプを担当する）。
+    constexpr void ApplyScrollTarget(const LayoutCache& cache) noexcept
+    {
+        if (!scroll_target_.IsValid()) {
+            return;
+        }
+        scroll_y_ = NodeOffsetToScrollY(cache, scroll_target_.node, scroll_target_.offset);
+    }
+
+    // scroll_target が未設定なら、現在の可視先頭ノードから合成する。
+    // レイアウト変化を挟む処理（OnPaint/OnResizeEnd/OnDeferredLayout 等）の直前に呼んで、
+    // 「見ている位置を保つ」挙動を target ベースで表現する。
+    constexpr void EnsureScrollTarget(const LayoutCache& cache, size_t node_count) noexcept
+    {
+        if (scroll_target_.IsValid()) {
+            return;
+        }
+        const int idx = FindFirstVisibleNodeIndex(cache, node_count, scroll_y_);
+        if (idx < static_cast<int>(node_count)) {
+            scroll_target_ = { idx, scroll_y_ - cache[idx].y_position };
+        }
+    }
+
+    // target を触らずクランプも掛けない生の scroll_y 書き込み。
+    // max_scroll が未確定な段階（ファイルロード直後など）のシード投入に使う。target との整合は呼び出し側責任。
     constexpr void SetScrollY(float y) noexcept { scroll_y_ = y; }
 
     constexpr bool IsScrollbarTracking() const noexcept { return is_scrollbar_tracking_; }
@@ -133,6 +182,7 @@ private:
     float scroll_y_ = 0.0f;
     float max_scroll_ = 0.0f;
     bool is_scrollbar_tracking_ = false;
+    ScrollTarget scroll_target_{};
 
     // 選択状態
     TextSelection selection_;

--- a/tests/test_side_effect_executor.cpp
+++ b/tests/test_side_effect_executor.cpp
@@ -173,18 +173,12 @@ TEST_F(SideEffectExecutorTest, ApplyThemeChangeForwardsStruct)
 {
     effect::ApplyThemeChange in{};
     in.type = effect::ApplyThemeChange::Type::Zoom;
-    in.anchor_idx = 5;
-    in.anchor_y_before = 100.0f;
-    in.anchor_offset = 10.0f;
-    in.offset_scale = 1.25f;
     in.new_zoom = 1.25f;
     in.zoom_index = 4;
     exec_.ExecuteOne(in);
     EXPECT_EQ(apply_theme_change_count_, 1);
     EXPECT_EQ(last_theme_change_.type, effect::ApplyThemeChange::Type::Zoom);
-    EXPECT_EQ(last_theme_change_.anchor_idx, 5);
-    EXPECT_FLOAT_EQ(last_theme_change_.anchor_y_before, 100.0f);
-    EXPECT_FLOAT_EQ(last_theme_change_.offset_scale, 1.25f);
+    EXPECT_FLOAT_EQ(last_theme_change_.new_zoom, 1.25f);
     EXPECT_EQ(last_theme_change_.zoom_index, 4);
 }
 

--- a/tests/test_viewport_manager.cpp
+++ b/tests/test_viewport_manager.cpp
@@ -120,35 +120,85 @@ TEST(ViewportManagerTest, FindFirstVisibleNodeEmpty)
     EXPECT_EQ(vm.FindFirstVisibleNode(cache, 0), -1);
 }
 
-// ---- AnchorCompensateScroll テスト ----
+// ---- ScrollTarget テスト ----
 
-TEST(ViewportManagerTest, AnchorCompensateScroll)
+TEST(ViewportManagerTest, ScrollTargetAppliesNewYPosition)
 {
+    // レイアウト変更でターゲットノードの y_position が動くと scroll_y も追従する
     ViewportManager vm;
     auto cache = MakeUniformCache(5, 100.0f);
     vm.SyncMaxScroll(500.0f, 200.0f);
     vm.ScrollTo(100.0f);
 
-    float y_before = cache[1].y_position; // 100.0f
+    float offset = vm.GetScrollY() - cache[1].y_position; // 0
+    vm.SetScrollTarget(1, offset);
+
     // レイアウト変更をシミュレーション: ノード1を30下にシフト
     cache[1].y_position = 130.0f;
     cache[2].y_position = 230.0f;
     cache[3].y_position = 330.0f;
     cache[4].y_position = 430.0f;
 
-    vm.AnchorCompensateScroll(1, y_before, cache);
+    vm.ApplyScrollTarget(cache);
     EXPECT_FLOAT_EQ(vm.GetScrollY(), 130.0f);
 }
 
-TEST(ViewportManagerTest, AnchorCompensateNegativeIndex)
+TEST(ViewportManagerTest, ApplyScrollTargetIsNoOpWhenInvalid)
 {
     ViewportManager vm;
     auto cache = MakeUniformCache(3, 100.0f);
     vm.SyncMaxScroll(300.0f, 100.0f);
     vm.ScrollTo(50.0f);
     float before = vm.GetScrollY();
-    vm.AnchorCompensateScroll(-1, 0.0f, cache);
-    EXPECT_FLOAT_EQ(vm.GetScrollY(), before); // 変更なし
+    // target 未設定なので何もしない
+    EXPECT_FALSE(vm.HasScrollTarget());
+    vm.ApplyScrollTarget(cache);
+    EXPECT_FLOAT_EQ(vm.GetScrollY(), before);
+}
+
+TEST(ViewportManagerTest, ScrollToInvalidatesScrollTarget)
+{
+    ViewportManager vm;
+    vm.SetScrollTarget(2, 10.0f);
+    EXPECT_TRUE(vm.HasScrollTarget());
+    vm.ScrollTo(100.0f);
+    EXPECT_FALSE(vm.HasScrollTarget());
+}
+
+TEST(ViewportManagerTest, DirectScrollByInvalidatesScrollTarget)
+{
+    ViewportManager vm;
+    vm.SyncMaxScroll(1000.0f, 200.0f);
+    vm.SetScrollTarget(2, 10.0f);
+    vm.DirectScrollBy(50.0f);
+    EXPECT_FALSE(vm.HasScrollTarget());
+}
+
+TEST(ViewportManagerTest, EnsureScrollTargetSynthesizesFromVisibleAnchor)
+{
+    ViewportManager vm;
+    auto cache = MakeUniformCache(5, 100.0f);
+    vm.SyncMaxScroll(500.0f, 200.0f);
+    vm.ScrollTo(150.0f); // ノード1の途中（scroll_y=150, cache[1].y=100）
+
+    vm.EnsureScrollTarget(cache, 5);
+    ASSERT_TRUE(vm.HasScrollTarget());
+    EXPECT_EQ(vm.GetScrollTarget().node, 1);
+    EXPECT_FLOAT_EQ(vm.GetScrollTarget().offset, 50.0f);
+}
+
+TEST(ViewportManagerTest, EnsureScrollTargetPreservesExistingTarget)
+{
+    ViewportManager vm;
+    auto cache = MakeUniformCache(5, 100.0f);
+    vm.SyncMaxScroll(500.0f, 200.0f);
+    vm.SetScrollY(150.0f);
+    vm.SetScrollTarget(3, 25.0f);
+
+    vm.EnsureScrollTarget(cache, 5);
+    // 既存ターゲットは上書きされない
+    EXPECT_EQ(vm.GetScrollTarget().node, 3);
+    EXPECT_FLOAT_EQ(vm.GetScrollTarget().offset, 25.0f);
 }
 
 // ---- 選択テスト ----
@@ -255,37 +305,39 @@ TEST(ViewportManagerTest, ScrollbarTracking)
     EXPECT_TRUE(vm.IsScrollbarTracking());
 }
 
-// ---- バグ #17: AnchorCompensateScrollの非負クランプ ----
+// ---- バグ #17: scroll_y の非負クランプ ----
 
-TEST(ViewportManagerTest, AnchorCompensateScrollClampsNegative)
+TEST(ViewportManagerTest, ApplyScrollTargetClampsNegative)
 {
     ViewportManager vm;
     auto cache = MakeUniformCache(5, 100.0f);
     vm.SyncMaxScroll(500.0f, 200.0f);
     vm.ScrollTo(50.0f);
 
-    float y_before = cache[2].y_position; // 200.0f
+    // target 設定: scroll_y - y_position[2] = 50 - 200 = -150
+    vm.SetScrollTarget(2, vm.GetScrollY() - cache[2].y_position);
+
     // ノード2を上方に300シフトするレイアウト変更をシミュレーション
     // （例: 上にある大きなノードが削除された場合）
     cache[2].y_position = 0.0f;
 
-    vm.AnchorCompensateScroll(2, y_before, cache);
+    vm.ApplyScrollTarget(cache);
 
     // scroll_yは-150ではなく0にクランプされるべき
     EXPECT_GE(vm.GetScrollY(), 0.0f);
 }
 
-TEST(ViewportManagerTest, AnchorCompensateScrollPositiveShiftOk)
+TEST(ViewportManagerTest, ApplyScrollTargetPositiveShiftOk)
 {
     ViewportManager vm;
     auto cache = MakeUniformCache(5, 100.0f);
     vm.SyncMaxScroll(500.0f, 200.0f);
     vm.ScrollTo(100.0f);
 
-    float y_before = cache[1].y_position; // 100.0f
+    vm.SetScrollTarget(1, vm.GetScrollY() - cache[1].y_position);
     cache[1].y_position = 150.0f; // shifted down by 50
 
-    vm.AnchorCompensateScroll(1, y_before, cache);
+    vm.ApplyScrollTarget(cache);
     EXPECT_FLOAT_EQ(vm.GetScrollY(), 150.0f);
 }
 
@@ -397,9 +449,9 @@ TEST(ViewportManagerTest, ScrollRestoreAtDocumentEnd)
     EXPECT_FLOAT_EQ(restored, 300.0f);
 }
 
-TEST(ViewportManagerTest, ScrollRestoreAnchorCompensationAfterHeightChange)
+TEST(ViewportManagerTest, ScrollRestoreTargetCompensationAfterHeightChange)
 {
-    // ノードベース復元後に画像読み込みでアンカー補正が正しく機能する
+    // ノードベース復元後に画像読み込みで target 再評価が正しく機能する
     ViewportManager vm;
     auto cache = MakeUniformCache(10, 50.0f);
     vm.SyncMaxScroll(500.0f, 200.0f);
@@ -407,18 +459,18 @@ TEST(ViewportManagerTest, ScrollRestoreAnchorCompensationAfterHeightChange)
     // ノード5(y=250)付近にスクロール復元
     int restore_node = 5;
     float restore_offset = 10.0f;
-    float scroll_y = cache[restore_node].y_position + restore_offset; // 260
-    vm.ScrollTo(scroll_y);
+    vm.SetScrollTarget(restore_node, restore_offset);
+    vm.ApplyScrollTarget(cache);
+    EXPECT_FLOAT_EQ(vm.GetScrollY(), 260.0f);
 
     // ノード2の高さが100増加（画像読み込み）→ ノード5が下にシフト
-    float anchor_y_before = cache[5].y_position; // 250
     for (int i = 2; i < 10; ++i) {
         cache[i].y_position += 100.0f;
     }
     cache[2].height = 150.0f;
 
-    // アンカー補正
-    vm.AnchorCompensateScroll(5, anchor_y_before, cache);
+    // target 再評価
+    vm.ApplyScrollTarget(cache);
     // scroll_yが100増加して360になるべき（ノード5が350に移動+オフセット10）
     EXPECT_FLOAT_EQ(vm.GetScrollY(), 360.0f);
 }


### PR DESCRIPTION
## Summary
- アンカー保存→レイアウト→補償という命令的ロジック（`SaveAnchor` / `RestoreAnchor` / `AnchorCompensateScroll`）を、`ViewportManager` が保持する宣言的な `ScrollTarget`（node + offset）に一本化
- `LayoutService` の各レイアウト操作後に `ApplyScrollTarget` を自動呼び出しし、レイアウト確定と scroll_y 再評価を密結合化
- 付随して `effect::CompensateScrollAfterLayout` を廃止し、`effect::ApplyThemeChange` からアンカー関連フィールドを除去

## 変更の主な狙い
従来は「保存→レイアウト→`AnchorCompensateScroll`」の三点セットを呼び出し側が正しく並べる必要があり、TOCクリック / 戻る進む / テーマ変更 / ズーム / リサイズ / 遅延レイアウト など経路ごとに同じ定型を書いていた。`ScrollTarget` を `ViewportManager` の状態として保持し、`LayoutService` が再評価を担当することで、呼び出し側の定型を削減し、経路間の挙動差を減らしている。

## 主な API 変更
- 追加: `ScrollTarget` 型、`MakeHeadingTopTarget`, `ViewportManager::{SetScrollTarget, ApplyScrollTarget, EnsureScrollTarget, ClearScrollTarget, HasScrollTarget, GetScrollTarget}`
- 削除: `AnchorState`, `App::{SaveAnchor, RestoreAnchor, RestoreAnchorWithScale, ViewportLayoutAndCompensate, HandleCompensateScrollAfterLayout}`, `ViewportManager::AnchorCompensateScroll`, `effect::CompensateScrollAfterLayout`
- 挙動: `ScrollTo` / `DirectScrollBy` はユーザー発のピクセルスクロールなので `scroll_target_` を自動無効化。`SetScrollY` は生の書き込みで target を触らない

## Test plan
- [x] `cmake --build build --config Release` がクリーンビルドで通る
- [x] `mendo_tests.exe` 1856 tests all PASSED
- [ ] 手動確認: TOC クリックで見出し先頭にスクロールし、推定→実測差の補償が効く
- [ ] 手動確認: 戻る/進むで同一ファイル内のノード復元が正しい
- [ ] 手動確認: ズーム変更後も可視位置が維持され、ノード内オフセットがズーム比でスケールする
- [ ] 手動確認: ダークモード切替後も可視位置が維持される
- [ ] 手動確認: リサイズ中/後に可視位置が維持される
- [ ] 手動確認: リロード時にピクセル位置で固定（target は破棄）される
- [ ] 手動確認: Home/End キーと PageUp/PageDown の挙動
- [ ] 手動確認: 画像読み込みや Mermaid 再レンダリング後に可視位置が維持される

🤖 Generated with [Claude Code](https://claude.com/claude-code)