### PR TITLE
検索ジャンプが長い段落内で動かない問題を修正

### DIFF
--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -217,8 +217,8 @@ SearchBarController::Callbacks App::BuildSearchBarCallbacks()
         .get_md_pane_height = [this]() -> float {
             return GetPaneLayout().md_rect.height;
         },
-        .on_scroll_changed = [this](float visible_h) {
-            EmitEffect(effect::SyncMaxScroll{ visible_h });
+        .on_scroll_changed = [this](float md_pane_height) {
+            EmitEffect(effect::SyncMaxScroll{ md_pane_height });
             InvalidateHitPositions();
             // Why: 検索ヒット移動で可視化されたmermaid/画像の描画要求を出す (issue #102)
             resource_manager_.ScheduleBitmapManage();

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -60,29 +60,40 @@ struct NodeLayoutEntry {
     }
     bool has_table_layout() const noexcept { return table_layout != nullptr; }
 
-    // table_row に対応する絶対 Y。行情報が無ければ y_position にフォールバックする。
+    // マッチの絶対 Y とその行の高さを返す。text_layout（テーブルはセル layout）が
+    // あれば text_offset に対応する行 Y を精密に計算し、無ければ
+    // ブロック先頭/テーブル行先頭の座標にフォールバックする。
+    // Why: 長い段落内の複数マッチで同じブロック先頭 Y に丸まると「次へ」でスクロールしない。
     // row_cum_y は row_count+1 要素（末尾は合計高さ）なので、行として有効なのは [0, row_heights.size()) のみ。
-    float GetTableRowY(int table_row) const noexcept
+    std::pair<float, float> GetMatchYRange(int table_row, int table_col, uint32_t text_offset) const noexcept
     {
+        IDWriteTextLayout* layout = nullptr;
+        float base_y = y_position;
+        float fallback_h = height;
+
         if (table_row >= 0 && has_table_layout()) {
             const auto row = static_cast<size_t>(table_row);
             if (row < table_layout->row_heights.size() && row < table_layout->row_cum_y.size()) {
-                return y_position + table_layout->row_cum_y[row];
+                base_y = y_position + table_layout->row_cum_y[row];
+                fallback_h = table_layout->row_heights[row];
+            }
+            if (table_col >= 0) {
+                layout = table_layout->GetCellLayout(row, static_cast<size_t>(table_col));
             }
         }
-        return y_position;
-    }
+        else {
+            layout = text_layout.Get();
+        }
 
-    // table_row の高さ。行情報が無ければエントリ全体の高さにフォールバックする。
-    float GetTableRowHeight(int table_row) const noexcept
-    {
-        if (table_row >= 0 && has_table_layout()) {
-            const auto row = static_cast<size_t>(table_row);
-            if (row < table_layout->row_heights.size()) {
-                return table_layout->row_heights[row];
+        if (layout != nullptr) {
+            FLOAT px = 0.0f, py = 0.0f;
+            DWRITE_HIT_TEST_METRICS htm{};
+            if (SUCCEEDED(layout->HitTestTextPosition(text_offset, FALSE, &px, &py, &htm))) {
+                const float line_h = (htm.height > 0.0f) ? htm.height : fallback_h;
+                return { base_y + py, line_h };
             }
         }
-        return height;
+        return { base_y, fallback_h };
     }
 };
 

--- a/src/ui/search_bar_controller.cpp
+++ b/src/ui/search_bar_controller.cpp
@@ -181,9 +181,9 @@ void SearchBarController::ScrollToCurrentMatch()
     }
 
     const auto& entry = (*cache_)[match.node_index];
-    // Why: 長いテーブルがウィンドウより縦長の場合、ブロック先頭に合わせるとヒット行が画面外になる (issue #97)
-    const float match_y = entry.GetTableRowY(match.table_row);
-    const float match_h = entry.GetTableRowHeight(match.table_row);
+    // Why: ブロック先頭/行先頭に丸めると、長い段落内の複数マッチ間で同じ Y に集約され
+    //      「次へ」を押してもスクロールしない。match.start を使って行単位の Y を出す。
+    const auto [match_y, match_h] = entry.GetMatchYRange(match.table_row, match.table_col, match.start);
     const float md_pane_height = cb_.get_md_pane_height();
     const float visible_height = md_pane_height
         - (state_->IsVisible() ? SEARCH_BAR_HEIGHT : 0.0f);
@@ -193,8 +193,11 @@ void SearchBarController::ScrollToCurrentMatch()
     // マッチが可視範囲外の場合のみスクロール
     if (match_y < scroll_y || match_y + match_h > effective_bottom) {
         const float target = std::max(0.0f, match_y - visible_height / 3.0f);
-        viewport_->SetScrollY(target);
-        cb_.on_scroll_changed(visible_height);
+        // Why: ScrollTo は scroll_target_ を無効化してくれる。SetScrollY のままだと、
+        //      直後のレイアウト変化 (Mermaid 読込等) で古い scroll_target から再計算されて
+        //      検索ジャンプが上書きされる恐れがある。
+        viewport_->ScrollTo(target);
+        cb_.on_scroll_changed(md_pane_height);
     }
 }
 

--- a/src/ui/search_bar_controller.h
+++ b/src/ui/search_bar_controller.h
@@ -27,7 +27,7 @@ public:
         std::move_only_function<void(int, int)> focus_set_selection; // anchor,caret指定でフォーカス
         std::move_only_function<void()> unfocus;                     // フォーカス解除
         std::move_only_function<float()> get_md_pane_height;         // Markdownペイン高さ取得
-        std::move_only_function<void(float)> on_scroll_changed;      // スクロール変更後処理(visible_h)
+        std::move_only_function<void(float)> on_scroll_changed;      // スクロール変更後処理(md_pane_height)
     };
 
     // タイマーID（App::HandleTimerでのルーティング用）

