### PR TITLE
検索ハイライトのHitTest結果をキャッシュ & IStreamヘルパ集約

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -195,10 +195,12 @@ void App::OnPaint()
     else {
         // 検索マッチ情報をコマンドジェネレータに設定
         if (state_.search.search_state.IsVisible() && state_.search.search_state.IsHighlightEnabled() && !state_.search.search_state.GetMatches().empty()) {
-            renderer_.SetSearchMatches(&state_.search.search_state.GetMatches(), state_.search.search_state.GetCurrentMatchIndex());
+            renderer_.SetSearchMatches(&state_.search.search_state.GetMatches(),
+                state_.search.search_state.GetCurrentMatchIndex(),
+                state_.search.search_state.GetGeneration());
         }
         else {
-            renderer_.SetSearchMatches(nullptr, -1);
+            renderer_.SetSearchMatches(nullptr, -1, 0);
         }
 
         // 描画前パス: 可視ノードに描画エフェクトを適用（Render の前に実行）

--- a/src/app/resource_manager.cpp
+++ b/src/app/resource_manager.cpp
@@ -113,22 +113,24 @@ int ResourceManager::ApplyCachedImages()
             continue;
         }
 
-        // 解決済みパスのキャッシュを確認し、ディスクI/Oを回避
+        // 解決済みパスのキャッシュを確認し、再計算を回避
         auto [path_it, inserted] = resolved_image_paths_.try_emplace(i);
         auto& abs_str = std::get<1>(*path_it);
         if (inserted) {
+            // canonical() は symlink 解決のためにファイルシステムを叩くので、
+            // UI 同期パスから外すため absolute() + lexically_normal() を使う。
+            // 画像参照が symlink を跨ぐのはレアケースとして許容する。
             std::filesystem::path img_path(node.image_data->src);
             if (img_path.is_relative()) {
                 img_path = std::filesystem::path(doc_dir) / img_path;
             }
-
             std::error_code ec;
-            const auto abs_path = std::filesystem::canonical(img_path, ec);
+            auto abs_path = std::filesystem::absolute(img_path, ec);
             if (ec) {
                 resolved_image_paths_.erase(i);
                 continue;
             }
-            abs_str = abs_path.wstring();
+            abs_str = abs_path.lexically_normal().wstring();
         }
 
         if (image_loader_->GetCachedImage(abs_str, diagram)) {
@@ -378,6 +380,7 @@ void ResourceManager::EvictOffscreenBitmaps()
         entry.inline_code_bgs.clear();
         entry.table_layout.reset();
         entry.layout_dirty = true;
+        entry.invalidate_search_hl_cache();
     };
 
     for (size_t i = 0; i < static_cast<size_t>(first_keep); i++) {

--- a/src/io/image_loader.cpp
+++ b/src/io/image_loader.cpp
@@ -1,6 +1,7 @@
 #include "image_loader.h"
 #include "file_io.h"
 #include "file_loader.h"
+#include "stream_util.h"
 #include "task_scheduler.h"
 #include "ui_constants.h"
 #include "wic_util.h"
@@ -18,30 +19,7 @@ static Microsoft::WRL::ComPtr<IStream> ReadFileToStream(const std::wstring& path
         return nullptr;
     }
 
-    const auto alloc_size = static_cast<SIZE_T>(r.size);
-    UniqueGlobalMem hMem{ GlobalAlloc(GMEM_MOVEABLE, alloc_size) };
-    if (!hMem) {
-        return nullptr;
-    }
-
-    void* ptr = GlobalLock(hMem.get());
-    if (!ptr) {
-        return nullptr;
-    }
-    DWORD bytesRead = 0;
-    const BOOL ok = ReadFile(r.handle.get(), ptr, static_cast<DWORD>(alloc_size), &bytesRead, nullptr);
-    GlobalUnlock(hMem.get());
-
-    if (!ok || bytesRead != alloc_size) {
-        return nullptr;
-    }
-
-    Microsoft::WRL::ComPtr<IStream> stream;
-    if (FAILED(CreateStreamOnHGlobal(hMem.get(), TRUE, &stream))) {
-        return nullptr;
-    }
-    hMem.release();
-    return stream;
+    return stream_util::CreateMemoryStreamFromFile(r.handle.get(), r.size);
 }
 
 

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -254,6 +254,7 @@ void DWriteTextMeasurer::MeasureNode(Node& node, NodeLayoutEntry& entry, float m
     entry.layout_dirty = false;
     entry.effects_applied = false;
     entry.inline_code_bgs.clear();
+    entry.invalidate_search_hl_cache();
 }
 
 void DWriteTextMeasurer::MeasureTableCells(Node& node, NodeLayoutEntry& entry, std::pmr::vector<float>& natural_widths)
