### PR TITLE
レビュー指摘対応: I/Oヘルパー統一・検索バー hit-test 一本化ほか

### DIFF
--- a/src/app/app_mouse_click.cpp
+++ b/src/app/app_mouse_click.cpp
@@ -18,34 +18,33 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
         const auto& r = pane_layout.md_rect;
         const auto sbl = ComputeSearchBarLayout(r.x, r.width, r.y + r.height, !state_.search.search_state.GetQuery().empty());
         if (dip_y >= sbl.bar_top) {
-            if (PointInRect(dip_x, dip_y, sbl.up_btn)) {
+            switch (HitTestSearchBar(sbl, dip_x, dip_y)) {
+            case SearchBarHitZone::Up:
                 OnSearchPrev();
-                return;
-            }
-            if (PointInRect(dip_x, dip_y, sbl.down_btn)) {
+                break;
+            case SearchBarHitZone::Down:
                 OnSearchNext();
-                return;
-            }
-            if (PointInRect(dip_x, dip_y, sbl.case_btn)) {
+                break;
+            case SearchBarHitZone::CaseSensitive:
                 OnToggleCaseSensitive();
-                return;
-            }
-            if (PointInRect(dip_x, dip_y, sbl.highlight_btn)) {
+                break;
+            case SearchBarHitZone::Highlight:
                 OnToggleHighlight();
-                return;
-            }
-            if (PointInRect(dip_x, dip_y, sbl.close_btn)) {
+                break;
+            case SearchBarHitZone::Close:
                 OnSearchClose();
-                return;
-            }
-            if (PointInRect(dip_x, dip_y, sbl.input_rect)) {
+                break;
+            case SearchBarHitZone::Input: {
                 const float text_left = sbl.input_rect.left + SEARCH_INPUT_TEXT_PAD_LEFT;
                 const float input_w = sbl.input_rect.right - SEARCH_INPUT_TEXT_PAD_RIGHT - text_left;
                 const int pos = renderer_.HitTestSearchInput(state_.search.search_state.GetQuery(), dip_x - text_left, input_w);
                 Dispatch(SearchInputDragStartedAction{ pos });
-                return;
+                break;
             }
-            PostMessage(hwnd_, app_msg::SEARCH_FOCUS, app_param::SEARCH_FOCUS_SELECT_ALL, 0);
+            case SearchBarHitZone::None:
+                PostMessage(hwnd_, app_msg::SEARCH_FOCUS, app_param::SEARCH_FOCUS_SELECT_ALL, 0);
+                break;
+            }
             return;
         }
     }

