### PR TITLE
スクロール状態でヘルプを開くと真っ白になる問題を修正 (#128)

### DIFF
--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -36,6 +36,10 @@ void App::LoadHelpDocument()
     state_.file_explorer.SetCurrentFile(L"");
 
     // ビューポート優先レイアウト + 遅延処理
+    // 旧ドキュメントで合成された scroll_target は直後の ViewportLayout →
+    // ApplyScrollTarget で旧ノード位置から scroll_y を再評価してしまうため、
+    // SetScrollY(0) より前に破棄する必要がある。
+    state_.view.viewport.ClearScrollTarget();
     state_.view.viewport.SetScrollY(0.0f);
     {
         const auto pane_layout = GetPaneLayout();


### PR DESCRIPTION
## Summary
- `LoadHelpDocument` で `SetScrollY(0.0f)` の前に `ClearScrollTarget()` を呼び、旧ドキュメントで合成された `scroll_target_` の残留を防ぐ
- これにより直後の `ViewportLayout` → `ApplyScrollTarget` が旧ノード位置で `scroll_y` を再計算し、ヘルプが空白で表示される不具合 (#128) を解消
- 通常ファイルロード経路の `ReduceRestoreScrollAfterLoad` (reducer.cpp:727) や `FinishReload` (app_file.cpp:370) と同じパターンに揃えた

## Test plan
- [x] `cmake --build build --config Release` ビルド成功
- [x] `mendo_tests.exe` 1890テスト全PASS
- [x] md ファイルをページ末尾までスクロール → F1 でヘルプを開いたとき、ヘルプ先頭が表示されることを確認
- [x] ヘルプを開いた後、元ファイルに戻ってもスクロール復元に副作用がないことを確認

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)