### PR TITLE
リファクタリング & パフォーマンス改善: TOC同期集約・検索lowercaseキャッシュ・HitTest分離ほか

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -300,9 +300,8 @@ void App::Dispatch(const AppAction& action)
 {
     GetPaneLayout();
 
-    // SyncTocActiveAndAutoScroll は「スクロール位置」または「TOCペイン表示状態」が
-    // 変化したときにのみ実行すれば十分。ホバー/ツールチップ等の高頻度アクションで
-    // partition_point 探索を毎回走らせないよう、前後差分でガードする。
+    // ホバー/ツールチップ等の高頻度アクションで partition_point 探索を
+    // 空回りさせないよう、scroll_y / TOC可視状態の前後差分で同期する。
     const float old_scroll_y = state_.view.viewport.GetScrollY();
     const bool old_toc_visible = state_.view.panes.IsTocPaneVisible();
 

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -164,14 +164,8 @@ void App::OnPaint()
     BeginPaint(hwnd_, &ps);
 
     const auto& layout = GetPaneLayout();
-    // state_.pending_prefix_shrink 中は loading_ が true でも旧コンテンツを表示する。
-    // エディタの truncate→rewrite 中間状態をスキップしているだけなので、
-    // ローディング画面を表示する必要がない。
     const bool show_loading = file_load_service_.IsLoading() && !state_.pending_prefix_shrink;
     if (!show_loading) {
-        // FlushPendingResources は描画パスから外し、BITMAP_MANAGE タイマ経由で
-        // 集約実行する（ScheduleBitmapManage の 50ms debounce + 150ms 周期タイマ）。
-        // ロード完了時は OnAppImageLoaded → OnImageLoadComplete で個別反映される。
         // 現在表示中のダーティなノードを現在の幅でレイアウトする
         EnsureScrollTarget();
 
@@ -184,39 +178,6 @@ void App::OnPaint()
 
         if (updated) {
             SyncMaxScroll(layout.md_rect.height);
-        }
-    }
-    // 目次ペインの同期: mdペインのスクロール位置からアクティブ見出しを判定し、
-    // 目次ペインを自動スクロールする
-    if (state_.view.panes.IsTocPaneVisible() && !show_loading) {
-        const float toc_margin = layout.md_rect.y + renderer_.GetTheme().heading_spacing_above;
-        const int new_active = state_.document.doc.GetToc().FindActiveIndex(state_.document.layout_cache, state_.view.viewport.GetScrollY(), toc_margin);
-        if (new_active != state_.active_toc_index) {
-            state_.active_toc_index = new_active;
-            renderer_.InvalidateTocPaneCache();
-
-            // アクティブ見出しが目次ペインの表示範囲外なら自動スクロール
-            if (new_active >= 0) {
-                const auto& theme = renderer_.GetTheme();
-                const float item_y = static_cast<float>(new_active) * theme.pane_item_height;
-                const float total = static_cast<float>(state_.document.doc.GetToc().GetEntries().size()) * theme.pane_item_height;
-                const auto info = ComputeScrollInfo(layout.toc_rect, theme.pane_header_height, total);
-                auto& toc_scroll = state_.view.panes.TocScroll();
-                toc_scroll.max_scroll = info.max_scroll;
-                float& sy = toc_scroll.scroll_y;
-                sy = std::clamp(sy, 0.0f, info.max_scroll);
-                if (info.content_height > 0.0f) {
-                    // フォーカスを表示領域の5等分中、区画2〜4(1/5〜4/5)に留める
-                    const float zone_upper = info.content_height * (1.0f / 5.0f);
-                    const float zone_lower = info.content_height * (4.0f / 5.0f);
-                    if (item_y < sy + zone_upper) {
-                        sy = std::clamp(item_y - zone_upper, 0.0f, info.max_scroll);
-                    }
-                    else if (item_y + theme.pane_item_height > sy + zone_lower) {
-                        sy = std::clamp(item_y + theme.pane_item_height - zone_lower, 0.0f, info.max_scroll);
-                    }
-                }
-            }
         }
     }
 
@@ -337,14 +298,12 @@ void App::OnKeyDown(WPARAM key)
 
 void App::Dispatch(const AppAction& action)
 {
-    // reducer が cached_pane_layout（window サイズ / ペイン幅から導出される派生値）を
-    // 参照するため、reducer 呼び出し前に最新化する。これは state の直接変更ではなく
-    // 「派生キャッシュの更新」で、GetPaneLayout はキャッシュ済みなら O(1) で返る。
-    // hybrid モデル下での reducer 入力保証の一部（reducer.h 参照）。
     GetPaneLayout();
 
     auto effects = Reduce(state_, action);
     effect_executor_.Execute(effects);
+
+    SyncTocActiveAndAutoScroll();
 }
 
 void App::OnDropFiles(HDROP hDrop)
@@ -387,21 +346,12 @@ void App::OnCaptureChanged()
 void App::ShowToast(std::wstring_view message)
 {
     // reducer 経由ではなく effect を直接発火する簡易経路。
-    // toast は state 遷移を伴わない単発副作用で、Action 化しても boilerplate が
-    // 増えるだけなので hybrid モデルの例外として許容している（reducer.h 参照）。
     effect_executor_.ExecuteOne(effect::ShowToast{ std::wstring{message} });
 }
 
 void App::OnDestroy()
 {
-    // メッセージループが生きているうちにWebView2を閉じる。
-    // デストラクタではメッセージループが停止済みのため、
-    // WebView2のClose()がブロックしてハングする。
     mermaid_renderer_.Shutdown();
-
-    // スケジューラを停止してキュー済み書き込みを完了させた後、
-    // file_cacheのscheduler_をnullにして遅延COMコールバックからの
-    // 新規ポストを防ぐ。
     scheduler_.Shutdown();
     file_cache_.Shutdown();
     file_cache_.SaveIndex();

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -300,10 +300,19 @@ void App::Dispatch(const AppAction& action)
 {
     GetPaneLayout();
 
+    // SyncTocActiveAndAutoScroll は「スクロール位置」または「TOCペイン表示状態」が
+    // 変化したときにのみ実行すれば十分。ホバー/ツールチップ等の高頻度アクションで
+    // partition_point 探索を毎回走らせないよう、前後差分でガードする。
+    const float old_scroll_y = state_.view.viewport.GetScrollY();
+    const bool old_toc_visible = state_.view.panes.IsTocPaneVisible();
+
     auto effects = Reduce(state_, action);
     effect_executor_.Execute(effects);
 
-    SyncTocActiveAndAutoScroll();
+    if (state_.view.viewport.GetScrollY() != old_scroll_y
+        || state_.view.panes.IsTocPaneVisible() != old_toc_visible) {
+        SyncTocActiveAndAutoScroll();
+    }
 }
 
 void App::OnDropFiles(HDROP hDrop)

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -17,6 +17,7 @@
 #include "resource_manager.h"
 #include "session_service.h"
 #include "cursor_manager.h"
+#include "hit_test_service.h"
 #include <windows.h>
 #include <shellapi.h>
 #include <string>
@@ -25,7 +26,6 @@
 #include <memory>
 #include <memory_resource>
 
-// ウィンドウのタイトルバーとスクロールバーにダークモードスタイルを適用する。
 void ApplyDarkModeToWindow(HWND hwnd, bool dark);
 
 class App {
@@ -89,7 +89,6 @@ public:
     void SetImeComposition(std::wstring_view comp) { Dispatch(ImeCompositionAction{ std::pmr::wstring{comp} }); }
     RECT GetSearchEditRect();
 
-    // 前回セッションのスクロール位置復元用（LoadMarkdownFileの前に呼ぶ）
     void SetPendingRestoreNode(int node, int offset) noexcept
     {
         state_.view.scroll_restore.SetNodeRestore(node, offset);
@@ -99,19 +98,10 @@ public:
     void OnEnterSizeMove() { Dispatch(EnterSizeMoveAction{}); }
     void OnExitSizeMove() { Dispatch(ExitSizeMoveAction{}); }
 
-    // D2D レンダーターゲットが初期化済みか。処理前のガードに使う
     bool IsRenderReady() const noexcept { return renderer_.GetRenderTarget() != nullptr; }
-
-    // ウィンドウ全体の再描画を要求する
     void Invalidate() noexcept { InvalidateRect(hwnd_, nullptr, FALSE); }
-
-    // 指定ペイン領域のみ再描画を要求する
     void InvalidatePane(const PaneRect& rect) noexcept;
-
-    // タイトルバー領域のみ再描画を要求する
     void InvalidateTitleBar() noexcept;
-
-    // Win32Windowのカーソル/再描画用にDPIスケールを公開
     constexpr float GetDpiScale() const noexcept { return state_.window.cached_dpi_scale; }
 
     // カスタムタイトルバー
@@ -129,8 +119,6 @@ private:
     ResourceManager::Callbacks BuildResourceManagerCallbacks();
     SearchBarController::Callbacks BuildSearchBarCallbacks();
 
-    // 現在可視アンカーから scroll_target を合成（未設定時のみ）。
-    // レイアウト操作の直前に呼び、直後のフックで補償を掛ける。
     void EnsureScrollTarget();
 
     // DIP変換
@@ -177,25 +165,22 @@ private:
     void RefreshFilePane();
     void OnDeferredLayout();
 
+    void SyncTocActiveAndAutoScroll();
+
     // ファイル読み込み (file_load_service_に委譲)
     void ReloadCurrentFile();
     void DoReloadCurrentFile();
     void DoLoadMarkdownFile();
     void BeginAsyncLoad(const std::pmr::wstring& path);
     void FinishLoadMarkdownFile(bool heights_estimated = false);
-    // ロード失敗時のフォールバック: 初回起動で空画面になるのを避けるためヘルプを表示する
     void HandleLoadFailureFallback();
     float CalcScrollForDiff(size_t diff_pos, float viewport_height) const;
     void ApplyMermaidCacheHeights(float md_width);
     void UpdateTitleBar();
 
-    // リロード共通処理: 差分分析後のレイアウト更新・スクロール復元・検索再実行
     void FinishReload(bool is_prefix_only, size_t diff_pos);
 
-    // ファイル読み込み/リロード共通ヘルパー
     void CancelPendingResources();
-    // 新規ドキュメントロード時の view 状態リセット（選択/保留リソース/
-    // ペイン関連バッファをまとめて初期化）。ファイル切替パス共通の前処理。
     void ResetViewForNewDocument();
     void FinalizeLayout(float md_pane_height);
     void SaveLastFilePath();
@@ -203,19 +188,12 @@ private:
     void LoadPaneState();
     void SaveScrollPosition();
 
-    // ペインレイアウト（結果はキャッシュされる）
     const ::PaneLayout& GetPaneLayout();
     void InvalidatePaneLayoutCache() noexcept { state_.pane_layout_valid = false; }
     ::PaneZone PaneAtPoint(float dip_x, float dip_y);
     float GetMarkdownPaneWidth();
-
-    // Reducer 用テーマ定数キャッシュの同期
     void SyncPaneThemeCache();
-
-    // ダークモード / ズーム (theme_service_に委譲)
     void HandleApplyThemeChange(const effect::ApplyThemeChange& e);
-
-    // テーマ/ズーム変更後の共通後処理（ViewportLayout→scroll_target フックで復元→再描画）
     void FinishThemeOrZoomChange();
 
 private:
@@ -242,6 +220,7 @@ private:
     AppState state_;
 
     // ---- サービス（状態ではなく振る舞い） ----
+    HitTestService hit_test_;
     std::optional<LayoutService> layout_service_;
     ResourceManager resource_manager_;
     Win32Host win32_host_;

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -389,12 +389,14 @@ void App::FinishReload(bool is_prefix_only, size_t diff_pos)
 
     FinalizeLayout(md_height);
 
-    if (state_.search.search_state.IsVisible() && !state_.search.search_state.GetQuery().empty()) {
+    if (state_.search.search_state.IsVisible()) {
         // ReplaceFromMarkdown でノード列が再構築されたため、SearchState の lowercase
         // キャッシュは内容が無効。ポインタ/サイズ一致では PMR プール再利用時に
-        // 偽のヒットを起こすため、ここで明示的に破棄する。
+        // 偽のヒットを起こすため、クエリが空でもここで明示的に破棄する。
         state_.search.search_state.InvalidateLowercaseCache();
-        state_.search.search_bar_ctrl.RunSearchAndLocate(state_.document.doc.GetNodes());
+        if (!state_.search.search_state.GetQuery().empty()) {
+            state_.search.search_bar_ctrl.RunSearchAndLocate(state_.document.doc.GetNodes());
+        }
     }
 
     SyncTocActiveAndAutoScroll();

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -256,6 +256,8 @@ void App::FinishLoadMarkdownFile(bool heights_estimated)
 
     UpdateTitleBar();
 
+    SyncTocActiveAndAutoScroll();
+
     doc_service_.StartWatching(state_.document.doc.GetFilePath(), [this]() {
         KillTimer(hwnd_, app_timer::FILE_RELOAD_DEBOUNCE);
         SetTimer(hwnd_, app_timer::FILE_RELOAD_DEBOUNCE, app_timer::FILE_RELOAD_DEBOUNCE_MS, nullptr);
@@ -388,8 +390,14 @@ void App::FinishReload(bool is_prefix_only, size_t diff_pos)
     FinalizeLayout(md_height);
 
     if (state_.search.search_state.IsVisible() && !state_.search.search_state.GetQuery().empty()) {
+        // ReplaceFromMarkdown でノード列が再構築されたため、SearchState の lowercase
+        // キャッシュは内容が無効。ポインタ/サイズ一致では PMR プール再利用時に
+        // 偽のヒットを起こすため、ここで明示的に破棄する。
+        state_.search.search_state.InvalidateLowercaseCache();
         state_.search.search_bar_ctrl.RunSearchAndLocate(state_.document.doc.GetNodes());
     }
+
+    SyncTocActiveAndAutoScroll();
 
     doc_service_.ResumeWatching();
 }

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -390,9 +390,8 @@ void App::FinishReload(bool is_prefix_only, size_t diff_pos)
     FinalizeLayout(md_height);
 
     if (state_.search.search_state.IsVisible()) {
-        // ReplaceFromMarkdown でノード列が再構築されたため、SearchState の lowercase
-        // キャッシュは内容が無効。ポインタ/サイズ一致では PMR プール再利用時に
-        // 偽のヒットを起こすため、クエリが空でもここで明示的に破棄する。
+        // PMR プール再利用で (nodes.data(), size) が一致すると古いキャッシュを
+        // 誤用するため、クエリ有無に関わらず明示破棄する。
         state_.search.search_state.InvalidateLowercaseCache();
         if (!state_.search.search_state.GetQuery().empty()) {
             state_.search.search_bar_ctrl.RunSearchAndLocate(state_.document.doc.GetNodes());

--- a/src/app/app_mouse.cpp
+++ b/src/app/app_mouse.cpp
@@ -13,7 +13,7 @@
 App::HitResult App::HitTest(int screen_x, int screen_y)
 {
     const auto& layout = GetPaneLayout();
-    return state_.hit_test.HitTest({
+    return hit_test_.HitTest({
         state_.document.doc.GetNodes(), state_.document.layout_cache, renderer_.GetTheme(),
         state_.view.viewport.GetScrollY(), layout.md_rect.x,
         state_.window.cached_dpi_scale, screen_x, screen_y

--- a/src/app/app_mouse_click.cpp
+++ b/src/app/app_mouse_click.cpp
@@ -49,7 +49,7 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
         }
     }
 
-    const auto nav_hit = state_.hit_test.NavButtonHitTest(dip_x, dip_y, pane_layout.md_rect);
+    const auto nav_hit = hit_test_.NavButtonHitTest(dip_x, dip_y, pane_layout.md_rect);
     if (nav_hit == NavButtonHover::Back) {
         Dispatch(NavigateBackAction{});
         return;
@@ -66,13 +66,13 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
         state_.window.cached_dpi_scale, px, py,
         content_width, pane_layout.md_rect.height
     };
-    const auto copy_node = state_.hit_test.CopyButtonHitTest(hit_ctx);
+    const auto copy_node = hit_test_.CopyButtonHitTest(hit_ctx);
     if (copy_node >= 0) {
         CopyCodeBlockToClipboard(copy_node);
         return;
     }
     // 保存ボタンのクリック判定
-    const auto save_node = state_.hit_test.SaveButtonHitTest(hit_ctx);
+    const auto save_node = hit_test_.SaveButtonHitTest(hit_ctx);
     if (save_node >= 0) {
         SaveDiagramAsPng(save_node);
         return;

--- a/src/app/app_mouse_hover.cpp
+++ b/src/app/app_mouse_hover.cpp
@@ -89,7 +89,7 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
         return;
     }
 
-    const auto nav_hit = state_.hit_test.NavButtonHitTest(dip_x, dip_y, pane_layout.md_rect);
+    const auto nav_hit = hit_test_.NavButtonHitTest(dip_x, dip_y, pane_layout.md_rect);
     Dispatch(MdPaneNavHoverAction{ nav_hit });
     if (nav_hit != NavButtonHover::None) {
         SetCursor(cursors_.Hand());
@@ -119,7 +119,7 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
         const int cdy = py - state_.interaction.hover_throttle.last_copy_hit_pos.y;
         if (cdx * cdx + cdy * cdy > HOVER_THROTTLE_DISTANCE_SQ) {
             state_.interaction.hover_throttle.last_copy_hit_pos = { px, py };
-            new_copy_hover = state_.hit_test.CopyButtonHitTest(hit_ctx);
+            new_copy_hover = hit_test_.CopyButtonHitTest(hit_ctx);
         }
     }
     int new_save_hover = state_.interaction.hovered_save_node;
@@ -128,7 +128,7 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
         const int sdy = py - state_.interaction.hover_throttle.last_save_hit_pos.y;
         if (sdx * sdx + sdy * sdy > HOVER_THROTTLE_DISTANCE_SQ) {
             state_.interaction.hover_throttle.last_save_hit_pos = { px, py };
-            new_save_hover = state_.hit_test.SaveButtonHitTest(hit_ctx);
+            new_save_hover = hit_test_.SaveButtonHitTest(hit_ctx);
         }
     }
     if (new_copy_hover != state_.interaction.hovered_copy_node || new_save_hover != state_.interaction.hovered_save_node) {

--- a/src/app/app_navigate.cpp
+++ b/src/app/app_navigate.cpp
@@ -19,8 +19,6 @@ void App::HandleLinkClick(std::wstring_view url)
         NavigateToAnchor(result.target);
         break;
     case LinkClickResult::Type::ExternalUrl: {
-        // reducer を経由せず effect を直接発火する。外部 URL 起動は state 遷移を
-        // 伴わない単発 I/O で、hybrid モデル（reducer.h 参照）の service 経路扱い。
         SideEffectList effects;
         effects.emplace_back(effect::ShellOpen{ result.target });
         effect_executor_.Execute(effects);
@@ -51,6 +49,8 @@ void App::NavigateToAnchor(std::wstring_view anchor)
     UpdateScrollBar();
     InvalidateMdPane(layout.md_rect);
     resource_manager_.ScheduleBitmapManage();
+
+    SyncTocActiveAndAutoScroll();
 }
 
 void App::PushNavHistory()
@@ -83,6 +83,8 @@ void App::FinishThemeOrZoomChange()
     ScheduleDeferredLayoutIfNeeded();
     UpdateScrollBar();
     Invalidate();
+
+    SyncTocActiveAndAutoScroll();
 }
 
 void App::HandleApplyThemeChange(const effect::ApplyThemeChange& e)

--- a/src/app/app_scroll.cpp
+++ b/src/app/app_scroll.cpp
@@ -3,6 +3,7 @@
 #include "app_events.h"
 #include "pane_layout.h"
 #include "profiler.h"
+#include "toc.h"
 #include <windows.h>
 #include <algorithm>
 
@@ -27,6 +28,48 @@ void App::ScrollTo(float position)
 {
     state_.view.viewport.ScrollTo(position);
     InvalidateHitPositions();
+    SyncTocActiveAndAutoScroll();
+}
+
+void App::SyncTocActiveAndAutoScroll()
+{
+    if (!state_.view.panes.IsTocPaneVisible()) {
+        return;
+    }
+    const auto& layout = GetPaneLayout();
+    const auto& theme = renderer_.GetTheme();
+    const float toc_margin = layout.md_rect.y + theme.heading_spacing_above;
+    const int new_active = state_.document.doc.GetToc().FindActiveIndex(
+        state_.document.layout_cache, state_.view.viewport.GetScrollY(), toc_margin);
+    if (new_active == state_.active_toc_index) {
+        return;
+    }
+    state_.active_toc_index = new_active;
+    renderer_.InvalidateTocPaneCache();
+
+    if (new_active < 0) {
+        return;
+    }
+
+    // アクティブ見出しが目次ペインの表示範囲外なら自動スクロール
+    const float item_y = static_cast<float>(new_active) * theme.pane_item_height;
+    const float total = static_cast<float>(state_.document.doc.GetToc().GetEntries().size()) * theme.pane_item_height;
+    const auto info = ComputePaneScrollInfo(layout.toc_rect, total);
+    auto& toc_scroll = state_.view.panes.TocScroll();
+    toc_scroll.max_scroll = info.max_scroll;
+    float& sy = toc_scroll.scroll_y;
+    sy = std::clamp(sy, 0.0f, info.max_scroll);
+    if (info.content_height > 0.0f) {
+        // フォーカスを表示領域の5等分中、区画2〜4(1/5〜4/5)に留める
+        const float zone_upper = info.content_height * (1.0f / 5.0f);
+        const float zone_lower = info.content_height * (4.0f / 5.0f);
+        if (item_y < sy + zone_upper) {
+            sy = std::clamp(item_y - zone_upper, 0.0f, info.max_scroll);
+        }
+        else if (item_y + theme.pane_item_height > sy + zone_lower) {
+            sy = std::clamp(item_y + theme.pane_item_height - zone_lower, 0.0f, info.max_scroll);
+        }
+    }
 }
 
 void App::InvalidateMdPane(const PaneRect& md_rect)
@@ -35,8 +78,8 @@ void App::InvalidateMdPane(const PaneRect& md_rect)
         Invalidate();
         return;
     }
-    // MDペインはタイトルバーを含む縦ストリップ全体を無効化する
-    InvalidatePane(PaneRect{ md_rect.x, 0.0f, md_rect.width, md_rect.y + md_rect.height });
+    // MDペインは本文領域のみ無効化する。タイトルバーは別途 InvalidateTitleBar() を使う。
+    InvalidatePane(md_rect);
 }
 
 void App::SyncMaxScroll(float md_pane_height)
@@ -92,6 +135,8 @@ void App::OnResizeEnd()
     ScheduleDeferredLayoutIfNeeded();
 
     resource_manager_.ScheduleMermaidBatch();
+
+    SyncTocActiveAndAutoScroll();
 }
 
 void App::RefreshPaneLayout()
@@ -146,6 +191,10 @@ void App::OnDeferredLayout()
 
         UpdateScrollBar();
         Invalidate();
+
+        // 遅延レイアウト確定で layout_cache の y_position が安定したので
+        // 目次アクティブ見出しを再同期する。
+        SyncTocActiveAndAutoScroll();
     }
 }
 

--- a/src/app/app_state.h
+++ b/src/app/app_state.h
@@ -14,8 +14,8 @@
 #include "tooltip.h"
 #include "scroll_restoration.h"
 #include "context_menu.h"
-#include "hit_test_service.h"
 #include "hover_throttle.h"
+#include "nav_button.h"
 #include "pane_layout.h"
 #include "theme_constants.h"
 #include <string>
@@ -64,10 +64,7 @@ struct WindowState {
     ThemeConstants cached_theme;
 };
 
-// アプリケーションの全状態を集約する構造体。
-// Win32ハンドルは含まない。状態に加えて一部のコントローラ
-// (ContextMenu, HitTestService, SearchBarController) を含む。
-// Reducer パターンの入出力として使用する。
+// アプリケーションの全状態を集約する構造体
 struct AppState {
     // ---- サブグループ ----
     DocumentState document;
@@ -79,7 +76,6 @@ struct AppState {
     // ---- UIコンポーネント ----
     FileExplorer file_explorer;
     ContextMenu ctx_menu;
-    HitTestService hit_test;
     int active_toc_index = -1;
 
     // ---- リロード管理 ----
@@ -93,11 +89,6 @@ struct AppState {
     bool pane_layout_valid = false;
 };
 
-// 現在の可視先頭ノードから ScrollTarget を合成する。Reducer と App の共通ヘルパー。
 ScrollTarget SnapshotVisibleTarget(const AppState& state) noexcept;
-
-// 現在のファイル/スクロール位置をナビゲーション履歴に Push する。
 void PushCurrentNavEntry(AppState& state);
-
-// 現在のファイル/スクロール位置を NavEntry として返す（Push せず）。
 NavEntry CurrentNavEntry(const AppState& state);

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -214,7 +214,7 @@ void ReduceCopyFormattedClipboard(const AppState& state, SideEffectList& effects
     effects.emplace_back(effect::ClipboardWriteHtml{
         ExtractSelectedTextAsHtml(nodes, sel, state.window.cached_theme.is_dark),
         ExtractSelectedText(nodes, sel)
-    });
+        });
 }
 
 // ============================================================
@@ -341,7 +341,7 @@ void ReduceSearchStep(AppState& state, bool forward)
 {
     if (state.search.search_state.IsVisible()) {
         forward ? state.search.search_bar_ctrl.OnNext()
-                : state.search.search_bar_ctrl.OnPrev();
+            : state.search.search_bar_ctrl.OnPrev();
     }
     else {
         state.search.search_bar_ctrl.OnOpen(state.document.doc.GetNodes());
@@ -841,8 +841,6 @@ SideEffectList Reduce(AppState& state, const AppAction& action)
 
         // ---- マウス関連 ----
         [&](const MouseLeaveAction&) {
-            // 再侵入時に同一座標の最初の WM_MOUSEMOVE が ShouldSkipSameDispatch で
-            // 弾かれるとカーソル/ツールチップの復帰が遅れるため、hover 状態もリセットする
             state.interaction.hover_throttle.Reset();
             ClearTooltip(state, effects);
         },

--- a/src/app/resource_manager.cpp
+++ b/src/app/resource_manager.cpp
@@ -15,10 +15,6 @@
 
 namespace {
 
-// 単調増加する node-index 配列 (GetImageNodeIndices / GetDiagramNodeIndices の戻り値)
-// から [first_visible_node, last_visible_node_plus_1) と交差する部分範囲を
-// 二分探索で切り出す。全件走査 O(total_media) を O(log total_media + visible_media)
-// まで落とすためのヘルパ。
 struct IndexSlice {
     std::pmr::vector<size_t>::const_iterator begin;
     std::pmr::vector<size_t>::const_iterator end;

--- a/src/app/resource_manager.h
+++ b/src/app/resource_manager.h
@@ -22,26 +22,22 @@ public:
         std::move_only_function<void(UINT_PTR)> kill_timer;
         std::move_only_function<float()> get_content_width;
         std::move_only_function<float()> get_viewport_height;
-        // 現在テーマの indent_width（画像の実サイズ計算に使用）
         std::move_only_function<float()> get_indent_width;
-        // レイアウト再計算
-        std::move_only_function<void()> recompute_layout;           // RecomputeAfterDiagram
-        std::move_only_function<void()> recompute_layout_anchored;  // anchor付き: 保存→再計算→復元→Invalidate
+        std::move_only_function<void()> recompute_layout;
+        std::move_only_function<void()> recompute_layout_anchored;
     };
 
     static constexpr UINT_PTR TIMER_MERMAID_BATCH = 10;
     static constexpr UINT_PTR TIMER_BITMAP_MANAGE = 11;
-    // ビューポート外リソース解放のバッファ倍率
     static constexpr float EVICT_BUFFER_SCREENS = 5.0f;
     static constexpr float PREFETCH_BUFFER_SCREENS = 3.0f;
-    // バッチ処理の時間予算（マイクロ秒）
     static constexpr int BATCH_TIME_BUDGET_US = 6000;
 
     ResourceManager() = default;
     void Init(Document& doc, LayoutCache& cache, ViewportManager& viewport,
-              ImageLoader& image_loader, IMermaidRenderer& mermaid,
-              ThemeService& theme_service,
-              Callbacks cb);
+        ImageLoader& image_loader, IMermaidRenderer& mermaid,
+        ThemeService& theme_service,
+        Callbacks cb);
 
     // --- 画像リソース ---
     int ApplyCachedImages();
@@ -77,8 +73,6 @@ private:
     Callbacks cb_;
 
     float last_mermaid_content_width_ = 0.0f;
-    // バッチ/フラッシュ中の OnMermaidRenderComplete 再入ガード。
-    // 同期的にレンダー完了が連鎖した場合に recompute_layout_anchored が毎回走るのを抑止する。
     bool mermaid_batch_loading_ = false;
     size_t mermaid_batch_next_ = 0;
     FlatMap<size_t, std::wstring> resolved_image_paths_;

--- a/src/app/side_effect.h
+++ b/src/app/side_effect.h
@@ -81,13 +81,11 @@ struct RefreshPaneLayout {};
 // ---- テーマ・ダークモード ----
 struct ApplyDarkMode { bool dark; };
 
-// テーマ/ズーム変更の複合副作用。executor がレンダラー適用 + レイアウトを実行する。
-// スクロール位置保持は scroll_target を介して行うのでアンカー情報は含めない。
 struct ApplyThemeChange {
     enum class Type { Zoom, DarkMode };
     Type type;
-    float new_zoom;       // Zoom 用: 新しいズーム値
-    int zoom_index;       // Zoom 用: ズームインデックス（設定保存用）
+    float new_zoom;
+    int zoom_index;
 };
 
 // ---- ファイル監視・リソース ----

--- a/src/app/side_effect_executor.h
+++ b/src/app/side_effect_executor.h
@@ -10,11 +10,8 @@ class ConfigService;
 class LayoutService;
 struct AppState;
 
-// SideEffectExecutor: Reducer が返した副作用リストを実行する。
-// Win32 API 呼び出しは IWin32Host adapter 経由で行い、プラットフォーム依存を隔離する。
 class SideEffectExecutor {
 public:
-    // App のメソッドチェーンに依存する複雑な操作のコールバック
     struct Callbacks {
         std::move_only_function<void(std::wstring_view)> load_file;
         std::move_only_function<void()> reload_file;

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -24,22 +24,11 @@ public:
     const std::pmr::string& GetRawUtf8() const noexcept { return raw_utf8_; }
     std::pmr::wstring GetDirectory() const;
 
-    // ファイルパス設定（LoadMarkdownFile で使用）
     constexpr void SetFilePath(std::wstring_view path) { file_path_ = path; }
-
-    // 内容の差し替え（再パース時）
     void ReplaceContent(ParseResult&& result);
-
-    // Markdown文字列から内容を再パース（パスは保持）
     void ReplaceFromMarkdown(std::pmr::string utf8);
-
-    // アンカーIDに一致する見出しノードのインデックスを O(1) で検索する。
-    // 見つからない場合は -1 を返す。
     int FindAnchorIndex(std::wstring_view anchor) const;
-
-    // 特殊ノードインデックスの高速アクセス
     constexpr const std::pmr::vector<size_t>& GetImageNodeIndices() const noexcept { return image_node_indices_; }
-    // Mermaid / LatexMath など IsDiagramLanguage() を満たすコードブロックのノードインデックス
     constexpr const std::pmr::vector<size_t>& GetDiagramNodeIndices() const noexcept { return diagram_node_indices_; }
 
 private:

--- a/src/core/document_service.cpp
+++ b/src/core/document_service.cpp
@@ -36,8 +36,6 @@ void DocumentService::ResumeWatching()
     watcher_.ResumeWatching();
 }
 
-// ファイルサイズがしきい値を超えるか判定するヘルパー。
-// サイズ取得に失敗した場合（存在しないファイル等）は true を返す。
 static bool ExceedsFileSize(const std::pmr::wstring& path, DWORD threshold) noexcept
 {
     WIN32_FILE_ATTRIBUTE_DATA attr{};
@@ -50,14 +48,12 @@ static bool ExceedsFileSize(const std::pmr::wstring& path, DWORD threshold) noex
 
 bool DocumentService::NeedsAsyncLoad(const std::pmr::wstring& path) noexcept
 {
-    // 64KB 超: パースに数十ms以上かかりUIブロックが体感される
     static constexpr DWORD ASYNC_LOAD_THRESHOLD = 64 * 1024;
     return ExceedsFileSize(path, ASYNC_LOAD_THRESHOLD);
 }
 
 bool DocumentService::NeedsLoadingAnimation(const std::pmr::wstring& path) noexcept
 {
-    // 16MB 超: パースに数秒かかるためスピナーを表示する
     static constexpr DWORD LOADING_ANIM_THRESHOLD = 16 * 1024 * 1024;
     return ExceedsFileSize(path, LOADING_ANIM_THRESHOLD);
 }

--- a/src/core/document_service.h
+++ b/src/core/document_service.h
@@ -8,20 +8,14 @@ class DocumentService {
 public:
     explicit DocumentService(FileWatcher& watcher) noexcept : watcher_(watcher) {}
 
-    // ファイルを読み込み、Document を構築。
     std::expected<Document, FileLoadError> LoadFile(const std::pmr::wstring& path);
-
-    // ファイル監視
     void StartWatching(const std::pmr::wstring& path, FileWatcher::ChangeCallback cb);
     void StopWatching() noexcept;
     void CheckForChanges();
     void ResumeWatching();
     HANDLE GetFileWatchEvent() const noexcept { return watcher_.GetEventHandle(); }
 
-    // パース時間がUIブロックとして体感されるサイズか（非同期ロード判定用）
     static bool NeedsAsyncLoad(const std::pmr::wstring& path) noexcept;
-
-    // 非常に大きいファイルか（ローディングアニメーション表示判定用）
     static bool NeedsLoadingAnimation(const std::pmr::wstring& path) noexcept;
 
 private:

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -36,7 +36,6 @@ static_assert(static_cast<size_t>(AlertType::Caution) == 5, "AlertType::Caution 
 
 inline constexpr size_t ALERT_TYPE_COUNT = 5;
 
-// AlertType → 0ベースの色/ブラシインデックス。None の場合は ALERT_TYPE_COUNT を返す（範囲外）。
 constexpr size_t AlertColorIndex(AlertType t) noexcept
 {
     if (t == AlertType::None) {
@@ -45,13 +44,12 @@ constexpr size_t AlertColorIndex(AlertType t) noexcept
     return static_cast<size_t>(t) - 1;
 }
 
-// md4c の MD_ALIGN と値を一致させる（0=DEFAULT, 1=LEFT, 2=CENTER, 3=RIGHT）。
-// parser では static_cast<TableAlign>(td->align) で直接変換できる。
+// md4c の MD_ALIGN と値を一致させる（0=DEFAULT, 1=LEFT, 2=CENTER, 3=RIGHT）
 enum class TableAlign : uint8_t {
     Default = 0,
-    Left    = 1,
-    Center  = 2,
-    Right   = 3,
+    Left = 1,
+    Center = 2,
+    Right = 3,
 };
 
 // テーブルセルデータ（純粋なドメインデータ — レイアウトキャッシュなし）
@@ -89,22 +87,13 @@ struct NodeImageData {
 };
 
 struct Node {
-    mutable std::pmr::string text_utf8; // テキスト主記憶（UTF-8、パーサーが設定。GetText()後に解放される場合あり）
+    mutable std::pmr::string text_utf8;
     std::pmr::vector<TextRun> runs;
 
-    // runs および table_data->rows 内の TextRun::link_url_index が参照するリンクURLプール
     std::pmr::vector<std::pmr::wstring> link_urls;
-
-    // テーブルデータ（type == Table の場合のみ確保、それ以外は nullptr）
     std::unique_ptr<NodeTableData> table_data;
-
-    // 画像データ（type == Image の場合のみ確保、それ以外は nullptr）
     std::unique_ptr<NodeImageData> image_data;
-
-    // 見出しデータ（type == Heading の場合のみ確保、それ以外は nullptr）
     std::unique_ptr<NodeHeadingData> heading_data;
-
-    // コードブロックデータ（type == CodeBlock の場合のみ確保、それ以外は nullptr）
     std::unique_ptr<NodeCodeData> code_data;
 
     int heading_level = 0;
@@ -145,31 +134,26 @@ struct Node {
         }
     }
 
-    // テキスト取得。EnsureTextConverted() が事前に呼ばれていれば O(1) で返る。
     const std::pmr::wstring& GetText() const
     {
         EnsureTextConverted();
         return text_;
     }
 
-    // const wchar_t* からの呼び出し（リテラル文字列等）をオーバーロード解決で曖昧にしないための委譲
     void SetText(const wchar_t* s) { SetText(std::wstring_view{ s }); }
 
-    // Wideテキストを直接設定
     void SetText(std::wstring_view s)
     {
         text_.assign(s);
         FinalizeSetText();
     }
 
-    // Wideテキストをムーブで設定（コピー回避）
     void SetText(std::pmr::wstring&& s) noexcept
     {
         text_ = std::move(s);
         FinalizeSetText();
     }
 
-    // テーブル行への便利アクセサ
     std::pmr::vector<TableRow>& table_rows() noexcept { return table_data->rows; }
     const std::pmr::vector<TableRow>& table_rows() const noexcept { return table_data->rows; }
     void ensure_table()
@@ -180,7 +164,6 @@ struct Node {
     }
     bool has_table() const noexcept { return table_data != nullptr; }
 
-    // 画像への便利アクセサ
     void ensure_image()
     {
         if (!image_data) {
@@ -189,7 +172,6 @@ struct Node {
     }
     bool has_image() const noexcept { return image_data != nullptr; }
 
-    // 見出しへの便利アクセサ
     void ensure_heading()
     {
         if (!heading_data) {
@@ -197,28 +179,25 @@ struct Node {
         }
     }
     bool has_heading() const noexcept { return heading_data != nullptr; }
-    // アンカーIDへの安全アクセス。Headingでなければ空文字列を返す。
-    // 注: 戻り値は heading_data のライフタイムに依存する。
+
     std::wstring_view anchor_id() const noexcept
     {
         return heading_data ? std::wstring_view(heading_data->anchor_id) : std::wstring_view{};
     }
 
-    // コードブロックへの便利アクセサ
     void ensure_code()
     {
         if (!code_data) {
             code_data = std::make_unique<NodeCodeData>();
         }
     }
+
     bool has_code() const noexcept { return code_data != nullptr; }
     const std::pmr::vector<SyntaxToken>& syntax_tokens() const noexcept
     {
-        // code_data が nullptr の場合のみ呼ばれる想定だが、安全のためガード
         if (code_data) {
             return code_data->syntax_tokens;
         }
-        // 空のベクターを返す（CodeBlock以外では syntax_tokens() は呼ばれない設計）
         static const std::pmr::vector<SyntaxToken> empty;
         return empty;
     }

--- a/src/core/document_utils.cpp
+++ b/src/core/document_utils.cpp
@@ -84,8 +84,6 @@ public:
 
     // 開く順: <a> → <strong> → <em> → <s> → <code>（code は最内側）。
     // 開いたタグと対の閉じタグをスタックにペアで積むため、フィールドと閉じ文字列のズレが起きない。
-    // Plain な state（タグが一つも立たない）でも applied_ を立て、同じ state 内の
-    // 2文字目以降で Open() を再呼び出ししないようにする。
     constexpr void Open(const InlineState& s, const std::pmr::vector<std::pmr::wstring>& link_urls)
     {
         applied_ = true;
@@ -113,7 +111,6 @@ public:
         }
     }
 
-    // out_.append() は bad_alloc を投げうるため noexcept にはしない。
     constexpr void CloseAll()
     {
         applied_ = false;
@@ -369,9 +366,6 @@ constexpr void AppendTableCellStyle(std::pmr::wstring& out, const TableCell& cel
     out.append(L";\"");
 }
 
-// テーブルノードは常に <table> 構造で出力する。
-// node.GetText() の線形化テキストはレイアウトパスで初めて埋まるため、
-// ここで start/end による部分選択判定は行わない（全体出力が実用的）。
 void AppendTableHtml(std::pmr::wstring& out, const Node& node, uint32_t start, uint32_t end,
     bool dark_mode)
 {
@@ -433,8 +427,6 @@ constexpr bool IsListNode(const Node& n) noexcept
     return n.type == NodeType::ListItem || n.type == NodeType::TaskListItem;
 }
 
-// 順序付きリスト内の項目なら true。TaskListItem も親リストに応じて
-// list_number が設定されるため両タイプを対象とする。
 constexpr bool IsOrderedList(const Node& n) noexcept
 {
     return IsListNode(n) && n.list_number > 0;

--- a/src/core/parser.h
+++ b/src/core/parser.h
@@ -10,7 +10,6 @@ struct ParseResult {
     std::pmr::vector<Node> nodes;
     std::pmr::vector<size_t> heading_indices;
     std::pmr::vector<size_t> image_indices;
-    // ビットマップレンダリング対象（Mermaid / LatexMath など IsDiagramLanguage() を満たすコードブロック）
     std::pmr::vector<size_t> diagram_indices;
 };
 

--- a/src/core/parser_alerts.cpp
+++ b/src/core/parser_alerts.cpp
@@ -40,9 +40,7 @@ bool AsciiCaseEqual(std::string_view a, std::string_view b) noexcept
     return std::ranges::equal(a, b, {}, to_upper, to_upper);
 }
 
-// テキスト先頭から [!TYPE] パターンを検出し、AlertTypeを返す（UTF-8版）。
-// marker_end には ']' の次の位置（スペース/改行をスキップ済み）を設定する。
-// マーカーは全てASCIIなので、バイトオフセット＝ワイド文字オフセット。
+// テキスト先頭から [!TYPE] パターンを検出し、AlertTypeを返す（UTF-8版）
 AlertType DetectAlertMarker(std::string_view text, size_t& marker_end)
 {
     if (text.size() < 3 || text[0] != '[' || text[1] != '!') {

--- a/src/core/syntax.h
+++ b/src/core/syntax.h
@@ -17,10 +17,9 @@ enum class SyntaxLanguage : uint8_t {
     Bash,
     PowerShell,
     Cmd,
-    LatexMath    // $$...$$ ブロック。mermaid flowchart にラップして KaTeX 描画する
+    LatexMath
 };
 
-// ビットマップとして描画される（テキストレイアウト・ハイライト・トークナイズ不可）コードブロック言語か。
 constexpr bool IsDiagramLanguage(SyntaxLanguage lang) noexcept
 {
     return lang == SyntaxLanguage::Mermaid || lang == SyntaxLanguage::LatexMath;

--- a/src/core/text_types.h
+++ b/src/core/text_types.h
@@ -33,7 +33,6 @@ private:
 };
 
 // テキスト選択: 位置は (node_index, char_offset) のペアで表す。
-// "start" はドキュメント順で常に "end" 以下。
 struct TextSelection {
     int start_node = -1;
     uint32_t start_pos = 0;

--- a/src/core/toc.h
+++ b/src/core/toc.h
@@ -18,7 +18,6 @@ public:
     int HitTest(float local_y, float item_height) const noexcept;
 
     // ビューポート先頭のスクロール位置から、現在表示中の見出しに対応するTOCエントリのインデックスを返す。
-    // margin: MDペイン上端までのオフセット＋見出し上部余白（y_position <= scroll_y + margin で判定）。
     // 見つからない場合は -1 を返す。
     int FindActiveIndex(const LayoutCache& cache, float scroll_y, float margin = 0.0f) const noexcept;
 

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -6,16 +6,6 @@
 
 namespace {
 
-// 物理ピクセルをMDペインローカルのDIP座標に変換する。
-struct PaneDip { float x, y; };
-PaneDip ScreenToPaneDip(int screen_x, int screen_y, float dpi_scale, float md_pane_left, float scroll_y) noexcept
-{
-    return {
-        screen_x / dpi_scale - md_pane_left,
-        screen_y / dpi_scale + scroll_y
-    };
-}
-
 // ノードのインデント幅を返す。
 float NodeIndent(const Node& node, const Theme& theme) noexcept
 {
@@ -169,7 +159,7 @@ HitTestService::HitResult HitTestService::HitTest(
         return last_md_hit_.result;
     }
 
-    const auto [dip_x, dip_y] = ScreenToPaneDip(ctx.screen_x, ctx.screen_y, ctx.dpi_scale, ctx.md_pane_left, ctx.scroll_y);
+    const auto [dip_x, dip_y] = ScreenToPaneDip(ctx);
 
     // dip_yを含むノードを検索
     const auto first = ctx.cache.cbegin();
@@ -279,110 +269,64 @@ int HitTestService::CopyButtonHitTest(const MdPaneHitContext& ctx) const noexcep
 {
     assert(ctx.content_width > 0.0f && "content_width must be set for button hit test");
     assert(ctx.md_pane_height > 0.0f && "md_pane_height must be set for button hit test");
+
     if (ctx.nodes.empty()) {
         return -1;
     }
-
     const uint32_t gen = ctx.cache.GetEffectsGeneration();
     if (last_copy_hit_.Matches(ctx, gen)) {
         return last_copy_hit_.result;
     }
 
-    const auto [dip_x, dip_y] = ScreenToPaneDip(ctx.screen_x, ctx.screen_y, ctx.dpi_scale, ctx.md_pane_left, ctx.scroll_y);
-
     // コピーボタンはコンテンツ右端にあるため、X座標で大半のマウス位置を早期棄却
     const float btn_left_bound = ctx.theme.margin_left + ctx.content_width - COPY_BTN_MARGIN - COPY_BTN_SIZE;
-    if (dip_x < btn_left_bound) {
+    if (ScreenToPaneDip(ctx).x < btn_left_bound) {
         last_copy_hit_.Store(ctx, gen, -1);
         return -1;
     }
 
-    const float viewport_top = ctx.scroll_y;
-    const float viewport_bottom = ctx.scroll_y + ctx.md_pane_height;
-
-    // 可視範囲のコードブロックを検索
-    const int first = FindFirstVisibleNodeIndex(ctx.cache, ctx.nodes.size(), viewport_top);
-    const int count = static_cast<int>(ctx.nodes.size());
-    for (int i = first; i < count; i++) {
-        if (ctx.cache[i].y_position - ctx.theme.code_block_padding > viewport_bottom) {
-            break;
-        }
-
-        const auto& node = ctx.nodes[i];
-        if (node.type != NodeType::CodeBlock) {
-            continue;
-        }
-        // ダイアグラム系 (Mermaid / LatexMath) はコピーボタン非対応
-        if (IsDiagramLanguage(node.code_language)) {
-            continue;
-        }
-
-        const float indent = NodeIndent(node, ctx.theme);
-        const float x = ctx.theme.margin_left + indent;
-        const float w = ctx.content_width - indent;
-        const float pad = ctx.theme.code_block_padding;
-
-        const float block_right = x + w;
-        const float block_top = ctx.cache[i].y_position - pad;
-
-        const D2D1_RECT_F btn = OverlayButtonRect(block_right, block_top);
-        if (dip_x >= btn.left && dip_x <= btn.right && dip_y >= btn.top && dip_y <= btn.bottom) {
-            last_copy_hit_.Store(ctx, gen, i);
-            return i;
-        }
-    }
-    last_copy_hit_.Store(ctx, gen, -1);
-    return -1;
+    return HitTestCodeBlockButton(ctx, last_copy_hit_,
+        [&](int /*i*/, const Node& node, const NodeLayoutEntry& entry,
+            float dip_x, float dip_y) noexcept -> bool {
+            // ダイアグラム系 (Mermaid / LatexMath) はコピーボタン非対応
+            if (IsDiagramLanguage(node.code_language)) {
+                return false;
+            }
+            const float indent = NodeIndent(node, ctx.theme);
+            const float x = ctx.theme.margin_left + indent;
+            const float w = ctx.content_width - indent;
+            const float pad = ctx.theme.code_block_padding;
+            const float block_right = x + w;
+            const float block_top = entry.y_position - pad;
+            const D2D1_RECT_F btn = OverlayButtonRect(block_right, block_top);
+            return dip_x >= btn.left && dip_x <= btn.right
+                && dip_y >= btn.top && dip_y <= btn.bottom;
+        });
 }
 
 int HitTestService::SaveButtonHitTest(const MdPaneHitContext& ctx) const noexcept
 {
     assert(ctx.content_width > 0.0f && "content_width must be set for button hit test");
     assert(ctx.md_pane_height > 0.0f && "md_pane_height must be set for button hit test");
-    if (ctx.nodes.empty()) {
-        return -1;
-    }
 
-    const uint32_t gen = ctx.cache.GetEffectsGeneration();
-    if (last_save_hit_.Matches(ctx, gen)) {
-        return last_save_hit_.result;
-    }
-
-    const auto [dip_x, dip_y] = ScreenToPaneDip(ctx.screen_x, ctx.screen_y, ctx.dpi_scale, ctx.md_pane_left, ctx.scroll_y);
-
-    const float viewport_top = ctx.scroll_y;
-    const float viewport_bottom = ctx.scroll_y + ctx.md_pane_height;
-
-    const int first = FindFirstVisibleNodeIndex(ctx.cache, ctx.nodes.size(), viewport_top);
-    const int count = static_cast<int>(ctx.nodes.size());
-    for (int i = first; i < count; i++) {
-        if (ctx.cache[i].y_position > viewport_bottom) {
-            break;
-        }
-
-        const auto& node = ctx.nodes[i];
-        if (node.type != NodeType::CodeBlock || !IsDiagramLanguage(node.code_language)) {
-            continue;
-        }
-
-        const auto& diagram = ctx.cache.GetDiagram(i);
-        if (!diagram.bitmap) {
-            continue;
-        }
-
-        const float indent = NodeIndent(node, ctx.theme);
-        const float x = ctx.theme.margin_left + indent;
-        const float cw = ctx.content_width - indent;
-
-        const auto bmp = MermaidBitmapRect(diagram.width, diagram.height, x, cw, ctx.cache[i].y_position);
-        const D2D1_RECT_F btn = OverlayButtonRect(bmp.right, bmp.top);
-        if (dip_x >= btn.left && dip_x <= btn.right && dip_y >= btn.top && dip_y <= btn.bottom) {
-            last_save_hit_.Store(ctx, gen, i);
-            return i;
-        }
-    }
-    last_save_hit_.Store(ctx, gen, -1);
-    return -1;
+    return HitTestCodeBlockButton(ctx, last_save_hit_,
+        [&](int i, const Node& node, const NodeLayoutEntry& entry,
+            float dip_x, float dip_y) noexcept -> bool {
+            if (!IsDiagramLanguage(node.code_language)) {
+                return false;
+            }
+            const auto& diagram = ctx.cache.GetDiagram(i);
+            if (!diagram.bitmap) {
+                return false;
+            }
+            const float indent = NodeIndent(node, ctx.theme);
+            const float x = ctx.theme.margin_left + indent;
+            const float cw = ctx.content_width - indent;
+            const auto bmp = MermaidBitmapRect(diagram.width, diagram.height, x, cw, entry.y_position);
+            const D2D1_RECT_F btn = OverlayButtonRect(bmp.right, bmp.top);
+            return dip_x >= btn.left && dip_x <= btn.right
+                && dip_y >= btn.top && dip_y <= btn.bottom;
+        });
 }
 
 NavButtonHover HitTestService::NavButtonHitTest(

--- a/src/input/hit_test_service.h
+++ b/src/input/hit_test_service.h
@@ -1,14 +1,11 @@
 #pragma once
 #include "document_types.h"
+#include "layout_cache.h"
 #include "nav_button.h"
 #include "pane.h"
 #include "theme.h"
 #include <climits>
 #include <memory_resource>
-
-// 参照としてのみ扱うため前方宣言（layout_cache.h は <dwrite.h> を巻き込むため）。
-class LayoutCache;
-struct NodeLayoutEntry;
 
 // MDペインのヒットテストに必要なコンテキスト情報。
 // ドキュメントデータ、ビューポート状態、マウス位置をまとめる。
@@ -25,6 +22,16 @@ struct MdPaneHitContext {
     float content_width = 0.0f;
     float md_pane_height = 0.0f;
 };
+
+// 物理ピクセルをMDペインローカルのDIP座標に変換する。
+struct PaneDip { float x, y; };
+inline PaneDip ScreenToPaneDip(const MdPaneHitContext& ctx) noexcept
+{
+    return {
+        ctx.screen_x / ctx.dpi_scale - ctx.md_pane_left,
+        ctx.screen_y / ctx.dpi_scale + ctx.scroll_y,
+    };
+}
 
 class HitTestService {
 public:
@@ -77,6 +84,49 @@ private:
             result = r;
         }
     };
+
+    // CodeBlock ノードのオーバーレイボタン（Copy/Save）共通ヒットテスト。
+    // キャッシュ照合・座標変換・可視範囲走査を一元化する。Predicate は
+    // `(int index, const Node&, const NodeLayoutEntry&, float dip_x, float dip_y) -> bool`
+    // を返し、true を返したノードの index が結果となる。
+    template <typename Predicate>
+    int HitTestCodeBlockButton(
+        const MdPaneHitContext& ctx,
+        HitCache<int>& cache,
+        Predicate&& matches) const noexcept
+    {
+        if (ctx.nodes.empty()) {
+            return -1;
+        }
+        const uint32_t gen = ctx.cache.GetEffectsGeneration();
+        if (cache.Matches(ctx, gen)) {
+            return cache.result;
+        }
+
+        const auto [dip_x, dip_y] = ScreenToPaneDip(ctx);
+
+        const float viewport_top = ctx.scroll_y;
+        const float viewport_bottom = ctx.scroll_y + ctx.md_pane_height;
+        const int first = FindFirstVisibleNodeIndex(ctx.cache, ctx.nodes.size(), viewport_top);
+        const int count = static_cast<int>(ctx.nodes.size());
+        for (int i = first; i < count; i++) {
+            // 早期 break: CopyButton は padding 分だけ y_position の上に出るため padding を引いて比較する。
+            if (ctx.cache[i].y_position - ctx.theme.code_block_padding > viewport_bottom) {
+                break;
+            }
+            const auto& node = ctx.nodes[i];
+            if (node.type != NodeType::CodeBlock) {
+                continue;
+            }
+            if (matches(i, node, ctx.cache[i], dip_x, dip_y)) {
+                cache.Store(ctx, gen, i);
+                return i;
+            }
+        }
+        cache.Store(ctx, gen, -1);
+        return -1;
+    }
+
     mutable HitCache<HitResult> last_md_hit_{};
     mutable HitCache<int> last_copy_hit_{ .result = -1 };
     mutable HitCache<int> last_save_hit_{ .result = -1 };

--- a/src/input/swipe_detector.h
+++ b/src/input/swipe_detector.h
@@ -10,9 +10,6 @@ enum class SwipeResult { None, Back, Forward };
 // タイムアウト: 一定時間水平入力がなければ蓄積をリセットする。
 class SwipeDetector {
 public:
-    // 水平ホイールイベントを処理。デルタを蓄積するのみで即時発火しない。
-    // 指を離した後の Commit() 呼び出しでナビゲーションが発動する。
-    // now_ms: 現在時刻（ミリ秒）。呼び出し側で GetTickCount64() 等を渡す。
     void OnHWheel(int delta, uint64_t now_ms) noexcept
     {
         // 直近の縦スクロールから一定時間内なら無視（軸ロック）
@@ -29,8 +26,6 @@ public:
         accumulated_delta_ += delta;
     }
 
-    // 指を離した（一定時間入力が途絶えた）タイミングで呼び出す。
-    // 蓄積デルタが閾値を超えていれば Back/Forward を返し、状態をリセットする。
     SwipeResult Commit() noexcept
     {
         SwipeResult result = SwipeResult::None;
@@ -45,8 +40,6 @@ public:
         return result;
     }
 
-    // 縦スクロールイベントが発生したことを通知する。
-    // 軸ロックの基準時刻を更新し、蓄積中のデルタをリセットする。
     void NotifyVScroll(uint64_t now_ms) noexcept
     {
         last_vscroll_time_ = now_ms;
@@ -62,15 +55,12 @@ public:
 
     // ---- オーバーレイ表示用 ----
 
-    // 蓄積デルタが発動閾値に達していればオーバーレイを表示する。
     constexpr bool IsOverlayVisible() const noexcept
     {
         const int abs_d = accumulated_delta_ < 0 ? -accumulated_delta_ : accumulated_delta_;
         return abs_d >= TRIGGER_THRESHOLD;
     }
 
-    // オーバーレイの方向。 -1=戻る（右スワイプ）, 1=進む（左スワイプ）, 0=なし。
-    // GestureRenderState::direction と同じ符号規約。
     constexpr int GetOverlayDirection() const noexcept
     {
         if (accumulated_delta_ >= TRIGGER_THRESHOLD) {
@@ -82,13 +72,11 @@ public:
         return 0;
     }
 
-    // オーバーレイ表示中は 1.0、非表示時は 0.0 を返す。
     constexpr float GetOverlayAlpha() const noexcept
     {
         return IsOverlayVisible() ? 1.0f : 0.0f;
     }
 
-    // テスト・チューニング用のアクセサ
     constexpr int GetAccumulatedDelta() const noexcept { return accumulated_delta_; }
 
     static constexpr int TRIGGER_THRESHOLD = 400;           // ナビゲーション発動閾値（WHEEL_DELTA単位の蓄積値）

--- a/src/io/config_store.h
+++ b/src/io/config_store.h
@@ -6,22 +6,11 @@
 
 namespace config {
 
-// 設定ディレクトリを上書きする（テスト用）。デフォルトに戻すには空のパスを渡す。
 void SetConfigDirOverride(const std::filesystem::path& dir);
-
-// mendoの設定ディレクトリを返す（%LOCALAPPDATA%/mendo）。
 std::filesystem::path GetConfigDir();
-
-// 設定ディレクトリ内のファイルのフルパスを返す（MermaidFileCache等で使用）。
 std::filesystem::path GetConfigPath(std::wstring_view filename);
-
-// INIファイルをディスクからメモリに読み込む。起動時に1回呼ぶ。
 void Load();
-
-// メモリ上のデータをディスクに書き込む。終了時や即時保存時に呼ぶ。
 void Save();
-
-// メモリ上のデータをクリアする（テスト用）。
 void Clear() noexcept;
 
 // ---- 型付きアクセサ（メモリ上のマップを読み書き） ----

--- a/src/io/file_explorer.cpp
+++ b/src/io/file_explorer.cpp
@@ -49,9 +49,6 @@ void FileExplorer::Refresh()
     }
 
     struct SortSlot {
-        // ASCII A-Z のみ小文字化した比較キー。_wcsicmp は Unicode 大小無視だったが
-        // ローカルファイル名の実用上の並びは ASCII 大小無視で十分なため、
-        // ソート前処理コストを削減する Schwartzian transform を優先する。
         std::pmr::wstring sort_key;
         FileEntry entry;
     };

--- a/src/io/file_load_service.h
+++ b/src/io/file_load_service.h
@@ -18,7 +18,6 @@ struct AsyncLoadResult {
 };
 
 // ファイル読み込みのオーケストレーションとローディングアニメーション状態を管理。
-// Win32非依存 — 完全にテスト可能。
 class FileLoadService {
 public:
     explicit constexpr FileLoadService(DocumentService& doc_service) noexcept : doc_service_(doc_service) {}
@@ -28,32 +27,18 @@ public:
     constexpr bool IsLoading() const noexcept { return loading_; }
     constexpr float GetLoadingAngle() const noexcept { return loading_angle_; }
 
-    // ファイルのローディングアニメーションを開始。
     void StartLoading(std::wstring_view path);
-
-    // ローディングアニメーションを停止。
     void StopLoading() noexcept;
-
-    // ローディングアニメーションを1フレーム進める。
     void TickLoadingAnimation() noexcept;
 
     // ---- ファイル読み込み ----
 
-    // 保存されたローディングパスを使ってファイル読み込みを実行。
-    // 成功時はdoc/cacheを更新したうえで値を持つexpectedを返し、失敗時はFileLoadErrorを返す。
     std::expected<void, FileLoadError> ExecuteLoad(Document& doc, LayoutCache& cache);
 
     // ---- 非同期ファイル読み込み ----
 
-    // ワーカースレッドでファイル読み込み+パース+推定高さ計算を実行し、完了時にPostMessageで通知する。
-    // theme は推定高さ計算用にコピーされる（ワーカースレッドでの安全なアクセスのため）。
     void StartAsyncLoad(TaskScheduler& scheduler, HWND hwnd, UINT msg_id, const Theme& theme);
-
-    // ワーカースレッドで生成された結果を取り出す（UIスレッドから呼ぶ）。
-    // 結果がない場合はnulloptを返す。
     std::optional<AsyncLoadResult> TakeAsyncResult();
-
-    // 進行中の非同期読み込みをキャンセルする。
     void CancelAsyncLoad() noexcept { async_gen_.fetch_add(1, std::memory_order_relaxed); }
 
     // ---- パスアクセス ----

--- a/src/io/file_loader.h
+++ b/src/io/file_loader.h
@@ -5,18 +5,16 @@
 #include <expected>
 #include <windows.h>
 
-// ファイル読み込みの最大サイズ（256MB）。FileLoader / ImageLoader で共有。
+// ファイル読み込みの最大サイズ（256MB）。FileLoader / ImageLoader で共有
 inline constexpr LONGLONG MAX_FILE_SIZE = 256LL * 1024 * 1024;
 
-// FileLoader::LoadFile のエラー型。
+// FileLoader::LoadFile のエラー型
 enum class FileLoadError {
     NotFound,    // ファイルが見つからない、またはアクセス拒否
     TooLarge,    // ファイルサイズが MAX_FILE_SIZE を超過
     ReadFailed,  // 読み込み中のI/Oエラー
 };
 
-// FileLoadError に対応するローカライズ済みメッセージを返す。
-// i18n.h に依存しないよう、呼び出し側が Strings を渡す設計。
 inline std::wstring_view FileLoadErrorMessage(FileLoadError e, const auto& strings) noexcept
 {
     switch (e) {
@@ -27,7 +25,7 @@ inline std::wstring_view FileLoadErrorMessage(FileLoadError e, const auto& strin
     }
 }
 
-// ファイル読み込みユーティリティ（静的メソッドのみ）。
+// ファイル読み込みユーティリティ（静的メソッドのみ）
 class FileLoader {
 public:
     static std::expected<std::pmr::string, FileLoadError> LoadFile(const std::pmr::wstring& path);

--- a/src/io/file_watcher.h
+++ b/src/io/file_watcher.h
@@ -5,10 +5,7 @@
 #include <windows.h>
 #include "win_handle.h"
 
-// ReadDirectoryChangesW によるファイル変更監視。
-// 指定ファイルの親ディレクトリを監視し、対象ファイルの変更を検出してコールバックを呼ぶ。
-// 変更検出後はコールバック呼び出しを一時停止し、ResumeWatching() で再開する。
-// 一時停止中も I/O は継続し、追加の変更は蓄積される。
+// ReadDirectoryChangesW によるファイル変更監視
 class FileWatcher {
 public:
     ~FileWatcher();
@@ -22,12 +19,7 @@ public:
     void StopWatching() noexcept;
     void CheckForChanges();
 
-    // 変更検出後に一時停止した監視を再開する。
-    // リロード完了後に呼び出すこと。
     void ResumeWatching();
-
-    // MsgWaitForMultipleObjects に渡す待機ハンドルを返す。
-    // 監視中でなければ nullptr を返す。
     HANDLE GetEventHandle() const noexcept;
 
 private:
@@ -38,7 +30,7 @@ private:
     bool watching_ = false;
 
     UniqueHandle dir_handle_;
-    UniqueEventHandle event_;          // overlapped_.hEvent のオーナー（StartWatching で同期）
+    UniqueEventHandle event_;
     OVERLAPPED overlapped_{};
     alignas(DWORD) char change_buf_[32768]{};
     bool read_pending_ = false;

--- a/src/io/image_loader.cpp
+++ b/src/io/image_loader.cpp
@@ -9,9 +9,6 @@
 
 #pragma comment(lib, "shlwapi.lib")
 
-// ファイルを共有モードでメモリに読み込みIStreamとして返す。
-// CreateDecoderFromFilename はファイルを排他的に開くため、
-// 外部エディタ等がファイルを更新できなくなる問題を回避する。
 static Microsoft::WRL::ComPtr<IStream> ReadFileToStream(const std::wstring& path)
 {
     auto r = OpenFileForReadShared(
@@ -43,7 +40,7 @@ static Microsoft::WRL::ComPtr<IStream> ReadFileToStream(const std::wstring& path
     if (FAILED(CreateStreamOnHGlobal(hMem.get(), TRUE, &stream))) {
         return nullptr;
     }
-    hMem.release(); // CreateStreamOnHGlobal(TRUE) が所有権を取得
+    hMem.release();
     return stream;
 }
 

--- a/src/io/image_loader.h
+++ b/src/io/image_loader.h
@@ -24,33 +24,17 @@ public:
     void Init(ID2D1RenderTarget* rt, IWICImagingFactory* wic = nullptr);
     void SetRenderTarget(ID2D1RenderTarget* rt) noexcept { render_target_ = rt; }
 
-    // TaskSchedulerを設定し、非同期読み込みを有効にする。
     void InitAsync(HWND hwnd, UINT msg_id, TaskScheduler& scheduler);
-
-    // 画像ファイルを同期的に読み込む（テスト用に残す）。
     bool LoadImage(const std::wstring& abs_path, DiagramEntry& out);
-
-    // キャッシュのみを参照する。I/O は行わない。
     bool GetCachedImage(const std::wstring& abs_path, DiagramEntry& out) const;
-
-    // 非同期読み込みをキューに追加する。重複パスは無視される。
     void RequestLoadAsync(const std::wstring& abs_path, Callback on_complete);
-
-    // UI スレッドから呼び出す: 完了した WIC デコード結果を D2D ビットマップに変換し、
-    // キャッシュに格納する。バッチ内の最後の結果のコールバックのみを1回発火する
-    // （呼び出し側が全ノードを再スキャンする設計のため）。
     void ProcessCompletedDecodes();
-
-    // 保留中のリクエストと完了結果をすべて破棄する。
     void CancelPending();
 
     void ClearCache() noexcept { cache_.Clear(); }
     size_t CacheSize() const noexcept { return cache_.Size(); }
 
-    // テスト用: ビットマップなしのダミーエントリをキャッシュに挿入する。
     void InsertCacheEntry(const std::wstring& path, float width, float height);
-
-    // 保留中のリクエストをキャンセルする（CancelPendingと同等）。
     void Shutdown();
 
 private:
@@ -79,7 +63,6 @@ private:
     ID2D1RenderTarget* render_target_ = nullptr;
     LruCache<std::wstring, CachedImage> cache_{ MAX_CACHE_ENTRIES };
 
-    // 非同期読み込み
     HWND hwnd_ = nullptr;
     UINT msg_id_ = 0;
     TaskScheduler* scheduler_ = nullptr;

--- a/src/io/ini_parser.h
+++ b/src/io/ini_parser.h
@@ -91,7 +91,6 @@ inline IniData Parse(std::string_view text)
     return data;
 }
 
-// 構造化データをINIテキストにシリアライズする。
 inline std::string Serialize(const IniData& data)
 {
     std::string result;

--- a/src/io/session_service.h
+++ b/src/io/session_service.h
@@ -4,7 +4,7 @@
 #include <string_view>
 #include <memory_resource>
 
-// セッション状態（最後に開いたファイル、ペイン構成、スクロール位置）の永続化を担当する。
+// セッション状態（最後に開いたファイル、ペイン構成、スクロール位置）の永続化を担当する
 class SessionService {
 public:
     explicit SessionService(ConfigService& config) noexcept : config_(config) {}

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -6,49 +6,34 @@
 #include <dwrite.h>
 #include <memory_resource>
 
-// コードブロック本文の左端を背景内側にオフセットする量（段落は 0）。
-// 描画側（command_generator）と入力側（hit_test_service）で座標空間がずれないよう
-// 単一のソースに集約する。
+
 [[nodiscard]] inline float NodeTextXOffset(const Node& node, const Theme& theme) noexcept
 {
     return (node.type == NodeType::CodeBlock) ? theme.code_block_padding : 0.0f;
 }
 
-// テーブルの自然幅と利用可能幅から列幅を算出し out に書き込む。
-// out は呼び出し側の既存バッファを再利用することで再レイアウト時の再確保を避ける。
 void ComputeColumnWidths(std::pmr::vector<float>& out,
     const std::pmr::vector<float>& natural_widths,
     float available_width, size_t col_count);
 
-// テーブル行から線形化テキストを構築する（セルはタブ区切り、行は改行区切り）。
-// テキスト選択機能のサポートに使用する。
 [[nodiscard]] std::pmr::wstring BuildLinearizedTableText(const std::pmr::vector<TableRow>& rows);
 
-// from_index 以降の全ノードの Y 位置とスペーシングを再計算する。
-// {total_height, has_dirty_nodes} を返す。
 struct YPositionResult {
     float total_height = 0.0f;
     bool has_dirty_nodes = false;
 };
-// safe_exit_after: この位置以降でY位置が一致すれば早期終了する。
-// SIZE_MAX（デフォルト）の場合は早期終了しない。
+
 YPositionResult RecomputeYPositions(std::pmr::vector<Node>& nodes, LayoutCache& cache, const Theme& theme,
     size_t from_index = 0, bool has_earlier_dirty = false, size_t safe_exit_after = SIZE_MAX) noexcept;
 
-// 単一ノードの高さをテーマ定数から推定する（DirectWrite を呼ばない）。
-// 部分レイアウトで MeasureNode をスキップする際の暫定値や、
-// EstimateNodeHeights からも利用される共通実装。
 [[nodiscard]] float EstimateNodeHeight(const Node& node, const Theme& theme) noexcept;
 
-// DirectWriteを使わず、ノードの種類からおおよその高さを割り当ててY座標を推定する。
-// セッション復元時のスクロール位置計算用（O(n)の算術演算のみ、layout_dirtyは変更しない）。
 void EstimateNodeHeights(const std::pmr::vector<Node>& nodes, LayoutCache& cache, const Theme& theme) noexcept;
 
 class LayoutEngine {
 public:
     bool Init(ITextMeasurer* measurer, const Theme& theme);
     void UpdateTheme(const Theme& theme) noexcept { theme_ = &theme; measurer_->UpdateTheme(theme); }
-    // すべてのテキストフォーマットオブジェクトを再作成する（ズームやテーマ変更後など）。
     bool RecreateFormats();
     void ComputeLayout(std::pmr::vector<Node>& nodes, LayoutCache& cache, float viewport_width,
         float viewport_top = -1.0f, float viewport_bottom = -1.0f);

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -118,9 +118,6 @@ public:
         }
     }
 
-    // 既存のエントリをすべてクリアし、デフォルト値でリサイズする。
-    // shrink=true (デフォルト): ファイル切り替え時に古い容量を解放する。
-    // shrink=false: リロード時に容量を保持し、同サイズファイルの再確保を回避する。
     void Reset(size_t node_count, bool shrink = true)
     {
         entries_.clear();
@@ -267,7 +264,6 @@ constexpr int FindFirstVisibleNodeIndex(const LayoutCache& cache, size_t node_co
 
 // (node, offset) → 絶対スクロール位置。
 // 負の node や空キャッシュは 0 を返し、末尾を超える node は最後の要素へクランプする
-// （ドキュメントが縮んでいた場合にトップではなく末尾近くへ復帰する）。
 constexpr float NodeOffsetToScrollY(const LayoutCache& cache, int node, float offset) noexcept
 {
     if (cache.size() == 0 || node < 0) {

--- a/src/layout/layout_service.cpp
+++ b/src/layout/layout_service.cpp
@@ -26,8 +26,7 @@ bool LayoutService::EnsureVisibleLayout(Document& doc, LayoutCache& cache, float
 {
     const float scroll_y = viewport_.GetScrollY();
     const bool updated = engine_.EnsureVisibleLayout(doc.GetNodesMut(), cache, width, scroll_y, scroll_y + height);
-    // updated=false でもレイアウト操作の一貫した契約として target を再適用する
-    // （target 無効時は ApplyScrollTarget 側で早期 return）
+
     viewport_.ApplyScrollTarget(cache);
     return updated;
 }

--- a/src/layout/layout_service.h
+++ b/src/layout/layout_service.h
@@ -11,24 +11,13 @@ public:
     {
     }
 
-    // ビューポート優先レイアウト（リサイズ時）
     void ViewportLayout(Document& doc, LayoutCache& cache, float width, float height);
-
-    // ダーティバッチ処理（遅延レイアウト）
-    // viewport_height > 0 の場合、ビューポート付近のダーティノードのみ処理する。
     bool ProcessDirtyBatch(Document& doc, LayoutCache& cache, float width, int batch_size, int time_budget_us = 0,
         float viewport_height = -1.0f, float buffer_screens = 5.0f);
-
-    // 可視領域のレイアウト保証（OnPaint 時）
     bool EnsureVisibleLayout(Document& doc, LayoutCache& cache, float width, float height);
-
-    // ダイアグラム反映後の Y 位置再計算
     void RecomputeAfterDiagram(Document& doc, LayoutCache& cache, const Theme& theme) noexcept;
 
-    // ダーティノードが残っているか
     constexpr bool HasDirtyNodes() const noexcept { return engine_.HasDirtyNodes(); }
-
-    // 合計高さ
     constexpr float GetTotalHeight() const noexcept { return engine_.GetTotalHeight(); }
     constexpr void SetTotalHeight(float h) noexcept { engine_.SetTotalHeight(h); }
 

--- a/src/layout/text_measurer.h
+++ b/src/layout/text_measurer.h
@@ -3,8 +3,7 @@
 #include "layout_cache.h"
 #include "theme.h"
 
-// テキスト計測の抽象インターフェース。
-// DirectWrite依存をレイアウトロジックから分離し、モックベースのテストを可能にする。
+// テキスト計測の抽象インターフェース
 class ITextMeasurer {
 public:
     virtual ~ITextMeasurer() = default;
@@ -12,12 +11,6 @@ public:
     virtual bool Init(const Theme& theme) = 0;
     virtual bool RecreateFormats() = 0;
     virtual void UpdateTheme(const Theme& theme) noexcept = 0;
-
-    // 非テーブルノードのテキストレイアウトを作成・計測する。
-    // entry.text_layout, entry.height, entry.layout_dirty, entry.effects_applied を設定する。
     virtual void MeasureNode(Node& node, NodeLayoutEntry& entry, float max_width) = 0;
-
-    // テーブルセルのレイアウトを作成・計測する。
-    // entry.table_layout->cell_layouts/col_widths/row_heights, entry.height, entry.layout_dirty を設定する。
     virtual void MeasureTable(Node& node, NodeLayoutEntry& entry, float max_width) = 0;
 };

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -480,9 +480,7 @@ void MermaidRenderer::RequestRender(Node& node, NodeLayoutEntry& layout_entry,
         }
     }
 
-    // WebView2未初期化ならキューには追加しない。
-    // on_ready コールバックで RequestMermaidRenders が再度呼ばれるため、
-    // その時点でキャッシュミス分がキューに入る。
+    // WebView2未初期化ならキューには追加しない
     if (!ready_) {
         EnsureInitialized();
         return;

--- a/src/mermaid/mermaid.h
+++ b/src/mermaid/mermaid.h
@@ -29,43 +29,17 @@ public:
     MermaidRenderer(const MermaidRenderer&) = delete;
     MermaidRenderer& operator=(const MermaidRenderer&) = delete;
 
-    // レンダラーを初期化する。hwndはメインアプリウィンドウ。
-    // render_targetはD2Dビットマップの作成に使用する。
-    // wicはPNGデコード用のWICファクトリ（nullの場合は内部で作成する）。
-    // on_readyはWebView2の初期化完了時にUIスレッドで呼び出される。
     void Init(HWND hwnd, ID2D1RenderTarget* render_target, IWICImagingFactory* wic, std::move_only_function<void()> on_ready);
 
-    // WebView2が初期化済みでレンダリング可能な場合にtrueを返す。
     constexpr bool IsReady() const noexcept { return ready_; }
 
-    // IMermaidRenderer::Callback を継承
-
-    // Mermaidコードブロックのレンダリングを要求する。
-    // 完了時、ダイアグラムエントリのbitmap/width/heightとレイアウトエントリの
-    // height/layout_dirtyが設定され、on_completeがUIスレッドで呼び出される。
     void RequestRender(Node& node, NodeLayoutEntry& layout_entry, DiagramEntry& diagram_entry, float max_width, bool dark_mode, Callback on_complete) override;
-
-    // D2Dレンダーターゲットを更新する（例：リサイズ後）。
     void SetRenderTarget(ID2D1RenderTarget* render_target);
-
-    // ファイルキャッシュを設定する。Init()の前に呼び出す。
     void SetFileCache(MermaidFileCache* cache) noexcept { file_cache_ = cache; }
-
-    // キャッシュされたビットマップをすべてクリアする。
     void ClearCache() override;
-
-    // WebView2ワーカーを閉じてリソースを解放する。
-    // メッセージループが生きているうちに（OnDestroyで）呼び出す。
     void Shutdown();
-
-    // 保留中のリクエストをすべてキャンセルし、処理中のリクエストを無効化する。
-    // nodesベクターが置き換えられる前に呼び出す必要がある。
     void CancelPending() override;
-
-    // WebView2初期化リトライのタイマーハンドラ
     void OnInitRetryTimer();
-
-    // タイマーID（App側でルーティングする）
     static constexpr UINT_PTR TIMER_INIT_RETRY = 12;
 
 #ifdef MENDO_TESTING

--- a/src/mermaid/mermaid_file_cache.h
+++ b/src/mermaid/mermaid_file_cache.h
@@ -37,35 +37,14 @@ public:
         size_t size = 0;
     };
 
-    // キャッシュを初期化し、インデックスをディスクから読み込む。
-    // current_dprが保存済みDPRと異なる場合、キャッシュを全削除する。
     void Init(float current_dpr, TaskScheduler& scheduler);
-
-    // キャッシュされたPNGを検索する。見つかった場合trueを返す。
-    // last_usedタイムスタンプも更新される。
     bool Lookup(uint64_t key, CacheEntry& entry, PngBlob& png);
-
-    // インデックスからCSSサイズのみを取得する（ディスクI/O無し）。
-    // スクロール位置復元時の高さ推定に使用する。
     bool LookupDimensions(uint64_t key, CacheEntry& entry) const noexcept;
-
-    // PNGファイルをバックグラウンドスレッドで非同期に書き出す。
-    // インデックスエントリは即座に追加される。
     void StoreAsync(uint64_t key, float css_width, float css_height, std::vector<uint8_t> png_data);
-
-    // インデックスをディスクに保存する（アプリ終了時に呼び出す）。
     void SaveIndex();
-
-    // すべてのキャッシュファイルとインデックスを削除する。
     void ClearAll();
-
-    // 保留中の書き込みタスクを無効化する。
     void Shutdown();
-
-    // テスト用: キャッシュディレクトリを上書きする。Init()の前に呼び出す。
     void SetCacheDir(const std::filesystem::path& dir);
-
-    // テスト用: エントリ数・サイズ上限を変更する。Init()の前に呼び出す。
     void SetLimits(size_t max_entries, uint64_t max_total_size);
 
     size_t EntryCount() const noexcept { return index_.size(); }
@@ -84,7 +63,7 @@ private:
         float css_height = 0.0f;
         uint32_t png_size = 0;
         int64_t last_used = 0;
-        LruOrder::iterator lru_iter{}; // png_size > 0 なら lru_order_ 内の該当エントリを指す
+        LruOrder::iterator lru_iter{};
     };
 
     std::filesystem::path GetCacheDir() const;
@@ -93,7 +72,6 @@ private:
     std::filesystem::path GetIndexPath() const;
     void LoadIndex();
     void EvictIfNeeded(uint32_t new_png_size);
-    // total_size_ から安全に減算する（アンダーフロー時は 0 にクランプ）
     void DecrementTotalSize(uint32_t png_size) noexcept;
     static int64_t Now() noexcept;
 
@@ -101,9 +79,7 @@ private:
     float stored_dpr_ = 0.0f;
     float current_dpr_ = 0.0f;
 
-    // インデックス: key → エントリメタデータ（最大4096エントリ）
     std::unordered_map<uint64_t, IndexEntry> index_;
-    // LRU順序: last_used → keys（最古エントリは begin() で O(1)）
     LruOrder lru_order_;
     uint64_t total_size_ = 0;
 
@@ -114,9 +90,6 @@ private:
     TaskScheduler* scheduler_ = nullptr;
     std::atomic<uint32_t> write_gen_{ 0 };
 
-    // 書き込み in-flight キーの集合。Lookup が PNG 未着地を stale と
-    // 誤判定して index を消すのを防ぐためのガード。
-    // UI スレッドからもバックグラウンドスレッドからも触るため mutex で保護。
     mutable std::mutex pending_mutex_;
     std::unordered_set<uint64_t> pending_writes_;
 };

--- a/src/mermaid/mermaid_renderer_interface.h
+++ b/src/mermaid/mermaid_renderer_interface.h
@@ -11,16 +11,9 @@ public:
     using Callback = std::move_only_function<void()>;
     virtual ~IMermaidRenderer() = default;
 
-    // Mermaid コードブロックのレンダリングを要求する。完了時、
-    // diagram_entry.bitmap/width/height と layout_entry.height/layout_dirty が
-    // 設定され、on_complete が UI スレッドで呼び出される。
     virtual void RequestRender(Node& node, NodeLayoutEntry& layout_entry,
         DiagramEntry& diagram_entry, float max_width, bool dark_mode,
         Callback on_complete) = 0;
-
-    // 保留中のリクエストをすべてキャンセルし、処理中のリクエストを無効化する。
     virtual void CancelPending() = 0;
-
-    // キャッシュされたビットマップをすべてクリアする。
     virtual void ClearCache() = 0;
 };

--- a/src/mermaid/mermaid_util.h
+++ b/src/mermaid/mermaid_util.h
@@ -15,46 +15,23 @@ std::pmr::wstring BuildLatexFlowchartCode(std::wstring_view latex);
 // 同じ UTF-8 コンテンツの Mermaid / LatexMath がキー衝突しないようにする。
 uint64_t NodeDiagramHash(const Node& node, float max_width, bool dark_mode) noexcept;
 
-// wstringをJavaScript文字列リテラルとして安全に埋め込むためにエスケープする。
 std::pmr::wstring JsEscape(std::wstring_view input);
 
-// FNV-1a 64ビットハッシュ。16文字の16進数wstringとして返す。
 std::pmr::wstring SimpleHash(std::wstring_view input);
 
-// FNV-1a 64ビットハッシュの生の値を返す。
 uint64_t HashRaw(std::wstring_view input) noexcept;
 uint64_t HashRaw(std::string_view input) noexcept;
 
-// 複数の値からキャッシュキーのハッシュを計算する（コード全体のコピーを回避）。
 uint64_t CombinedHash(std::wstring_view code, int max_width_int, bool dark_mode) noexcept;
 uint64_t CombinedHash(std::string_view code, int max_width_int, bool dark_mode) noexcept;
 
-// 論理プロセッサ数からMermaidレンダリング用ワーカー数を計算する。
-// 結果は [2, 4] にクランプされる。
 int ComputeWorkerCount(unsigned int processor_count) noexcept;
-
-// 幅を100px単位に量子化する（ファイルキャッシュのキー用）。
-// 結果は常に100以上の100の倍数。
 int QuantizeWidth(float max_width) noexcept;
-
-// 幅を量子化してからキャッシュキーのハッシュを計算する。
 uint64_t HashCode(std::wstring_view code, float max_width, bool dark_mode) noexcept;
 uint64_t HashCode(std::string_view code, float max_width, bool dark_mode) noexcept;
-
-// 簡易 JSON 数値抽出。key は引用符込み（例: L"\"width\""）で渡す。
-// 見つからない / 末尾到達時は 0.0f を返す。レンダリング結果の JSON 解析用で
-// ネスト・エスケープ・負数記法には対応しない（送り手側が単一オブジェクトを
-// 返す前提）。
 float ParseJsonNumber(std::wstring_view json, std::wstring_view key) noexcept;
-
-// 簡易 JSON "key":true 判定。キー直後の空白 1 つまでを許容する。
 bool ParseJsonTrueFlag(std::wstring_view json, std::wstring_view key) noexcept;
 
-// WebView2 からの "<id>" または "<id>:<payload>" 形式のメッセージ本文から
-// 先頭リクエスト ID と残り payload を取り出す。
-// valid: 先頭が有効な符号なし整数でパースできた場合に true
-// has_payload: "<id>:" の区切りコロンが存在した場合に true
-// payload: コロン直後の view（has_payload=false の場合は空）
 struct RequestPrefix {
     unsigned int id = 0;
     std::wstring_view payload;

--- a/src/nav/nav_history.h
+++ b/src/nav/nav_history.h
@@ -26,16 +26,8 @@ struct NavEntry {
 // 内部ではパスをインターン化し、同一パスの重複保持を回避する。
 class NavHistory {
 public:
-    // ナビゲーション前の現在の状態を記録する。
-    // currentを戻るスタックにプッシュし、進むスタックをクリアする。
     void Push(const NavEntry& current);
-
-    // 戻るナビゲーション: currentを進むスタックに移動し、戻るスタックからポップする。
-    // ナビゲート先のエントリを`out`に書き込みtrueを返す。戻る先がない場合はfalseを返す。
-    // `current`は現在の状態（戻る前の状態）。
     bool GoBack(const NavEntry& current, NavEntry& out);
-
-    // 進むナビゲーション: currentを戻るスタックに移動し、進むスタックからポップする。
     bool GoForward(const NavEntry& current, NavEntry& out);
 
     bool CanGoBack() const noexcept { return !back_stack_.empty(); }
@@ -46,14 +38,11 @@ public:
 
     void Clear() noexcept;
 
-    // 現在アクティブにインターン化されているパス数（テスト/診断用）。
-    // path_pool_ が永久に伸び続けないことの確認に使う。
     size_t InternedPathCount() const noexcept { return path_index_.size(); }
 
     static constexpr size_t MAX_HISTORY = 1024;
 
 private:
-    // 内部エントリ: パスインデックス + ノードインデックス + オフセット（12バイト）
     struct InternalEntry {
         uint32_t path_index = 0;
         int node = -1;
@@ -67,14 +56,10 @@ private:
         uint32_t refcount = 0;
     };
 
-    // パスをインターン化し、インデックスを返す（refcount は変更しない）
     uint32_t InternPath(std::wstring_view path);
-    // 既存スロットの refcount を +1
     void RetainPath(uint32_t idx) noexcept;
-    // refcount を -1。0 になったらスロットをフリーリストに戻す。
     void ReleasePath(uint32_t idx) noexcept;
 
-    // NavEntry ↔ InternalEntry 変換（ToInternal は refcount を +1 する）
     InternalEntry ToInternal(const NavEntry& e);
     NavEntry ToExternal(const InternalEntry& e) const;
 
@@ -84,8 +69,6 @@ private:
     // バケット配列のキャッシュミスを避けられる std::pmr::map のほうが優位。
     std::pmr::deque<PathSlot> path_pool_;
     std::pmr::map<std::wstring_view, uint32_t> path_index_;
-    // free_slots_ はスタックとしてのみ使用（push_back/back/pop_back）。
-    // キャッシュ局所性の観点で deque より vector が有利。
     std::pmr::vector<uint32_t> free_slots_;
     std::pmr::deque<InternalEntry> back_stack_;
     std::pmr::deque<InternalEntry> forward_stack_;

--- a/src/nav/navigation_service.h
+++ b/src/nav/navigation_service.h
@@ -3,17 +3,11 @@
 #include <string_view>
 #include <memory_resource>
 
-// リンククリックの結果を表す値型。
-// URLスキーム検証とアンカー判定のみを行い、副作用は持たない。
 struct LinkClickResult {
     enum class Type { None, Anchor, ExternalUrl };
     Type type = Type::None;
     std::pmr::wstring target;
 };
 
-// リンククリック処理。URLの種類を判定して結果を返す。副作用は起こさない。
 LinkClickResult HandleLinkClick(std::wstring_view url);
-
-// ShellExecuteW に渡しても安全な URL スキームか判定する。
-// http / https / mailto のみ許可し、file://, javascript: などはブロック。
 bool IsSafeUrlScheme(std::wstring_view url) noexcept;

--- a/src/render/command_executor.h
+++ b/src/render/command_executor.h
@@ -13,8 +13,6 @@ public:
 private:
     ID2D1SolidColorBrush* GetBrush(ID2D1RenderTarget* rt, D2D1_COLOR_F color);
 
-    // ブラシ数が超過したらプールを一掃し、肥大化を防ぐ。
-    // テーマ + UI アクセント色は通常 ~50 個以内に収まる。
     static constexpr size_t MAX_POOLED_BRUSHES = 256;
 
     std::unordered_map<uint32_t, Microsoft::WRL::ComPtr<ID2D1SolidColorBrush>> brush_pool_;

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -63,14 +63,6 @@ void Renderer::SetDpi(float dpi) noexcept
     toc_pane_cache_.Reset();
 }
 
-void Renderer::ApplyZoom(float new_zoom)
-{
-    theme_.ApplyZoom(new_zoom);
-    UpdateLayoutTheme();
-    RecreatePaneFormats();
-    cmd_generator_.SetTheme(&theme_);
-}
-
 void Renderer::ApplyZoomFromBase(const Theme& base_theme, float new_zoom)
 {
     theme_ = base_theme;

--- a/src/render/renderer.h
+++ b/src/render/renderer.h
@@ -53,7 +53,8 @@ public:
     constexpr LayoutEngine& GetLayout() noexcept { return layout_; }
     constexpr const Theme& GetTheme() const noexcept { return theme_; }
     void SetTheme(const Theme& theme);
-    void ApplyZoom(float new_zoom);
+    // base theme (zoom=1.0) から再構築して現在 zoom を適用する。
+    // 累積適用による誤差蓄積を避けるため、ズーム変更経路はこの関数に統一する。
     void ApplyZoomFromBase(const Theme& base_theme, float new_zoom);
 
     // LayoutEngineのテーマを更新しフォーマットを再作成する。

--- a/src/theme/theme.cpp
+++ b/src/theme/theme.cpp
@@ -38,37 +38,41 @@ void Theme::ApplyZoom(float new_zoom) noexcept
     if (new_zoom <= 0.0f || zoom <= 0.0f) {
         return;
     }
-    // 前のズームを元に戻してから新しいズームを適用する
     const float ratio = new_zoom / zoom;
     zoom = new_zoom;
 
-    font_size_body *= ratio;
-    for (int i = 0; i < 6; ++i) {
-        font_size_h[i] *= ratio;
+    // Theme 内の「ズームでスケールする float メンバ」を一元管理する。
+    // 新規のスケーラブルフィールドを追加する際はここに追記すれば
+    // ApplyZoom へのスケール漏れを防げる。
+    static constexpr float Theme::* kScalable[] = {
+        &Theme::font_size_body,
+        &Theme::font_size_code,
+        &Theme::margin_left,
+        &Theme::margin_right,
+        &Theme::margin_top,
+        &Theme::paragraph_spacing,
+        &Theme::list_item_spacing,
+        &Theme::heading_spacing_above,
+        &Theme::heading_spacing_below,
+        &Theme::heading_spacing_below_h1h2,
+        &Theme::code_block_spacing_above,
+        &Theme::code_block_padding,
+        &Theme::indent_width,
+        &Theme::blockquote_bar_width,
+        &Theme::list_bullet_offset,
+        &Theme::hr_thickness,
+        &Theme::h2_underline_thickness,
+        &Theme::pane_item_height,
+        &Theme::pane_header_height,
+        &Theme::splitter_width,
+        &Theme::pane_font_size,
+    };
+    for (float Theme::* field : kScalable) {
+        this->*field *= ratio;
     }
-    font_size_code *= ratio;
-
-    margin_left *= ratio;
-    margin_right *= ratio;
-    margin_top *= ratio;
-    paragraph_spacing *= ratio;
-    list_item_spacing *= ratio;
-    heading_spacing_above *= ratio;
-    heading_spacing_below *= ratio;
-    heading_spacing_below_h1h2 *= ratio;
-    code_block_spacing_above *= ratio;
-    code_block_padding *= ratio;
-    indent_width *= ratio;
-    blockquote_bar_width *= ratio;
-    list_bullet_offset *= ratio;
-    hr_thickness *= ratio;
-    h2_underline_thickness *= ratio;
-
-    // ペインサイズ
-    pane_item_height *= ratio;
-    pane_header_height *= ratio;
-    splitter_width *= ratio;
-    pane_font_size *= ratio;
+    for (auto& f : font_size_h) {
+        f *= ratio;
+    }
 }
 
 // ライトテーマとダークテーマで共有するレイアウト定数

--- a/src/theme/theme.h
+++ b/src/theme/theme.h
@@ -95,11 +95,7 @@ struct Theme {
     }
     constexpr bool IsDark() const noexcept { return (bg_color.r + bg_color.g + bg_color.b) < 1.5f; }
 
-    // Reducer用のテーマ定数キャッシュを生成する。
     ThemeConstants ToReducerConstants() const noexcept;
-
-    // すべてのスケーラブルなサイズ（フォントサイズ、マージン、スペーシング）にズーム倍率を適用する。
-    // `zoom` を変更した後に呼び出して派生値を更新する。
     void ApplyZoom(float new_zoom) noexcept;
 };
 

--- a/src/theme/theme_service.h
+++ b/src/theme/theme_service.h
@@ -13,11 +13,8 @@ public:
 
     constexpr bool IsDarkMode() const noexcept { return dark_mode_; }
 
-    // 現在のダークモード状態に基づきテーマを作成する（オプションでズームを適用）。
     Theme CreateTheme() const;
     Theme CreateTheme(int zoom_index) const;
-
-    // ダークモードを切り替える。新しいdark_mode状態を返す。
     bool ToggleDarkMode() noexcept;
 
     // ---- 永続化 ----

--- a/src/ui/context_menu.h
+++ b/src/ui/context_menu.h
@@ -61,8 +61,7 @@ public:
     // D2D/DWriteファクトリーを受け取り初期化する。Appの初期化時に1回呼ぶ。
     void Init(ID2D1Factory* d2d_factory, IDWriteFactory* dwrite_factory);
 
-    // メニューを表示しユーザーの選択を待つ（モーダル）。
-    // 戻り値: 選択されたコマンドID（IDM_NAV_BACK等）、キャンセル時は0。
+    // メニューを表示しユーザーの選択を待つ（モーダル）
     int Show(HWND owner_hwnd, const ContextMenuParams& params);
 
     // ヒットテスト

--- a/src/ui/pane_layout.h
+++ b/src/ui/pane_layout.h
@@ -27,23 +27,11 @@ struct PaneScrollInfo {
     float thumb_height = 0.0f;
 };
 
-// ウィンドウサイズとペイン設定からペインレイアウトを計算する。
-// top_offset: ペイン上端のY座標オフセット（カスタムタイトルバーの高さ等）
 [[nodiscard]] PaneLayout ComputePaneLayout(float total_width, float total_height,
     float file_pane_width, float toc_pane_width,
     float splitter_width, bool show_file, bool show_toc,
     float md_min_width = 200.0f, float top_offset = 0.0f) noexcept;
-
-// ある座標（DIP座標）がどのペイン領域に属するかを判定する。
 PaneZone DetectPaneZone(float dip_x, const PaneLayout& layout, float splitter_width, bool show_file, bool show_toc) noexcept;
-
-// ペインのスクロール情報を計算する。スクロールバーの描画と操作に使用。
 PaneScrollInfo ComputeScrollInfo(const PaneRect& rect, float header_height, float total_content, float thumb_min = PANE_SCROLLBAR_THUMB_MIN) noexcept;
-
-// ドラッグ計算用にスクロールバーのつまみ位置を計算する。
-// つまみ上端のY座標を返す。
 float ComputeThumbY(const PaneScrollInfo& info, float scroll_y) noexcept;
-
-// つまみのドラッグから新しいスクロール位置を計算する。
-// 新しいつまみのY座標を指定する。
 float ScrollFromThumbY(const PaneScrollInfo& info, float thumb_y) noexcept;

--- a/src/ui/search_state.cpp
+++ b/src/ui/search_state.cpp
@@ -3,6 +3,12 @@
 #include <cwctype>
 #include <iterator>
 
+namespace {
+constexpr auto to_lower = [](wchar_t ch) static noexcept {
+    return static_cast<wchar_t>(std::towlower(ch));
+};
+} // namespace
+
 void SearchState::SetQuery(std::wstring_view query)
 {
     query_.assign(query);
@@ -22,11 +28,10 @@ void SearchState::ExecuteSearch(const std::pmr::vector<Node>& nodes)
     std::pmr::wstring lower_query;
     if (!case_sensitive_) {
         lower_query.reserve(query_.size());
-        std::ranges::transform(
-            query_,
-            std::back_inserter(lower_query),
-            [](wchar_t ch) static noexcept { return static_cast<wchar_t>(std::towlower(ch)); }
-        );
+        std::ranges::transform(query_, std::back_inserter(lower_query), to_lower);
+        // ドキュメント単位で lowercase 化結果をキャッシュし、入力1文字ごとの
+        // 全文再変換コストを除去する。ドキュメント切替時は自動で再生成される。
+        EnsureLowercaseCache(nodes);
     }
 
     const auto node_count = static_cast<int>(nodes.size());
@@ -57,6 +62,48 @@ void SearchState::ExecuteSearch(const std::pmr::vector<Node>& nodes)
     matches_truncated_ = (matches_.size() >= MAX_MATCHES);
 }
 
+void SearchState::EnsureLowercaseCache(const std::pmr::vector<Node>& nodes)
+{
+    if (cached_nodes_ptr_ == nodes.data() && cached_node_count_ == nodes.size()) {
+        return;
+    }
+
+    lower_cache_.clear();
+    lower_cache_.resize(nodes.size());
+
+    for (size_t i = 0; i < nodes.size(); ++i) {
+        const auto& node = nodes[i];
+        auto& entry = lower_cache_[i];
+        if (node.type == NodeType::Table && node.has_table()) {
+            const auto& rows = node.table_rows();
+            entry.table_cells.resize(rows.size());
+            for (size_t r = 0; r < rows.size(); ++r) {
+                const auto& cells = rows[r].cells;
+                entry.table_cells[r].resize(cells.size());
+                for (size_t c = 0; c < cells.size(); ++c) {
+                    const auto& src = cells[c].text;
+                    auto& dst = entry.table_cells[r][c];
+                    dst.resize(src.size());
+                    std::ranges::transform(src, dst.begin(), to_lower);
+                }
+            }
+        }
+        else if (node.type == NodeType::Image ||
+            (node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language))) {
+            // 検索対象外ノードはキャッシュ不要（空のまま）
+        }
+        else {
+            const auto& src = node.GetText();
+            auto& dst = entry.text;
+            dst.resize(src.size());
+            std::ranges::transform(src, dst.begin(), to_lower);
+        }
+    }
+
+    cached_nodes_ptr_ = nodes.data();
+    cached_node_count_ = nodes.size();
+}
+
 void SearchState::FindMatches(std::wstring_view text, const std::pmr::wstring& lower_query, int node_index, int table_row, int table_col)
 {
     if (matches_.size() >= MAX_MATCHES) {
@@ -72,13 +119,11 @@ void SearchState::FindMatches(std::wstring_view text, const std::pmr::wstring& l
         }
     }
     else {
-        // テキスト全体を一括で小文字変換し、find()で検索する。
-        // std::search + towlower の文字単位呼び出しよりも高速。
-        lower_text_buf_.resize_and_overwrite(text.size(), [&text](wchar_t* buf, size_t count) noexcept -> size_t {
-            std::ranges::transform(text, buf, [](wchar_t ch) static noexcept { return static_cast<wchar_t>(std::towlower(ch)); });
-            return count;
-        });
-        const std::wstring_view lower_text(lower_text_buf_.data(), lower_text_buf_.size());
+        // ドキュメント単位でキャッシュした lowercase 文字列を使う。
+        // EnsureLowercaseCache が ExecuteSearch 先頭で呼ばれている前提。
+        const std::wstring_view lower_text = (table_row < 0)
+            ? std::wstring_view{ lower_cache_[node_index].text }
+            : std::wstring_view{ lower_cache_[node_index].table_cells[table_row][table_col] };
 
         size_t pos = 0;
         while (matches_.size() < MAX_MATCHES && (pos = lower_text.find(lower_query, pos)) != std::wstring_view::npos) {

--- a/src/ui/search_state.h
+++ b/src/ui/search_state.h
@@ -25,7 +25,7 @@ public:
         current_match_ = -1;
         matches_.clear();
         matches_truncated_ = false;
-        lower_text_buf_ = {};
+        InvalidateLowercaseCache();
     }
     void Reset() noexcept
     {
@@ -33,7 +33,16 @@ public:
         matches_.clear();
         query_.clear();
         matches_truncated_ = false;
-        lower_text_buf_ = {};
+        InvalidateLowercaseCache();
+    }
+
+    // ドキュメントが切り替わった/構造が変わったときに呼ぶ。
+    // 次回 ExecuteSearch 時に lowercase キャッシュが再生成される。
+    void InvalidateLowercaseCache() noexcept
+    {
+        lower_cache_.clear();
+        cached_nodes_ptr_ = nullptr;
+        cached_node_count_ = 0;
     }
 
     const std::pmr::wstring& GetQuery() const noexcept { return query_; }
@@ -53,18 +62,27 @@ public:
     void ExecuteSearch(const std::pmr::vector<Node>& nodes);
     bool NextMatch() noexcept;   // ラップしたらtrueを返す
     bool PrevMatch() noexcept;   // ラップしたらtrueを返す
-
-    // スクロール位置に最も近いマッチを現在マッチとして選択
     void SetCurrentMatchNear(float scroll_y, const LayoutCache& cache) noexcept;
 
 private:
     void FindMatches(std::wstring_view text, const std::pmr::wstring& lower_query, int node_index, int table_row = -1, int table_col = -1);
+    void EnsureLowercaseCache(const std::pmr::vector<Node>& nodes);
 
     static constexpr size_t MAX_MATCHES = 10000;
 
+    // 大文字小文字無視検索の lowercase キャッシュ。
+    // ノード毎に text を lowercase 化した結果を保持する。テーブルノードは
+    // rows[r][c] の2次元配列に格納する（空のノードは空文字列）。
+    struct LowercaseEntry {
+        std::pmr::wstring text;
+        std::pmr::vector<std::pmr::vector<std::pmr::wstring>> table_cells;
+    };
+
     std::pmr::wstring query_;
     std::pmr::vector<SearchMatch> matches_;
-    std::pmr::wstring lower_text_buf_; // 大文字小文字無視検索用の再利用可能バッファ
+    std::pmr::vector<LowercaseEntry> lower_cache_;
+    const Node* cached_nodes_ptr_ = nullptr;
+    size_t cached_node_count_ = 0;
     int current_match_ = -1;
     bool visible_ = false;
     bool case_sensitive_ = false;

--- a/src/ui/toast_notifier.h
+++ b/src/ui/toast_notifier.h
@@ -38,13 +38,8 @@ public:
     }
 
     constexpr bool IsVisible() const noexcept { return alpha_ > 0.0f; }
-
-    // 描画用アルファ値（ホールド期間中は 1.0 にクランプ）
-    float GetRenderAlpha() const noexcept { return std::min(alpha_, 1.0f); }
-
-    // 内部アルファ値（ホールド期間を含む生の値）
+    constexpr float GetRenderAlpha() const noexcept { return std::min(alpha_, 1.0f); }
     constexpr float GetAlpha() const noexcept { return alpha_; }
-
     constexpr std::wstring_view GetMessage() const noexcept { return message_; }
 
 private:

--- a/src/ui/tooltip.h
+++ b/src/ui/tooltip.h
@@ -17,14 +17,8 @@ public:
     Tooltip(Tooltip&&) noexcept;
     Tooltip& operator=(Tooltip&&) noexcept;
 
-    // 親ウィンドウを受け取り、ツールチップを作成する。
     void Init(HWND parent_hwnd);
-
-    // ホバー対象が変わったらタイマーのリセットが必要かを返す。
-    // screen_x / screen_y: マウスのスクリーン座標（ツールチップ表示位置用）。
-    // 戻り値: タイマーを再設定すべきなら true。
     bool Update(const TooltipTarget& target, int screen_x, int screen_y);
-
     void Show();
     void Hide();
     void ApplyDarkMode(bool dark);

--- a/src/util/lru_cache.h
+++ b/src/util/lru_cache.h
@@ -23,8 +23,6 @@ public:
         generations_.reserve(max_entries);
     }
 
-    // キーに対応する値を検索し、見つかった場合はアクセス世代を更新する。
-    // const 版も世代を更新する（mutable）。
     auto* Find(this auto& self, const Key& key)
     {
         for (size_t i = 0; i < self.size_; i++) {
@@ -36,15 +34,11 @@ public:
         return decltype(&self.values_[0]){ nullptr };
     }
 
-    // キーが存在するかチェック（アクセス世代は更新しない）。
-    // 有効エントリは [0, size_) の範囲に限定する（他メソッドと同じ論理サイズ）。
     bool Contains(const Key& key) const
     {
         return std::ranges::contains(keys_ | std::views::take(size_), key);
     }
 
-    // エントリを挿入する。既存キーの場合は値を上書きしてアクセス世代を更新する。
-    // 容量超過時は最も古いエントリを自動的に破棄する。
     void Insert(const Key& key, Value value)
     {
         if (max_entries_ == 0) {

--- a/src/util/task_scheduler.h
+++ b/src/util/task_scheduler.h
@@ -19,13 +19,8 @@ public:
     TaskScheduler(const TaskScheduler&) = delete;
     TaskScheduler& operator=(const TaskScheduler&) = delete;
 
-    // ワーカースレッドを起動する。
     void Init(int thread_count);
-
-    // タスクをキューに追加する。任意のワーカースレッドで実行される。
     void Post(std::move_only_function<void()> task);
-
-    // キューに残っているタスクをすべて処理してからワーカースレッドを終了する。
     void Shutdown();
 
 private:
@@ -35,5 +30,5 @@ private:
     std::queue<std::move_only_function<void()>> queue_;
     std::mutex mutex_;
     std::condition_variable cv_;
-    std::atomic<bool> shutdown_{false};
+    std::atomic<bool> shutdown_{ false };
 };


### PR DESCRIPTION
## Summary

- **TOC アクティブ見出し同期の集約**: OnPaint のたびに毎フレーム計算していた TOC 同期ロジックを `SyncTocActiveAndAutoScroll()` に切り出し、`ScrollTo` / `Dispatch` / `OnResizeEnd` / `OnDeferredLayout` / ファイルロード完了の各フックから必要時のみ呼ぶ形に整理。
- **検索 lowercase キャッシュをドキュメント単位で保持**: 従来は `FindMatches` 内でマッチ判定のたびに対象テキストを lowercase 化していたが、`SearchState::EnsureLowercaseCache` でノード単位（テーブルは行×列）にキャッシュ。`ReplaceFromMarkdown` 後は `InvalidateLowercaseCache` で明示破棄し PMR プール再利用時の偽ヒットを防止。
- **HitTestService を App 直接所有へ**: `AppState` から取り出し `App` のサービスフィールドへ。Copy / Save ボタンヒットテストの重複ループを `HitTestCodeBlockButton` テンプレートヘルパに一本化。`ScreenToPaneDip` はヘッダに inline 移動して呼び出し箇所で統一。
- **`Theme::ApplyZoom` のメンバーポインタ配列化**: スケール対象フィールドを `static constexpr float Theme::* kScalable[]` で一元管理し、新規スケーラブルフィールド追加時のスケール漏れを防止。累積誤差回避のため未使用だった `Renderer::ApplyZoom` を削除し `ApplyZoomFromBase` に統一。
- **コメント整理 & スタイル統一**: 自明・冗長コメントの削除、インデント/改行の統一（62 ファイル、+317 / -619）。

## Test plan

- [x] Release ビルド成功
- [x] `mendo_tests.exe` 1876 件 全 PASS
- [ ] 目次ペイン表示時にスクロール/リサイズ/戻る進むで TOC ハイライトが追従することを実機確認
- [ ] 大きい Markdown（>1MB）で検索バー打鍵時の遅延が改善していることを実機確認
- [ ] コピー / Mermaid 保存ボタンのホバー/クリック判定が従来通り機能すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)