--- a/src/ui/search_state.cpp
+++ b/src/ui/search_state.cpp
@@ -166,11 +166,16 @@ void SearchState::SetCurrentMatchNear(float scroll_y, const LayoutCache& cache) 
         return;
     }
 
-    // matches_ は node_index 昇順、同一テーブル内では (row, col) 昇順で追加されるため
-    // GetTableRowY(m.table_row) も単調非減少となり二分探索が使える (issue #97)。
+    // matches_ は node_index 昇順、同一ノード内では start 昇順、同一テーブル内では
+    // (row, col, start) 昇順で追加される。GetMatchYRange も同じ順序で単調非減少となるため
+    // 二分探索が使える (issue #97, 検索ジャンプ精度向上)。
     const auto it = std::ranges::partition_point(matches_, [&](const SearchMatch& m) noexcept {
-        return m.node_index >= static_cast<int>(cache.size())
-            || cache[m.node_index].GetTableRowY(m.table_row) < scroll_y;
+        if (m.node_index >= static_cast<int>(cache.size())) {
+            return true;
+        }
+        const auto [y, h] = cache[m.node_index].GetMatchYRange(m.table_row, m.table_col, m.start);
+        (void)h;
+        return y < scroll_y;
     });
     current_match_ = (it != matches_.end()) ? static_cast<int>(it - matches_.begin()) : 0;
 }

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -5,8 +5,36 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <utility>
 #include <windows.h>
+#include "document_types.h"
 #include "layout_cache.h"
+
+// テキスト持ちの Paragraph ノードを作るテスト用ヘルパー。
+inline Node MakeTextNode(const wchar_t* text)
+{
+    Node n;
+    n.type = NodeType::Paragraph;
+    n.SetText(text);
+    return n;
+}
+
+// 1行2列のテーブルノードを作るテスト用ヘルパー。
+inline Node MakeTableNode(const wchar_t* cell0, const wchar_t* cell1)
+{
+    Node n;
+    n.type = NodeType::Table;
+    n.ensure_table();
+    TableRow row;
+    TableCell c0;
+    c0.text.assign(cell0);
+    row.cells.push_back(std::move(c0));
+    TableCell c1;
+    c1.text.assign(cell1);
+    row.cells.push_back(std::move(c1));
+    n.table_data->rows.push_back(std::move(row));
+    return n;
+}
 
 // 等間隔ノードの LayoutCache を構築するテスト用ヘルパー。
 // 複数テストファイルで共通して使用される。

