### PR TITLE
タイトルバーのテキストをズーム非依存にする

### DIFF
--- a/src/render/renderer_resources.cpp
+++ b/src/render/renderer_resources.cpp
@@ -156,7 +156,7 @@ void Renderer::RecreatePaneFormats()
         { &fmt_.copy_btn_icon,    icon_font, W,                            theme_.font_size_body,         L"en-us", TA_CTR,  PA_CTR, true  },
         { &fmt_.list_number,      body_font, W,                            theme_.font_size_body,         L"ja-jp", TA_TAIL, PA_TOP, false },
         { &fmt_.placeholder_text, body_font, W,                            theme_.font_size_body,         L"ja-jp", TA_CTR,  PA_CTR, false },
-        { &fmt_.titlebar_text,    body_font, W,                            theme_.pane_font_size,         L"ja-jp", TA_CTR,  PA_CTR, true  },
+        { &fmt_.titlebar_text,    body_font, W,                            TITLEBAR_TEXT_FONT_SIZE,       L"ja-jp", TA_CTR,  PA_CTR, true  },
         { &fmt_.titlebar_icon,    icon_font, W,                            14.0f,                         L"en-us", TA_CTR,  PA_CTR, true  },
         { &fmt_.pane_icon,        icon_font, W,                            theme_.pane_font_size,         L"en-us", TA_CTR,  PA_CTR, true  },
         { &fmt_.pane_item,        body_font, W,                            theme_.pane_font_size,         L"ja-jp", TA_LEAD, PA_CTR, true  },

--- a/src/ui/ui_constants.h
+++ b/src/ui/ui_constants.h
@@ -102,6 +102,10 @@ inline float SnapScrollToPixel(float scroll_y, float dpi_scale) noexcept {
     return std::round(scroll_y * dpi_scale) / dpi_scale;
 }
 
+// タイトルバーのテキストフォントサイズ（DIP）。
+// pane_font_size と共有すると Zoom に追従してしまうため、専用の固定値を用意する。
+inline constexpr float TITLEBAR_TEXT_FONT_SIZE = 13.0f;
+
 // 検索バーの定数（DIP単位）
 inline constexpr float SEARCH_BAR_HEIGHT = 36.0f;
 inline constexpr float SEARCH_BAR_PADDING = 6.0f;


### PR DESCRIPTION
## Summary
- ズーム操作でタイトルバーの文字まで拡大縮小される問題を修正
- `titlebar_text` のフォントサイズを `theme_.pane_font_size`（`Theme::ApplyZoom` でスケールされる）から、専用の固定定数 `TITLEBAR_TEXT_FONT_SIZE = 13.0f`（`ui_constants.h`）に切替

## Test plan
- [x] アプリ起動時、タイトルバー左側にファイル名／タイトルが表示されること
- [x] Ctrl + マウスホイールでズームしても、タイトルバーの文字サイズが変化しないこと
- [x] 本文・ファイルペイン・目次ペインなど他のテキストは従来通りズームに追従すること
- [x] ライト／ダーク両テーマでタイトルバーの見た目が崩れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)