### PR TITLE
コードレビュー対応とMermaidハッシュのWide化

### DIFF
--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -404,7 +404,7 @@ float App::CalcScrollForDiff(size_t diff_pos, float viewport_height) const
     MENDO_TRACEF("CalcScrollForDiff: diff_pos=%zu node_count=%zu", diff_pos, state_.document.doc.GetNodes().size());
     return CalcScrollYForDiff(
         state_.document.doc.GetNodes(), state_.document.layout_cache,
-        std::string_view(state_.document.doc.GetRawUtf8()),
+        state_.document.doc.GetRawUtf8(),
         diff_pos, viewport_height, state_.view.viewport.GetScrollY());
 }
 

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -87,9 +87,8 @@ struct NodeImageData {
 };
 
 struct Node {
-    // パース中は UTF-8 文字列を蓄積する一時領域。
-    // ParseMarkdown 末尾の ConvertTextFromUtf8() 呼び出し後は、
-    // CodeBlock（Mermaidハッシュ計算で参照）以外は解放される。
+    // パース中の md4c コールバック専用の UTF-8 蓄積領域。
+    // ConvertTextFromUtf8() 後は空である契約 — 下流は text_ のみを読む。
     std::pmr::string text_utf8;
     std::pmr::vector<TextRun> runs;
 
@@ -112,25 +111,17 @@ struct Node {
     AlertType alert_type = AlertType::None;
     SyntaxLanguage code_language = SyntaxLanguage::None;
 
-    // テキストが存在するか（ReplaceContent 前後のどちらでも正しく判定するため両表現をチェック）
-    bool HasText() const noexcept
-    {
-        return !text_.empty() || !text_utf8.empty();
-    }
+    bool HasText() const noexcept { return !text_.empty(); }
 
-    // UTF-8→Wide 変換。通常の経路では ParseMarkdown 末尾で全ノードに一括呼び出しされ、
-    // 呼び出し側は ParseResult を「変換済み」として扱える。Node を手動で構築する
-    // テストやアラート前処理など、外部で text_utf8 を直接書く経路では個別に呼ぶ。
-    // CodeBlock 以外では text_utf8 を解放（Mermaidハッシュ計算で直接参照する CodeBlock は保持）。
+    // UTF-8→Wide 変換。ParseMarkdown 末尾で全ノードに一括呼び出しされる。
+    // Node を手動構築する経路（テスト等）では個別に呼ぶ。
     void ConvertTextFromUtf8()
     {
         if (text_utf8.empty()) {
             return;
         }
         string_convert::Utf8ToWide(text_utf8, text_);
-        if (type != NodeType::CodeBlock) {
-            text_utf8.clear();
-        }
+        text_utf8.clear();
     }
 
     const std::pmr::wstring& GetText() const noexcept { return text_; }

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -745,13 +745,12 @@ ParseResult ParseMarkdown(std::string_view markdown_text)
 
     md_parse(markdown_text.data(), static_cast<MD_SIZE>(markdown_text.size()), &parser, &ctx);
 
-    DetectAlerts(ctx.nodes);
-
-    // パース結果は UTF-8→Wide 変換済みで返す（呼び出し側での二重管理を避ける）。
-    // CodeBlock は Mermaidハッシュ計算で text_utf8 を直接参照するため保持される。
+    // Alert 検出は Wide テキストを見るため、変換を先に行う。
     for (auto& node : ctx.nodes) {
         node.ConvertTextFromUtf8();
     }
+
+    DetectAlerts(ctx.nodes);
 
     ParseResult result;
     result.nodes = std::move(ctx.nodes);

--- a/src/core/parser_alerts.cpp
+++ b/src/core/parser_alerts.cpp
@@ -31,42 +31,42 @@ const wchar_t* GetAlertIcon(AlertType type) noexcept
 
 namespace {
 
-// 大文字小文字を無視して string_view を比較する（ASCII範囲のみ）
-bool AsciiCaseEqual(std::string_view a, std::string_view b) noexcept
+// 大文字小文字を無視して比較する。Alert マーカーは GitHub 仕様で ASCII 固定。
+bool AsciiCaseEqual(std::wstring_view a, std::wstring_view b) noexcept
 {
-    constexpr auto to_upper = [](char c) noexcept -> char {
-        return (c >= 'a' && c <= 'z') ? static_cast<char>(c - 'a' + 'A') : c;
+    constexpr auto to_upper = [](wchar_t c) noexcept -> wchar_t {
+        return (c >= L'a' && c <= L'z') ? static_cast<wchar_t>(c - L'a' + L'A') : c;
     };
     return std::ranges::equal(a, b, {}, to_upper, to_upper);
 }
 
-// テキスト先頭から [!TYPE] パターンを検出し、AlertTypeを返す（UTF-8版）
-AlertType DetectAlertMarker(std::string_view text, size_t& marker_end)
+// テキスト先頭から [!TYPE] パターンを検出し、AlertTypeを返す。
+AlertType DetectAlertMarker(std::wstring_view text, size_t& marker_end)
 {
-    if (text.size() < 3 || text[0] != '[' || text[1] != '!') {
+    if (text.size() < 3 || text[0] != L'[' || text[1] != L'!') {
         return AlertType::None;
     }
-    const auto close = text.find(']');
-    if (close == std::string_view::npos || close <= 2) {
+    const auto close = text.find(L']');
+    if (close == std::wstring_view::npos || close <= 2) {
         return AlertType::None;
     }
 
     const auto type_str = text.substr(2, close - 2);
 
     AlertType type = AlertType::None;
-    if (AsciiCaseEqual(type_str, "NOTE")) {
+    if (AsciiCaseEqual(type_str, L"NOTE")) {
         type = AlertType::Note;
     }
-    else if (AsciiCaseEqual(type_str, "TIP")) {
+    else if (AsciiCaseEqual(type_str, L"TIP")) {
         type = AlertType::Tip;
     }
-    else if (AsciiCaseEqual(type_str, "IMPORTANT")) {
+    else if (AsciiCaseEqual(type_str, L"IMPORTANT")) {
         type = AlertType::Important;
     }
-    else if (AsciiCaseEqual(type_str, "WARNING")) {
+    else if (AsciiCaseEqual(type_str, L"WARNING")) {
         type = AlertType::Warning;
     }
-    else if (AsciiCaseEqual(type_str, "CAUTION")) {
+    else if (AsciiCaseEqual(type_str, L"CAUTION")) {
         type = AlertType::Caution;
     }
 
@@ -76,7 +76,7 @@ AlertType DetectAlertMarker(std::string_view text, size_t& marker_end)
 
     marker_end = close + 1;
     // マーカー直後のスペースまたは改行を1つスキップ
-    if (marker_end < text.size() && (text[marker_end] == ' ' || text[marker_end] == '\n')) {
+    if (marker_end < text.size() && (text[marker_end] == L' ' || text[marker_end] == L'\n')) {
         marker_end++;
     }
     return type;
@@ -153,13 +153,10 @@ void DetectAlerts(std::pmr::vector<Node>& nodes)
             continue;
         }
         size_t marker_end = 0;
-        const AlertType type = DetectAlertMarker(nodes[i].text_utf8, marker_end);
+        const AlertType type = DetectAlertMarker(nodes[i].GetText(), marker_end);
         if (type == AlertType::None) {
             continue;
         }
-        // マーカー以降のテキストは ASCII のみで UTF-8/wide の位置が一致するため、
-        // Transform 前に wide 変換を済ませて GetText() の結果を使えるようにする。
-        nodes[i].ConvertTextFromUtf8();
         const int group = nodes[i].blockquote_group;
         TransformAlertNode(nodes[i], type, marker_end);
 

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -102,50 +102,6 @@ int FindTableCol(const TableLayoutData& tl, float base_x, float dip_x,
 
 } // namespace
 
-// 指定された行・列までのフラットテキストオフセットを計算する。
-// プリコンピュート済みのrow_flat_offsetsがあれば行スキャンを省略し、
-// 対象行内のセルのみスキャンする（O(rows*cols) → O(cols)）。
-static uint32_t ComputeTableFlatOffset(const Node& node, const NodeLayoutEntry& entry, int target_row, int target_col) noexcept
-{
-    const auto& rows = node.table_rows();
-
-    // プリコンピュート済みオフセットを使用（レイアウト計算時に構築済み）
-    if (entry.has_table_layout() && target_row >= 0 &&
-        static_cast<size_t>(target_row) < entry.table_layout->row_flat_offsets.size()) {
-        uint32_t offset = entry.table_layout->row_flat_offsets[target_row];
-        const auto& row_cells = rows[target_row].cells;
-        const auto col_count = row_cells.size();
-        for (size_t c = 0; c < col_count && static_cast<int>(c) < target_col; c++) {
-            offset += static_cast<uint32_t>(row_cells[c].text.size());
-            if (c + 1 < col_count) {
-                offset++;
-            }
-        }
-        return offset;
-    }
-
-    // フォールバック: 全走査
-    uint32_t offset = 0;
-    const auto row_count = rows.size();
-    for (size_t r = 0; r < row_count; r++) {
-        const auto& row_cells = rows[r].cells;
-        const auto col_count = row_cells.size();
-        for (size_t c = 0; c < col_count; c++) {
-            if (static_cast<int>(r) == target_row && static_cast<int>(c) == target_col) {
-                return offset;
-            }
-            offset += static_cast<uint32_t>(row_cells[c].text.size());
-            if (c + 1 < col_count) {
-                offset++;
-            }
-        }
-        if (r + 1 < row_count) {
-            offset++;
-        }
-    }
-    return static_cast<uint32_t>(node.GetText().size());
-}
-
 HitTestService::HitResult HitTestService::HitTest(
     const MdPaneHitContext& ctx) const noexcept
 {
@@ -235,7 +191,8 @@ HitTestService::HitResult HitTestService::HitTestTable(
     float cell_left_x = 0.0f;
     const int hit_col = FindTableCol(tl, base_x, dip_x, cell_left_x);
 
-    const uint32_t flat_offset = ComputeTableFlatOffset(node, entry, hit_row, hit_col);
+    const uint32_t flat_offset = tl.CellFlatOffset(
+        node.table_rows(), static_cast<size_t>(hit_row), static_cast<size_t>(hit_col));
 
     const size_t r = static_cast<size_t>(hit_row);
     const size_t c = static_cast<size_t>(hit_col);

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -373,14 +373,7 @@ void DWriteTextMeasurer::FinalizeTableLayout(Node& node, NodeLayoutEntry& entry,
     uint32_t flat_offset = 0;
     for (size_t r = 0; r < row_count; r++) {
         tl.row_flat_offsets[r] = flat_offset;
-        const auto& row = rows[r];
-        const auto cell_count = row.cells.size();
-        for (size_t c = 0; c < cell_count; c++) {
-            flat_offset += static_cast<uint32_t>(row.cells[c].text.size());
-            if (c + 1 < cell_count) {
-                flat_offset++; // タブ区切り
-            }
-        }
+        TableLayoutData::AdvanceFlatOffsetInRow(rows[r], 0, rows[r].cells.size(), flat_offset);
         if (r + 1 < row_count) {
             flat_offset++; // 改行区切り
         }

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -40,6 +40,33 @@ struct TableLayoutData {
         const size_t idx = CellIndex(row, col);
         return (idx < cell_layouts.size()) ? cell_layouts[idx].Get() : nullptr;
     }
+
+    // 行内 [col_from, col_to) のセル幅とタブ区切りだけ flat_offset を進める。
+    // 線形化規約は dwrite_measurer.cpp の row_flat_offsets 構築と一致する。
+    static void AdvanceFlatOffsetInRow(const TableRow& row,
+        size_t col_from, size_t col_to, uint32_t& flat_offset) noexcept
+    {
+        const auto col_count_actual = row.cells.size();
+        const size_t end = std::min(col_to, col_count_actual);
+        for (size_t c = col_from; c < end; c++) {
+            flat_offset += static_cast<uint32_t>(row.cells[c].text.size());
+            if (c + 1 < col_count_actual) {
+                flat_offset++;
+            }
+        }
+    }
+
+    // (row_idx, col) セルの線形化テキスト先頭オフセット。
+    // dwrite_measurer の MeasureTable がレイアウト確定時に row_flat_offsets を必ず埋めるため、
+    // ここでの存在は前提扱い。
+    uint32_t CellFlatOffset(const std::pmr::vector<TableRow>& rows,
+        size_t row_idx, size_t col) const noexcept
+    {
+        assert(row_idx < row_flat_offsets.size());
+        uint32_t offset = row_flat_offsets[row_idx];
+        AdvanceFlatOffsetInRow(rows[row_idx], 0, col, offset);
+        return offset;
+    }
 };
 
 struct NodeLayoutEntry {

--- a/src/mermaid/mermaid_util.cpp
+++ b/src/mermaid/mermaid_util.cpp
@@ -197,7 +197,7 @@ uint64_t mermaid_util::NodeDiagramHash(const Node& node, float max_width, bool d
 {
     // LatexMath を Mermaid とキャッシュ衝突させないためのソルト（任意の定数）。
     constexpr uint64_t LATEX_MATH_HASH_SALT = 0xA1B2C3D4E5F60718ULL;
-    uint64_t h = HashCode(node.text_utf8, max_width, dark_mode);
+    uint64_t h = HashCode(node.GetText(), max_width, dark_mode);
     if (node.code_language == SyntaxLanguage::LatexMath) {
         h ^= LATEX_MATH_HASH_SALT;
     }

--- a/src/mermaid/mermaid_util.h
+++ b/src/mermaid/mermaid_util.h
@@ -12,7 +12,7 @@ namespace mermaid_util {
 std::pmr::wstring BuildLatexFlowchartCode(std::wstring_view latex);
 
 // ダイアグラムノード用キャッシュキー。言語種別に応じたソルトを内部で混ぜ、
-// 同じ UTF-8 コンテンツの Mermaid / LatexMath がキー衝突しないようにする。
+// 同じ Wide テキストの Mermaid / LatexMath がキー衝突しないようにする。
 uint64_t NodeDiagramHash(const Node& node, float max_width, bool dark_mode) noexcept;
 
 std::pmr::wstring JsEscape(std::wstring_view input);

--- a/src/render/command_executor.cpp
+++ b/src/render/command_executor.cpp
@@ -1,25 +1,6 @@
 #include "command_executor.h"
 #include "utility.h"
 
-namespace {
-
-// D2D1_COLOR_F を 8bit RGBA にパックしたキー。テーマ色は 8bit 精度で作られているため十分。
-constexpr uint32_t PackColor(D2D1_COLOR_F c) noexcept
-{
-    const auto quant = [](float v) noexcept -> uint32_t {
-        if (v <= 0.0f) {
-            return 0;
-        }
-        if (v >= 1.0f) {
-            return 255;
-        }
-        return static_cast<uint32_t>(v * 255.0f + 0.5f);
-    };
-    return (quant(c.r) << 24) | (quant(c.g) << 16) | (quant(c.b) << 8) | quant(c.a);
-}
-
-} // namespace
-
 ID2D1SolidColorBrush* CommandExecutor::GetBrush(ID2D1RenderTarget* rt, D2D1_COLOR_F color)
 {
     if (rt != bound_rt_) {
@@ -29,7 +10,7 @@ ID2D1SolidColorBrush* CommandExecutor::GetBrush(ID2D1RenderTarget* rt, D2D1_COLO
         last_key_ = 0xFFFFFFFFu;
         last_brush_ = nullptr;
     }
-    const uint32_t key = PackColor(color);
+    const uint32_t key = command_executor_internal::PackColor(color);
     if (key == last_key_ && last_brush_) {
         return last_brush_;
     }

--- a/src/render/command_executor.h
+++ b/src/render/command_executor.h
@@ -9,6 +9,7 @@ namespace command_executor_internal {
 
 // D2D1_COLOR_F を 8bit RGBA にパックしたキー。CommandExecutor のブラシキャッシュキーに使う。
 // テーマ色は 8bit 精度で作られているため 8bit 量子化で衝突しない。
+// command_executor.cpp の GetBrush から呼ばれる本番実装の一部のため MENDO_TESTING でガードしない。
 constexpr uint32_t PackColor(D2D1_COLOR_F c) noexcept
 {
     const auto quant = [](float v) noexcept -> uint32_t {

--- a/src/render/command_executor.h
+++ b/src/render/command_executor.h
@@ -2,13 +2,38 @@
 #include "draw_command.h"
 #include <d2d1.h>
 #include <wrl/client.h>
+#include <cstdint>
 #include <unordered_map>
+
+namespace command_executor_internal {
+
+// D2D1_COLOR_F を 8bit RGBA にパックしたキー。CommandExecutor のブラシキャッシュキーに使う。
+// テーマ色は 8bit 精度で作られているため 8bit 量子化で衝突しない。
+constexpr uint32_t PackColor(D2D1_COLOR_F c) noexcept
+{
+    const auto quant = [](float v) noexcept -> uint32_t {
+        if (v <= 0.0f) {
+            return 0;
+        }
+        if (v >= 1.0f) {
+            return 255;
+        }
+        return static_cast<uint32_t>(v * 255.0f + 0.5f);
+    };
+    return (quant(c.r) << 24) | (quant(c.g) << 16) | (quant(c.b) << 8) | quant(c.a);
+}
+
+} // namespace command_executor_internal
 
 // DrawCommandList を Direct2D レンダーターゲット上で実行する。
 // 色ごとに ID2D1SolidColorBrush をプールし、SetColor 呼び出しも削減する。
 class CommandExecutor {
 public:
     void Execute(const DrawCommandList& cmds, ID2D1RenderTarget* rt);
+
+    // テスト用 inspector。本番コードからは使わない。
+    size_t PoolSizeForTest() const noexcept { return brush_pool_.size(); }
+    const ID2D1RenderTarget* BoundRtForTest() const noexcept { return bound_rt_; }
 
 private:
     ID2D1SolidColorBrush* GetBrush(ID2D1RenderTarget* rt, D2D1_COLOR_F color);

--- a/src/render/command_executor.h
+++ b/src/render/command_executor.h
@@ -31,9 +31,10 @@ class CommandExecutor {
 public:
     void Execute(const DrawCommandList& cmds, ID2D1RenderTarget* rt);
 
-    // テスト用 inspector。本番コードからは使わない。
+#ifdef MENDO_TESTING
     size_t PoolSizeForTest() const noexcept { return brush_pool_.size(); }
     const ID2D1RenderTarget* BoundRtForTest() const noexcept { return bound_rt_; }
+#endif
 
 private:
     ID2D1SolidColorBrush* GetBrush(ID2D1RenderTarget* rt, D2D1_COLOR_F color);

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -605,16 +605,6 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
         }
     }
 
-    // セル範囲の flat_offset を進めるヘルパー
-    const auto advance_flat_offset = [](uint32_t& offset, const TableRow& row, size_t from, size_t to) static noexcept {
-        for (size_t c = from; c < to; c++) {
-            offset += static_cast<uint32_t>(row.cells[c].text.size());
-            if (c + 1 < row.cells.size()) {
-                offset++;
-            }
-        }
-    };
-
     float y = entry.y_position;
     uint32_t flat_offset = 0;
 
@@ -629,7 +619,7 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
                 flat_offset = tl.row_flat_offsets[r + 1];
             }
             else {
-                advance_flat_offset(flat_offset, row, 0, row.cells.size());
+                TableLayoutData::AdvanceFlatOffsetInRow(row, 0, row.cells.size(), flat_offset);
                 if (r + 1 < node.table_rows().size()) {
                     flat_offset++;
                 }
@@ -686,7 +676,7 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
             cx += cw + cell_padding * 2.0f + border;
         }
 
-        advance_flat_offset(flat_offset, row, drawn_cols, row.cells.size());
+        TableLayoutData::AdvanceFlatOffsetInRow(row, drawn_cols, row.cells.size(), flat_offset);
 
         // 右罫線
         cmds.emplace_back(DrawLineCmd{

--- a/src/theme/theme_service.cpp
+++ b/src/theme/theme_service.cpp
@@ -1,4 +1,5 @@
 #include "theme_service.h"
+#include <cassert>
 
 ThemeService::ThemeService(ConfigService& config) noexcept
     : config_(config)
@@ -12,6 +13,8 @@ Theme ThemeService::CreateTheme() const
 
 Theme ThemeService::CreateTheme(int zoom_index) const
 {
+    assert(zoom_index >= 0 && zoom_index < ZOOM_STEP_COUNT
+        && "zoom_index must be within ZOOM_STEPS bounds; ViewportManager::SetZoomIndex clamps it");
     Theme theme = CreateTheme();
     if (zoom_index != ZOOM_DEFAULT_INDEX) {
         theme.ApplyZoom(ZOOM_STEPS[zoom_index]);

--- a/src/ui/viewport_manager.h
+++ b/src/ui/viewport_manager.h
@@ -154,7 +154,12 @@ public:
     // ---- ズーム ----
 
     constexpr int GetZoomIndex() const noexcept { return zoom_index_; }
-    constexpr void SetZoomIndex(int idx) noexcept { zoom_index_ = idx; }
+    // ZOOM_STEPS の有効範囲 [0, ZOOM_STEP_COUNT) に必ずクランプする。
+    // 設定ファイル等の外部入力経路から不正値が来ても out-of-bounds にならない契約を setter 側で保証する。
+    constexpr void SetZoomIndex(int idx) noexcept
+    {
+        zoom_index_ = std::clamp(idx, 0, ZOOM_STEP_COUNT - 1);
+    }
     constexpr float GetCurrentZoom() const noexcept { return ZOOM_STEPS[zoom_index_]; }
 
     // 新しいズーム値を返す。既に上限/下限の場合は0を返す。

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,8 @@ add_executable(mendo_tests
     test_side_effect_executor.cpp
     test_command_generator_frame.cpp
     test_measurer_parity.cpp
+    test_command_executor.cpp
+    test_resource_manager.cpp
 )
 
 target_link_libraries(mendo_tests PRIVATE

--- a/tests/mock_text_measurer.h
+++ b/tests/mock_text_measurer.h
@@ -92,13 +92,26 @@ public:
         if (col_count == 0) { entry.layout_dirty = false; return; }
 
         auto& tl = entry.ensure_table_layout();
+        const auto row_count = node.table_rows().size();
         tl.col_widths.assign(col_count, max_width / static_cast<float>(col_count));
-        tl.row_heights.assign(node.table_rows().size(), table_row_height);
+        tl.row_heights.assign(row_count, table_row_height);
         tl.col_count = col_count;
-        tl.cell_layouts.resize(node.table_rows().size() * col_count);
+        tl.cell_layouts.resize(row_count * col_count);
+
+        // dwrite_measurer.cpp と同じ規約で行先頭オフセットを埋める。
+        tl.row_flat_offsets.resize(row_count);
+        uint32_t flat_offset = 0;
+        for (size_t r = 0; r < row_count; r++) {
+            tl.row_flat_offsets[r] = flat_offset;
+            TableLayoutData::AdvanceFlatOffsetInRow(node.table_rows()[r], 0,
+                node.table_rows()[r].cells.size(), flat_offset);
+            if (r + 1 < row_count) {
+                flat_offset++;
+            }
+        }
 
         float total = table_border;
-        for (size_t r = 0; r < node.table_rows().size(); r++) {
+        for (size_t r = 0; r < row_count; r++) {
             total += table_row_height + table_border;
         }
         entry.height = total;

--- a/tests/test_command_executor.cpp
+++ b/tests/test_command_executor.cpp
@@ -1,0 +1,237 @@
+#include <gtest/gtest.h>
+#include "command_executor.h"
+#include "test_helpers.h"
+#include <d2d1.h>
+#include <wincodec.h>
+#include <wrl/client.h>
+
+using Microsoft::WRL::ComPtr;
+using command_executor_internal::PackColor;
+
+// ---- PackColor の単体テスト ----
+
+TEST(CommandExecutorPackColor, FullyTransparentBlackIsZero)
+{
+    EXPECT_EQ(PackColor(D2D1::ColorF(0.0f, 0.0f, 0.0f, 0.0f)), 0u);
+}
+
+TEST(CommandExecutorPackColor, FullyOpaqueWhiteIsAllOnes)
+{
+    EXPECT_EQ(PackColor(D2D1::ColorF(1.0f, 1.0f, 1.0f, 1.0f)), 0xFFFFFFFFu);
+}
+
+TEST(CommandExecutorPackColor, ChannelOrderIsRGBA)
+{
+    // R=255, G=0, B=0, A=255 → 0xFF0000FF
+    EXPECT_EQ(PackColor(D2D1::ColorF(1.0f, 0.0f, 0.0f, 1.0f)), 0xFF0000FFu);
+    // R=0, G=255, B=0, A=255 → 0x00FF00FF
+    EXPECT_EQ(PackColor(D2D1::ColorF(0.0f, 1.0f, 0.0f, 1.0f)), 0x00FF00FFu);
+    // R=0, G=0, B=255, A=255 → 0x0000FFFF
+    EXPECT_EQ(PackColor(D2D1::ColorF(0.0f, 0.0f, 1.0f, 1.0f)), 0x0000FFFFu);
+}
+
+TEST(CommandExecutorPackColor, ClampsBelowZero)
+{
+    // 範囲外（負値）は 0 にクランプされる
+    EXPECT_EQ(PackColor(D2D1::ColorF(-1.0f, -2.0f, -0.5f, -3.0f)), 0u);
+}
+
+TEST(CommandExecutorPackColor, ClampsAboveOne)
+{
+    // 範囲外（1超え）は 255 にクランプされる
+    EXPECT_EQ(PackColor(D2D1::ColorF(2.0f, 5.0f, 100.0f, 10.0f)), 0xFFFFFFFFu);
+}
+
+TEST(CommandExecutorPackColor, RoundsToNearest)
+{
+    // 0.5f * 255 + 0.5 = 128.0 → 128
+    const auto v = PackColor(D2D1::ColorF(0.5f, 0.5f, 0.5f, 0.5f));
+    EXPECT_EQ((v >> 24) & 0xFF, 128u);
+    EXPECT_EQ((v >> 16) & 0xFF, 128u);
+    EXPECT_EQ((v >> 8) & 0xFF, 128u);
+    EXPECT_EQ(v & 0xFF, 128u);
+}
+
+TEST(CommandExecutorPackColor, DistinctColorsHaveDistinctKeys)
+{
+    EXPECT_NE(PackColor(D2D1::ColorF(0.1f, 0.2f, 0.3f, 1.0f)),
+        PackColor(D2D1::ColorF(0.1f, 0.2f, 0.4f, 1.0f)));
+}
+
+// ---- WIC bitmap render target を使った Execute の統合テスト ----
+
+class CommandExecutorIntegrationTest : public ComApartmentTest {
+protected:
+    void SetUp() override
+    {
+        ASSERT_HRESULT_SUCCEEDED(D2D1CreateFactory(
+            D2D1_FACTORY_TYPE_SINGLE_THREADED,
+            IID_PPV_ARGS(&d2d_factory_)));
+        ASSERT_HRESULT_SUCCEEDED(CoCreateInstance(
+            CLSID_WICImagingFactory,
+            nullptr,
+            CLSCTX_INPROC_SERVER,
+            IID_PPV_ARGS(&wic_factory_)));
+
+        ASSERT_HRESULT_SUCCEEDED(CreateRenderTarget(rt_));
+    }
+
+    HRESULT CreateRenderTarget(ComPtr<ID2D1RenderTarget>& out)
+    {
+        ComPtr<IWICBitmap> bitmap;
+        if (FAILED(wic_factory_->CreateBitmap(32, 32,
+            GUID_WICPixelFormat32bppPBGRA, WICBitmapCacheOnLoad, &bitmap))) {
+            return E_FAIL;
+        }
+        D2D1_RENDER_TARGET_PROPERTIES props = D2D1::RenderTargetProperties(
+            D2D1_RENDER_TARGET_TYPE_DEFAULT,
+            D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED));
+        ComPtr<ID2D1RenderTarget> rt;
+        const HRESULT hr = d2d_factory_->CreateWicBitmapRenderTarget(bitmap.Get(), props, &rt);
+        if (SUCCEEDED(hr)) {
+            wic_bitmap_ = bitmap;
+            out = rt;
+        }
+        return hr;
+    }
+
+    ComPtr<ID2D1Factory> d2d_factory_;
+    ComPtr<IWICImagingFactory> wic_factory_;
+    ComPtr<IWICBitmap> wic_bitmap_;
+    ComPtr<ID2D1RenderTarget> rt_;
+};
+
+TEST_F(CommandExecutorIntegrationTest, ExecuteIgnoresNullRenderTarget)
+{
+    CommandExecutor exec;
+    DrawCommandList cmds;
+    cmds.emplace_back(FillRectCmd{ D2D1::RectF(0, 0, 10, 10), D2D1::ColorF(D2D1::ColorF::Red) });
+    exec.Execute(cmds, nullptr);
+    EXPECT_EQ(exec.PoolSizeForTest(), 0u);
+}
+
+TEST_F(CommandExecutorIntegrationTest, ExecuteEmptyListSucceeds)
+{
+    CommandExecutor exec;
+    DrawCommandList cmds;
+    rt_->BeginDraw();
+    exec.Execute(cmds, rt_.Get());
+    EXPECT_HRESULT_SUCCEEDED(rt_->EndDraw());
+    EXPECT_EQ(exec.PoolSizeForTest(), 0u);
+}
+
+TEST_F(CommandExecutorIntegrationTest, FillRectCreatesPooledBrush)
+{
+    CommandExecutor exec;
+    DrawCommandList cmds;
+    cmds.emplace_back(FillRectCmd{ D2D1::RectF(0, 0, 32, 32), D2D1::ColorF(D2D1::ColorF::Red) });
+
+    rt_->BeginDraw();
+    exec.Execute(cmds, rt_.Get());
+    EXPECT_HRESULT_SUCCEEDED(rt_->EndDraw());
+
+    EXPECT_EQ(exec.PoolSizeForTest(), 1u);
+    EXPECT_EQ(exec.BoundRtForTest(), rt_.Get());
+}
+
+TEST_F(CommandExecutorIntegrationTest, SameColorReusesPooledBrush)
+{
+    CommandExecutor exec;
+    DrawCommandList cmds;
+    // 同色を繰り返し描画 → ブラシは1つだけプールされる
+    for (int i = 0; i < 5; i++) {
+        cmds.emplace_back(FillRectCmd{ D2D1::RectF(0, 0, 4, 4), D2D1::ColorF(D2D1::ColorF::Red) });
+    }
+    rt_->BeginDraw();
+    exec.Execute(cmds, rt_.Get());
+    EXPECT_HRESULT_SUCCEEDED(rt_->EndDraw());
+    EXPECT_EQ(exec.PoolSizeForTest(), 1u);
+}
+
+TEST_F(CommandExecutorIntegrationTest, DistinctColorsCreateDistinctBrushes)
+{
+    CommandExecutor exec;
+    DrawCommandList cmds;
+    cmds.emplace_back(FillRectCmd{ D2D1::RectF(0, 0, 4, 4), D2D1::ColorF(D2D1::ColorF::Red) });
+    cmds.emplace_back(FillRectCmd{ D2D1::RectF(4, 0, 8, 4), D2D1::ColorF(D2D1::ColorF::Green) });
+    cmds.emplace_back(FillRectCmd{ D2D1::RectF(8, 0, 12, 4), D2D1::ColorF(D2D1::ColorF::Blue) });
+
+    rt_->BeginDraw();
+    exec.Execute(cmds, rt_.Get());
+    EXPECT_HRESULT_SUCCEEDED(rt_->EndDraw());
+    EXPECT_EQ(exec.PoolSizeForTest(), 3u);
+}
+
+TEST_F(CommandExecutorIntegrationTest, RenderTargetSwitchClearsPool)
+{
+    CommandExecutor exec;
+    DrawCommandList cmds;
+    cmds.emplace_back(FillRectCmd{ D2D1::RectF(0, 0, 4, 4), D2D1::ColorF(D2D1::ColorF::Red) });
+    cmds.emplace_back(FillRectCmd{ D2D1::RectF(4, 0, 8, 4), D2D1::ColorF(D2D1::ColorF::Green) });
+
+    rt_->BeginDraw();
+    exec.Execute(cmds, rt_.Get());
+    EXPECT_HRESULT_SUCCEEDED(rt_->EndDraw());
+    EXPECT_EQ(exec.PoolSizeForTest(), 2u);
+
+    // 別の RT に切り替えるとプールはクリアされる
+    ComPtr<ID2D1RenderTarget> rt2;
+    ASSERT_HRESULT_SUCCEEDED(CreateRenderTarget(rt2));
+
+    DrawCommandList cmds2;
+    cmds2.emplace_back(FillRectCmd{ D2D1::RectF(0, 0, 4, 4), D2D1::ColorF(D2D1::ColorF::Red) });
+    rt2->BeginDraw();
+    exec.Execute(cmds2, rt2.Get());
+    EXPECT_HRESULT_SUCCEEDED(rt2->EndDraw());
+    EXPECT_EQ(exec.PoolSizeForTest(), 1u); // 切替後の Red のみ
+    EXPECT_EQ(exec.BoundRtForTest(), rt2.Get());
+}
+
+TEST_F(CommandExecutorIntegrationTest, AllShapeCommandsExecuteWithoutError)
+{
+    CommandExecutor exec;
+    DrawCommandList cmds;
+    cmds.emplace_back(ClearCmd{ D2D1::ColorF(D2D1::ColorF::Black, 0.0f) });
+    cmds.emplace_back(FillRectCmd{ D2D1::RectF(0, 0, 8, 8), D2D1::ColorF(D2D1::ColorF::Red) });
+    cmds.emplace_back(FillRoundedRectCmd{
+        D2D1::RectF(8, 0, 16, 8), 2.0f, 2.0f, D2D1::ColorF(D2D1::ColorF::Green) });
+    cmds.emplace_back(DrawLineCmd{
+        D2D1::Point2F(0, 16), D2D1::Point2F(32, 16),
+        D2D1::ColorF(D2D1::ColorF::Blue), 1.0f });
+    cmds.emplace_back(FillEllipseCmd{ D2D1::Point2F(20, 20), 4.0f, 4.0f, D2D1::ColorF(D2D1::ColorF::Yellow) });
+    cmds.emplace_back(DrawEllipseCmd{ D2D1::Point2F(28, 28), 2.0f, 2.0f, D2D1::ColorF(D2D1::ColorF::Magenta), 1.0f });
+    cmds.emplace_back(PushClipCmd{ D2D1::RectF(0, 0, 32, 32) });
+    cmds.emplace_back(SetTransformCmd{ D2D1::Matrix3x2F::Identity() });
+    cmds.emplace_back(PopClipCmd{});
+
+    rt_->BeginDraw();
+    exec.Execute(cmds, rt_.Get());
+    EXPECT_HRESULT_SUCCEEDED(rt_->EndDraw());
+}
+
+TEST_F(CommandExecutorIntegrationTest, NullBitmapDrawIsSkipped)
+{
+    CommandExecutor exec;
+    DrawCommandList cmds;
+    cmds.emplace_back(DrawBitmapCmd{
+        nullptr, D2D1::RectF(0, 0, 8, 8), 1.0f, D2D1_BITMAP_INTERPOLATION_MODE_LINEAR });
+
+    rt_->BeginDraw();
+    exec.Execute(cmds, rt_.Get());
+    EXPECT_HRESULT_SUCCEEDED(rt_->EndDraw());
+    // bitmap 未指定なら何も描画されず、ブラシも不要
+    EXPECT_EQ(exec.PoolSizeForTest(), 0u);
+}
+
+TEST_F(CommandExecutorIntegrationTest, NullTextLayoutDrawIsSkipped)
+{
+    CommandExecutor exec;
+    DrawCommandList cmds;
+    cmds.emplace_back(DrawTextLayoutCmd{
+        D2D1::Point2F(0, 0), nullptr, D2D1::ColorF(D2D1::ColorF::Black) });
+
+    rt_->BeginDraw();
+    exec.Execute(cmds, rt_.Get());
+    EXPECT_HRESULT_SUCCEEDED(rt_->EndDraw());
+    EXPECT_EQ(exec.PoolSizeForTest(), 0u);
+}

--- a/tests/test_help.cpp
+++ b/tests/test_help.cpp
@@ -86,7 +86,7 @@ TEST_F(HelpNavigationTest, GoForwardFromFileToHelp)
 
     NavEntry fwd_out;
     ASSERT_TRUE(history_.GoForward(NavEntry{ L"C:\\file.md", 5, 10.0f }, fwd_out));
-    EXPECT_EQ(std::wstring_view(fwd_out.file_path), HELP_PATH);
+    EXPECT_EQ(fwd_out.file_path, HELP_PATH);
     EXPECT_EQ(fwd_out.node, 0);
     EXPECT_FLOAT_EQ(fwd_out.offset, 0.0f);
 }
@@ -97,7 +97,7 @@ TEST_F(HelpNavigationTest, PushHelpThenGoBack)
 
     NavEntry out;
     ASSERT_TRUE(history_.GoBack(NavEntry{ L"C:\\file.md", 3, 40.0f }, out));
-    EXPECT_EQ(std::wstring_view(out.file_path), HELP_PATH);
+    EXPECT_EQ(out.file_path, HELP_PATH);
 }
 
 TEST_F(HelpNavigationTest, HelpPathInHistoryCanGoBack)

--- a/tests/test_measurer_parity.cpp
+++ b/tests/test_measurer_parity.cpp
@@ -53,19 +53,14 @@ protected:
 
 private:
     // text_layout が非コピー可能なので、計測前の入力のみを複製する。
-    // SetText は text_utf8 をクリアするため、utf8 のみ保持している src のケースを
-    // 壊さないように text_utf8 と text_ の両経路を使い分ける。
+    // ParseMarkdown 完了後は text_utf8 が常に空である契約のため、Wide テキスト経路のみ扱う。
     static Node CloneNode(const Node& src)
     {
         Node n;
         n.type = src.type;
         n.heading_level = src.heading_level;
         n.code_language = src.code_language;
-        if (!src.text_utf8.empty()) {
-            n.text_utf8 = src.text_utf8;
-            n.ConvertTextFromUtf8();
-        }
-        else if (!src.GetText().empty()) {
+        if (!src.GetText().empty()) {
             n.SetText(src.GetText());
         }
         n.runs = src.runs;

--- a/tests/test_mermaid_util.cpp
+++ b/tests/test_mermaid_util.cpp
@@ -445,7 +445,7 @@ TEST(ParseRequestPrefix, IdWithJsonPayload)
     EXPECT_TRUE(p.valid);
     EXPECT_EQ(p.id, 123u);
     EXPECT_TRUE(p.has_payload);
-    EXPECT_EQ(p.payload, std::wstring_view(L"{\"ok\":true}"));
+    EXPECT_EQ(p.payload, L"{\"ok\":true}");
 }
 
 TEST(ParseRequestPrefix, LargeId)
@@ -454,7 +454,7 @@ TEST(ParseRequestPrefix, LargeId)
     EXPECT_TRUE(p.valid);
     EXPECT_EQ(p.id, 4294967290u);
     EXPECT_TRUE(p.has_payload);
-    EXPECT_EQ(p.payload, std::wstring_view(L"done"));
+    EXPECT_EQ(p.payload, L"done");
 }
 
 TEST(ParseRequestPrefix, TrailingGarbageWithoutColon)
@@ -488,5 +488,5 @@ TEST(ParseRequestPrefix, MaxUintBoundary)
     EXPECT_TRUE(p.valid);
     EXPECT_EQ(p.id, 4294967295u);
     EXPECT_TRUE(p.has_payload);
-    EXPECT_EQ(p.payload, std::wstring_view(L"ok"));
+    EXPECT_EQ(p.payload, L"ok");
 }

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -874,7 +874,7 @@ TEST(Parser, LatexDisplayMathSingleLinePromotedToCodeBlock)
     ASSERT_EQ(result.nodes.size(), 1u);
     EXPECT_EQ(result.nodes[0].type, NodeType::CodeBlock);
     EXPECT_EQ(result.nodes[0].code_language, SyntaxLanguage::LatexMath);
-    EXPECT_EQ(result.nodes[0].text_utf8, "E = mc^2");
+    EXPECT_EQ(result.nodes[0].GetText(), L"E = mc^2");
     // diagram_indices に登録される（描画パイプラインに流すため）
     ASSERT_EQ(result.diagram_indices.size(), 1u);
     EXPECT_EQ(result.diagram_indices[0], 0u);
@@ -941,8 +941,8 @@ TEST(Parser, LatexDisplayMathMultiline)
     EXPECT_EQ(result.nodes[0].type, NodeType::CodeBlock);
     EXPECT_EQ(result.nodes[0].code_language, SyntaxLanguage::LatexMath);
     // 中身に 'E = mc^2' が含まれること（md4c の改行扱いに依存するが、式本体は保持される）
-    const auto& body = result.nodes[0].text_utf8;
-    EXPECT_NE(body.find("E = mc^2"), std::string::npos);
+    const auto& body = result.nodes[0].GetText();
+    EXPECT_NE(body.find(L"E = mc^2"), std::wstring::npos);
 }
 
 TEST(Parser, LatexDisplayMathSurroundingParagraphs)
@@ -953,7 +953,7 @@ TEST(Parser, LatexDisplayMathSurroundingParagraphs)
     EXPECT_EQ(result.nodes[0].type, NodeType::Paragraph);
     EXPECT_EQ(result.nodes[1].type, NodeType::CodeBlock);
     EXPECT_EQ(result.nodes[1].code_language, SyntaxLanguage::LatexMath);
-    EXPECT_EQ(result.nodes[1].text_utf8, "E=mc^2");
+    EXPECT_EQ(result.nodes[1].GetText(), L"E=mc^2");
     EXPECT_EQ(result.nodes[2].type, NodeType::Paragraph);
     ASSERT_EQ(result.diagram_indices.size(), 1u);
     EXPECT_EQ(result.diagram_indices[0], 1u);

--- a/tests/test_render_composer.cpp
+++ b/tests/test_render_composer.cpp
@@ -115,7 +115,7 @@ TEST(RenderComposer, TitleBarState_CopiesFlags)
     EXPECT_FLOAT_EQ(tb.window_width, 1024.0f);
     EXPECT_TRUE(tb.is_dark_mode);
     EXPECT_FALSE(tb.is_maximized);
-    EXPECT_EQ(tb.title_text, std::wstring_view(L"example.md"));
+    EXPECT_EQ(tb.title_text, L"example.md");
     EXPECT_FLOAT_EQ(tb.height, state.window.titlebar.GetHeight());
 }
 

--- a/tests/test_resource_manager.cpp
+++ b/tests/test_resource_manager.cpp
@@ -1,0 +1,323 @@
+#include <gtest/gtest.h>
+#include "resource_manager.h"
+#include "document.h"
+#include "layout_cache.h"
+#include "viewport_manager.h"
+#include "image_loader.h"
+#include "mermaid_renderer_interface.h"
+#include "theme_service.h"
+#include "config_service.h"
+#include "config_store.h"
+#include "test_helpers.h"
+#include <vector>
+
+namespace {
+
+// IMermaidRenderer のテスト用 mock。各メソッドの呼び出し回数と最後の引数を記録する。
+class MockMermaidRenderer : public IMermaidRenderer {
+public:
+    int request_render_count = 0;
+    int cancel_pending_count = 0;
+    int clear_cache_count = 0;
+    Node* last_node = nullptr;
+    float last_max_width = 0.0f;
+    bool last_dark_mode = false;
+
+    void RequestRender(Node& node, NodeLayoutEntry& /*layout_entry*/,
+        DiagramEntry& /*diagram_entry*/, float max_width, bool dark_mode,
+        Callback /*on_complete*/) override
+    {
+        request_render_count++;
+        last_node = &node;
+        last_max_width = max_width;
+        last_dark_mode = dark_mode;
+    }
+
+    void CancelPending() override { cancel_pending_count++; }
+    void ClearCache() override { clear_cache_count++; }
+};
+
+// ResourceManager::Callbacks の各呼び出しを観測するための counter。
+struct CallbackTracker {
+    int invalidate = 0;
+    int set_timer = 0;
+    int kill_timer = 0;
+    int recompute_layout = 0;
+    int recompute_layout_anchored = 0;
+    UINT_PTR last_set_timer_id = 0;
+    UINT last_set_timer_ms = 0;
+    UINT_PTR last_killed_timer_id = 0;
+
+    float content_width = 800.0f;
+    float viewport_height = 600.0f;
+    float indent_width = 20.0f;
+};
+
+ResourceManager::Callbacks MakeCallbacks(CallbackTracker& t)
+{
+    return ResourceManager::Callbacks{
+        .invalidate = [&t]() { t.invalidate++; },
+        .set_timer = [&t](UINT_PTR id, UINT ms) {
+            t.set_timer++;
+            t.last_set_timer_id = id;
+            t.last_set_timer_ms = ms;
+        },
+        .kill_timer = [&t](UINT_PTR id) {
+            t.kill_timer++;
+            t.last_killed_timer_id = id;
+        },
+        .get_content_width = [&t]() { return t.content_width; },
+        .get_viewport_height = [&t]() { return t.viewport_height; },
+        .get_indent_width = [&t]() { return t.indent_width; },
+        .recompute_layout = [&t]() { t.recompute_layout++; },
+        .recompute_layout_anchored = [&t]() { t.recompute_layout_anchored++; },
+    };
+}
+
+// MakeUniformCache をベースに layout_dirty=false を立てたキャッシュを返す。
+LayoutCache SeedLayoutCache(size_t node_count, float block_height = 100.0f)
+{
+    LayoutCache cache = MakeUniformCache(static_cast<int>(node_count), block_height);
+    for (size_t i = 0; i < node_count; i++) {
+        cache[i].layout_dirty = false;
+    }
+    return cache;
+}
+
+} // namespace
+
+class ResourceManagerTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        config::Clear();
+    }
+
+    void TearDown() override
+    {
+        config::Clear();
+    }
+
+    // Markdown を Document に流し込み、対応する LayoutCache をシードしたうえで
+    // ResourceManager を初期化する。テストごとに 1 度だけ呼ぶ。
+    void LoadMarkdown(std::string_view md, float block_height = 100.0f)
+    {
+        std::pmr::string utf8(md);
+        doc_ = Document::FromMarkdown(std::move(utf8), L"test.md");
+        cache_ = SeedLayoutCache(doc_.GetNodes().size(), block_height);
+        rm_.Init(doc_, cache_, viewport_, image_loader_, mock_mermaid_, theme_service_,
+            MakeCallbacks(tracker_));
+    }
+
+    Document doc_;
+    LayoutCache cache_;
+    ViewportManager viewport_;
+    ImageLoader image_loader_; // Init せずに使う（画像経路は通らないテストのみ）
+    MockMermaidRenderer mock_mermaid_;
+    ConfigService config_;
+    ThemeService theme_service_{ config_ };
+    CallbackTracker tracker_;
+    ResourceManager rm_;
+};
+
+// ---- 画像経路 ----
+
+TEST_F(ResourceManagerTest, ApplyCachedImagesReturnsZeroWhenNoImagesInDocument)
+{
+    LoadMarkdown("# heading\n\nparagraph text\n");
+    EXPECT_EQ(rm_.ApplyCachedImages(), 0);
+}
+
+TEST_F(ResourceManagerTest, ApplyCachedImagesReturnsZeroWhenContentWidthIsZero)
+{
+    LoadMarkdown("# heading\n\n![alt](image.png)\n");
+    tracker_.content_width = 0.0f;
+    EXPECT_EQ(rm_.ApplyCachedImages(), 0);
+}
+
+TEST_F(ResourceManagerTest, ApplyCachedImagesSkipsRemoteImages)
+{
+    // http:// 等のリモート画像はスキップされる（ImageLoader は呼ばれない）
+    LoadMarkdown("![alt](https://example.com/foo.png)\n");
+    EXPECT_EQ(rm_.ApplyCachedImages(), 0);
+}
+
+// ---- Mermaid 経路 ----
+
+TEST_F(ResourceManagerTest, RequestMermaidRendersInvokesRendererForVisibleDiagram)
+{
+    LoadMarkdown("```mermaid\ngraph TD;A-->B\n```\n");
+    ASSERT_FALSE(doc_.GetDiagramNodeIndices().empty());
+
+    const int applied = rm_.RequestMermaidRenders();
+    EXPECT_EQ(applied, 0); // mock は bitmap をセットしないため 0
+    EXPECT_EQ(mock_mermaid_.request_render_count, 1);
+    EXPECT_FLOAT_EQ(mock_mermaid_.last_max_width, tracker_.content_width);
+    EXPECT_FALSE(mock_mermaid_.last_dark_mode);
+}
+
+TEST_F(ResourceManagerTest, RequestMermaidRendersSkipsBeyondVisibleRange)
+{
+    // diagram が 2 個。1個目を可視範囲、2個目を範囲外に置く。
+    LoadMarkdown("```mermaid\ngraph TD;A-->B\n```\n\n```mermaid\ngraph TD;C-->D\n```\n",
+        /*block_height=*/200.0f);
+    ASSERT_GE(doc_.GetDiagramNodeIndices().size(), 2u);
+
+    // viewport_height = 600, PREFETCH_BUFFER = 3 screens → range_top=-1800, range_bottom=2400
+    // 各ノード間隔を広くして 2 個目を確実に範囲外に置く。
+    cache_ = SeedLayoutCache(doc_.GetNodes().size(), /*block_height=*/3000.0f);
+
+    rm_.RequestMermaidRenders();
+    // 1個目 (y=0, 可視範囲内) のみ Render される
+    EXPECT_EQ(mock_mermaid_.request_render_count, 1);
+}
+
+TEST_F(ResourceManagerTest, RequestMermaidRendersZeroWidthIsNoOp)
+{
+    LoadMarkdown("```mermaid\ngraph TD;A-->B\n```\n");
+    tracker_.content_width = 0.0f;
+    EXPECT_EQ(rm_.RequestMermaidRenders(), 0);
+    EXPECT_EQ(mock_mermaid_.request_render_count, 0);
+}
+
+TEST_F(ResourceManagerTest, RequestMermaidRendersUsesDarkModeFromThemeService)
+{
+    LoadMarkdown("```mermaid\ngraph TD;A-->B\n```\n");
+    theme_service_.ToggleDarkMode();
+    ASSERT_TRUE(theme_service_.IsDarkMode());
+
+    rm_.RequestMermaidRenders();
+    EXPECT_TRUE(mock_mermaid_.last_dark_mode);
+}
+
+TEST_F(ResourceManagerTest, InvalidateMermaidForWidthChangeFiresOnQuantizedWidthShift)
+{
+    LoadMarkdown("```mermaid\ngraph TD;A-->B\n```\n");
+
+    // 1 回目: 幅 800（最初の登録、last_mermaid_content_width_ をシードする）
+    tracker_.content_width = 800.0f;
+    rm_.RequestMermaidRenders();
+
+    const int initial_cancel = mock_mermaid_.cancel_pending_count;
+    const int initial_clear = mock_mermaid_.clear_cache_count;
+
+    // 2 回目: QuantizeWidth(800) != QuantizeWidth(1000) → 幅変化検出
+    tracker_.content_width = 1000.0f;
+    rm_.RequestMermaidRenders();
+
+    // 量子化幅が変化すると CancelPending と ClearCache の両方が発火する。
+    // 走査ループでは bitmap 不在の diagram も diagram.bitmap.Reset() / width=0 にリセットされ、
+    // any_invalidated が true になるため ClearCache も呼ばれる。
+    EXPECT_GT(mock_mermaid_.cancel_pending_count, initial_cancel);
+    EXPECT_GT(mock_mermaid_.clear_cache_count, initial_clear);
+}
+
+TEST_F(ResourceManagerTest, CancelMermaidBatchInvokesRendererCancelAndKillsTimer)
+{
+    LoadMarkdown("```mermaid\ngraph TD;A-->B\n```\n");
+    rm_.CancelMermaidBatch();
+    EXPECT_EQ(mock_mermaid_.cancel_pending_count, 1);
+    EXPECT_EQ(tracker_.kill_timer, 1);
+    EXPECT_EQ(tracker_.last_killed_timer_id, ResourceManager::TIMER_MERMAID_BATCH);
+}
+
+TEST_F(ResourceManagerTest, ScheduleMermaidBatchSetsTimer)
+{
+    LoadMarkdown("```mermaid\ngraph TD;A-->B\n```\n");
+    rm_.ScheduleMermaidBatch();
+    EXPECT_EQ(tracker_.set_timer, 1);
+    EXPECT_EQ(tracker_.last_set_timer_id, ResourceManager::TIMER_MERMAID_BATCH);
+    EXPECT_EQ(tracker_.last_set_timer_ms, 16u);
+}
+
+TEST_F(ResourceManagerTest, ProcessMermaidBatchKillsTimerWhenWidthIsZero)
+{
+    LoadMarkdown("```mermaid\ngraph TD;A-->B\n```\n");
+    tracker_.content_width = 0.0f;
+    rm_.ProcessMermaidBatch();
+    EXPECT_EQ(tracker_.kill_timer, 1);
+    EXPECT_EQ(tracker_.last_killed_timer_id, ResourceManager::TIMER_MERMAID_BATCH);
+}
+
+TEST_F(ResourceManagerTest, ProcessMermaidBatchKillsTimerWhenAllProcessed)
+{
+    LoadMarkdown("```mermaid\ngraph TD;A-->B\n```\n");
+    rm_.ProcessMermaidBatch();
+    // 1件しかないので走査が完了し、タイマーが kill される
+    EXPECT_GE(mock_mermaid_.request_render_count, 1);
+    EXPECT_GE(tracker_.kill_timer, 1);
+    EXPECT_EQ(tracker_.last_killed_timer_id, ResourceManager::TIMER_MERMAID_BATCH);
+}
+
+// ---- ビットマップ管理 ----
+
+TEST_F(ResourceManagerTest, EvictOffscreenBitmapsNoOpsWhenViewportHeightIsZero)
+{
+    LoadMarkdown("# heading\n\nparagraph\n");
+    tracker_.viewport_height = 0.0f;
+    // 例外を投げず即 return することを確認
+    rm_.EvictOffscreenBitmaps();
+    SUCCEED();
+}
+
+TEST_F(ResourceManagerTest, EvictOffscreenBitmapsReleasesOutOfRangeTextLayouts)
+{
+    // 多くのノードを持つ document を作り、可視範囲外の text_layout が解放されることを確認
+    std::string md;
+    for (int i = 0; i < 20; i++) {
+        md += "paragraph ";
+        md += std::to_string(i);
+        md += "\n\n";
+    }
+    LoadMarkdown(md, /*block_height=*/100.0f);
+
+    // 全ノードに layout_dirty=false をセット（SeedLayoutCache 後）
+    // text_layout は ComPtr で実物が必要なので、layout_dirty フラグの遷移のみ確認
+    for (size_t i = 0; i < cache_.size(); i++) {
+        cache_[i].layout_dirty = false;
+    }
+
+    // viewport は最初の 600px のみ可視。EVICT_BUFFER=5 screens → 6000px の幅で keep。
+    // 全 20 ノード（2000px）は keep 範囲内なので、解放されない（境界ケース確認）
+    viewport_.SetScrollY(0.0f);
+    rm_.EvictOffscreenBitmaps();
+
+    // 全ノードが範囲内のため layout_dirty は false のまま
+    for (size_t i = 0; i < cache_.size(); i++) {
+        EXPECT_FALSE(cache_[i].layout_dirty) << "node " << i;
+    }
+}
+
+TEST_F(ResourceManagerTest, ScheduleBitmapManageSetsTimer)
+{
+    LoadMarkdown("# heading\n");
+    rm_.ScheduleBitmapManage();
+    EXPECT_GE(tracker_.set_timer, 1);
+    EXPECT_EQ(tracker_.last_set_timer_id, ResourceManager::TIMER_BITMAP_MANAGE);
+    EXPECT_EQ(tracker_.last_set_timer_ms, 150u);
+}
+
+TEST_F(ResourceManagerTest, OnBitmapManageTimerKillsTimerAndInvalidates)
+{
+    LoadMarkdown("# heading\n");
+    rm_.OnBitmapManageTimer();
+    EXPECT_GE(tracker_.kill_timer, 1);
+    EXPECT_EQ(tracker_.invalidate, 1);
+}
+
+TEST_F(ResourceManagerTest, FlushPendingResourcesIsNoopWhenNotPending)
+{
+    LoadMarkdown("# heading\n");
+    rm_.FlushPendingResources();
+    // pending_flush_ が立っていないので recompute_layout は呼ばれない
+    EXPECT_EQ(tracker_.recompute_layout, 0);
+}
+
+// ---- ファイル切替時クリーンアップ ----
+
+TEST_F(ResourceManagerTest, ClearResolvedPathsRunsWithoutError)
+{
+    LoadMarkdown("# heading\n");
+    rm_.ClearResolvedPaths();
+    SUCCEED();
+}

--- a/tests/test_resource_manager.cpp
+++ b/tests/test_resource_manager.cpp
@@ -98,13 +98,16 @@ protected:
         config::Clear();
     }
 
+    // ApplyCachedImages は doc_dir.empty() で早期 return するため、テスト用ドキュメントパスは
+    // parent_path を持つ絶対パスでなければならない。
+    static constexpr const wchar_t* kTestDocPath = L"C:\\dir\\test.md";
+
     // Markdown を Document に流し込み、対応する LayoutCache をシードしたうえで
     // ResourceManager を初期化する。テストごとに 1 度だけ呼ぶ。
-    // パスは parent_path を持つ形にして ApplyCachedImages の doc_dir.empty() 早期 return を回避する。
     void LoadMarkdown(std::string_view md, float block_height = 100.0f)
     {
         std::pmr::string utf8(md);
-        doc_ = Document::FromMarkdown(std::move(utf8), L"C:\\dir\\test.md");
+        doc_ = Document::FromMarkdown(std::move(utf8), kTestDocPath);
         cache_ = SeedLayoutCache(doc_.GetNodes().size(), block_height);
         rm_.Init(doc_, cache_, viewport_, image_loader_, mock_mermaid_, theme_service_,
             MakeCallbacks(tracker_));
@@ -136,7 +139,7 @@ TEST_F(ResourceManagerTest, ApplyCachedImagesReturnsZeroWhenContentWidthIsZero)
     EXPECT_EQ(rm_.ApplyCachedImages(), 0);
 }
 
-TEST_F(ResourceManagerTest, ApplyCachedImagesSkipsRemoteImages)
+TEST_F(ResourceManagerTest, ApplyCachedImagesReturnsZeroForRemoteImages)
 {
     // http:// 等のリモート画像は適用対象にならないため、適用数は 0 のまま。
     LoadMarkdown("![alt](https://example.com/foo.png)\n");

--- a/tests/test_resource_manager.cpp
+++ b/tests/test_resource_manager.cpp
@@ -100,10 +100,11 @@ protected:
 
     // Markdown を Document に流し込み、対応する LayoutCache をシードしたうえで
     // ResourceManager を初期化する。テストごとに 1 度だけ呼ぶ。
+    // パスは parent_path を持つ形にして ApplyCachedImages の doc_dir.empty() 早期 return を回避する。
     void LoadMarkdown(std::string_view md, float block_height = 100.0f)
     {
         std::pmr::string utf8(md);
-        doc_ = Document::FromMarkdown(std::move(utf8), L"test.md");
+        doc_ = Document::FromMarkdown(std::move(utf8), L"C:\\dir\\test.md");
         cache_ = SeedLayoutCache(doc_.GetNodes().size(), block_height);
         rm_.Init(doc_, cache_, viewport_, image_loader_, mock_mermaid_, theme_service_,
             MakeCallbacks(tracker_));
@@ -137,7 +138,7 @@ TEST_F(ResourceManagerTest, ApplyCachedImagesReturnsZeroWhenContentWidthIsZero)
 
 TEST_F(ResourceManagerTest, ApplyCachedImagesSkipsRemoteImages)
 {
-    // http:// 等のリモート画像はスキップされる（ImageLoader は呼ばれない）
+    // http:// 等のリモート画像は適用対象にならないため、適用数は 0 のまま。
     LoadMarkdown("![alt](https://example.com/foo.png)\n");
     EXPECT_EQ(rm_.ApplyCachedImages(), 0);
 }

--- a/tests/test_types.cpp
+++ b/tests/test_types.cpp
@@ -312,9 +312,13 @@ TEST(NodeTest, ConvertsUtf8ToWide)
 {
     Node node;
     node.text_utf8 = "Explicit conversion";
-    EXPECT_TRUE(node.HasText());
+    // HasText は text_（Wide）のみを判定するため、変換前はまだ false。
+    EXPECT_FALSE(node.HasText());
     node.ConvertTextFromUtf8();
     EXPECT_EQ(node.GetText(), L"Explicit conversion");
+    // 変換後は text_utf8 が解放され、HasText が text_ で true になる。
+    EXPECT_TRUE(node.text_utf8.empty());
+    EXPECT_TRUE(node.HasText());
 }
 
 TEST(NodeTest, ConvertsJapaneseUtf8ToWide)
@@ -395,15 +399,38 @@ TEST(NodeTest, SyntaxTokensMutCreatesCodeData)
     EXPECT_TRUE(tokens.empty());
 }
 
-TEST(NodeTest, CodeBlockPreservesUtf8AfterConversion)
+TEST(NodeTest, MermaidCodeBlockReleasesUtf8AfterConversion)
 {
     Node node;
     node.type = NodeType::CodeBlock;
-    node.text_utf8 = "code content";
+    node.code_language = SyntaxLanguage::Mermaid;
+    node.text_utf8 = "graph TD;A-->B";
     node.ConvertTextFromUtf8();
-    // CodeBlock は Mermaidハッシュ計算で text_utf8 を直接参照するため保持する
-    EXPECT_FALSE(node.text_utf8.empty());
-    EXPECT_EQ(node.GetText(), L"code content");
+    // ハッシュ計算が GetText() ベースになったため、diagram 系 CodeBlock も text_utf8 を解放する
+    EXPECT_TRUE(node.text_utf8.empty());
+    EXPECT_EQ(node.GetText(), L"graph TD;A-->B");
+}
+
+TEST(NodeTest, LatexMathCodeBlockReleasesUtf8AfterConversion)
+{
+    Node node;
+    node.type = NodeType::CodeBlock;
+    node.code_language = SyntaxLanguage::LatexMath;
+    node.text_utf8 = "E = mc^2";
+    node.ConvertTextFromUtf8();
+    EXPECT_TRUE(node.text_utf8.empty());
+    EXPECT_EQ(node.GetText(), L"E = mc^2");
+}
+
+TEST(NodeTest, NonDiagramCodeBlockReleasesUtf8AfterConversion)
+{
+    Node node;
+    node.type = NodeType::CodeBlock;
+    node.code_language = SyntaxLanguage::Cpp;
+    node.text_utf8 = "int main() { return 0; }";
+    node.ConvertTextFromUtf8();
+    EXPECT_TRUE(node.text_utf8.empty());
+    EXPECT_EQ(node.GetText(), L"int main() { return 0; }");
 }
 
 TEST(NodeTest, ParagraphReleasesUtf8AfterConversion)
@@ -412,7 +439,6 @@ TEST(NodeTest, ParagraphReleasesUtf8AfterConversion)
     node.type = NodeType::Paragraph;
     node.text_utf8 = "paragraph content";
     node.ConvertTextFromUtf8();
-    // Paragraph 等は変換後に text_utf8 を解放する
     EXPECT_TRUE(node.text_utf8.empty());
     EXPECT_EQ(node.GetText(), L"paragraph content");
 }

--- a/tests/test_viewport_manager.cpp
+++ b/tests/test_viewport_manager.cpp
@@ -295,6 +295,30 @@ TEST(ViewportManagerTest, ZoomResetAlreadyDefault)
     EXPECT_FLOAT_EQ(z, 0.0f); // 変更不要
 }
 
+TEST(ViewportManagerTest, SetZoomIndexClampsBelowZero)
+{
+    ViewportManager vm;
+    vm.SetZoomIndex(-5);
+    EXPECT_EQ(vm.GetZoomIndex(), 0);
+    EXPECT_FLOAT_EQ(vm.GetCurrentZoom(), ZOOM_STEPS[0]);
+}
+
+TEST(ViewportManagerTest, SetZoomIndexClampsAboveMax)
+{
+    ViewportManager vm;
+    vm.SetZoomIndex(ZOOM_STEP_COUNT + 100);
+    EXPECT_EQ(vm.GetZoomIndex(), ZOOM_STEP_COUNT - 1);
+    EXPECT_FLOAT_EQ(vm.GetCurrentZoom(), ZOOM_STEPS[ZOOM_STEP_COUNT - 1]);
+}
+
+TEST(ViewportManagerTest, SetZoomIndexAcceptsValidValues)
+{
+    ViewportManager vm;
+    vm.SetZoomIndex(3);
+    EXPECT_EQ(vm.GetZoomIndex(), 3);
+    EXPECT_FLOAT_EQ(vm.GetCurrentZoom(), ZOOM_STEPS[3]);
+}
+
 // ---- スクロールバー追跡テスト ----
 
 TEST(ViewportManagerTest, ScrollbarTracking)


### PR DESCRIPTION
## Summary

- 外部レビュー指摘（WebView2 を除く 4 項目）への対応と、ユーザ提案による Mermaid ハッシュの Wide 化を実装。
- 関連して `command_executor` / `resource_manager` の専用テストを追加。

## 変更点

### コードレビュー対応
- **CodeBlock の UTF-8 二重保持を解消**: `Node::ConvertTextFromUtf8()` 後は全ノードで `text_utf8` を解放する契約に統一。`text_utf8` は md4c コールバック専用の一時領域となった。
- **テーブル flat offset 計算を共通化**: `TableLayoutData::AdvanceFlatOffsetInRow` / `CellFlatOffset` を追加し、`hit_test_service` / `command_generator` / `dwrite_measurer` / `mock_text_measurer` で同じヘルパーを使用。
- **ズーム index 境界の防御**: `ViewportManager::SetZoomIndex` で `[0, ZOOM_STEP_COUNT)` に clamp、`ThemeService::CreateTheme(int)` に assert を追加。
- **command_executor / resource_manager の専用テスト追加**: WIC bitmap RT を使った CommandExecutor の統合テストと、MockMermaidRenderer を使った ResourceManager の挙動テスト。計 35 件。

### Mermaid ハッシュの Wide 化
- `mermaid_util::NodeDiagramHash` を `node.GetText()`（Wide）ベースに変更。
- これにより diagram 系 CodeBlock も含めて `text_utf8` の保持が完全に不要に。
- `parser_alerts.cpp` の `DetectAlertMarker` を Wide 版に書き換え、parser 側の処理順を「Wide 変換 → Alert 検出」に変更。
- 既存の `MermaidFileCache` ファイルキャッシュは初回ロード時に再構築される（一時的なコスト）。

### 品質改善 (`/simplify` 適用)
- ナレーティブ・履歴ベースのコメントを削減。
- `TableLayoutData::AdvanceFlatOffsetInRow` のシグネチャを簡略化（`TableRow&` を直接受ける）。
- `tests/test_command_executor.cpp` を `ComApartmentTest` 派生に変更し、COM 初期化ロジックを共通化。
- `tests/test_resource_manager.cpp` の `Init` 二重呼び出しを解消し、`SeedLayoutCache` を `MakeUniformCache` ベースに置き換え。
- 不要な `std::wstring_view(...)` / `std::string_view(...)` 明示変換を 5 箇所削除。

## Test plan

- [x] Release ビルドが警告/エラーなく通る
- [x] `mendo_tests` 全 1929 件 pass（既存 1895 件 + 新規 35 件 + 削除 1 件）
- [x] 実機での Markdown ファイル表示・Mermaid 図描画が回帰していないこと
- [x] ズーム操作（Ctrl+/-、Ctrl+0）が正常に動作すること
- [x] テーブル選択・コピーが正常に動作すること
- [x] BlockQuote の Alert（NOTE/TIP/IMPORTANT/WARNING/CAUTION）が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)