--- a/tests/test_search_bar_controller.cpp
+++ b/tests/test_search_bar_controller.cpp
@@ -4,6 +4,7 @@
 #include "viewport_manager.h"
 #include "layout_cache.h"
 #include "renderer.h"
+#include "test_helpers.h"
 
 // コールバック呼び出しを記録するテストフィクスチャ
 class SearchBarControllerTest : public ::testing::Test {
@@ -34,17 +35,12 @@ protected:
                 last_sel_caret_ = c;
             },
             .unfocus = [this]() { unfocus_count_++; },
-            .get_md_pane_height = []() -> float { return 800.0f; },
-            .on_scroll_changed = [](float) {},
+            .get_md_pane_height = [this]() -> float { return md_pane_height_; },
+            .on_scroll_changed = [this](float v) {
+                last_scroll_changed_value_ = v;
+                on_scroll_changed_count_++;
+            },
         };
-    }
-
-    Node MakeTextNode(const wchar_t* text)
-    {
-        Node n;
-        n.type = NodeType::Paragraph;
-        n.SetText(text);
-        return n;
     }
 
     SearchState state_;
@@ -64,6 +60,9 @@ protected:
     int last_caret_pos_ = -1;
     int last_sel_anchor_ = -1;
     int last_sel_caret_ = -1;
+    float md_pane_height_ = 800.0f;
+    float last_scroll_changed_value_ = -1.0f;
+    int on_scroll_changed_count_ = 0;
 };
 
 // ═══════════════════════════════════════════════
@@ -310,4 +309,124 @@ TEST_F(SearchBarControllerTest, BuildRenderStateReflectsState)
     EXPECT_TRUE(rs.has_focus);
     const int matches = rs.total_matches;
     EXPECT_GE(matches, 1);
