### PR TITLE
CommandExecutorの1エントリブラシLRUキャッシュを削除

### DIFF
--- a/src/render/command_executor.cpp
+++ b/src/render/command_executor.cpp
@@ -7,32 +7,20 @@ ID2D1SolidColorBrush* CommandExecutor::GetBrush(ID2D1RenderTarget* rt, D2D1_COLO
         // ブラシは RT 付随リソースなので、RT 切替・デバイス再作成では破棄する
         brush_pool_.clear();
         bound_rt_ = rt;
-        last_key_ = 0xFFFFFFFFu;
-        last_brush_ = nullptr;
     }
     const uint32_t key = command_executor_internal::PackColor(color);
-    if (key == last_key_ && last_brush_) {
-        return last_brush_;
-    }
     if (const auto it = brush_pool_.find(key); it != brush_pool_.end()) {
-        last_key_ = key;
-        last_brush_ = it->second.Get();
-        return last_brush_;
+        return it->second.Get();
     }
     if (brush_pool_.size() >= MAX_POOLED_BRUSHES) {
-        // clear で既存ブラシを破棄するので、直近キャッシュもダングリング防止に無効化
         brush_pool_.clear();
-        last_key_ = 0xFFFFFFFFu;
-        last_brush_ = nullptr;
     }
     Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush;
     if (FAILED(rt->CreateSolidColorBrush(color, &brush)) || !brush) {
         return nullptr;
     }
     auto [it, _] = brush_pool_.emplace(key, std::move(brush));
-    last_key_ = key;
-    last_brush_ = it->second.Get();
-    return last_brush_;
+    return it->second.Get();
 }
 
 void CommandExecutor::Execute(const DrawCommandList& cmds, ID2D1RenderTarget* rt)

--- a/src/render/command_executor.h
+++ b/src/render/command_executor.h
@@ -44,6 +44,4 @@ private:
 
     std::unordered_map<uint32_t, Microsoft::WRL::ComPtr<ID2D1SolidColorBrush>> brush_pool_;
     ID2D1RenderTarget* bound_rt_ = nullptr;
-    uint32_t last_key_ = 0xFFFFFFFFu;
-    ID2D1SolidColorBrush* last_brush_ = nullptr;
 };


### PR DESCRIPTION
## Summary
- `CommandExecutor::GetBrush` の前段にあった `last_brush_` / `last_key_` の1エントリLRUキャッシュを削除し、`brush_pool_` (`unordered_map`) 単段に簡略化
- 効果: RT切替・プール上限到達の2箇所に分散していた無効化ルールを1本化し、将来の無効化パス追加時に発生し得るダングリング invariant リスクを除去
- `unordered_map<uint32_t, ...>::find` は identity-hash で十分軽く、後段の Direct2D API コール時間（μsオーダー）に対して LRU の差分は埋もれる見立て

## Test plan
- [x] `cmake --build build --config Release` 成功
- [x] `mendo_tests` 全 1929 テスト pass（`SameColorReusesPooledBrush` / `DistinctColorsCreateDistinctBrushes` / `RenderTargetSwitchClearsPool` を含む）
- [x] 大規模テーブル / 長コードブロックの実 .md でフレーム時間に体感の回帰がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)