@@ -410,6 +411,10 @@ void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float 
         entry.layout_dirty = false;
         return;
     }
+
+    // セル layout の再作成 or SetMaxWidth で metrics が変わるため、
+    // 検索ハイライト矩形のキャッシュは捨てる。
+    entry.invalidate_search_hl_cache();
 
     entry.effects_applied = false;
     auto& tl = entry.ensure_table_layout();

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -51,6 +51,22 @@ struct NodeLayoutEntry {
     std::pmr::vector<InlineCodeBg> inline_code_bgs;
     std::unique_ptr<TableLayoutData> table_layout; // テーブルのみ確保
 
+    // 検索ハイライト矩形のフレーム間キャッシュ。描画中に書き換える計算結果のため mutable。
+    // SearchState の generation と一致する間は HitTestTextRange を再計算せずに使い回す。
+    // text_layout / cell_layouts が再構築されたら invalidate_search_hl_cache() で破棄する。
+    // rects は layout 相対座標。match i (ノード内順) に対応する矩形は
+    // rects[rect_ends[i-1] ... rect_ends[i]) (i=0 なら先頭から rect_ends[0] まで)。
+    mutable uint32_t search_hl_gen = 0;
+    mutable std::pmr::vector<D2D1_RECT_F> search_hl_rects;
+    mutable std::pmr::vector<uint32_t> search_hl_rect_ends;
+
+    void invalidate_search_hl_cache() const noexcept
+    {
+        search_hl_gen = 0;
+        search_hl_rects.clear();
+        search_hl_rect_ends.clear();
+    }
+
     TableLayoutData& ensure_table_layout()
     {
         if (!table_layout) {
@@ -181,6 +197,7 @@ public:
             e.text_layout.Reset();
             e.effects_applied = false;
             e.inline_code_bgs.clear();
+            e.invalidate_search_hl_cache();
             if (e.table_layout) {
                 e.table_layout->cell_layouts.clear();
                 e.table_layout->cell_inline_code_bgs.clear();
@@ -220,6 +237,7 @@ public:
         for (auto& e : entries_) {
             e.layout_dirty = true;
             e.text_layout.Reset();
+            e.invalidate_search_hl_cache();
             if (e.table_layout) {
                 e.table_layout->cell_layouts.clear();
                 e.table_layout->row_bgs_computed.clear();

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -2,6 +2,7 @@
 #include "config_store.h"
 #include "mermaid_file_cache.h"
 #include "mermaid_util.h"
+#include "stream_util.h"
 #include "utility.h"
 #include "wic_util.h"
 #include "resource.h"
@@ -10,47 +11,6 @@
 #include <functional>
 
 #pragma comment(lib, "windowscodecs.lib")
-
-static std::vector<uint8_t> ReadAllStreamBytes(IStream* stream)
-{
-    if (!stream) {
-        return {};
-    }
-
-    STATSTG stat{};
-    if (FAILED(stream->Stat(&stat, STATFLAG_NONAME))) {
-        return {};
-    }
-
-    const auto size = static_cast<size_t>(stat.cbSize.QuadPart);
-    if (size == 0) {
-        return {};
-    }
-
-    const LARGE_INTEGER zero{};
-    stream->Seek(zero, STREAM_SEEK_SET, nullptr);
-
-    std::vector<uint8_t> data(size);
-    ULONG read = 0;
-    stream->Read(data.data(), static_cast<ULONG>(size), &read);
-    data.resize(read);
-    return data;
-}
-
-static Microsoft::WRL::ComPtr<IStream> CreateMemoryStream(const void* data, size_t size)
-{
-    Microsoft::WRL::ComPtr<IStream> stream;
-    if (FAILED(CreateStreamOnHGlobal(nullptr, TRUE, &stream)) || !stream) {
-        return nullptr;
-    }
-    if (size > 0 && data) {
-        ULONG written = 0;
-        stream->Write(data, static_cast<ULONG>(size), &written);
-        const LARGE_INTEGER zero{};
-        stream->Seek(zero, STREAM_SEEK_SET, nullptr);
-    }
-    return stream;
-}
 
 static std::pmr::wstring GetWebView2UserDataFolder()
 {
@@ -219,7 +179,10 @@ void MermaidRenderer::SetupWorker(int index)
 
         auto& w = workers_[index];
         w.controller = controller;
-        controller->get_CoreWebView2(&w.webview);
+        if (FAILED(controller->get_CoreWebView2(&w.webview)) || !w.webview) {
+            w.controller.Reset();
+            return S_OK;
+        }
 
         const RECT bounds = { 0, 0, 4096, 4096 };
         controller->put_Bounds(bounds);
@@ -361,7 +324,7 @@ void MermaidRenderer::SetupWorker(int index)
                 return S_OK;
             }
 
-            const auto stream = CreateMemoryStream(payload.data(), payload.size());
+            const auto stream = stream_util::CreateMemoryStream(payload.data(), payload.size());
             if (stream) {
                 Microsoft::WRL::ComPtr<ICoreWebView2WebResourceResponse> response;
                 webview_env_->CreateWebResourceResponse(stream.Get(), 200, L"OK", headers, &response);
@@ -435,7 +398,7 @@ void MermaidRenderer::RequestRender(Node& node, NodeLayoutEntry& layout_entry,
         MermaidFileCache::CacheEntry fentry;
         MermaidFileCache::PngBlob png;
         if (file_cache_->Lookup(hash, fentry, png)) {
-            auto stream = CreateMemoryStream(png.data.get(), png.size);
+            auto stream = stream_util::CreateMemoryStream(png.data.get(), png.size);
             if (stream) {
                 Microsoft::WRL::ComPtr<ID2D1Bitmap> bitmap;
                 float bw = 0, bh = 0;
@@ -627,8 +590,11 @@ void MermaidRenderer::DoCapturePreview(int worker_idx)
     // CapturePreviewコールバックでもリクエストIDを照合し、
     // CancelPending後に到着した古いキャプチャ結果を無視する
     const unsigned int req_id = w.current_request.request_id;
-    Microsoft::WRL::ComPtr<IStream> pngStream;
-    CreateStreamOnHGlobal(nullptr, TRUE, &pngStream);
+    auto pngStream = stream_util::CreateMemoryStream(nullptr, 0);
+    if (!pngStream) {
+        FinishWorkerRequest(w);
+        return;
+    }
 
     const HRESULT hr = w.webview->CapturePreview(
         COREWEBVIEW2_CAPTURE_PREVIEW_IMAGE_FORMAT_PNG,
@@ -685,7 +651,7 @@ void MermaidRenderer::OnCaptureComplete(int worker_idx, uint64_t code_hash, IStr
 
         if (file_cache_ && w.current_request.node) {
             const uint64_t fkey = mermaid_util::NodeDiagramHash(*w.current_request.node, w.current_request.max_width, w.current_request.dark_mode);
-            auto png_bytes = ReadAllStreamBytes(png_stream);
+            auto png_bytes = stream_util::ReadAllBytes(png_stream);
             if (!png_bytes.empty()) {
                 file_cache_->StoreAsync(fkey, draw_w, draw_h, std::move(png_bytes));
             }

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -10,6 +10,16 @@
 // 値を小さくすると下線は見出し文字に近づき、下線と次行の間隔が広がる。
 static constexpr float HEADING_UNDERLINE_OFFSET_RATIO = 0.25f;
 
+// DWRITE_HIT_TEST_METRICS を origin 加算付きの D2D1_RECT_F に変換する。
+static inline D2D1_RECT_F RectFromHitTest(const DWRITE_HIT_TEST_METRICS& m, float origin_x = 0.0f, float origin_y = 0.0f) noexcept
+{
+    return D2D1::RectF(
+        origin_x + m.left,
+        origin_y + m.top,
+        origin_x + m.left + m.width,
+        origin_y + m.top + m.height);
+}
+
 static float GetFirstLineHeight(IDWriteTextLayout* layout, float font_size)
 {
     float h = font_size * FALLBACK_LINE_HEIGHT_FACTOR;
@@ -185,7 +195,7 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
     GenInlineCodeBgs(cmds, entry.inline_code_bgs, text_x, entry.y_position, theme_->code_bg_color);
 
     // 検索マッチのハイライト（選択より先に描画し、選択が最前面になるようにする）
-    GenSearchHighlights(cmds, entry.text_layout.Get(), node_index, text_x, entry.y_position);
+    GenSearchHighlights(cmds, entry, node_index, text_x, entry.y_position);
 
     // 選択範囲のハイライト
     const auto& selection = *frame_selection_;
@@ -435,13 +445,7 @@ void CommandGenerator::EmitHighlightRects(DrawCommandList& cmds,
     auto& buf = GetHitTestBuffer();
     const UINT32 count = FetchHitTestMetrics(layout, start, length, buf);
     for (UINT32 i = 0; i < count; i++) {
-        cmds.emplace_back(FillRectCmd{
-            D2D1::RectF(
-                origin_x + buf[i].left,
-                origin_y + buf[i].top,
-                origin_x + buf[i].left + buf[i].width,
-                origin_y + buf[i].top + buf[i].height
-            ), color });
+        cmds.emplace_back(FillRectCmd{ RectFromHitTest(buf[i], origin_x, origin_y), color });
     }
 }
 
@@ -450,30 +454,83 @@ void CommandGenerator::GenSelectionHighlight(DrawCommandList& cmds, IDWriteTextL
     EmitHighlightRects(cmds, layout, start, length, origin_x, origin_y, SELECTION_COLOR);
 }
 
-void CommandGenerator::GenSearchHighlights(DrawCommandList& cmds, IDWriteTextLayout* layout, int node_index, float origin_x, float origin_y, int table_row, int table_col)
+void CommandGenerator::GenSearchHighlights(DrawCommandList& cmds, const NodeLayoutEntry& entry, int node_index, float origin_x, float origin_y, int table_row, int table_col)
 {
-    if (!layout || !search_matches_ || search_matches_->empty()) {
+    if (!search_matches_ || search_matches_->empty()) {
         return;
     }
 
     const auto& matches = *search_matches_;
     auto it = std::ranges::lower_bound(matches, node_index, {}, &SearchMatch::node_index);
-    for (int mi = static_cast<int>(it - matches.begin()); mi < static_cast<int>(matches.size()); mi++) {
+    const size_t first_global = static_cast<size_t>(it - matches.begin());
+    if (first_global >= matches.size() || matches[first_global].node_index != node_index) {
+        return;
+    }
+
+    // キャッシュミス時のみ HitTestTextRange を一括発行。layout 変更時は
+    // invalidate_search_hl_cache() で search_hl_gen=0 にされており、SearchState の
+    // generation は 1 から始まるため、entry.search_hl_gen == search_generation_ のみで
+    // キャッシュ有効性を完全判定できる。
+    if (entry.search_hl_gen != search_generation_) {
+        size_t node_match_count = 0;
+        for (size_t mi = first_global; mi < matches.size(); ++mi) {
+            if (matches[mi].node_index != node_index) {
+                break;
+            }
+            ++node_match_count;
+        }
+
+        entry.search_hl_rects.clear();
+        entry.search_hl_rect_ends.clear();
+        entry.search_hl_rect_ends.reserve(node_match_count);
+
+        auto& buf = GetHitTestBuffer();
+        for (size_t mi = first_global; mi < first_global + node_match_count; ++mi) {
+            const auto& m = matches[mi];
+            IDWriteTextLayout* l = nullptr;
+            if (m.table_row >= 0 && entry.has_table_layout()) {
+                l = entry.table_layout->GetCellLayout(static_cast<size_t>(m.table_row), static_cast<size_t>(m.table_col));
+            }
+            else if (m.table_row < 0) {
+                l = entry.text_layout.Get();
+            }
+            if (l && m.length > 0) {
+                const UINT32 count = FetchHitTestMetrics(l, m.start, m.length, buf);
+                for (UINT32 k = 0; k < count; ++k) {
+                    entry.search_hl_rects.emplace_back(RectFromHitTest(buf[k]));
+                }
+            }
+            entry.search_hl_rect_ends.push_back(static_cast<uint32_t>(entry.search_hl_rects.size()));
+        }
+        entry.search_hl_gen = search_generation_;
+    }
+
+    // キャッシュ済みの矩形を origin 加算してコマンド化する。
+    // 呼び出し側（セル/ノード本体）に属する match のみ描画する。
+    const size_t node_match_count = entry.search_hl_rect_ends.size();
+    for (size_t node_mi = 0; node_mi < node_match_count; ++node_mi) {
+        const size_t mi = first_global + node_mi;
         const auto& m = matches[mi];
-        if (m.node_index > node_index) {
-            break;
-        }
-        if (table_row >= 0 && (m.table_row != table_row || m.table_col != table_col)) {
-            continue;
-        }
-        if (table_row < 0 && m.table_row >= 0) {
+        const bool is_here = (table_row >= 0)
+            ? (m.table_row == table_row && m.table_col == table_col)
+            : (m.table_row < 0);
+        if (!is_here) {
             continue;
         }
 
-        const D2D1_COLOR_F color = (mi == current_match_index_)
+        const uint32_t rb = (node_mi == 0) ? 0 : entry.search_hl_rect_ends[node_mi - 1];
+        const uint32_t re = entry.search_hl_rect_ends[node_mi];
+
+        const D2D1_COLOR_F color = (static_cast<int>(mi) == current_match_index_)
             ? theme_->search_highlight_current_color
             : theme_->search_highlight_color;
-        EmitHighlightRects(cmds, layout, m.start, m.length, origin_x, origin_y, color);
+        for (uint32_t k = rb; k < re; ++k) {
+            const auto& r = entry.search_hl_rects[k];
+            cmds.emplace_back(FillRectCmd{
+                D2D1::RectF(origin_x + r.left, origin_y + r.top,
+                            origin_x + r.right, origin_y + r.bottom),
+                color });
+        }
     }
 }
 
@@ -617,7 +674,7 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
                 }
 
                 // 検索マッチのハイライト（テーブルセル）
-                GenSearchHighlights(cmds, cell_layout, node_index, text_x, text_y, static_cast<int>(r), static_cast<int>(c));
+                GenSearchHighlights(cmds, entry, node_index, text_x, text_y, static_cast<int>(r), static_cast<int>(c));
 
                 GenTableCellContent(cmds, cell, cell_layout, text_x, text_y, has_selection, sel_start, sel_end, flat_offset);
             }

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -79,10 +79,11 @@ public:
             : D2D1::ColorF(0.0f, 0.0f, 0.0f, a);
     }
     constexpr void SetFormats(const Formats& fmts) noexcept { formats_ = fmts; }
-    void SetSearchMatches(const std::pmr::vector<SearchMatch>* matches, int current_index) noexcept
+    void SetSearchMatches(const std::pmr::vector<SearchMatch>* matches, int current_index, uint32_t generation) noexcept
     {
         search_matches_ = matches;
         current_match_index_ = current_index;
+        search_generation_ = generation;
     }
 
     // Markdownコンテンツペインのすべての描画コマンドを生成する。
@@ -112,7 +113,7 @@ private:
     void GenDiagramPlaceholder(DrawCommandList& cmds, float x, float y, float w, float h);
     void EmitHighlightRects(DrawCommandList& cmds, IDWriteTextLayout* layout, uint32_t start, uint32_t length, float origin_x, float origin_y, D2D1_COLOR_F color);
     void GenSelectionHighlight(DrawCommandList& cmds, IDWriteTextLayout* layout, uint32_t start, uint32_t length, float origin_x, float origin_y);
-    void GenSearchHighlights(DrawCommandList& cmds, IDWriteTextLayout* layout, int node_index, float origin_x, float origin_y, int table_row = -1, int table_col = -1);
+    void GenSearchHighlights(DrawCommandList& cmds, const NodeLayoutEntry& entry, int node_index, float origin_x, float origin_y, int table_row = -1, int table_col = -1);
 
     const Theme* theme_ = nullptr;
     Formats formats_;
@@ -130,6 +131,7 @@ private:
 
     const std::pmr::vector<SearchMatch>* search_matches_ = nullptr;
     int current_match_index_ = -1;
+    uint32_t search_generation_ = 0;
 
     std::pmr::vector<DWRITE_HIT_TEST_METRICS>* shared_hit_test_buffer_ = nullptr;
     std::pmr::vector<DWRITE_HIT_TEST_METRICS> hit_test_buffer_;

--- a/src/render/renderer.h
+++ b/src/render/renderer.h
@@ -65,9 +65,9 @@ public:
     void SetDeviceLostCallback(std::move_only_function<void(ID2D1RenderTarget*)> cb) { on_device_lost_ = std::move(cb); }
 
     int HitTestSearchInput(std::wstring_view query, float local_x, float max_width) const;
-    void SetSearchMatches(const std::pmr::vector<SearchMatch>* matches, int current_index) noexcept
+    void SetSearchMatches(const std::pmr::vector<SearchMatch>* matches, int current_index, uint32_t generation) noexcept
     {
-        cmd_generator_.SetSearchMatches(matches, current_index);
+        cmd_generator_.SetSearchMatches(matches, current_index, generation);
     }
 
     constexpr void InvalidateFilePaneCache() noexcept { file_pane_cache_.dirty = true; }

--- a/src/ui/search_state.cpp
+++ b/src/ui/search_state.cpp
@@ -16,9 +16,7 @@ void SearchState::SetQuery(std::wstring_view query)
 
 void SearchState::ExecuteSearch(const std::pmr::vector<Node>& nodes)
 {
-    matches_.clear();
-    current_match_ = -1;
-    matches_truncated_ = false;
+    ClearMatches();
 
     if (query_.empty()) {
         return;
@@ -35,15 +33,15 @@ void SearchState::ExecuteSearch(const std::pmr::vector<Node>& nodes)
     }
 
     const auto node_count = static_cast<int>(nodes.size());
-    for (int i = 0; i < node_count; i++) {
+    for (int i = 0; i < node_count && matches_.size() < MAX_MATCHES; i++) {
         const auto& node = nodes[i];
         if (node.type == NodeType::Table && node.has_table()) {
             const auto& rows = node.table_rows();
             const auto row_count = static_cast<int>(rows.size());
-            for (int r = 0; r < row_count; r++) {
+            for (int r = 0; r < row_count && matches_.size() < MAX_MATCHES; r++) {
                 const auto& cells = rows[r].cells;
                 const auto col_count = static_cast<int>(cells.size());
-                for (int c = 0; c < col_count; c++) {
+                for (int c = 0; c < col_count && matches_.size() < MAX_MATCHES; c++) {
                     if (!cells[c].text.empty()) {
                         FindMatches(cells[c].text, lower_query, i, r, c);
                     }

--- a/src/ui/search_state.h
+++ b/src/ui/search_state.h
@@ -22,19 +22,20 @@ public:
     void Hide() noexcept
     {
         visible_ = false;
-        current_match_ = -1;
-        matches_.clear();
-        matches_truncated_ = false;
+        ClearMatches();
         InvalidateLowercaseCache();
     }
     void Reset() noexcept
     {
-        current_match_ = -1;
-        matches_.clear();
+        ClearMatches();
         query_.clear();
-        matches_truncated_ = false;
         InvalidateLowercaseCache();
     }
+
+    // ExecuteSearch / Hide / Reset のたびにインクリメントされる世代カウンタ。
+    // 描画側が検索ハイライト矩形のキャッシュ有効性判定に使う。0 は未初期化を意味するため
+    // 1 からカウントし始める（search_hl_gen=0 と常に不一致になる）。
+    uint32_t GetGeneration() const noexcept { return generation_; }
 
     // ドキュメントが切り替わった/構造が変わったときに呼ぶ。
     // 次回 ExecuteSearch 時に lowercase キャッシュが再生成される。
@@ -68,6 +69,16 @@ private:
     void FindMatches(std::wstring_view text, const std::pmr::wstring& lower_query, int node_index, int table_row = -1, int table_col = -1);
     void EnsureLowercaseCache(const std::pmr::vector<Node>& nodes);
 
+    // マッチ一覧と関連する世代カウンタ・トランケーションフラグを同時にリセットする。
+    // これらは常に一緒に更新しないとキャッシュ有効性判定が壊れるためヘルパに集約している。
+    void ClearMatches() noexcept
+    {
+        matches_.clear();
+        current_match_ = -1;
+        matches_truncated_ = false;
+        ++generation_;
+    }
+
     static constexpr size_t MAX_MATCHES = 10000;
 
     // 大文字小文字無視検索の lowercase キャッシュ。
@@ -84,6 +95,7 @@ private:
     const Node* cached_nodes_ptr_ = nullptr;
     size_t cached_node_count_ = 0;
     int current_match_ = -1;
+    uint32_t generation_ = 1;
     bool visible_ = false;
     bool case_sensitive_ = false;
     bool highlight_enabled_ = true;

--- a/src/ui/search_state.h
+++ b/src/ui/search_state.h
@@ -71,12 +71,16 @@ private:
 
     // マッチ一覧と関連する世代カウンタ・トランケーションフラグを同時にリセットする。
     // これらは常に一緒に更新しないとキャッシュ有効性判定が壊れるためヘルパに集約している。
+    // 0 は search_hl_gen の未初期化センチネルなので、32bit ラップアラウンドで 0 に
+    // 戻るケースだけはスキップして必ず非ゼロを維持する。
     void ClearMatches() noexcept
     {
         matches_.clear();
         current_match_ = -1;
         matches_truncated_ = false;
-        ++generation_;
+        if (++generation_ == 0) {
+            generation_ = 1;
+        }
     }
 
     static constexpr size_t MAX_MATCHES = 10000;

--- a/src/util/stream_util.h
+++ b/src/util/stream_util.h
@@ -1,0 +1,102 @@
+#pragma once
+#include "win_handle.h"
+#include <wrl/client.h>
+#include <objidl.h>
+#include <climits>
+#include <cstdint>
+#include <vector>
+
+// COM IStream 周りの共通ヘルパー。
+// WIC デコード入力や WebView2 CapturePreview 出力などで使い回される。
+namespace stream_util {
+
+// IStream の先頭から全バイトを読み出す。サイズ検証と Read/Seek の HRESULT を確認し、
+// 部分読込やサイズ不正は空ベクタを返す失敗扱いにする。
+inline std::vector<uint8_t> ReadAllBytes(IStream* stream)
+{
+    if (!stream) {
+        return {};
+    }
+
+    STATSTG stat{};
+    if (FAILED(stream->Stat(&stat, STATFLAG_NONAME))) {
+        return {};
+    }
+
+    const auto size64 = stat.cbSize.QuadPart;
+    if (size64 <= 0 || static_cast<uint64_t>(size64) > ULONG_MAX) {
+        return {};
+    }
+    const auto size = static_cast<size_t>(size64);
+
+    const LARGE_INTEGER zero{};
+    if (FAILED(stream->Seek(zero, STREAM_SEEK_SET, nullptr))) {
+        return {};
+    }
+
+    std::vector<uint8_t> data(size);
+    ULONG read = 0;
+    const HRESULT hr = stream->Read(data.data(), static_cast<ULONG>(size), &read);
+    if (FAILED(hr) || read != size) {
+        return {};
+    }
+    return data;
+}
+
+// HGLOBAL 上のメモリストリームを作成し、与えられたバイト列を書き込んで先頭に巻き戻す。
+// data == nullptr / size == 0 でも空ストリームを返す。
+inline Microsoft::WRL::ComPtr<IStream> CreateMemoryStream(const void* data, size_t size)
+{
+    Microsoft::WRL::ComPtr<IStream> stream;
+    if (FAILED(CreateStreamOnHGlobal(nullptr, TRUE, &stream)) || !stream) {
+        return nullptr;
+    }
+    if (size > 0 && data) {
+        if (size > ULONG_MAX) {
+            return nullptr;
+        }
+        ULONG written = 0;
+        if (FAILED(stream->Write(data, static_cast<ULONG>(size), &written)) || written != size) {
+            return nullptr;
+        }
+        const LARGE_INTEGER zero{};
+        if (FAILED(stream->Seek(zero, STREAM_SEEK_SET, nullptr))) {
+            return nullptr;
+        }
+    }
+    return stream;
+}
+
+// ファイルハンドルから size バイトを HGLOBAL に直接読み込んで IStream を返す。
+// 大きな画像ファイルで一時バッファへのコピーを避けるため、ReadFile を HGLOBAL にロックしたまま呼ぶ。
+inline Microsoft::WRL::ComPtr<IStream> CreateMemoryStreamFromFile(HANDLE file, size_t size)
+{
+    if (!file || file == INVALID_HANDLE_VALUE || size == 0 || size > ULONG_MAX) {
+        return nullptr;
+    }
+
+    UniqueGlobalMem hMem{ GlobalAlloc(GMEM_MOVEABLE, static_cast<SIZE_T>(size)) };
+    if (!hMem) {
+        return nullptr;
+    }
+
+    void* ptr = GlobalLock(hMem.get());
+    if (!ptr) {
+        return nullptr;
+    }
+    DWORD bytes_read = 0;
+    const BOOL ok = ReadFile(file, ptr, static_cast<DWORD>(size), &bytes_read, nullptr);
+    GlobalUnlock(hMem.get());
+    if (!ok || bytes_read != size) {
+        return nullptr;
+    }
+
+    Microsoft::WRL::ComPtr<IStream> stream;
+    if (FAILED(CreateStreamOnHGlobal(hMem.get(), TRUE, &stream)) || !stream) {
+        return nullptr;
+    }
+    hMem.release();
+    return stream;
+}
+
+} // namespace stream_util

--- a/src/util/stream_util.h
+++ b/src/util/stream_util.h
@@ -44,17 +44,23 @@ inline std::vector<uint8_t> ReadAllBytes(IStream* stream)
 }
 
 // HGLOBAL 上のメモリストリームを作成し、与えられたバイト列を書き込んで先頭に巻き戻す。
-// data == nullptr / size == 0 でも空ストリームを返す。
+// size == 0 は空ストリームを要求する正当なユースケース（WebView2 CapturePreview の
+// 書き込み先バッファ用途）として許容するが、size > 0 && data == nullptr は呼び出し
+// 側バグなので nullptr を返して失敗させる。
 inline Microsoft::WRL::ComPtr<IStream> CreateMemoryStream(const void* data, size_t size)
 {
+    if (size > 0 && !data) {
+        return nullptr;
+    }
+    if (size > ULONG_MAX) {
+        return nullptr;
+    }
+
     Microsoft::WRL::ComPtr<IStream> stream;
     if (FAILED(CreateStreamOnHGlobal(nullptr, TRUE, &stream)) || !stream) {
         return nullptr;
     }
-    if (size > 0 && data) {
-        if (size > ULONG_MAX) {
-            return nullptr;
-        }
+    if (size > 0) {
         ULONG written = 0;
         if (FAILED(stream->Write(data, static_cast<ULONG>(size), &written)) || written != size) {
             return nullptr;

--- a/tests/test_command_generator_frame.cpp
+++ b/tests/test_command_generator_frame.cpp
@@ -195,7 +195,7 @@ TEST_F(CmdGenFrameTest, SetSearchMatchesWithNullIsSafe)
 {
     Parse("Hello world");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 400.0f };
-    gen_.SetSearchMatches(nullptr, -1);
+    gen_.SetSearchMatches(nullptr, -1, 0);
     auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
     EXPECT_FALSE(cmds.empty());
 }
@@ -205,7 +205,7 @@ TEST_F(CmdGenFrameTest, SetSearchMatchesWithEmptyProducesNoHighlight)
     Parse("Hello world");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 400.0f };
     std::pmr::vector<SearchMatch> matches;
-    gen_.SetSearchMatches(&matches, -1);
+    gen_.SetSearchMatches(&matches, -1, 1);
     auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
     // マッチ空のため FillRectCmd は選択ハイライト経路以外は生成されない
     // (paragraph text_layout=null なので選択経路も走らない)


### PR DESCRIPTION
## Summary
- 検索ハイライト矩形を `NodeLayoutEntry` に世代付きでキャッシュし、フレームごとに可視ノード数×マッチ数ぶん発行していた `HitTestTextRange` を再計算不要にした
- `IStream` 関連の共通処理を新規 `src/util/stream_util.h` に集約し、`image_loader` と `mermaid` の重複コードを削除
- 細かな堅牢性/パフォーマンス改善（`canonical()` → `absolute()+lexically_normal()`、CoreWebView2 取得失敗ガード、`MAX_MATCHES` 到達時のループ早期break）

## 変更詳細

### 検索ハイライトキャッシュ
- `SearchState::generation_` を追加。`ExecuteSearch` / `Hide` / `Reset` で内部ヘルパ `ClearMatches()` に集約しインクリメント
- `NodeLayoutEntry` に `search_hl_gen` / `search_hl_rects` / `search_hl_rect_ends`（mutable）を追加
- layout 再構築パス（`MeasureNode` / `MeasureTable`、`LayoutCache::InvalidateAll` / `RelayoutWithNewWidth`、`EvictOffscreenBitmaps`）で `invalidate_search_hl_cache()` を呼びキャッシュを破棄
- `CommandGenerator::GenSearchHighlights` は generation 一致時はキャッシュ矩形を origin 加算してコマンド化するだけに変更
- テーブルセル/本文の切り分けは node 内マッチ順どおりに `rect_ends` でスライスして描画

### IStream ヘルパ集約
- `stream_util::ReadAllBytes`, `CreateMemoryStream`, `CreateMemoryStreamFromFile` を新設
- `image_loader.cpp` の `ReadFileToStream` を `CreateMemoryStreamFromFile` に置き換え
- `mermaid.cpp` の `ReadAllStreamBytes` / `CreateMemoryStream` ローカル実装を削除

### その他
- `ResourceManager::ApplyCachedImages`: `canonical()` は symlink 解決のため FS を叩くので UI 同期パスから外し、`absolute()+lexically_normal()` に変更
- `MermaidRenderer::SetupWorker`: `get_CoreWebView2` 失敗時に controller を Reset して早期リターン
- `MermaidRenderer::DoCapturePreview`: `CreateMemoryStream` 失敗時のハンドリング追加
- `SearchState::ExecuteSearch`: 各ループに `matches_.size() < MAX_MATCHES` ガードを追加

## Test plan
- [x] `cmake --build build --config Release` 成功
- [x] `mendo_tests.exe` 全 1890 件パス
- [ ] 手元で検索ハイライトを開いたままスクロール/リサイズ/テーマ切替して矩形のズレ・残留がないか目視確認
- [ ] 大量マッチ（MAX_MATCHES 近辺）検索でもスクロールがガクつかないこと
- [ ] Mermaid ブロックを含む Markdown のレンダリングが従来どおり動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)