+}
+
+// ═══════════════════════════════════════════════
+// ScrollToCurrentMatch の挙動
+// ═══════════════════════════════════════════════
+
+// scroll_target_ がジャンプでクリアされることを保証する。
+// Why: クリアされないと後続の ApplyScrollTarget で検索ジャンプが上書きされる (検索ジャンプ修正)。
+TEST_F(SearchBarControllerTest, ScrollToMatchClearsScrollTarget)
+{
+    std::pmr::vector<Node> nodes;
+    nodes.push_back(MakeTextNode(L"hello"));
+    nodes.push_back(MakeTextNode(L"world hello"));
+
+    cache_.Resize(2);
+    cache_[0].y_position = 0.0f;
+    cache_[0].height = 500.0f;
+    cache_[1].y_position = 500.0f;
+    cache_[1].height = 500.0f;
+
+    viewport_.SyncMaxScroll(1000.0f, 800.0f);
+    viewport_.SetScrollTarget(0, 0.0f);
+    EXPECT_TRUE(viewport_.HasScrollTarget());
+
+    state_.Show();
+    ctrl_.OnTextChanged(L"hello", nodes);
+    ctrl_.OnNext();
+
+    EXPECT_FALSE(viewport_.HasScrollTarget());
+}
+
+// on_scroll_changed には md_rect 全体の高さを渡す。SEARCH_BAR_HEIGHT を引いた値を渡すと
+// 他箇所（SyncMaxScroll）との viewport_height の意味論がブレる。
+TEST_F(SearchBarControllerTest, ScrollToMatchPassesMdPaneHeightToCallback)
+{
+    std::pmr::vector<Node> nodes;
+    nodes.push_back(MakeTextNode(L"a"));
+    nodes.push_back(MakeTextNode(L"target"));
+
+    cache_.Resize(2);
+    cache_[0].y_position = 0.0f;
+    cache_[0].height = 1000.0f;
+    cache_[1].y_position = 1000.0f;
+    cache_[1].height = 1000.0f;
+
+    viewport_.SyncMaxScroll(2000.0f, md_pane_height_);
+    state_.Show();
+    ctrl_.OnTextChanged(L"target", nodes);
+    on_scroll_changed_count_ = 0;
+    last_scroll_changed_value_ = -1.0f;
+    ctrl_.OnNext();
+
+    ASSERT_GE(on_scroll_changed_count_, 1);
+    EXPECT_FLOAT_EQ(last_scroll_changed_value_, md_pane_height_);
+}
+
+// 同一ノード内でテーブル複数行のマッチを連続で「次へ」したとき、行ごとに scroll_y が進むこと。
+// Why: 行毎の精密な Y が使われず block 先頭に丸まると、複数マッチ間でスクロールが進まない。
+TEST_F(SearchBarControllerTest, NextMatchAcrossTableRowsAdvancesScroll)
+{
+    Node table;
+    table.type = NodeType::Table;
+    table.ensure_table();
+    for (int r = 0; r < 5; r++) {
+        TableRow row;
+        TableCell c;
+        c.text.assign(L"hit");
+        row.cells.push_back(std::move(c));
+        table.table_data->rows.push_back(std::move(row));
+    }
+    std::pmr::vector<Node> nodes;
+    nodes.push_back(std::move(table));
+
+    cache_.Resize(1);
+    cache_[0].y_position = 0.0f;
+    cache_[0].height = 2000.0f;
+    auto& tl = cache_[0].ensure_table_layout();
+    tl.col_count = 1;
+    tl.row_heights = {400.0f, 400.0f, 400.0f, 400.0f, 400.0f};
+    tl.row_cum_y = {0.0f, 400.0f, 800.0f, 1200.0f, 1600.0f, 2000.0f};
+
+    md_pane_height_ = 600.0f;
+    viewport_.SyncMaxScroll(2000.0f, md_pane_height_);
+
+    state_.Show();
+    ctrl_.OnTextChanged(L"hit", nodes);
+
+    float prev_scroll = viewport_.GetScrollY();
+    int advanced = 0;
+    for (int i = 0; i < 4; i++) {
+        ctrl_.OnNext();
+        const float now = viewport_.GetScrollY();
+        if (now > prev_scroll) {
+            advanced++;
+        }
+        prev_scroll = now;
+    }
+    EXPECT_GE(advanced, 1)
+        << "行ごとに異なる Y に到達でき、最低1回はスクロールが進むこと";
+}
+
+// 現在位置が既に可視範囲内ならスクロールしない（余計な再描画を避ける）。
+TEST_F(SearchBarControllerTest, ScrollToMatchNoOpWhenAlreadyVisible)
+{
+    std::pmr::vector<Node> nodes;
+    nodes.push_back(MakeTextNode(L"hello"));
+
+    cache_.Resize(1);
+    cache_[0].y_position = 100.0f;
+    cache_[0].height = 50.0f;
+
+    viewport_.SyncMaxScroll(1000.0f, md_pane_height_);
+    state_.Show();
+    ctrl_.OnTextChanged(L"hello", nodes);
+
+    on_scroll_changed_count_ = 0;
+    const float before = viewport_.GetScrollY();
+    ctrl_.OnNext();
+    EXPECT_FLOAT_EQ(viewport_.GetScrollY(), before);
+    EXPECT_EQ(on_scroll_changed_count_, 0);
 }

--- a/tests/test_search_state.cpp
+++ b/tests/test_search_state.cpp
@@ -3,32 +3,6 @@
 #include "test_helpers.h"
 #include <memory_resource>
 
-// ヘルパー: テキストを持つ単純なNodeを作成
-static Node MakeTextNode(const wchar_t* text)
-{
-    Node n;
-    n.type = NodeType::Paragraph;
-    n.SetText(text);
-    return n;
-}
-
-// ヘルパー: テーブルノードを作成（1行2列）
-static Node MakeTableNode(const wchar_t* cell0, const wchar_t* cell1)
-{
-    Node n;
-    n.type = NodeType::Table;
-    n.ensure_table();
-    TableRow row;
-    TableCell c0;
-    c0.text.assign(cell0);
-    row.cells.push_back(std::move(c0));
-    TableCell c1;
-    c1.text.assign(cell1);
-    row.cells.push_back(std::move(c1));
-    n.table_data->rows.push_back(std::move(row));
-    return n;
-}
-
 // ═══════════════════════════════════════════════
 // 表示/非表示の基本操作
 // ═══════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- `NodeLayoutEntry::GetMatchYRange` を新設し、`match.start` を使った行単位の Y を `HitTestTextPosition` で取得。長い段落内の複数マッチで Y がブロック先頭に丸まって「次へ」でスクロールしない根本原因を解消