--- a/src/app/app_mouse_hover.cpp
+++ b/src/app/app_mouse_hover.cpp
@@ -47,44 +47,36 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
         const auto old_hover = state_.search.search_bar_ctrl.GetHover();
 
         if (dip_y >= sbl.bar_top) {
-            const auto hover = state_.search.search_bar_ctrl.UpdateHover(dip_x, dip_y, sbl);
+            const auto zone = HitTestSearchBar(sbl, dip_x, dip_y);
+            state_.search.search_bar_ctrl.UpdateHoverFromZone(zone);
 
-            if (PointInRect(dip_x, dip_y, sbl.input_rect)) {
-                SetCursor(cursors_.IBeam());
+            SetCursor(zone == SearchBarHitZone::Input ? cursors_.IBeam() : cursors_.Arrow());
+            const auto& ls = i18n::S();
+            TooltipTarget tt;
+            switch (zone) {
+            case SearchBarHitZone::Up:
+                tt = { TooltipTarget::Zone::SearchBarButton, ls.tooltip_search_prev };
+                break;
+            case SearchBarHitZone::Down:
+                tt = { TooltipTarget::Zone::SearchBarButton, ls.tooltip_search_next };
+                break;
+            case SearchBarHitZone::CaseSensitive:
+                tt = { TooltipTarget::Zone::SearchBarButton, ls.tooltip_search_case };
+                break;
+            case SearchBarHitZone::Highlight:
+                tt = { TooltipTarget::Zone::SearchBarButton, ls.tooltip_search_highlight };
+                break;
+            case SearchBarHitZone::Close:
+                tt = { TooltipTarget::Zone::SearchBarButton, ls.tooltip_search_close };
+                break;
+            default:
+                break;
             }
-            else {
-                SetCursor(cursors_.Arrow());
-            }
-            // 検索バーボタンのツールチップ
-            {
-                using HZ = SearchBarController::HoverZone;
-                const auto& ls = i18n::S();
-                TooltipTarget tt;
-                switch (hover) {
-                case HZ::Up:
-                    tt = { TooltipTarget::Zone::SearchBarButton, ls.tooltip_search_prev };
-                    break;
-                case HZ::Down:
-                    tt = { TooltipTarget::Zone::SearchBarButton, ls.tooltip_search_next };
-                    break;
-                case HZ::CaseSensitive:
-                    tt = { TooltipTarget::Zone::SearchBarButton, ls.tooltip_search_case };
-                    break;
-                case HZ::Highlight:
-                    tt = { TooltipTarget::Zone::SearchBarButton, ls.tooltip_search_highlight };
-                    break;
-                case HZ::Close:
-                    tt = { TooltipTarget::Zone::SearchBarButton, ls.tooltip_search_close };
-                    break;
-                default:
-                    break;
-                }
-                Dispatch(UpdateTooltipAction{ tt, px, py });
-            }
+            Dispatch(UpdateTooltipAction{ tt, px, py });
             return;
         }
 
-        if (old_hover != SearchBarController::HoverZone::None) {
+        if (old_hover != SearchBarHitZone::None) {
             state_.search.search_bar_ctrl.ResetHover();
             Invalidate();
         }

--- a/src/io/file_loader.cpp
+++ b/src/io/file_loader.cpp
@@ -1,4 +1,5 @@
 #include "file_loader.h"
+#include "file_io.h"
 #include "win_handle.h"
 #include <shlwapi.h>
 #include <commdlg.h>
@@ -8,40 +9,38 @@
 
 std::expected<std::pmr::string, FileLoadError> FileLoader::LoadFile(const std::pmr::wstring& path)
 {
-    // エディタがファイルを開いている間も読み取れるよう FILE_SHARE_READ | FILE_SHARE_WRITE を指定
-    UniqueHandle hFile{ CreateFileW(path.c_str(), GENERIC_READ,
-        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-        nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr) };
-    if (!hFile) {
+    // エディタがファイルを開いている間も読み取れるよう共有モードを許容
+    auto r = OpenFileForReadShared(
+        std::filesystem::path(path.c_str()),
+        FILE_SHARE_RW_DELETE, MAX_FILE_SIZE);
+    switch (r.error) {
+    case OpenFileError::NotFound:
         return std::unexpected(FileLoadError::NotFound);
-    }
-
-    LARGE_INTEGER size;
-    if (!GetFileSizeEx(hFile.get(), &size)) {
+    case OpenFileError::SizeQueryFailed:
         return std::unexpected(FileLoadError::ReadFailed);
+    case OpenFileError::TooLarge:
+        return std::unexpected(FileLoadError::TooLarge);
+    case OpenFileError::None:
+        break;
     }
 
-    if (size.QuadPart == 0) {
+    if (r.size == 0) {
         return std::pmr::string{};
     }
 
-    if (size.QuadPart > MAX_FILE_SIZE) {
-        return std::unexpected(FileLoadError::TooLarge);
-    }
-
     // UTF-8 BOMを先に検出し、全内容の memmove を回避する
-    const size_t file_size = static_cast<size_t>(size.QuadPart);
+    const size_t file_size = r.size;
     size_t bom_skip = 0;
     if (file_size >= 3) {
         unsigned char bom[3]{};
         DWORD bom_read = 0;
-        if (ReadFile(hFile.get(), bom, 3, &bom_read, nullptr) && bom_read == 3 &&
+        if (ReadFile(r.handle.get(), bom, 3, &bom_read, nullptr) && bom_read == 3 &&
             bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF) {
             bom_skip = 3;
         }
         else {
             // BOMなし: ファイル先頭に巻き戻す
-            SetFilePointer(hFile.get(), 0, nullptr, FILE_BEGIN);
+            SetFilePointer(r.handle.get(), 0, nullptr, FILE_BEGIN);
         }
     }
 
@@ -49,7 +48,7 @@ std::expected<std::pmr::string, FileLoadError> FileLoader::LoadFile(const std::p
     DWORD bytesRead = 0;
     BOOL ok = FALSE;
     content.resize_and_overwrite(file_size - bom_skip, [&](char* buf, size_t count) -> size_t {
-        ok = ReadFile(hFile.get(), buf, static_cast<DWORD>(count), &bytesRead, nullptr);
+        ok = ReadFile(r.handle.get(), buf, static_cast<DWORD>(count), &bytesRead, nullptr);
         return ok ? bytesRead : 0;
     });
 

--- a/src/io/file_watcher.cpp
+++ b/src/io/file_watcher.cpp
@@ -1,4 +1,5 @@
 #include "file_watcher.h"
+#include "file_io.h"
 #include <filesystem>
 
 FileWatcher::~FileWatcher()
@@ -22,7 +23,7 @@ void FileWatcher::StartWatching(const std::pmr::wstring& file_path, ChangeCallba
     dir_handle_.reset(CreateFileW(
         dir.c_str(),
         FILE_LIST_DIRECTORY,
-        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        FILE_SHARE_RW_DELETE,
         nullptr,
         OPEN_EXISTING,
         FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,

--- a/src/io/image_loader.cpp
+++ b/src/io/image_loader.cpp
@@ -1,4 +1,5 @@
 #include "image_loader.h"
+#include "file_io.h"
 #include "file_loader.h"
 #include "task_scheduler.h"
 #include "ui_constants.h"
@@ -13,19 +14,14 @@
 // 外部エディタ等がファイルを更新できなくなる問題を回避する。
 static Microsoft::WRL::ComPtr<IStream> ReadFileToStream(const std::wstring& path)
 {
-    UniqueHandle hFile{ CreateFileW(path.c_str(), GENERIC_READ,
-        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-        nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr) };
-    if (!hFile) {
+    auto r = OpenFileForReadShared(
+        std::filesystem::path(path),
+        FILE_SHARE_RW_DELETE, MAX_FILE_SIZE);
+    if (r.error != OpenFileError::None || r.size == 0) {
         return nullptr;
     }
 
-    LARGE_INTEGER size;
-    if (!GetFileSizeEx(hFile.get(), &size) || size.QuadPart == 0 || size.QuadPart > MAX_FILE_SIZE) {
-        return nullptr;
-    }
-
-    const auto alloc_size = static_cast<SIZE_T>(size.QuadPart);
+    const auto alloc_size = static_cast<SIZE_T>(r.size);
     UniqueGlobalMem hMem{ GlobalAlloc(GMEM_MOVEABLE, alloc_size) };
     if (!hMem) {
         return nullptr;
@@ -36,7 +32,7 @@ static Microsoft::WRL::ComPtr<IStream> ReadFileToStream(const std::wstring& path
         return nullptr;
     }
     DWORD bytesRead = 0;
-    const BOOL ok = ReadFile(hFile.get(), ptr, static_cast<DWORD>(alloc_size), &bytesRead, nullptr);
+    const BOOL ok = ReadFile(r.handle.get(), ptr, static_cast<DWORD>(alloc_size), &bytesRead, nullptr);
     GlobalUnlock(hMem.get());
 
     if (!ok || bytesRead != alloc_size) {

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -298,7 +298,7 @@ void DWriteTextMeasurer::FinalizeTableLayout(Node& node, NodeLayoutEntry& entry,
     auto& tl = *entry.table_layout;
 
     const float available = max_width - (static_cast<float>(col_count) + 1.0f) * border_width - static_cast<float>(col_count) * cell_padding * 2.0f;
-    tl.col_widths = ComputeColumnWidths(natural_widths, available, col_count);
+    ComputeColumnWidths(tl.col_widths, natural_widths, available, col_count);
 
     // セル毎の適用幅/高さキャッシュを確保（幅不変なら GetMetrics を省略）
     const size_t cell_total = tl.cell_layouts.size();

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -46,10 +46,11 @@ static float GetSpacingBelow(const Node& node, const Theme& theme) noexcept
 
 // ---- フリー関数 ----
 
-std::pmr::vector<float> ComputeColumnWidths(const std::pmr::vector<float>& natural_widths,
+void ComputeColumnWidths(std::pmr::vector<float>& out,
+    const std::pmr::vector<float>& natural_widths,
     float available_width, size_t col_count)
 {
-    std::pmr::vector<float> widths(col_count);
+    out.resize(col_count);
     available_width = std::max(available_width, static_cast<float>(col_count) * MIN_COLUMN_WIDTH);
 
     const float total_natural = std::ranges::fold_left(
@@ -59,17 +60,16 @@ std::pmr::vector<float> ComputeColumnWidths(const std::pmr::vector<float>& natur
     );
 
     if (total_natural > 0 && total_natural > available_width) {
-        for (auto [w, nw] : std::views::zip(widths, natural_widths) | std::views::take(col_count)) {
+        for (auto [w, nw] : std::views::zip(out, natural_widths) | std::views::take(col_count)) {
             w = std::max(MIN_COLUMN_WIDTH, available_width * nw / total_natural);
         }
     }
     else {
         const float even = available_width / static_cast<float>(col_count);
-        for (auto [w, nw] : std::views::zip(widths, natural_widths) | std::views::take(col_count)) {
+        for (auto [w, nw] : std::views::zip(out, natural_widths) | std::views::take(col_count)) {
             w = std::max(nw + COLUMN_WIDTH_PADDING, even);
         }
     }
-    return widths;
 }
 
 std::pmr::wstring BuildLinearizedTableText(const std::pmr::vector<TableRow>& rows)

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -14,9 +14,10 @@
     return (node.type == NodeType::CodeBlock) ? theme.code_block_padding : 0.0f;
 }
 
-// テーブルの自然幅（実測値）と利用可能な幅から列幅を計算する。
-// 最終的な列幅のベクターを返す。
-[[nodiscard]] std::pmr::vector<float> ComputeColumnWidths(const std::pmr::vector<float>& natural_widths,
+// テーブルの自然幅と利用可能幅から列幅を算出し out に書き込む。
+// out は呼び出し側の既存バッファを再利用することで再レイアウト時の再確保を避ける。
+void ComputeColumnWidths(std::pmr::vector<float>& out,
+    const std::pmr::vector<float>& natural_widths,
     float available_width, size_t col_count);
 
 // テーブル行から線形化テキストを構築する（セルはタブ区切り、行は改行区切り）。

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,10 +44,13 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nC
         // CommandLineToArgvWで正規のパースを行い、引用符やスペースを正しく処理する。
         // 引数が --version 等のフラグ文字列でも確実にヘルプへ落とすため
         // GetFileAttributesW で実在を検証する。
+        // ディレクトリが渡されても「有効なファイル」扱いしないよう属性ビットで除外。
         int argc = 0;
         LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
         const bool arg_given = argv && argc > 1 && argv[1][0] != L'\0';
-        const bool has_valid_file = arg_given && GetFileAttributesW(argv[1]) != INVALID_FILE_ATTRIBUTES;
+        const DWORD arg_attrs = arg_given ? GetFileAttributesW(argv[1]) : INVALID_FILE_ATTRIBUTES;
+        const bool has_valid_file = arg_attrs != INVALID_FILE_ATTRIBUTES
+            && !(arg_attrs & FILE_ATTRIBUTE_DIRECTORY);
 
         if (has_valid_file) {
             window.LoadMarkdownFile(argv[1]);

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -9,12 +9,16 @@
 #include "search_state.h"
 #include <cassert>
 
+// HitTestTextRange 初期バッファ容量。1 行中の inline code run が
+// 折り返される想定最大数に合わせる。描画 hot path 中の resize を避けるのが目的。
+inline constexpr size_t HIT_TEST_METRICS_INITIAL_CAPACITY = 64;
+
 // HitTestTextRange をバッファ再利用付きで呼び出し、取得件数を返す。
 inline UINT32 FetchHitTestMetrics(IDWriteTextLayout* layout, UINT32 start, UINT32 length,
     std::pmr::vector<DWRITE_HIT_TEST_METRICS>& buffer)
 {
-    if (buffer.empty()) {
-        buffer.resize(8);
+    if (buffer.size() < HIT_TEST_METRICS_INITIAL_CAPACITY) {
+        buffer.resize(HIT_TEST_METRICS_INITIAL_CAPACITY);
     }
     UINT32 count = static_cast<UINT32>(buffer.size());
     HRESULT hr = layout->HitTestTextRange(start, length, 0, 0,

--- a/src/render/d2d_render_backend.cpp
+++ b/src/render/d2d_render_backend.cpp
@@ -1,4 +1,5 @@
 #include "d2d_render_backend.h"
+#include <cstdio>
 
 using Microsoft::WRL::ComPtr;
 
@@ -39,13 +40,21 @@ bool D2DRenderBackend::Init(HWND hwnd)
         return false;
     }
 
-    // WICファクトリを作成（Renderer・ImageLoaderで共有）
-    CoCreateInstance(
+    // WICファクトリを作成（Renderer・ImageLoaderで共有）。
+    // アイコン／画像／ダイアグラムは WIC が無いと機能しないため fail-fast。
+    hr = CoCreateInstance(
         CLSID_WICImagingFactory,
         nullptr,
         CLSCTX_INPROC_SERVER,
         IID_PPV_ARGS(&wic_factory_)
     );
+    if (FAILED(hr)) {
+        wchar_t msg[128];
+        swprintf_s(msg, L"[mendo] WIC ImagingFactory creation failed (hr=0x%08lX). Aborting backend init.\n",
+            static_cast<unsigned long>(hr));
+        OutputDebugStringW(msg);
+        return false;
+    }
 
     // D3D11デバイスとD2Dデバイスコンテキストを作成
     if (!CreateDeviceResources()) {

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -32,6 +32,8 @@ bool Renderer::Init(HWND hwnd)
     cmd_generator_.SetTheme(&theme_);
     cmd_generator_.SetFormats({ fmt_.list_number.Get(), fmt_.icon_font.Get(), fmt_.copy_btn_icon.Get(), fmt_.placeholder_text.Get() });
     cmd_generator_.SetSharedHitTestBuffer(&hit_test_buffer_);
+    // 初回描画での拡大 resize を避けるため、共有バッファを事前に予約しておく。
+    hit_test_buffer_.reserve(HIT_TEST_METRICS_INITIAL_CAPACITY);
 
     return true;
 }

--- a/src/render/renderer.h
+++ b/src/render/renderer.h
@@ -72,8 +72,13 @@ public:
     constexpr void InvalidateFilePaneCache() noexcept { file_pane_cache_.dirty = true; }
     constexpr void InvalidateTocPaneCache() noexcept { toc_pane_cache_.dirty = true; }
 
-    // ファイル切替時にヒットテストバッファ等を縮小する
-    void ShrinkBuffers() { hit_test_buffer_.shrink_to_fit(); cmd_generator_.ShrinkBuffers(); }
+    // ファイル切替時にヒットテストバッファ等を縮小する。
+    // 初期容量は次ファイルの描画 hot path で再拡大されないよう事前確保する。
+    void ShrinkBuffers() {
+        hit_test_buffer_.shrink_to_fit();
+        hit_test_buffer_.reserve(HIT_TEST_METRICS_INITIAL_CAPACITY);
+        cmd_generator_.ShrinkBuffers();
+    }
 
     // 描画前パス: 可視ノードに描画エフェクト（シンタックスハイライト、リンク色）を適用。
     // Render() の前に呼ぶことで、RenderParams を const にできる。
@@ -147,13 +152,17 @@ private:
     Microsoft::WRL::ComPtr<IDWriteTextLayout> cached_toast_layout_;
     std::pmr::wstring cached_toast_text_;
 
-    // 検索バーの入力テキストレイアウトキャッシュ。display_text/width/height が
-    // 一致すれば使い回す。キャレット点滅や同一入力継続中の毎フレーム
-    // CreateTextLayout を抑止する。
+    // 検索バーの入力テキストレイアウトキャッシュ。
+    // キー: (query, ime_composition, caret_pos, input 幅)
+    // 値:   cached_search_layout_ と合成済み表示テキスト cached_search_text_。
+    // キャレット点滅や同一入力継続フレームで CreateTextLayout と
+    // 表示テキスト合成の双方を回避する。入力 height は定数なのでキーに含めない。
     mutable Microsoft::WRL::ComPtr<IDWriteTextLayout> cached_search_layout_;
-    mutable std::pmr::wstring cached_search_text_;
+    mutable std::pmr::wstring cached_search_text_;       // 合成後の表示テキスト (IME 未使用時は query と同一)
+    mutable std::pmr::wstring cached_search_query_;      // 直近フレームの sb.query
+    mutable std::pmr::wstring cached_search_ime_comp_;   // 直近フレームの sb.ime_composition
+    mutable int cached_search_caret_pos_ = -1;           // IME 合成時の挿入位置（無いとき -1）
     mutable float cached_search_width_ = -1.0f;
-    mutable float cached_search_height_ = -1.0f;
     mutable bool cached_search_has_underline_ = false;
     Microsoft::WRL::ComPtr<ID2D1Bitmap> app_icon_bitmap_;
     void LoadAppIconBitmap();

--- a/src/render/renderer_resources.cpp
+++ b/src/render/renderer_resources.cpp
@@ -192,8 +192,10 @@ void Renderer::RecreatePaneFormats()
     cached_toast_text_.clear();
     cached_search_layout_.Reset();
     cached_search_text_.clear();
+    cached_search_query_.clear();
+    cached_search_ime_comp_.clear();
+    cached_search_caret_pos_ = -1;
     cached_search_width_ = -1.0f;
-    cached_search_height_ = -1.0f;
     cached_search_has_underline_ = false;
     if (fmt_.nav_button) {
         auto* dw = backend_.GetDWriteFactory();

--- a/src/render/renderer_search.cpp
+++ b/src/render/renderer_search.cpp
@@ -70,38 +70,36 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
     float caret_x = text_left;
 
     const bool has_comp = !sb.ime_composition.empty();
-    std::wstring display_buf;
-    std::wstring_view display_text = sb.query;
-    int comp_start = 0;
     const int comp_len = static_cast<int>(sb.ime_composition.size());
-
+    int comp_start = 0;
     if (has_comp) {
-        int insert_pos = sb.caret_pos;
         const int qlen = static_cast<int>(sb.query.size());
-        if (insert_pos < 0 || insert_pos > qlen) {
-            insert_pos = qlen;
+        comp_start = sb.caret_pos;
+        if (comp_start < 0 || comp_start > qlen) {
+            comp_start = qlen;
         }
-        comp_start = insert_pos;
-        display_buf.reserve(sb.query.size() + sb.ime_composition.size());
-        display_buf.append(sb.query.data(), static_cast<size_t>(insert_pos));
-        display_buf.append(sb.ime_composition);
-        display_buf.append(sb.query.data() + insert_pos, sb.query.size() - static_cast<size_t>(insert_pos));
-        display_text = display_buf;
     }
+    // キャッシュキーは (query, caret_pos, ime_composition, width, height)。
+    // 表示テキスト (display_buf) の合成はキャッシュミス時まで遅延する。
+    const int key_caret_pos = has_comp ? comp_start : -1;
 
-    if (fmt_.search_input && !display_text.empty() && backend_.GetDWriteFactory()) {
+    std::wstring_view display_text = sb.query;
+    std::pmr::wstring display_buf;
+
+    if (fmt_.search_input && !sb.query.empty() && backend_.GetDWriteFactory()) {
         const float input_w = sbl.input_rect.right - SEARCH_INPUT_TEXT_PAD_RIGHT - text_left;
         const float input_h = sbl.input_rect.bottom - sbl.input_rect.top;
 
-        // 同一テキスト・同一サイズなら前回のレイアウトを使い回す。
-        // キャレット点滅で毎フレーム再描画されても CreateTextLayout を避ける。
+        // 比較は scalar → 空になりやすい ime_comp → query の順で短絡させる
         Microsoft::WRL::ComPtr<IDWriteTextLayout> text_layout;
         const bool cache_hit = cached_search_layout_
             && cached_search_width_ == input_w
-            && cached_search_height_ == input_h
-            && std::ranges::equal(cached_search_text_, display_text);
+            && cached_search_caret_pos_ == key_caret_pos
+            && cached_search_ime_comp_ == sb.ime_composition
+            && cached_search_query_ == sb.query;
         if (cache_hit) {
             text_layout = cached_search_layout_;
+            display_text = cached_search_text_;
             // 前フレームの下線範囲と異なる可能性があるため、キャッシュ上に下線が残っていれば
             // 常に全体をクリアする。IME 非アクティブ継続時はクリアも発行されない。
             if (cached_search_has_underline_) {
@@ -110,6 +108,14 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
             }
         }
         else {
+            // キャッシュミス時のみ display_buf を合成する。
+            if (has_comp) {
+                display_buf.reserve(sb.query.size() + sb.ime_composition.size());
+                display_buf.append(sb.query.data(), static_cast<size_t>(comp_start));
+                display_buf.append(sb.ime_composition.data(), sb.ime_composition.size());
+                display_buf.append(sb.query.data() + comp_start, sb.query.size() - static_cast<size_t>(comp_start));
+                display_text = display_buf;
+            }
             backend_.GetDWriteFactory()->CreateTextLayout(
                 display_text.data(),
                 static_cast<UINT32>(display_text.size()),
@@ -121,8 +127,10 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
             if (text_layout) {
                 cached_search_layout_ = text_layout;
                 cached_search_text_.assign(display_text);
+                cached_search_query_.assign(sb.query);
+                cached_search_ime_comp_.assign(sb.ime_composition);
+                cached_search_caret_pos_ = key_caret_pos;
                 cached_search_width_ = input_w;
-                cached_search_height_ = input_h;
                 cached_search_has_underline_ = false;
             }
         }
@@ -271,7 +279,8 @@ int Renderer::HitTestSearchInput(std::wstring_view query, float local_x, float m
     // （IME コンポジションが無く、query と表示テキストが一致）を高速パスに。
     const bool cache_hit = cached_search_layout_
         && cached_search_width_ == max_width
-        && std::ranges::equal(cached_search_text_, query);
+        && cached_search_caret_pos_ == -1
+        && cached_search_query_ == query;
     if (cache_hit) {
         layout = cached_search_layout_;
     }

--- a/src/render/renderer_search.cpp
+++ b/src/render/renderer_search.cpp
@@ -86,7 +86,7 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
     std::wstring_view display_text = sb.query;
     std::pmr::wstring display_buf;
 
-    if (fmt_.search_input && !sb.query.empty() && backend_.GetDWriteFactory()) {
+    if (fmt_.search_input && (!sb.query.empty() || has_comp) && backend_.GetDWriteFactory()) {
         const float input_w = sbl.input_rect.right - SEARCH_INPUT_TEXT_PAD_RIGHT - text_left;
         const float input_h = sbl.input_rect.bottom - sbl.input_rect.top;
 

--- a/src/ui/search_bar_controller.cpp
+++ b/src/ui/search_bar_controller.cpp
@@ -42,7 +42,7 @@ void SearchBarController::OnOpen(const std::pmr::vector<Node>& nodes)
 void SearchBarController::OnClose()
 {
     state_->Hide();
-    hover_ = HoverZone::None;
+    hover_ = SearchBarHitZone::None;
     has_focus_ = false;
     caret_visible_ = false;
     ime_composition_.clear();
@@ -205,7 +205,7 @@ void SearchBarController::ScrollToCurrentMatch()
 void SearchBarController::Reset()
 {
     state_->Reset();
-    hover_ = HoverZone::None;
+    hover_ = SearchBarHitZone::None;
     has_focus_ = false;
     caret_visible_ = false;
     caret_pos_ = -1;
@@ -230,33 +230,14 @@ void SearchBarController::StartDrag(int anchor_pos) noexcept
 // ホバー管理
 // ============================================================
 
-SearchBarController::HoverZone SearchBarController::UpdateHover(float dip_x, float dip_y, const SearchBarLayout& sbl)
+void SearchBarController::UpdateHoverFromZone(SearchBarHitZone zone)
 {
-    const auto old_hover = hover_;
-    hover_ = HoverZone::None;
-
-    if (dip_y >= sbl.bar_top) {
-        if (PointInRect(dip_x, dip_y, sbl.up_btn)) {
-            hover_ = HoverZone::Up;
-        }
-        else if (PointInRect(dip_x, dip_y, sbl.down_btn)) {
-            hover_ = HoverZone::Down;
-        }
-        else if (PointInRect(dip_x, dip_y, sbl.case_btn)) {
-            hover_ = HoverZone::CaseSensitive;
-        }
-        else if (PointInRect(dip_x, dip_y, sbl.highlight_btn)) {
-            hover_ = HoverZone::Highlight;
-        }
-        else if (PointInRect(dip_x, dip_y, sbl.close_btn)) {
-            hover_ = HoverZone::Close;
-        }
-    }
-
-    if (hover_ != old_hover) {
+    // Input ゾーンはテキスト編集領域でホバー強調は不要なので None に丸める。
+    const auto new_hover = (zone == SearchBarHitZone::Input) ? SearchBarHitZone::None : zone;
+    if (new_hover != hover_) {
+        hover_ = new_hover;
         cb_.invalidate_search_bar();
     }
-    return hover_;
 }
 
 // ============================================================
@@ -277,11 +258,11 @@ SearchBarRenderState SearchBarController::BuildRenderState() const
     sb.ime_composition = ime_composition_;
     sb.case_sensitive = state_->IsCaseSensitive();
     sb.highlight_enabled = state_->IsHighlightEnabled();
-    sb.up_btn_hovered = (hover_ == HoverZone::Up);
-    sb.down_btn_hovered = (hover_ == HoverZone::Down);
-    sb.close_btn_hovered = (hover_ == HoverZone::Close);
-    sb.case_btn_hovered = (hover_ == HoverZone::CaseSensitive);
-    sb.highlight_btn_hovered = (hover_ == HoverZone::Highlight);
+    sb.up_btn_hovered = (hover_ == SearchBarHitZone::Up);
+    sb.down_btn_hovered = (hover_ == SearchBarHitZone::Down);
+    sb.close_btn_hovered = (hover_ == SearchBarHitZone::Close);
+    sb.case_btn_hovered = (hover_ == SearchBarHitZone::CaseSensitive);
+    sb.highlight_btn_hovered = (hover_ == SearchBarHitZone::Highlight);
     return sb;
 }
 

--- a/src/ui/search_bar_controller.h
+++ b/src/ui/search_bar_controller.h
@@ -16,10 +16,6 @@ struct SearchBarRenderState;
 // Win32依存の操作はコールバック経由でAppに委譲する。
 class SearchBarController {
 public:
-    enum class HoverZone : uint8_t {
-        None, Up, Down, Close, CaseSensitive, Highlight
-    };
-
     // Win32操作をAppから注入するコールバック群
     struct Callbacks {
         std::move_only_function<void()> invalidate;                  // ウィンドウ全体の再描画
@@ -72,9 +68,9 @@ public:
     void OnCaptureChanged() noexcept { dragging_ = false; }
 
     // --- ホバー管理 ---
-    HoverZone UpdateHover(float dip_x, float dip_y, const SearchBarLayout& sbl);
-    HoverZone GetHover() const noexcept { return hover_; }
-    void ResetHover() noexcept { hover_ = HoverZone::None; }
+    void UpdateHoverFromZone(SearchBarHitZone zone);
+    SearchBarHitZone GetHover() const noexcept { return hover_; }
+    void ResetHover() noexcept { hover_ = SearchBarHitZone::None; }
 
     // --- レンダー状態構築 ---
     SearchBarRenderState BuildRenderState() const;
@@ -93,7 +89,7 @@ private:
     LayoutCache* cache_ = nullptr;
     Callbacks cb_;
 
-    HoverZone hover_ = HoverZone::None;
+    SearchBarHitZone hover_ = SearchBarHitZone::None;
     bool caret_visible_ = false;
     bool has_focus_ = false;
     int caret_pos_ = -1;

--- a/src/ui/ui_constants.h
+++ b/src/ui/ui_constants.h
@@ -172,6 +172,43 @@ inline SearchBarLayout ComputeSearchBarLayout(float md_left, float md_width, flo
     return l;
 }
 
+// 検索バーのヒット判定結果。クリック／ホバー／Controller で共有する。
+enum class SearchBarHitZone : uint8_t {
+    None,
+    Up,
+    Down,
+    CaseSensitive,
+    Highlight,
+    Close,
+    Input,
+};
+
+inline SearchBarHitZone HitTestSearchBar(const SearchBarLayout& sbl, float x, float y) noexcept
+{
+    if (y < sbl.bar_top) {
+        return SearchBarHitZone::None;
+    }
+    if (PointInRect(x, y, sbl.up_btn)) {
+        return SearchBarHitZone::Up;
+    }
+    if (PointInRect(x, y, sbl.down_btn)) {
+        return SearchBarHitZone::Down;
+    }
+    if (PointInRect(x, y, sbl.case_btn)) {
+        return SearchBarHitZone::CaseSensitive;
+    }
+    if (PointInRect(x, y, sbl.highlight_btn)) {
+        return SearchBarHitZone::Highlight;
+    }
+    if (PointInRect(x, y, sbl.close_btn)) {
+        return SearchBarHitZone::Close;
+    }
+    if (PointInRect(x, y, sbl.input_rect)) {
+        return SearchBarHitZone::Input;
+    }
+    return SearchBarHitZone::None;
+}
+
 // デフォルトウィンドウサイズ（ピクセル）
 inline constexpr int DEFAULT_WINDOW_WIDTH = 1600;
 inline constexpr int DEFAULT_WINDOW_HEIGHT = 900;

--- a/src/util/file_io.h
+++ b/src/util/file_io.h
@@ -21,7 +21,9 @@ enum class OpenFileError : uint8_t {
 
 // CreateFileW + GetFileSizeEx + サイズ上限チェックを束ねた共通ヘルパー。
 // 共有モードと最大サイズは呼び出し側で指定する。
-// 失敗時は handle が空で、error に区分が入る（out_error には最後の GetLastError）。
+// 失敗時は handle が空で、error に区分が入る。
+// out_error は CreateFileW 失敗時のみ GetLastError() を格納する
+// （SizeQueryFailed / TooLarge では更新しない）。
 struct OpenedFile {
     UniqueHandle handle;
     size_t size = 0;

--- a/src/util/file_io.h
+++ b/src/util/file_io.h
@@ -5,37 +5,75 @@
 #include <memory>
 #include <utility>
 
-// ファイルを全て読み込む。失敗時は{nullptr, 0}を返す。
-// out_errorが非nullの場合、CreateFileW失敗時のGetLastError()を格納する。
-inline std::pair<std::unique_ptr<uint8_t[]>, size_t> ReadAllBytes(
-    const std::filesystem::path& path, DWORD* out_error = nullptr)
+// 外部エディタとの同時アクセスを許容する共有モード。
+// 編集中のファイルを mendo で開いたまま再読込できるようにするため、
+// Markdown / 画像ファイルを扱う経路ではこれを指定する。
+inline constexpr DWORD FILE_SHARE_RW_DELETE =
+    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
+
+// OpenFileForReadShared の失敗区分。
+enum class OpenFileError : uint8_t {
+    None,             // 成功
+    NotFound,         // CreateFileW 失敗（存在しない/アクセス拒否など）
+    SizeQueryFailed,  // GetFileSizeEx 失敗 or 負のサイズ
+    TooLarge,         // max_size を超過
+};
+
+// CreateFileW + GetFileSizeEx + サイズ上限チェックを束ねた共通ヘルパー。
+// 共有モードと最大サイズは呼び出し側で指定する。
+// 失敗時は handle が空で、error に区分が入る（out_error には最後の GetLastError）。
+struct OpenedFile {
+    UniqueHandle handle;
+    size_t size = 0;
+    OpenFileError error = OpenFileError::None;
+};
+
+inline OpenedFile OpenFileForReadShared(const std::filesystem::path& path,
+    DWORD share_mode, LONGLONG max_size, DWORD* out_error = nullptr) noexcept
 {
     if (out_error) {
         *out_error = 0;
     }
-    UniqueHandle hFile(CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
+    OpenedFile r;
+    UniqueHandle hFile(CreateFileW(path.c_str(), GENERIC_READ, share_mode, nullptr,
         OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
     if (!hFile) {
         if (out_error) {
             *out_error = GetLastError();
         }
-        return {};
+        r.error = OpenFileError::NotFound;
+        return r;
     }
     LARGE_INTEGER file_size;
-    if (!GetFileSizeEx(hFile.get(), &file_size) || file_size.QuadPart <= 0) {
+    if (!GetFileSizeEx(hFile.get(), &file_size) || file_size.QuadPart < 0) {
+        r.error = OpenFileError::SizeQueryFailed;
+        return r;
+    }
+    if (file_size.QuadPart > max_size) {
+        r.error = OpenFileError::TooLarge;
+        return r;
+    }
+    r.handle = std::move(hFile);
+    r.size = static_cast<size_t>(file_size.QuadPart);
+    return r;
+}
+
+// ファイルを全て読み込む。失敗時は{nullptr, 0}を返す。
+// out_errorが非nullの場合、CreateFileW失敗時のGetLastError()を格納する。
+inline std::pair<std::unique_ptr<uint8_t[]>, size_t> ReadAllBytes(
+    const std::filesystem::path& path, DWORD* out_error = nullptr)
+{
+    auto r = OpenFileForReadShared(path, FILE_SHARE_READ, UINT32_MAX, out_error);
+    if (r.error != OpenFileError::None || r.size == 0) {
         return {};
     }
-    const auto size = static_cast<size_t>(file_size.QuadPart);
-    if (size > UINT32_MAX) {
-        return {};
-    }
-    auto buf = std::make_unique_for_overwrite<uint8_t[]>(size);
+    auto buf = std::make_unique_for_overwrite<uint8_t[]>(r.size);
     DWORD bytes_read = 0;
-    if (!ReadFile(hFile.get(), buf.get(), static_cast<DWORD>(size), &bytes_read, nullptr) ||
-        bytes_read != static_cast<DWORD>(size)) {
+    if (!ReadFile(r.handle.get(), buf.get(), static_cast<DWORD>(r.size), &bytes_read, nullptr) ||
+        bytes_read != static_cast<DWORD>(r.size)) {
         return {};
     }
-    return {std::move(buf), size};
+    return { std::move(buf), r.size };
 }
 
 // ファイルに全て書き込む。成功時はtrueを返す。

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -436,7 +436,8 @@ TEST(ComputeColumnWidthsTest, ProportionalDistributionWhenTooWide)
 {
     // 自然幅の合計300、利用可能幅150のみ -> 比例配分
     std::pmr::vector<float> natural = { 100.0f, 100.0f, 100.0f };
-    auto widths = ComputeColumnWidths(natural, 150.0f, 3);
+    std::pmr::vector<float> widths;
+    ComputeColumnWidths(widths, natural, 150.0f, 3);
     ASSERT_EQ(widths.size(), 3u);
     // 自然幅が等しいため、すべての列が均等な幅を得ること
     EXPECT_NEAR(widths[0], widths[1], 0.01f);
@@ -450,7 +451,8 @@ TEST(ComputeColumnWidthsTest, EvenDistributionWhenFits)
 {
     // 自然幅の合計30、利用可能幅300 -> 均等配分
     std::pmr::vector<float> natural = { 10.0f, 10.0f, 10.0f };
-    auto widths = ComputeColumnWidths(natural, 300.0f, 3);
+    std::pmr::vector<float> widths;
+    ComputeColumnWidths(widths, natural, 300.0f, 3);
     ASSERT_EQ(widths.size(), 3u);
     // 均等配分: 各列は少なくとも100であること
     float even = 300.0f / 3.0f;
@@ -463,7 +465,8 @@ TEST(ComputeColumnWidthsTest, MinimumWidthEnforced)
 {
     // 非常に小さな利用可能スペース
     std::pmr::vector<float> natural = { 200.0f, 200.0f };
-    auto widths = ComputeColumnWidths(natural, 40.0f, 2);
+    std::pmr::vector<float> widths;
+    ComputeColumnWidths(widths, natural, 40.0f, 2);
     ASSERT_EQ(widths.size(), 2u);
     // 最小幅は30
     for (auto w : widths) {
@@ -475,7 +478,8 @@ TEST(ComputeColumnWidthsTest, UnequalNaturalWidths)
 {
     // 列Aは列Bよりはるかに広い
     std::pmr::vector<float> natural = { 300.0f, 100.0f };
-    auto widths = ComputeColumnWidths(natural, 200.0f, 2);
+    std::pmr::vector<float> widths;
+    ComputeColumnWidths(widths, natural, 200.0f, 2);
     ASSERT_EQ(widths.size(), 2u);
     // 列Aは列Bよりも大きな割合を得ること
     EXPECT_GT(widths[0], widths[1]);
@@ -484,7 +488,8 @@ TEST(ComputeColumnWidthsTest, UnequalNaturalWidths)
 TEST(ComputeColumnWidthsTest, SingleColumn)
 {
     std::pmr::vector<float> natural = { 50.0f };
-    auto widths = ComputeColumnWidths(natural, 200.0f, 1);
+    std::pmr::vector<float> widths;
+    ComputeColumnWidths(widths, natural, 200.0f, 1);
     ASSERT_EQ(widths.size(), 1u);
     EXPECT_GE(widths[0], 50.0f);
 }
@@ -492,7 +497,8 @@ TEST(ComputeColumnWidthsTest, SingleColumn)
 TEST(ComputeColumnWidthsTest, ZeroNaturalWidths)
 {
     std::pmr::vector<float> natural = { 0.0f, 0.0f };
-    auto widths = ComputeColumnWidths(natural, 200.0f, 2);
+    std::pmr::vector<float> widths;
+    ComputeColumnWidths(widths, natural, 200.0f, 2);
     ASSERT_EQ(widths.size(), 2u);
     // それでも有効な幅を生成すること
     for (auto w : widths) {

--- a/tests/test_search_bar_controller.cpp
+++ b/tests/test_search_bar_controller.cpp
@@ -75,7 +75,7 @@ TEST_F(SearchBarControllerTest, InitialState)
     EXPECT_FALSE(ctrl_.HasFocus());
     EXPECT_EQ(ctrl_.GetCaretPos(), -1);
     EXPECT_EQ(ctrl_.GetSelectionStart(), -1);
-    EXPECT_EQ(ctrl_.GetHover(), SearchBarController::HoverZone::None);
+    EXPECT_EQ(ctrl_.GetHover(), SearchBarHitZone::None);
     EXPECT_FALSE(ctrl_.IsDragging());
     EXPECT_TRUE(ctrl_.GetImeComposition().empty());
 }
@@ -114,7 +114,7 @@ TEST_F(SearchBarControllerTest, OnCloseResetsState)
 
     EXPECT_FALSE(state_.IsVisible());
     EXPECT_FALSE(ctrl_.HasFocus());
-    EXPECT_EQ(ctrl_.GetHover(), SearchBarController::HoverZone::None);
+    EXPECT_EQ(ctrl_.GetHover(), SearchBarHitZone::None);
     EXPECT_GE(unfocus_count_, 1);
 }
 
@@ -287,7 +287,7 @@ TEST_F(SearchBarControllerTest, ResetClearsAll)
     EXPECT_EQ(ctrl_.GetSelectionStart(), -1);
     EXPECT_FALSE(ctrl_.IsDragging());
     EXPECT_TRUE(ctrl_.GetImeComposition().empty());
-    EXPECT_EQ(ctrl_.GetHover(), SearchBarController::HoverZone::None);
+    EXPECT_EQ(ctrl_.GetHover(), SearchBarHitZone::None);
 }
 
 // ═══════════════════════════════════════════════


### PR DESCRIPTION
## Summary

`review.md` に挙がった 7 項目 (High 1 / Medium 5 / Low 1) と、続く /simplify レビューで挙がった整理を反映。

### 主な変更

- **I/O ヘルパー統一** (High): `file_io.h` に `OpenFileForReadShared` / `FILE_SHARE_RW_DELETE` / `OpenFileError` を追加し、`FileLoader::LoadFile` / `image_loader::ReadFileToStream` / `ReadAllBytes` / `file_watcher` の低レベル処理を集約。
- **検索バー hit-test 一本化** (Medium): `SearchBarHitZone` + `HitTestSearchBar()` を `ui_constants.h` に新設。クリック／ホバー／Controller の 3 箇所の `PointInRect` 連鎖を集約。`SearchBarController::HoverZone` は廃止し `SearchBarHitZone` に統合。
- **検索バー描画 hot path** (Medium): 入力因子 (`query`, `caret_pos`, `ime_composition`) の構造化キャッシュキーに変更し、`std::ranges::equal` 全文比較と `display_buf` 合成をキャッシュミス時まで遅延。比較順は scalar-first。
- **テーブル描画 HitTest バッファ** (Medium): 初期容量を `HIT_TEST_METRICS_INITIAL_CAPACITY = 64` に固定し `Renderer::Init` で事前 reserve。`ShrinkBuffers` 後も 64 を維持して次ファイル初描画での再確保を回避。
- **D2D バックエンド初期化** (Medium): WIC ファクトリ生成失敗を fail-fast 化 (`Init` が `false` を返す)。
- **起動引数の有効ファイル判定** (Medium): `FILE_ATTRIBUTE_DIRECTORY` ビットを除外し、ディレクトリを「有効ファイル」扱いしない。
- **ComputeColumnWidths の out-parameter 化** (Low): `std::pmr::vector<float>` の新規生成を廃止し、呼び出し側 `tl.col_widths` を直接再利用。互換ラッパは削除し、テストは新シグネチャに移行。

### 副次的な整理 (/simplify)

- `d2d_render_backend::wic_init_hr_` と `GetWICInitHr()` を削除 (fail-fast 化で dead code)。
- `cached_search_height_` を削除 (`SEARCH_INPUT_HEIGHT` 定数由来で常に一致)。
- narration 寄りのコメントを契約表現に圧縮。

## Test plan

- [x] `cmake --build build --config Release` — 成功
- [x] `mendo_tests.exe` — **1876 tests PASSED**
- [x] 実アプリでの検索バー操作確認 (クリック／ホバー／IME 入力／キャレット点滅)
- [x] 画像／Mermaid 含む Markdown の表示確認
- [x] ディレクトリを引数に起動してヘルプへフォールバックすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)