- `SetScrollY` → `ScrollTo` に置換し、検索ジャンプ後に `scroll_target_` を無効化。Mermaid 読込等でレイアウト変化が走ったときにジャンプ位置が古い target から上書きされる副因を解消
- `on_scroll_changed` の引数を `md_pane_height` に統一し、他 7 箇所の `SyncMaxScroll` と viewport_height の意味論を揃えた

## 変更内容

### 根本原因（主因）

`ScrollToCurrentMatch` が `match.start`（ノード内テキストオフセット）を無視して `GetTableRowY(match.table_row)` / `GetTableRowHeight(match.table_row)` のみでスクロール判定・目的地計算を行っていた。普通のテキストノード（段落・見出し・コードブロック・リスト）では `table_row = -1` のため、**全マッチが同じノード先頭 Y に解決される**。

結果：

- 同一ノード内の複数マッチを「次へ」で回しても、match_y が変わらない → 可視判定が同じ結果 → `SetScrollY` が呼ばれずスクロールしない
- ノード先頭が可視なら「画面内」と判定され、マッチ自体がスクロール外でも動かない

### 副次的な問題

- `SetScrollY` は「max_scroll 未確定時のシード投入用」の低レベル API で、`scroll_target_` を無効化しない。検索ジャンプ直後のレイアウト変化で `ApplyScrollTarget` が走ると古い target で再計算され、ジャンプが上書きされる可能性
- `on_scroll_changed(visible_height = md_pane_height - SEARCH_BAR_HEIGHT)` だけ他 7 箇所 (`md_rect.height`) と不整合で、`SyncMaxScroll` の `viewport_height` の意味が経路によってズレていた

### 修正

| ファイル | 変更 |
|---|---|
| `src/layout/layout_cache.h` | `GetMatchYRange(table_row, table_col, text_offset)` を新設し、`IDWriteTextLayout::HitTestTextPosition` で精密な行 Y を返す。失敗時はブロック/行先頭にフォールバック。dead code となった `GetTableRowY` / `GetTableRowHeight` を削除して境界チェック重複も解消 |
| `src/ui/search_bar_controller.cpp` | `ScrollToCurrentMatch` を `GetMatchYRange` + `ScrollTo` + `on_scroll_changed(md_pane_height)` に変更 |
| `src/ui/search_state.cpp` | `SetCurrentMatchNear` の二分探索コールバックも `GetMatchYRange` ベースへ移行 |
| `tests/test_helpers.h` | `MakeTextNode` / `MakeTableNode` を集約（2ファイルで重複していた定義を排除） |
| `tests/test_search_bar_controller.cpp` | 検索ジャンプ挙動の回帰テスト 4 件追加 |

### 追加したテスト

- `ScrollToMatchClearsScrollTarget`: ジャンプ後に `scroll_target_` が無効化されること
- `ScrollToMatchPassesMdPaneHeightToCallback`: `on_scroll_changed` に `md_pane_height` が渡ること
- `NextMatchAcrossTableRowsAdvancesScroll`: テーブル複数行のマッチを連続で「次へ」したときに行ごとに scroll_y が進むこと
- `ScrollToMatchNoOpWhenAlreadyVisible`: 既に可視なら no-op であること

## Test plan

- [x] `cmake --build build --config Release` で正常ビルド
- [x] `build/tests/Release/mendo_tests.exe --gtest_brief=1` で全 1890 テスト PASS
- [ ] `example/test.md` を開き、長い段落内の同一単語を検索して「次へ」で順次ジャンプできることを確認
- [ ] 同じく画面外の見出し・テーブルセル・コードブロック内のマッチへジャンプ後、Mermaid レンダリング完了で位置が巻き戻らないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)