### PR TITLE
issue #107: Mermaid 図を SVG としてクリップボードにコピー

### DIFF
--- a/res/mermaid.html
+++ b/res/mermaid.html
@@ -9,11 +9,31 @@
   #container { display: block; }
 </style>
 <script>
+  let currentHtmlLabels = null;
   let currentTheme = null;
   let renderCount = 0;
 
   function mermaidReady() {
     return typeof mermaid !== 'undefined' && typeof mermaid.render === 'function';
+  }
+
+  // mermaid.initialize は破壊的にグローバル設定を書き換えるため、
+  // 表示用 (HTML ラベル付き) と SVG エクスポート用 (テキスト要素のみ) を
+  // 都度切り替える。SVG エクスポート時は htmlLabels=false にしないと
+  // <foreignObject> がオフィス SVG レンダラで描画されず文字が消える。
+  function applyMermaidConfig(useHtmlLabels, theme) {
+    if (currentHtmlLabels === useHtmlLabels && currentTheme === theme) {
+      return;
+    }
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: theme,
+      securityLevel: 'strict',
+      flowchart: { htmlLabels: useHtmlLabels },
+      class: { htmlLabels: useHtmlLabels }
+    });
+    currentHtmlLabels = useHtmlLabels;
+    currentTheme = theme;
   }
 
   async function renderMermaid(code, isDark, maxWidth) {
@@ -23,14 +43,7 @@
       }
       const wantTheme = isDark ? 'dark' : 'default';
       document.body.className = isDark ? 'dark' : '';
-      if (currentTheme !== wantTheme) {
-        mermaid.initialize({
-          startOnLoad: false,
-          theme: wantTheme,
-          securityLevel: 'strict'
-        });
-        currentTheme = wantTheme;
-      }
+      applyMermaidConfig(true, wantTheme);
       const container = document.getElementById('container');
       container.innerHTML = '';
       document.body.style.width = '';
@@ -53,6 +66,120 @@
       return JSON.stringify({ ok: false, error: 'SVG not found' });
     } catch (e) {
       return JSON.stringify({ ok: false, error: e.message || String(e) });
+    }
+  }
+
+  // foreignObject の中身を SVG <text> 要素に置換する。
+  // Office (Word/Excel/PowerPoint) の SVG レンダラは <foreignObject> をサポートしないため、
+  // mermaid v11 が htmlLabels:false でも残してしまうラベル foreignObject を変換する必要がある。
+  function inlineForeignObjectsToText(svgEl) {
+    const ns = 'http://www.w3.org/2000/svg';
+    const fos = Array.from(svgEl.querySelectorAll('foreignObject'));
+    for (const fo of fos) {
+      const x = parseFloat(fo.getAttribute('x') || '0');
+      const y = parseFloat(fo.getAttribute('y') || '0');
+      const w = parseFloat(fo.getAttribute('width') || '0');
+      const h = parseFloat(fo.getAttribute('height') || '0');
+      const cx = x + w / 2;
+      const cy = y + h / 2;
+
+      // <br>, <p>, <div> を行区切りとして子孫テキストを抽出。
+      const lines = [];
+      let current = '';
+      const flushLine = () => {
+        if (current.length > 0) { lines.push(current); current = ''; }
+      };
+      function walk(el) {
+        for (const child of el.childNodes) {
+          if (child.nodeType === Node.TEXT_NODE) {
+            current += child.textContent;
+          } else if (child.nodeType === Node.ELEMENT_NODE) {
+            const tag = child.tagName.toLowerCase();
+            if (tag === 'br') {
+              lines.push(current);
+              current = '';
+            } else if (tag === 'p' || tag === 'div') {
+              flushLine();
+              walk(child);
+              flushLine();
+            } else {
+              walk(child);
+            }
+          }
+        }
+      }
+      walk(fo);
+      flushLine();
+      const cleanLines = lines.map(s => s.trim()).filter(s => s.length > 0);
+      if (cleanLines.length === 0) {
+        if (fo.parentNode) fo.parentNode.removeChild(fo);
+        continue;
+      }
+
+      // フォントスタイルを computed style から継承
+      const fontEl = fo.querySelector('.nodeLabel, span, p, div') || fo;
+      const cs = window.getComputedStyle(fontEl);
+      const fontSize = parseFloat(cs.fontSize) || 14;
+      const fontFamily = cs.fontFamily || 'sans-serif';
+      const fontWeight = cs.fontWeight || 'normal';
+      const color = cs.color || '#000';
+      const lineHeight = fontSize * 1.2;
+
+      const text = document.createElementNS(ns, 'text');
+      text.setAttribute('text-anchor', 'middle');
+      text.setAttribute('font-family', fontFamily);
+      text.setAttribute('font-size', String(fontSize));
+      if (fontWeight !== 'normal' && fontWeight !== '400') {
+        text.setAttribute('font-weight', fontWeight);
+      }
+      text.setAttribute('fill', color);
+
+      // dominant-baseline はオフィスSVG実装で挙動が割れるため使わず、
+      // ベースライン位置を fontSize/3 だけ下げて視覚的中央に揃える。
+      const totalHeight = (cleanLines.length - 1) * lineHeight;
+      const startY = cy - totalHeight / 2 + fontSize / 3;
+      for (let i = 0; i < cleanLines.length; i++) {
+        const tspan = document.createElementNS(ns, 'tspan');
+        tspan.setAttribute('x', String(cx));
+        tspan.setAttribute('y', String(startY + i * lineHeight));
+        tspan.textContent = cleanLines[i];
+        text.appendChild(tspan);
+      }
+      if (fo.parentNode) {
+        fo.parentNode.replaceChild(text, fo);
+      }
+    }
+  }
+
+  // 表示用 container を触らず SVG 文字列のみ返す。PNG キャプチャ無し。
+  // 一時コンテナにレンダリングして computed style を読み取り、foreignObject を <text> に置換する。
+  async function renderMermaidSvg(code, isDark) {
+    let temp = null;
+    try {
+      if (!mermaidReady()) {
+        return null;
+      }
+      const wantTheme = isDark ? 'dark' : 'default';
+      applyMermaidConfig(false, wantTheme);
+      renderCount++;
+      const { svg: rawSvg } = await mermaid.render('mmd-svg-' + renderCount, code);
+
+      temp = document.createElement('div');
+      temp.style.cssText = 'position:absolute;left:-99999px;top:-99999px;';
+      temp.innerHTML = rawSvg;
+      document.body.appendChild(temp);
+      await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+
+      const svgEl = temp.querySelector('svg');
+      if (!svgEl) {
+        return rawSvg;
+      }
+      inlineForeignObjectsToText(svgEl);
+      return new XMLSerializer().serializeToString(svgEl);
+    } catch (e) {
+      return null;
+    } finally {
+      if (temp && temp.parentNode) temp.parentNode.removeChild(temp);
     }
   }
 

--- a/res/mermaid.html
+++ b/res/mermaid.html
@@ -9,31 +9,11 @@
   #container { display: block; }
 </style>
 <script>
-  let currentHtmlLabels = null;
   let currentTheme = null;
   let renderCount = 0;
 
   function mermaidReady() {
     return typeof mermaid !== 'undefined' && typeof mermaid.render === 'function';
-  }
-
-  // mermaid.initialize は破壊的にグローバル設定を書き換えるため、
-  // 表示用 (HTML ラベル付き) と SVG エクスポート用 (テキスト要素のみ) を
-  // 都度切り替える。SVG エクスポート時は htmlLabels=false にしないと
-  // <foreignObject> がオフィス SVG レンダラで描画されず文字が消える。
-  function applyMermaidConfig(useHtmlLabels, theme) {
-    if (currentHtmlLabels === useHtmlLabels && currentTheme === theme) {
-      return;
-    }
-    mermaid.initialize({
-      startOnLoad: false,
-      theme: theme,
-      securityLevel: 'strict',
-      flowchart: { htmlLabels: useHtmlLabels },
-      class: { htmlLabels: useHtmlLabels }
-    });
-    currentHtmlLabels = useHtmlLabels;
-    currentTheme = theme;
   }
 
   async function renderMermaid(code, isDark, maxWidth) {
@@ -43,7 +23,14 @@
       }
       const wantTheme = isDark ? 'dark' : 'default';
       document.body.className = isDark ? 'dark' : '';
-      applyMermaidConfig(true, wantTheme);
+      if (currentTheme !== wantTheme) {
+        mermaid.initialize({
+          startOnLoad: false,
+          theme: wantTheme,
+          securityLevel: 'strict'
+        });
+        currentTheme = wantTheme;
+      }
       const container = document.getElementById('container');
       container.innerHTML = '';
       document.body.style.width = '';
@@ -69,117 +56,26 @@
     }
   }
 
-  // foreignObject の中身を SVG <text> 要素に置換する。
-  // Office (Word/Excel/PowerPoint) の SVG レンダラは <foreignObject> をサポートしないため、
-  // mermaid v11 が htmlLabels:false でも残してしまうラベル foreignObject を変換する必要がある。
-  function inlineForeignObjectsToText(svgEl) {
-    const ns = 'http://www.w3.org/2000/svg';
-    const fos = Array.from(svgEl.querySelectorAll('foreignObject'));
-    for (const fo of fos) {
-      const x = parseFloat(fo.getAttribute('x') || '0');
-      const y = parseFloat(fo.getAttribute('y') || '0');
-      const w = parseFloat(fo.getAttribute('width') || '0');
-      const h = parseFloat(fo.getAttribute('height') || '0');
-      const cx = x + w / 2;
-      const cy = y + h / 2;
-
-      // <br>, <p>, <div> を行区切りとして子孫テキストを抽出。
-      const lines = [];
-      let current = '';
-      const flushLine = () => {
-        if (current.length > 0) { lines.push(current); current = ''; }
-      };
-      function walk(el) {
-        for (const child of el.childNodes) {
-          if (child.nodeType === Node.TEXT_NODE) {
-            current += child.textContent;
-          } else if (child.nodeType === Node.ELEMENT_NODE) {
-            const tag = child.tagName.toLowerCase();
-            if (tag === 'br') {
-              lines.push(current);
-              current = '';
-            } else if (tag === 'p' || tag === 'div') {
-              flushLine();
-              walk(child);
-              flushLine();
-            } else {
-              walk(child);
-            }
-          }
-        }
-      }
-      walk(fo);
-      flushLine();
-      const cleanLines = lines.map(s => s.trim()).filter(s => s.length > 0);
-      if (cleanLines.length === 0) {
-        if (fo.parentNode) fo.parentNode.removeChild(fo);
-        continue;
-      }
-
-      // フォントスタイルを computed style から継承
-      const fontEl = fo.querySelector('.nodeLabel, span, p, div') || fo;
-      const cs = window.getComputedStyle(fontEl);
-      const fontSize = parseFloat(cs.fontSize) || 14;
-      const fontFamily = cs.fontFamily || 'sans-serif';
-      const fontWeight = cs.fontWeight || 'normal';
-      const color = cs.color || '#000';
-      const lineHeight = fontSize * 1.2;
-
-      const text = document.createElementNS(ns, 'text');
-      text.setAttribute('text-anchor', 'middle');
-      text.setAttribute('font-family', fontFamily);
-      text.setAttribute('font-size', String(fontSize));
-      if (fontWeight !== 'normal' && fontWeight !== '400') {
-        text.setAttribute('font-weight', fontWeight);
-      }
-      text.setAttribute('fill', color);
-
-      // dominant-baseline はオフィスSVG実装で挙動が割れるため使わず、
-      // ベースライン位置を fontSize/3 だけ下げて視覚的中央に揃える。
-      const totalHeight = (cleanLines.length - 1) * lineHeight;
-      const startY = cy - totalHeight / 2 + fontSize / 3;
-      for (let i = 0; i < cleanLines.length; i++) {
-        const tspan = document.createElementNS(ns, 'tspan');
-        tspan.setAttribute('x', String(cx));
-        tspan.setAttribute('y', String(startY + i * lineHeight));
-        tspan.textContent = cleanLines[i];
-        text.appendChild(tspan);
-      }
-      if (fo.parentNode) {
-        fo.parentNode.replaceChild(text, fo);
-      }
-    }
-  }
-
   // 表示用 container を触らず SVG 文字列のみ返す。PNG キャプチャ無し。
-  // 一時コンテナにレンダリングして computed style を読み取り、foreignObject を <text> に置換する。
   async function renderMermaidSvg(code, isDark) {
-    let temp = null;
     try {
       if (!mermaidReady()) {
         return null;
       }
       const wantTheme = isDark ? 'dark' : 'default';
-      applyMermaidConfig(false, wantTheme);
-      renderCount++;
-      const { svg: rawSvg } = await mermaid.render('mmd-svg-' + renderCount, code);
-
-      temp = document.createElement('div');
-      temp.style.cssText = 'position:absolute;left:-99999px;top:-99999px;';
-      temp.innerHTML = rawSvg;
-      document.body.appendChild(temp);
-      await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
-
-      const svgEl = temp.querySelector('svg');
-      if (!svgEl) {
-        return rawSvg;
+      if (currentTheme !== wantTheme) {
+        mermaid.initialize({
+          startOnLoad: false,
+          theme: wantTheme,
+          securityLevel: 'strict'
+        });
+        currentTheme = wantTheme;
       }
-      inlineForeignObjectsToText(svgEl);
-      return new XMLSerializer().serializeToString(svgEl);
+      renderCount++;
+      const { svg } = await mermaid.render('mmd-svg-' + renderCount, code);
+      return svg;
     } catch (e) {
       return null;
-    } finally {
-      if (temp && temp.parentNode) temp.parentNode.removeChild(temp);
     }
   }
 

--- a/res/mermaid.html
+++ b/res/mermaid.html
@@ -16,21 +16,25 @@
     return typeof mermaid !== 'undefined' && typeof mermaid.render === 'function';
   }
 
+  function ensureThemeInitialized(isDark) {
+    const wantTheme = isDark ? 'dark' : 'default';
+    if (currentTheme !== wantTheme) {
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: wantTheme,
+        securityLevel: 'strict'
+      });
+      currentTheme = wantTheme;
+    }
+  }
+
   async function renderMermaid(code, isDark, maxWidth) {
     try {
       if (!mermaidReady()) {
         return JSON.stringify({ ok: false, error: 'mermaid not loaded' });
       }
-      const wantTheme = isDark ? 'dark' : 'default';
       document.body.className = isDark ? 'dark' : '';
-      if (currentTheme !== wantTheme) {
-        mermaid.initialize({
-          startOnLoad: false,
-          theme: wantTheme,
-          securityLevel: 'strict'
-        });
-        currentTheme = wantTheme;
-      }
+      ensureThemeInitialized(isDark);
       const container = document.getElementById('container');
       container.innerHTML = '';
       document.body.style.width = '';
@@ -62,15 +66,7 @@
       if (!mermaidReady()) {
         return null;
       }
-      const wantTheme = isDark ? 'dark' : 'default';
-      if (currentTheme !== wantTheme) {
-        mermaid.initialize({
-          startOnLoad: false,
-          theme: wantTheme,
-          securityLevel: 'strict'
-        });
-        currentTheme = wantTheme;
-      }
+      ensureThemeInitialized(isDark);
       renderCount++;
       const { svg } = await mermaid.render('mmd-svg-' + renderCount, code);
       return svg;

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -215,6 +215,7 @@ void App::OnPaint()
                 state_.view.viewport.GetSelection(), layout.md_rect, sp, tb, gs, ts, sb,
                 state_.view.viewport.GetScrollY(), layout_service_->GetTotalHeight(),
                 static_cast<int>(state_.interaction.nav_hover), state_.interaction.hovered_copy_node, state_.interaction.hovered_save_node,
+                state_.interaction.hovered_svg_copy_node,
                 state_.view.nav_history.CanGoBack(), state_.view.nav_history.CanGoForward(),
                 layout_service_->HasDirtyNodes()
                 });

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -18,6 +18,7 @@
 #include "session_service.h"
 #include "cursor_manager.h"
 #include "hit_test_service.h"
+#include "lru_cache.h"
 #include <windows.h>
 #include <shellapi.h>
 #include <string>
@@ -150,6 +151,7 @@ private:
     void CopySelectionToClipboard() const;
     void CopyCodeBlockToClipboard(int node_index) const;
     void SaveDiagramAsPng(int node_index);
+    void CopyDiagramAsSvg(int node_index);
 
     // クリックハンドラ (OnLButtonDownから抽出)
     bool HandleTitleBarClick(float dip_x, float dip_y);
@@ -235,4 +237,11 @@ private:
     SideEffectExecutor effect_executor_;
 
     void ShowToast(std::wstring_view message);
+
+    // SVG クリップボードコピーのセッション内 LRU キャッシュ。
+    // キーは PNG キャッシュと同じ NodeDiagramHash。LatexMath は SVG コピー対象外。
+    static constexpr size_t MAX_SVG_CACHE_ENTRIES = 64;
+    LruCache<uint64_t, std::pmr::wstring> svg_cache_{ MAX_SVG_CACHE_ENTRIES };
+    // 連続クリック中の重複リクエスト抑止
+    bool svg_copy_in_flight_ = false;
 };

--- a/src/app/app_clipboard.cpp
+++ b/src/app/app_clipboard.cpp
@@ -138,9 +138,13 @@ void App::CopyDiagramAsSvg(int node_index)
     ShowToast(i18n::S().toast_svg_copying);
     svg_copy_in_flight_ = true;
 
-    mermaid_renderer_.RequestSvg(node.GetText(), dark,
-        [this, key](std::pmr::wstring svg) {
+    mermaid_renderer_.RequestSvg(node.GetText(), md_width, dark,
+        [this, key](std::pmr::wstring svg, bool cancelled) {
             svg_copy_in_flight_ = false;
+            if (cancelled) {
+                // テーマ変更/幅変更/シャットダウン等によるキャンセル。トーストは出さない。
+                return;
+            }
             if (svg.empty()) {
                 ShowToast(i18n::S().toast_svg_copy_failed);
                 return;

--- a/src/app/app_clipboard.cpp
+++ b/src/app/app_clipboard.cpp
@@ -110,3 +110,43 @@ void App::SaveDiagramAsPng(int node_index)
         DeleteFileW(filename);
     }
 }
+
+void App::CopyDiagramAsSvg(int node_index)
+{
+    const auto& nodes = state_.document.doc.GetNodes();
+    if (node_index < 0 || node_index >= static_cast<int>(nodes.size())) {
+        return;
+    }
+    const auto& node = nodes[node_index];
+    if (node.type != NodeType::CodeBlock || !IsSvgExportable(node.code_language)) {
+        return;
+    }
+    if (svg_copy_in_flight_) {
+        return;
+    }
+
+    const float md_width = renderer_.GetTheme().ContentWidth(GetMarkdownPaneWidth());
+    const bool dark = renderer_.GetTheme().IsDark();
+    const uint64_t key = mermaid_util::NodeDiagramHash(node, md_width, dark);
+
+    if (const auto* hit = svg_cache_.Find(key)) {
+        WriteClipboardSvg(hwnd_, *hit);
+        ShowToast(i18n::S().toast_svg_copied);
+        return;
+    }
+
+    ShowToast(i18n::S().toast_svg_copying);
+    svg_copy_in_flight_ = true;
+
+    mermaid_renderer_.RequestSvg(node.GetText(), dark,
+        [this, key](std::pmr::wstring svg) {
+            svg_copy_in_flight_ = false;
+            if (svg.empty()) {
+                ShowToast(i18n::S().toast_svg_copy_failed);
+                return;
+            }
+            WriteClipboardSvg(hwnd_, svg);
+            svg_cache_.Insert(key, std::move(svg));
+            ShowToast(i18n::S().toast_svg_copied);
+        });
+}

--- a/src/app/app_clipboard.cpp
+++ b/src/app/app_clipboard.cpp
@@ -130,8 +130,8 @@ void App::CopyDiagramAsSvg(int node_index)
     const uint64_t key = mermaid_util::NodeDiagramHash(node, md_width, dark);
 
     if (const auto* hit = svg_cache_.Find(key)) {
-        WriteClipboardSvg(hwnd_, *hit);
-        ShowToast(i18n::S().toast_svg_copied);
+        const bool ok = WriteClipboardSvg(hwnd_, *hit);
+        ShowToast(ok ? i18n::S().toast_svg_copied : i18n::S().toast_svg_copy_failed);
         return;
     }
 
@@ -149,8 +149,10 @@ void App::CopyDiagramAsSvg(int node_index)
                 ShowToast(i18n::S().toast_svg_copy_failed);
                 return;
             }
-            WriteClipboardSvg(hwnd_, svg);
-            svg_cache_.Insert(key, std::move(svg));
-            ShowToast(i18n::S().toast_svg_copied);
+            const bool ok = WriteClipboardSvg(hwnd_, svg);
+            if (ok) {
+                svg_cache_.Insert(key, std::move(svg));
+            }
+            ShowToast(ok ? i18n::S().toast_svg_copied : i18n::S().toast_svg_copy_failed);
         });
 }

--- a/src/app/app_events.h
+++ b/src/app/app_events.h
@@ -104,6 +104,7 @@ struct MdPaneNavHoverAction {
 struct MdPaneButtonHoverChangedAction {
     int hovered_copy_node;
     int hovered_save_node;
+    int hovered_svg_copy_node = -1;
 };
 struct SplitterDragStartedAction {
     PaneController::DragTarget target;

--- a/src/app/app_mouse_click.cpp
+++ b/src/app/app_mouse_click.cpp
@@ -58,22 +58,19 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
         Dispatch(NavigateForwardAction{});
         return;
     }
-    // コピーボタンのクリック判定（クリック位置で再判定）
+    // コードブロック系ボタン（コピー/SVGコピー/保存）を1回の可視ノード走査でまとめて判定。
     const auto hit_ctx = BuildMdPaneHitContext(px, py, pane_layout);
-    const auto copy_node = hit_test_.CopyButtonHitTest(hit_ctx);
-    if (copy_node >= 0) {
-        CopyCodeBlockToClipboard(copy_node);
+    const auto btn_hit = hit_test_.CodeBlockButtonsHitTest(hit_ctx);
+    if (btn_hit.copy_node >= 0) {
+        CopyCodeBlockToClipboard(btn_hit.copy_node);
         return;
     }
-    const auto svg_copy_node = hit_test_.SvgCopyButtonHitTest(hit_ctx);
-    if (svg_copy_node >= 0) {
-        CopyDiagramAsSvg(svg_copy_node);
+    if (btn_hit.svg_copy_node >= 0) {
+        CopyDiagramAsSvg(btn_hit.svg_copy_node);
         return;
     }
-    // 保存ボタンのクリック判定
-    const auto save_node = hit_test_.SaveButtonHitTest(hit_ctx);
-    if (save_node >= 0) {
-        SaveDiagramAsPng(save_node);
+    if (btn_hit.save_node >= 0) {
+        SaveDiagramAsPng(btn_hit.save_node);
         return;
     }
     // MDペインスクロールバーのクリック判定

--- a/src/app/app_mouse_click.cpp
+++ b/src/app/app_mouse_click.cpp
@@ -65,6 +65,11 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
         CopyCodeBlockToClipboard(copy_node);
         return;
     }
+    const auto svg_copy_node = hit_test_.SvgCopyButtonHitTest(hit_ctx);
+    if (svg_copy_node >= 0) {
+        CopyDiagramAsSvg(svg_copy_node);
+        return;
+    }
     // 保存ボタンのクリック判定
     const auto save_node = hit_test_.SaveButtonHitTest(hit_ctx);
     if (save_node >= 0) {

--- a/src/app/app_mouse_hover.cpp
+++ b/src/app/app_mouse_hover.cpp
@@ -105,24 +105,33 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
         return;
     }
 
-    // コピー/保存ボタンのホバー判定（距離 + 時間スロットリングで不要な再計算を回避）。
-    // 1 回の可視ノード走査で Copy/Save 両方を判定する。
+    // コピー/保存/SVGコピーボタンのホバー判定（距離 + 時間スロットリングで不要な再計算を回避）。
+    // 1 回の可視ノード走査で 3 つを同時に判定する。
     const auto hit_ctx = BuildMdPaneHitContext(px, py, pane_layout);
     auto& ht = state_.interaction.hover_throttle;
     int new_copy_hover = state_.interaction.hovered_copy_node;
     int new_save_hover = state_.interaction.hovered_save_node;
+    int new_svg_copy_hover = state_.interaction.hovered_svg_copy_node;
     if (ht.TryMarkMoved(ht.last_copy_hit_pos, ht.last_copy_hit_tick, px, py)) {
         const auto btn_hit = hit_test_.CodeBlockButtonsHitTest(hit_ctx);
         new_copy_hover = btn_hit.copy_node;
         new_save_hover = btn_hit.save_node;
+        new_svg_copy_hover = btn_hit.svg_copy_node;
     }
-    if (new_copy_hover != state_.interaction.hovered_copy_node || new_save_hover != state_.interaction.hovered_save_node) {
-        Dispatch(MdPaneButtonHoverChangedAction{ new_copy_hover, new_save_hover });
+    if (new_copy_hover != state_.interaction.hovered_copy_node
+        || new_save_hover != state_.interaction.hovered_save_node
+        || new_svg_copy_hover != state_.interaction.hovered_svg_copy_node) {
+        Dispatch(MdPaneButtonHoverChangedAction{ new_copy_hover, new_save_hover, new_svg_copy_hover });
     }
 
     if (new_copy_hover >= 0) {
         SetCursor(cursors_.Hand());
         Dispatch(UpdateTooltipAction{ TooltipTarget{ TooltipTarget::Zone::CopyButton, i18n::S().tooltip_copy }, px, py });
+        return;
+    }
+    if (new_svg_copy_hover >= 0) {
+        SetCursor(cursors_.Hand());
+        Dispatch(UpdateTooltipAction{ TooltipTarget{ TooltipTarget::Zone::SvgCopyButton, i18n::S().tooltip_copy_svg }, px, py });
         return;
     }
     if (new_save_hover >= 0) {

--- a/src/app/app_state.h
+++ b/src/app/app_state.h
@@ -46,6 +46,7 @@ struct InteractionState {
     ToastNotifier toast;
     int hovered_copy_node = -1;
     int hovered_save_node = -1;
+    int hovered_svg_copy_node = -1;
     NavButtonHover nav_hover = NavButtonHover::None;
 };
 

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -376,10 +376,11 @@ void ReduceMdPaneNavHover(AppState& state, SideEffectList& effects, const MdPane
         return;
     }
     state.interaction.nav_hover = a.nav_hover;
-    // ナビボタンホバー時は、コピー/保存ボタンホバー状態をクリア（重ならないように）
+    // ナビボタンホバー時は、コピー/保存/SVGコピーボタンホバー状態をクリア（重ならないように）
     if (a.nav_hover != NavButtonHover::None) {
         state.interaction.hovered_copy_node = -1;
         state.interaction.hovered_save_node = -1;
+        state.interaction.hovered_svg_copy_node = -1;
     }
     PushEffect(effects, effect::InvalidateWindow{});
 }
@@ -387,11 +388,13 @@ void ReduceMdPaneNavHover(AppState& state, SideEffectList& effects, const MdPane
 void ReduceMdPaneButtonHoverChanged(AppState& state, SideEffectList& effects, const MdPaneButtonHoverChangedAction& a)
 {
     if (state.interaction.hovered_copy_node == a.hovered_copy_node
-        && state.interaction.hovered_save_node == a.hovered_save_node) {
+        && state.interaction.hovered_save_node == a.hovered_save_node
+        && state.interaction.hovered_svg_copy_node == a.hovered_svg_copy_node) {
         return;
     }
     state.interaction.hovered_copy_node = a.hovered_copy_node;
     state.interaction.hovered_save_node = a.hovered_save_node;
+    state.interaction.hovered_svg_copy_node = a.hovered_svg_copy_node;
     PushEffect(effects, effect::InvalidateWindow{});
 }
 

--- a/src/core/syntax.h
+++ b/src/core/syntax.h
@@ -25,6 +25,12 @@ constexpr bool IsDiagramLanguage(SyntaxLanguage lang) noexcept
     return lang == SyntaxLanguage::Mermaid || lang == SyntaxLanguage::LatexMath;
 }
 
+// SVG クリップボードコピーの対象。LatexMath は flowchart ラッパなので意味のある SVG にならず除外する。
+constexpr bool IsSvgExportable(SyntaxLanguage lang) noexcept
+{
+    return lang == SyntaxLanguage::Mermaid;
+}
+
 enum class SyntaxTokenType : uint8_t {
     Plain,
     Keyword,

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -384,7 +384,9 @@ HitTestService::CodeBlockButtonHit HitTestService::CodeBlockButtonsHitTest(
                 copy_hit = i;
             }
         }
-        if (copy_hit >= 0 && save_hit >= 0 && svg_copy_hit >= 0) {
+        // マウス座標は1点なので、コピー/保存/SVGコピーボタンが同時にヒットすることはない。
+        // 1つでも見つかった時点で残りの可視ノード走査をスキップする。
+        if (copy_hit >= 0 || save_hit >= 0 || svg_copy_hit >= 0) {
             break;
         }
     }

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -283,6 +283,32 @@ int HitTestService::SaveButtonHitTest(const MdPaneHitContext& ctx) const noexcep
         });
 }
 
+int HitTestService::SvgCopyButtonHitTest(const MdPaneHitContext& ctx) const noexcept
+{
+    assert(ctx.content_width > 0.0f && "content_width must be set for button hit test");
+    assert(ctx.md_pane_height > 0.0f && "md_pane_height must be set for button hit test");
+
+    return HitTestCodeBlockButton(ctx, last_svg_copy_hit_,
+        [&](int i, const Node& node, const NodeLayoutEntry& entry,
+            float dip_x, float dip_y) noexcept -> bool {
+            if (!IsSvgExportable(node.code_language)) {
+                return false;
+            }
+            const auto& diagram = ctx.cache.GetDiagram(i);
+            if (!diagram.bitmap) {
+                return false;
+            }
+            const float indent = NodeIndent(node, ctx.theme);
+            const float x = ctx.theme.margin_left + indent;
+            const float cw = ctx.content_width - indent;
+            const auto bmp = MermaidBitmapRect(diagram.width, diagram.height, x, cw, entry.y_position);
+            // 保存ボタン (index 0) の左隣 (index 1)
+            const D2D1_RECT_F btn = OverlayButtonRect(bmp.right, bmp.top, 1);
+            return dip_x >= btn.left && dip_x <= btn.right
+                && dip_y >= btn.top && dip_y <= btn.bottom;
+        });
+}
+
 HitTestService::CodeBlockButtonHit HitTestService::CodeBlockButtonsHitTest(
     const MdPaneHitContext& ctx) const noexcept
 {
@@ -296,9 +322,11 @@ HitTestService::CodeBlockButtonHit HitTestService::CodeBlockButtonsHitTest(
     const uint32_t gen = ctx.cache.GetEffectsGeneration();
     const bool copy_cached = last_copy_hit_.Matches(ctx, gen);
     const bool save_cached = last_save_hit_.Matches(ctx, gen);
-    if (copy_cached && save_cached) {
+    const bool svg_cached = last_svg_copy_hit_.Matches(ctx, gen);
+    if (copy_cached && save_cached && svg_cached) {
         out.copy_node = last_copy_hit_.result;
         out.save_node = last_save_hit_.result;
+        out.svg_copy_node = last_svg_copy_hit_.result;
         return out;
     }
 
@@ -313,6 +341,7 @@ HitTestService::CodeBlockButtonHit HitTestService::CodeBlockButtonsHitTest(
 
     int copy_hit = -1;
     int save_hit = -1;
+    int svg_copy_hit = -1;
     for (int i = first; i < count; i++) {
         const auto& entry = ctx.cache[i];
         if (entry.y_position - ctx.theme.code_block_padding > viewport_bottom) {
@@ -327,14 +356,21 @@ HitTestService::CodeBlockButtonHit HitTestService::CodeBlockButtonsHitTest(
         const float w = ctx.content_width - indent;
         const float pad = ctx.theme.code_block_padding;
         if (IsDiagramLanguage(node.code_language)) {
-            if (save_hit < 0) {
-                const auto& diagram = ctx.cache.GetDiagram(i);
-                if (diagram.bitmap) {
-                    const auto bmp = MermaidBitmapRect(diagram.width, diagram.height, x, w, entry.y_position);
+            const auto& diagram = ctx.cache.GetDiagram(i);
+            if (diagram.bitmap) {
+                const auto bmp = MermaidBitmapRect(diagram.width, diagram.height, x, w, entry.y_position);
+                if (save_hit < 0) {
                     const D2D1_RECT_F btn = OverlayButtonRect(bmp.right, bmp.top);
                     if (dip_x >= btn.left && dip_x <= btn.right
                         && dip_y >= btn.top && dip_y <= btn.bottom) {
                         save_hit = i;
+                    }
+                }
+                if (svg_copy_hit < 0 && IsSvgExportable(node.code_language)) {
+                    const D2D1_RECT_F btn2 = OverlayButtonRect(bmp.right, bmp.top, 1);
+                    if (dip_x >= btn2.left && dip_x <= btn2.right
+                        && dip_y >= btn2.top && dip_y <= btn2.bottom) {
+                        svg_copy_hit = i;
                     }
                 }
             }
@@ -348,15 +384,17 @@ HitTestService::CodeBlockButtonHit HitTestService::CodeBlockButtonsHitTest(
                 copy_hit = i;
             }
         }
-        if (copy_hit >= 0 && save_hit >= 0) {
+        if (copy_hit >= 0 && save_hit >= 0 && svg_copy_hit >= 0) {
             break;
         }
     }
 
     last_copy_hit_.Store(ctx, gen, copy_hit);
     last_save_hit_.Store(ctx, gen, save_hit);
+    last_svg_copy_hit_.Store(ctx, gen, svg_copy_hit);
     out.copy_node = copy_hit;
     out.save_node = save_hit;
+    out.svg_copy_node = svg_copy_hit;
     return out;
 }
 

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -283,32 +283,6 @@ int HitTestService::SaveButtonHitTest(const MdPaneHitContext& ctx) const noexcep
         });
 }
 
-int HitTestService::SvgCopyButtonHitTest(const MdPaneHitContext& ctx) const noexcept
-{
-    assert(ctx.content_width > 0.0f && "content_width must be set for button hit test");
-    assert(ctx.md_pane_height > 0.0f && "md_pane_height must be set for button hit test");
-
-    return HitTestCodeBlockButton(ctx, last_svg_copy_hit_,
-        [&](int i, const Node& node, const NodeLayoutEntry& entry,
-            float dip_x, float dip_y) noexcept -> bool {
-            if (!IsSvgExportable(node.code_language)) {
-                return false;
-            }
-            const auto& diagram = ctx.cache.GetDiagram(i);
-            if (!diagram.bitmap) {
-                return false;
-            }
-            const float indent = NodeIndent(node, ctx.theme);
-            const float x = ctx.theme.margin_left + indent;
-            const float cw = ctx.content_width - indent;
-            const auto bmp = MermaidBitmapRect(diagram.width, diagram.height, x, cw, entry.y_position);
-            // 保存ボタン (index 0) の左隣 (index 1)
-            const D2D1_RECT_F btn = OverlayButtonRect(bmp.right, bmp.top, 1);
-            return dip_x >= btn.left && dip_x <= btn.right
-                && dip_y >= btn.top && dip_y <= btn.bottom;
-        });
-}
-
 HitTestService::CodeBlockButtonHit HitTestService::CodeBlockButtonsHitTest(
     const MdPaneHitContext& ctx) const noexcept
 {

--- a/src/input/hit_test_service.h
+++ b/src/input/hit_test_service.h
@@ -60,10 +60,14 @@ public:
     // ヒットしたダイアグラムのノードインデックスを返す（-1=なし）。
     int SaveButtonHitTest(const MdPaneHitContext& ctx) const noexcept;
 
-    // 可視ノード走査・座標変換・キャッシュ照合を共有して Copy / Save を一度に判定する。
+    // Mermaidダイアグラムの SVG コピー ボタンのヒットテスト（Mermaid のみ対象。LatexMath は対象外）。
+    int SvgCopyButtonHitTest(const MdPaneHitContext& ctx) const noexcept;
+
+    // 可視ノード走査・座標変換・キャッシュ照合を共有して Copy / Save / SvgCopy を一度に判定する。
     struct CodeBlockButtonHit {
         int copy_node = -1;
         int save_node = -1;
+        int svg_copy_node = -1;
     };
     CodeBlockButtonHit CodeBlockButtonsHitTest(const MdPaneHitContext& ctx) const noexcept;
 
@@ -137,4 +141,5 @@ private:
     mutable HitCache<HitResult> last_md_hit_{};
     mutable HitCache<int> last_copy_hit_{ .result = -1 };
     mutable HitCache<int> last_save_hit_{ .result = -1 };
+    mutable HitCache<int> last_svg_copy_hit_{ .result = -1 };
 };

--- a/src/input/hit_test_service.h
+++ b/src/input/hit_test_service.h
@@ -60,9 +60,6 @@ public:
     // ヒットしたダイアグラムのノードインデックスを返す（-1=なし）。
     int SaveButtonHitTest(const MdPaneHitContext& ctx) const noexcept;
 
-    // Mermaidダイアグラムの SVG コピー ボタンのヒットテスト（Mermaid のみ対象。LatexMath は対象外）。
-    int SvgCopyButtonHitTest(const MdPaneHitContext& ctx) const noexcept;
-
     // 可視ノード走査・座標変換・キャッシュ照合を共有して Copy / Save / SvgCopy を一度に判定する。
     struct CodeBlockButtonHit {
         int copy_node = -1;

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -367,14 +367,29 @@ void MermaidRenderer::ClearCache()
 
 void MermaidRenderer::CancelPending()
 {
-    decltype(pending_requests_) empty;
-    pending_requests_.swap(empty);
+    // SVG 専用リクエストのコールバックは空 SVG で呼んで呼び出し元の状態をリセットさせる。
+    // PNG レンダリング (on_complete) は無引数のため呼び出し元側でフラグを持っていない前提。
+    while (!pending_requests_.empty()) {
+        auto& req = pending_requests_.front();
+        if (req.svg_only) {
+            if (auto cb = std::move(req.svg_callback)) {
+                cb(std::pmr::wstring{});
+            }
+        }
+        pending_requests_.pop();
+    }
 
     // current_request の request_id が 0 に戻るため、処理中の非同期コールバックは
     // ID 不一致で自動的に無視される。
     for (int i = 0; i < worker_count_; i++) {
-        workers_[i].rendering = false;
-        workers_[i].current_request = {};
+        auto& w = workers_[i];
+        if (w.current_request.svg_only) {
+            if (auto cb = std::move(w.current_request.svg_callback)) {
+                cb(std::pmr::wstring{});
+            }
+        }
+        w.rendering = false;
+        w.current_request = {};
     }
 }
 

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -236,7 +236,7 @@ void MermaidRenderer::SetupWorker(int index)
                     if (p.valid && p.id == w.current_request.request_id && w.current_request.svg_only) {
                         std::pmr::wstring svg{ p.has_payload ? p.payload : std::wstring_view{} };
                         if (auto cb = std::move(w.current_request.svg_callback)) {
-                            cb(std::move(svg));
+                            cb(std::move(svg), false);
                         }
                         FinishWorkerRequest(w);
                     }
@@ -246,7 +246,7 @@ void MermaidRenderer::SetupWorker(int index)
                     if (p.valid && p.id == w.current_request.request_id) {
                         if (w.current_request.svg_only) {
                             if (auto cb = std::move(w.current_request.svg_callback)) {
-                                cb(std::pmr::wstring{});
+                                cb(std::pmr::wstring{}, false);
                             }
                         }
                         FinishWorkerRequest(w);
@@ -367,13 +367,13 @@ void MermaidRenderer::ClearCache()
 
 void MermaidRenderer::CancelPending()
 {
-    // SVG 専用リクエストのコールバックは空 SVG で呼んで呼び出し元の状態をリセットさせる。
+    // SVG 専用リクエストのコールバックは cancelled=true で呼び、呼び出し元の状態をリセットさせる。
     // PNG レンダリング (on_complete) は無引数のため呼び出し元側でフラグを持っていない前提。
     while (!pending_requests_.empty()) {
         auto& req = pending_requests_.front();
         if (req.svg_only) {
             if (auto cb = std::move(req.svg_callback)) {
-                cb(std::pmr::wstring{});
+                cb(std::pmr::wstring{}, true);
             }
         }
         pending_requests_.pop();
@@ -385,7 +385,7 @@ void MermaidRenderer::CancelPending()
         auto& w = workers_[i];
         if (w.current_request.svg_only) {
             if (auto cb = std::move(w.current_request.svg_callback)) {
-                cb(std::pmr::wstring{});
+                cb(std::pmr::wstring{}, true);
             }
         }
         w.rendering = false;
@@ -465,17 +465,18 @@ void MermaidRenderer::RequestRender(Node& node, NodeLayoutEntry& layout_entry,
     ProcessQueue();
 }
 
-void MermaidRenderer::RequestSvg(std::wstring_view code, bool dark_mode, SvgCallback callback)
+void MermaidRenderer::RequestSvg(std::wstring_view code, float max_width, bool dark_mode, SvgCallback callback)
 {
     if (code.empty() || !callback) {
         if (callback) {
-            callback(std::pmr::wstring{});
+            callback(std::pmr::wstring{}, false);
         }
         return;
     }
 
     RenderRequest req;
     req.svg_only = true;
+    req.max_width = max_width;
     req.dark_mode = dark_mode;
     req.svg_callback = std::move(callback);
     req.code_storage.assign(code.begin(), code.end());
@@ -552,7 +553,20 @@ void MermaidRenderer::RenderInWorker(Worker& worker)
         return;
     }
 
-    // SVG 専用リクエスト: ビューポートサイズ調整と PNG キャプチャをスキップする。
+    // CSSビューポートがmax_width（DIP）と等しくなるようにWebView2の境界を設定する。
+    // 境界はポップアップウィンドウの物理ピクセル単位で、WebView2は
+    // 内部でdevicePixelRatioで除算してCSSビューポートサイズを求める。
+    // SVG 出力（折返し等）も CSS 幅に依存するため、PNG/SVG 両経路で同じ bounds を使う。
+    int vp_phys = static_cast<int>(std::ceil(worker.current_request.max_width * worker.dpr));
+    if (vp_phys < 1) {
+        vp_phys = 1;
+    }
+    const int h_phys = static_cast<int>(4096 * worker.dpr);
+    const RECT bounds = { 0, 0, vp_phys, h_phys };
+    worker.controller->put_Bounds(bounds);
+    SetWindowPos(worker.hwnd, nullptr, -32000, -32000, vp_phys, h_phys, SWP_NOZORDER | SWP_NOACTIVATE);
+
+    // SVG 専用リクエスト: PNG キャプチャ用の再リサイズはスキップし、SVG 文字列のみ取得する。
     if (worker.current_request.svg_only) {
         const auto js = PmrFormat(
             L"renderMermaidSvg('{}', {})"
@@ -564,18 +578,6 @@ void MermaidRenderer::RenderInWorker(Worker& worker)
         worker.webview->ExecuteScript(js.c_str(), nullptr);
         return;
     }
-
-    // CSSビューポートがmax_width（DIP）と等しくなるようにWebView2の境界を設定する。
-    // 境界はポップアップウィンドウの物理ピクセル単位で、WebView2は
-    // 内部でdevicePixelRatioで除算してCSSビューポートサイズを求める。
-    int vp_phys = static_cast<int>(std::ceil(worker.current_request.max_width * worker.dpr));
-    if (vp_phys < 1) {
-        vp_phys = 1;
-    }
-    const int h_phys = static_cast<int>(4096 * worker.dpr);
-    const RECT bounds = { 0, 0, vp_phys, h_phys };
-    worker.controller->put_Bounds(bounds);
-    SetWindowPos(worker.hwnd, nullptr, -32000, -32000, vp_phys, h_phys, SWP_NOZORDER | SWP_NOACTIVATE);
 
     // Mermaidをレンダリングする（maxWidth=0はCSS制約なし、ビューポートが制約する）
     // LatexMath ノードは flowchart ラッパに変換してから JS に渡す。

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -6,6 +6,7 @@
 #include "wic_util.h"
 #include "resource.h"
 #include <wrl/event.h>
+#include <cassert>
 #include <filesystem>
 #include <functional>
 
@@ -235,20 +236,14 @@ void MermaidRenderer::SetupWorker(int index)
                     const auto p = mermaid_util::ParseRequestPrefix(msg + 11);
                     if (p.valid && p.id == w.current_request.request_id && w.current_request.svg_only) {
                         std::pmr::wstring svg{ p.has_payload ? p.payload : std::wstring_view{} };
-                        if (auto cb = std::move(w.current_request.svg_callback)) {
-                            cb(std::move(svg), false);
-                        }
+                        InvokeSvgCallbackIfAny(w.current_request, std::move(svg), false);
                         FinishWorkerRequest(w);
                     }
                 }
                 else if (wcsncmp(msg, L"render-error:", 13) == 0) {
                     const auto p = mermaid_util::ParseRequestPrefix(msg + 13);
                     if (p.valid && p.id == w.current_request.request_id) {
-                        if (w.current_request.svg_only) {
-                            if (auto cb = std::move(w.current_request.svg_callback)) {
-                                cb(std::pmr::wstring{}, false);
-                            }
-                        }
+                        InvokeSvgCallbackIfAny(w.current_request, {}, false);
                         FinishWorkerRequest(w);
                     }
                 }
@@ -365,17 +360,22 @@ void MermaidRenderer::ClearCache()
     cache_.Clear();
 }
 
+void MermaidRenderer::InvokeSvgCallbackIfAny(RenderRequest& req, std::pmr::wstring svg, bool cancelled)
+{
+    if (!req.svg_only) {
+        return;
+    }
+    if (auto cb = std::move(req.svg_callback)) {
+        cb(std::move(svg), cancelled);
+    }
+}
+
 void MermaidRenderer::CancelPending()
 {
     // SVG 専用リクエストのコールバックは cancelled=true で呼び、呼び出し元の状態をリセットさせる。
     // PNG レンダリング (on_complete) は無引数のため呼び出し元側でフラグを持っていない前提。
     while (!pending_requests_.empty()) {
-        auto& req = pending_requests_.front();
-        if (req.svg_only) {
-            if (auto cb = std::move(req.svg_callback)) {
-                cb(std::pmr::wstring{}, true);
-            }
-        }
+        InvokeSvgCallbackIfAny(pending_requests_.front(), {}, true);
         pending_requests_.pop();
     }
 
@@ -383,11 +383,7 @@ void MermaidRenderer::CancelPending()
     // ID 不一致で自動的に無視される。
     for (int i = 0; i < worker_count_; i++) {
         auto& w = workers_[i];
-        if (w.current_request.svg_only) {
-            if (auto cb = std::move(w.current_request.svg_callback)) {
-                cb(std::pmr::wstring{}, true);
-            }
-        }
+        InvokeSvgCallbackIfAny(w.current_request, {}, true);
         w.rendering = false;
         w.current_request = {};
     }
@@ -467,12 +463,9 @@ void MermaidRenderer::RequestRender(Node& node, NodeLayoutEntry& layout_entry,
 
 void MermaidRenderer::RequestSvg(std::wstring_view code, float max_width, bool dark_mode, SvgCallback callback)
 {
-    if (code.empty() || !callback) {
-        if (callback) {
-            callback(std::pmr::wstring{}, false);
-        }
-        return;
-    }
+    // 呼び出し元 (App::CopyDiagramAsSvg) は IsSvgExportable と非空コード、有効なコールバックを保証する。
+    assert(callback && "RequestSvg requires a callable SvgCallback");
+    assert(!code.empty() && "RequestSvg requires non-empty code");
 
     RenderRequest req;
     req.svg_only = true;
@@ -496,24 +489,23 @@ void MermaidRenderer::ProcessQueue()
     }
 
     // 同一コードの図が複数あるとき、最初の1つのレンダリング完了後に
-    // 残りをキャッシュから即座に解決できる。
+    // 残りをキャッシュから即座に解決できる。SVG 専用リクエストは PNG ビットマップ
+    // キャッシュ対象外なので常にワーカー経由でレンダリングする。
     while (!pending_requests_.empty()) {
         auto& front = pending_requests_.front();
-        // SVG 専用リクエストは PNG ビットマップキャッシュとは別物のためスキップしない
-        if (!front.svg_only) {
-            if (const auto* hit = cache_.Find(front.code_hash)) {
-                front.diagram_entry->bitmap = hit->bitmap;
-                front.diagram_entry->width = hit->width;
-                front.diagram_entry->height = hit->height;
-                front.layout_entry->height = hit->height;
-                front.layout_entry->layout_dirty = false;
-                auto cb = std::move(front.on_complete);
-                pending_requests_.pop();
-                if (cb) {
-                    cb();
-                }
-                continue;
+        const CachedBitmap* png_hit = front.svg_only ? nullptr : cache_.Find(front.code_hash);
+        if (png_hit) {
+            front.diagram_entry->bitmap = png_hit->bitmap;
+            front.diagram_entry->width = png_hit->width;
+            front.diagram_entry->height = png_hit->height;
+            front.layout_entry->height = png_hit->height;
+            front.layout_entry->layout_dirty = false;
+            auto cb = std::move(front.on_complete);
+            pending_requests_.pop();
+            if (cb) {
+                cb();
             }
+            continue;
         }
 
         Worker* idle = nullptr;

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -231,9 +231,24 @@ void MermaidRenderer::SetupWorker(int index)
                         DoCapturePreview(index);
                     }
                 }
+                else if (wcsncmp(msg, L"svg-result:", 11) == 0) {
+                    const auto p = mermaid_util::ParseRequestPrefix(msg + 11);
+                    if (p.valid && p.id == w.current_request.request_id && w.current_request.svg_only) {
+                        std::pmr::wstring svg{ p.has_payload ? p.payload : std::wstring_view{} };
+                        if (auto cb = std::move(w.current_request.svg_callback)) {
+                            cb(std::move(svg));
+                        }
+                        FinishWorkerRequest(w);
+                    }
+                }
                 else if (wcsncmp(msg, L"render-error:", 13) == 0) {
                     const auto p = mermaid_util::ParseRequestPrefix(msg + 13);
                     if (p.valid && p.id == w.current_request.request_id) {
+                        if (w.current_request.svg_only) {
+                            if (auto cb = std::move(w.current_request.svg_callback)) {
+                                cb(std::pmr::wstring{});
+                            }
+                        }
                         FinishWorkerRequest(w);
                     }
                 }
@@ -435,6 +450,29 @@ void MermaidRenderer::RequestRender(Node& node, NodeLayoutEntry& layout_entry,
     ProcessQueue();
 }
 
+void MermaidRenderer::RequestSvg(std::wstring_view code, bool dark_mode, SvgCallback callback)
+{
+    if (code.empty() || !callback) {
+        if (callback) {
+            callback(std::pmr::wstring{});
+        }
+        return;
+    }
+
+    RenderRequest req;
+    req.svg_only = true;
+    req.dark_mode = dark_mode;
+    req.svg_callback = std::move(callback);
+    req.code_storage.assign(code.begin(), code.end());
+    pending_requests_.push(std::move(req));
+
+    if (!lifecycle_.IsReady()) {
+        EnsureInitialized();
+        return;
+    }
+    ProcessQueue();
+}
+
 void MermaidRenderer::ProcessQueue()
 {
     if (!lifecycle_.IsReady() || pending_requests_.empty()) {
@@ -445,18 +483,21 @@ void MermaidRenderer::ProcessQueue()
     // 残りをキャッシュから即座に解決できる。
     while (!pending_requests_.empty()) {
         auto& front = pending_requests_.front();
-        if (const auto* hit = cache_.Find(front.code_hash)) {
-            front.diagram_entry->bitmap = hit->bitmap;
-            front.diagram_entry->width = hit->width;
-            front.diagram_entry->height = hit->height;
-            front.layout_entry->height = hit->height;
-            front.layout_entry->layout_dirty = false;
-            auto cb = std::move(front.on_complete);
-            pending_requests_.pop();
-            if (cb) {
-                cb();
+        // SVG 専用リクエストは PNG ビットマップキャッシュとは別物のためスキップしない
+        if (!front.svg_only) {
+            if (const auto* hit = cache_.Find(front.code_hash)) {
+                front.diagram_entry->bitmap = hit->bitmap;
+                front.diagram_entry->width = hit->width;
+                front.diagram_entry->height = hit->height;
+                front.layout_entry->height = hit->height;
+                front.layout_entry->layout_dirty = false;
+                auto cb = std::move(front.on_complete);
+                pending_requests_.pop();
+                if (cb) {
+                    cb();
+                }
+                continue;
             }
-            continue;
         }
 
         Worker* idle = nullptr;
@@ -493,6 +534,19 @@ void MermaidRenderer::RenderInWorker(Worker& worker)
 {
     if (!worker.webview) {
         FinishWorkerRequest(worker);
+        return;
+    }
+
+    // SVG 専用リクエスト: ビューポートサイズ調整と PNG キャプチャをスキップする。
+    if (worker.current_request.svg_only) {
+        const auto js = PmrFormat(
+            L"renderMermaidSvg('{}', {})"
+            L".then(function(s){{window.chrome.webview.postMessage('svg-result:{}:'+(s||''));}})"
+            L".catch(function(e){{window.chrome.webview.postMessage('render-error:{}:'+String(e));}})",
+            mermaid_util::JsEscape(worker.current_request.code_storage),
+            worker.current_request.dark_mode ? L"true" : L"false",
+            worker.current_request.request_id, worker.current_request.request_id);
+        worker.webview->ExecuteScript(js.c_str(), nullptr);
         return;
     }
 

--- a/src/mermaid/mermaid.h
+++ b/src/mermaid/mermaid.h
@@ -38,6 +38,7 @@ public:
     constexpr bool IsReady() const noexcept { return lifecycle_.IsReady(); }
 
     void RequestRender(Node& node, NodeLayoutEntry& layout_entry, DiagramEntry& diagram_entry, float max_width, bool dark_mode, Callback on_complete) override;
+    void RequestSvg(std::wstring_view code, bool dark_mode, SvgCallback callback) override;
     void SetRenderTarget(ID2D1RenderTarget* render_target);
     void SetFileCache(MermaidFileCache* cache) noexcept { file_cache_ = cache; }
     void ClearCache() override;
@@ -63,6 +64,13 @@ private:
         float css_height = 0.0f;
         float dpr = 1.0f;         // JSから取得したdevicePixelRatio
         unsigned int request_id = 0; // リクエスト固有のID（JS側のpostMessageと照合）
+
+        // SVGクリップボードコピー用リクエスト。true の場合 layout/diagram は使わず、
+        // SVG文字列を svg_callback で返す。
+        bool svg_only = false;
+        SvgCallback svg_callback;
+        // SVG リクエスト時のコード保持（呼び出し側の文字列ライフタイムから切り離す）
+        std::pmr::wstring code_storage;
     };
 
     static constexpr int MAX_WORKERS = 4;

--- a/src/mermaid/mermaid.h
+++ b/src/mermaid/mermaid.h
@@ -38,7 +38,7 @@ public:
     constexpr bool IsReady() const noexcept { return lifecycle_.IsReady(); }
 
     void RequestRender(Node& node, NodeLayoutEntry& layout_entry, DiagramEntry& diagram_entry, float max_width, bool dark_mode, Callback on_complete) override;
-    void RequestSvg(std::wstring_view code, bool dark_mode, SvgCallback callback) override;
+    void RequestSvg(std::wstring_view code, float max_width, bool dark_mode, SvgCallback callback) override;
     void SetRenderTarget(ID2D1RenderTarget* render_target);
     void SetFileCache(MermaidFileCache* cache) noexcept { file_cache_ = cache; }
     void ClearCache() override;

--- a/src/mermaid/mermaid.h
+++ b/src/mermaid/mermaid.h
@@ -89,6 +89,9 @@ private:
     };
 
     static int ComputeWorkerCount() noexcept;
+    // SVG 専用リクエストならコールバックを呼んで svg_callback をクリアする。
+    // 同じパターン（cancel / render-error / svg-result の各経路）を1か所に集約する。
+    static void InvokeSvgCallbackIfAny(RenderRequest& req, std::pmr::wstring svg, bool cancelled);
     void EnsureInitialized();
     void CreateWebView2Environment();
     void SetupWorker(int index);

--- a/src/mermaid/mermaid_renderer_interface.h
+++ b/src/mermaid/mermaid_renderer_interface.h
@@ -2,6 +2,9 @@
 #include "document_types.h"
 #include "layout_cache.h"
 #include <functional>
+#include <string>
+#include <string_view>
+#include <memory_resource>
 
 // MermaidRenderer のうち ResourceManager から使う最小 API を抽出した interface。
 // mermaid.h は <WebView2.h> を transitively 引き込むため、mendo_core 入りの
@@ -9,11 +12,16 @@
 class IMermaidRenderer {
 public:
     using Callback = std::move_only_function<void()>;
+    // SVG 取得結果コールバック。空文字列なら失敗。
+    using SvgCallback = std::move_only_function<void(std::pmr::wstring svg)>;
     virtual ~IMermaidRenderer() = default;
 
     virtual void RequestRender(Node& node, NodeLayoutEntry& layout_entry,
         DiagramEntry& diagram_entry, float max_width, bool dark_mode,
         Callback on_complete) = 0;
+    // SVG をクリップボード用に取得する。PNG レンダリングと同じワーカー枠を共有する。
+    // code は内部でコピーされるため呼び出し後に解放してよい。
+    virtual void RequestSvg(std::wstring_view code, bool dark_mode, SvgCallback callback) = 0;
     virtual void CancelPending() = 0;
     virtual void ClearCache() = 0;
 };

--- a/src/mermaid/mermaid_renderer_interface.h
+++ b/src/mermaid/mermaid_renderer_interface.h
@@ -12,8 +12,11 @@
 class IMermaidRenderer {
 public:
     using Callback = std::move_only_function<void()>;
-    // SVG 取得結果コールバック。空文字列なら失敗。
-    using SvgCallback = std::move_only_function<void(std::pmr::wstring svg)>;
+    // SVG 取得結果コールバック。
+    //   svg が非空      : 成功
+    //   svg が空, cancelled=false : mermaid のレンダリング失敗
+    //   svg が空, cancelled=true  : CancelPending 経由（テーマ変更等のキャンセル）
+    using SvgCallback = std::move_only_function<void(std::pmr::wstring svg, bool cancelled)>;
     virtual ~IMermaidRenderer() = default;
 
     virtual void RequestRender(Node& node, NodeLayoutEntry& layout_entry,
@@ -21,7 +24,8 @@ public:
         Callback on_complete) = 0;
     // SVG をクリップボード用に取得する。PNG レンダリングと同じワーカー枠を共有する。
     // code は内部でコピーされるため呼び出し後に解放してよい。
-    virtual void RequestSvg(std::wstring_view code, bool dark_mode, SvgCallback callback) = 0;
+    // max_width は CSS ビューポート幅（DIP）。表示中の図と同じ折返し結果を得るため、PNG と同じ値を渡す。
+    virtual void RequestSvg(std::wstring_view code, float max_width, bool dark_mode, SvgCallback callback) = 0;
     virtual void CancelPending() = 0;
     virtual void ClearCache() = 0;
 };

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -40,6 +40,7 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     int first_visible,
     int hovered_copy_node,
     int hovered_save_node,
+    int hovered_svg_copy_node,
     float dpi_scale)
 {
     // 古いコマンドを destruct してから resource をリセットする。
@@ -69,6 +70,7 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     frame_selection_ = &selection;
     frame_hovered_copy_node_ = hovered_copy_node;
     frame_hovered_save_node_ = hovered_save_node;
+    frame_hovered_svg_copy_node_ = hovered_svg_copy_node;
 
     // 最初の可視ノードを二分探索で検索（事前計算済みのインデックスがあればそれを使用）
     const int node_count = static_cast<int>(nodes.size());
@@ -143,6 +145,9 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
                 const auto bmp = MermaidBitmapRect(diagram.width, diagram.height, x, cw, entry.y_position);
                 cmds.emplace_back(DrawBitmapCmd{ diagram.bitmap.Get(), bmp });
                 GenSaveButton(cmds, bmp.right, bmp.top, node_index == frame_hovered_save_node_);
+                if (IsSvgExportable(node.code_language)) {
+                    GenSvgCopyButton(cmds, bmp.right, bmp.top, node_index == frame_hovered_svg_copy_node_);
+                }
             }
             else {
                 GenDiagramPlaceholder(cmds, x, entry.y_position, cw, entry.height);
@@ -274,6 +279,16 @@ void CommandGenerator::GenSaveButton(DrawCommandList& cmds,
     }
     const D2D1_RECT_F btn = OverlayButtonRect(bitmap_right, bitmap_top);
     GenOverlayButton(cmds, btn, L'\uE896', is_hovered);
+}
+
+void CommandGenerator::GenSvgCopyButton(DrawCommandList& cmds,
+    float bitmap_right, float bitmap_top, bool is_hovered)
+{
+    if (!formats_.copy_btn_icon) {
+        return;
+    }
+    const D2D1_RECT_F btn = OverlayButtonRect(bitmap_right, bitmap_top, 1);
+    GenOverlayButton(cmds, btn, L'', is_hovered);
 }
 
 void CommandGenerator::GenOverlayButton(DrawCommandList& cmds,

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -288,7 +288,7 @@ void CommandGenerator::GenSvgCopyButton(DrawCommandList& cmds,
         return;
     }
     const D2D1_RECT_F btn = OverlayButtonRect(bitmap_right, bitmap_top, 1);
-    GenOverlayButton(cmds, btn, L'', is_hovered);
+    GenOverlayButton(cmds, btn, L'\uE8C8', is_hovered);
 }
 
 void CommandGenerator::GenOverlayButton(DrawCommandList& cmds,

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -95,6 +95,7 @@ public:
         int first_visible = -1,
         int hovered_copy_node = -1,
         int hovered_save_node = -1,
+        int hovered_svg_copy_node = -1,
         float dpi_scale = 1.0f);
 
 private:
@@ -108,6 +109,7 @@ private:
     void GenOverlayButton(DrawCommandList& cmds, D2D1_RECT_F btn, wchar_t icon, bool is_hovered);
     void GenCopyButton(DrawCommandList& cmds, const NodeLayoutEntry& entry, float x, float w, bool is_hovered);
     void GenSaveButton(DrawCommandList& cmds, float bitmap_right, float bitmap_top, bool is_hovered);
+    void GenSvgCopyButton(DrawCommandList& cmds, float bitmap_right, float bitmap_top, bool is_hovered);
     void GenListBullet(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, float x);
     void GenBlockQuoteGroupDecorations(DrawCommandList& cmds, const std::pmr::vector<Node>& nodes, const LayoutCache& cache, int node_count, int first_visible);
     void GenDiagramPlaceholder(DrawCommandList& cmds, float x, float y, float w, float h);
@@ -169,4 +171,5 @@ private:
     const TextSelection* frame_selection_ = nullptr;
     int frame_hovered_copy_node_ = -1;
     int frame_hovered_save_node_ = -1;
+    int frame_hovered_svg_copy_node_ = -1;
 };

--- a/src/render/render_params.h
+++ b/src/render/render_params.h
@@ -148,6 +148,7 @@ struct RenderParams {
     int nav_hovered = 0;
     int hovered_copy_node = -1;
     int hovered_save_node = -1;
+    int hovered_svg_copy_node = -1;
     // --- 1バイトアライメント ---
     bool can_go_back = false;
     bool can_go_forward = false;

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -378,7 +378,7 @@ void Renderer::Render(const RenderParams& p)
     const float dpi_scale = backend_.GetDpi() / DEFAULT_DPI;
     {
         MENDO_PROFILE("GenerateMdPane");
-        const auto& cmds = cmd_generator_.GenerateMdPane(p.nodes, p.cache, p.md_pane_rect, p.scroll_y, p.selection, first_visible, p.hovered_copy_node, p.hovered_save_node, dpi_scale);
+        const auto& cmds = cmd_generator_.GenerateMdPane(p.nodes, p.cache, p.md_pane_rect, p.scroll_y, p.selection, first_visible, p.hovered_copy_node, p.hovered_save_node, p.hovered_svg_copy_node, dpi_scale);
         {
             MENDO_PROFILE("CommandExecutor::Execute");
             cmd_executor_.Execute(cmds, rt());

--- a/src/ui/i18n.h
+++ b/src/ui/i18n.h
@@ -39,6 +39,9 @@ struct Strings {
     // 保存ボタン tooltip
     std::wstring_view tooltip_save_image;
 
+    // SVG コピーボタン tooltip
+    std::wstring_view tooltip_copy_svg;
+
     // コンテキストメニュー
     std::wstring_view menu_edit_file;
     std::wstring_view menu_copy;
@@ -59,6 +62,9 @@ struct Strings {
     std::wstring_view toast_file_too_large;
     std::wstring_view toast_file_read_failed;
     std::wstring_view toast_image_saved;
+    std::wstring_view toast_svg_copying;
+    std::wstring_view toast_svg_copied;
+    std::wstring_view toast_svg_copy_failed;
 
     // ローディング
     std::wstring_view loading;
@@ -95,6 +101,8 @@ inline constexpr Strings kJa = {
     L"コピー",
     // 保存ボタン tooltip
     L"画像を保存",
+    // SVG コピーボタン tooltip
+    L"SVGとしてコピー",
     // コンテキストメニュー
     L"エディタで開く",
     L"コピー",
@@ -112,6 +120,9 @@ inline constexpr Strings kJa = {
     L"ファイルが大きすぎます",
     L"ファイルの読み込みに失敗しました",
     L"画像を保存しました",
+    L"SVGをコピー中...",
+    L"SVGをコピーしました",
+    L"SVGのコピーに失敗しました",
     // ローディング
     L"読み込み中...",
     // ヘルプリソースID
@@ -146,6 +157,8 @@ inline constexpr Strings kEn = {
     L"Copy",
     // 保存ボタン tooltip
     L"Save Image",
+    // SVG コピーボタン tooltip
+    L"Copy as SVG",
     // コンテキストメニュー
     L"Open in Editor",
     L"Copy",
@@ -163,6 +176,9 @@ inline constexpr Strings kEn = {
     L"File is too large",
     L"Failed to read file",
     L"Image saved",
+    L"Copying SVG...",
+    L"SVG copied",
+    L"Failed to copy SVG",
     // ローディング
     L"Loading...",
     // ヘルプリソースID

--- a/src/ui/tooltip_target.h
+++ b/src/ui/tooltip_target.h
@@ -19,6 +19,7 @@ struct TooltipTarget {
         MdImage,
         CopyButton,
         SaveButton,
+        SvgCopyButton,
         NavButton,
     };
 

--- a/src/ui/ui_constants.h
+++ b/src/ui/ui_constants.h
@@ -47,6 +47,7 @@ inline constexpr float NAV_BTN_SCROLLBAR_OFFSET = 16.0f;
 inline constexpr float COPY_BTN_SIZE = 28.0f;
 inline constexpr float COPY_BTN_MARGIN = 6.0f;
 inline constexpr float COPY_BTN_CORNER = 4.0f;
+inline constexpr float COPY_BTN_GAP = 4.0f;
 
 inline constexpr float INLINE_CODE_PAD_X = 3.0f;
 inline constexpr float INLINE_CODE_PAD_Y = 2.0f;
@@ -234,8 +235,10 @@ inline constexpr float GESTURE_TRAIL_STROKE_WIDTH = 4.0f;
 
 // 要素の右上を基準にオーバーレイボタン（コピー/保存）の矩形を返す。
 // anchor_right: 基準領域の右端, anchor_top: 基準領域の上端
-inline D2D1_RECT_F OverlayButtonRect(float anchor_right, float anchor_top) noexcept {
-    const float bx = anchor_right - COPY_BTN_MARGIN - COPY_BTN_SIZE;
+// button_index: 0=最も右, 1 以降は左隣に COPY_BTN_GAP 分ずれる。
+inline D2D1_RECT_F OverlayButtonRect(float anchor_right, float anchor_top, int button_index = 0) noexcept {
+    const float bx = anchor_right - COPY_BTN_MARGIN - COPY_BTN_SIZE
+        - static_cast<float>(button_index) * (COPY_BTN_SIZE + COPY_BTN_GAP);
     const float by = anchor_top + COPY_BTN_MARGIN;
     return D2D1::RectF(bx, by, bx + COPY_BTN_SIZE, by + COPY_BTN_SIZE);
 }

--- a/src/util/win_handle.h
+++ b/src/util/win_handle.h
@@ -159,12 +159,16 @@ inline std::string BuildCfHtmlPayload(std::string_view fragment_utf8)
 // "image/svg+xml": Office (Word/Excel/PowerPoint 2016+) の「形式を選択して貼り付け → SVG」
 //                  および Inkscape などのベクタ編集アプリがベクタ画像として認識する。
 // CF_UNICODETEXT:  テキストエディタへの貼り付けフォールバック（SVG マークアップ原文）。
-inline void WriteClipboardSvg(HWND hwnd, std::wstring_view svg_text) noexcept
+// 戻り値: いずれか 1 つ以上のフォーマットが SetClipboardData まで成功したら true。
+//        OpenClipboard / SetClipboardData が全滅したら false（呼び出し側で失敗トースト表示用）。
+inline bool WriteClipboardSvg(HWND hwnd, std::wstring_view svg_text) noexcept
 {
     if (svg_text.empty() || !OpenClipboard(hwnd)) {
-        return;
+        return false;
     }
     EmptyClipboard();
+
+    bool any_set = false;
 
     const std::string svg_utf8 = string_convert::WideToUtf8(svg_text);
     if (!svg_utf8.empty()) {
@@ -177,6 +181,7 @@ inline void WriteClipboardSvg(HWND hwnd, std::wstring_view svg_text) noexcept
                 static const UINT cf_svg = RegisterClipboardFormatW(L"image/svg+xml");
                 if (cf_svg != 0 && SetClipboardData(cf_svg, hSvg.get())) {
                     hSvg.release();
+                    any_set = true;
                 }
             }
         }
@@ -191,11 +196,13 @@ inline void WriteClipboardSvg(HWND hwnd, std::wstring_view svg_text) noexcept
             GlobalUnlock(hText.get());
             if (SetClipboardData(CF_UNICODETEXT, hText.get())) {
                 hText.release();
+                any_set = true;
             }
         }
     }
 
     CloseClipboard();
+    return any_set;
 }
 
 // クリップボードに CF_HTML（書式付き）と CF_UNICODETEXT（プレーンテキスト）を同時に書き込む。

--- a/src/util/win_handle.h
+++ b/src/util/win_handle.h
@@ -155,36 +155,10 @@ inline std::string BuildCfHtmlPayload(std::string_view fragment_utf8)
     return payload;
 }
 
-// HGLOBAL を確保して任意のバイト列を SetClipboardData する内部ヘルパ。
-// 失敗時は何もしない。成功時はメモリ所有権がクリップボードへ移譲される。
-// クリップボードは事前に OpenClipboard / EmptyClipboard で開かれている前提。
-inline void SetClipboardBytes(UINT format, const void* data, size_t size) noexcept
-{
-    if (format == 0 || size == 0) {
-        return;
-    }
-    UniqueGlobalMem h{ GlobalAlloc(GMEM_MOVEABLE, size) };
-    if (!h) {
-        return;
-    }
-    if (auto* dest = static_cast<char*>(GlobalLock(h.get()))) {
-        std::char_traits<char>::copy(dest, static_cast<const char*>(data), size);
-        GlobalUnlock(h.get());
-        if (SetClipboardData(format, h.get())) {
-            h.release();
-        }
-    }
-}
-
-// SVG をクリップボードに書き込む。Office 系（Word / PowerPoint / Excel 2016+）が
-// 画像として貼り付けるには CF_HTML に <svg> タグを直接埋め込むのが最も互換性が高い
-// （Microsoft Edge / Chromium が採用する方式）。<img> data URI 経由は Office の
-// 一部バージョンでレンダリングが透明になる事象が報告されている。
-//
-// 書き込むフォーマット:
-//   - CF_HTML            : SVG タグそのもの（Office 系がベクタ画像として貼付）
-//   - "image/svg+xml"    : 生 SVG（UTF-8）（Inkscape などベクタ編集アプリ向け）
-//   - CF_UNICODETEXT     : SVG マークアップ原文（テキストエディタ向け）
+// SVG をクリップボードに書き込む。
+// "image/svg+xml": Office (Word/Excel/PowerPoint 2016+) の「形式を選択して貼り付け → SVG」
+//                  および Inkscape などのベクタ編集アプリがベクタ画像として認識する。
+// CF_UNICODETEXT:  テキストエディタへの貼り付けフォールバック（SVG マークアップ原文）。
 inline void WriteClipboardSvg(HWND hwnd, std::wstring_view svg_text) noexcept
 {
     if (svg_text.empty() || !OpenClipboard(hwnd)) {
@@ -193,31 +167,30 @@ inline void WriteClipboardSvg(HWND hwnd, std::wstring_view svg_text) noexcept
     EmptyClipboard();
 
     const std::string svg_utf8 = string_convert::WideToUtf8(svg_text);
-
     if (!svg_utf8.empty()) {
-        // CF_HTML: SVG タグを fragment にそのまま入れる。Office はインライン SVG を
-        // ベクタ画像として認識し、後で「グラフィックに変換」で個別図形に分解できる。
-        const std::string cf_html_payload = BuildCfHtmlPayload(svg_utf8);
-        static const UINT cf_html = RegisterClipboardFormatW(L"HTML Format");
-        SetClipboardBytes(cf_html, cf_html_payload.c_str(), cf_html_payload.size() + 1);
-
-        // "image/svg+xml": Inkscape など SVG ネイティブ対応アプリ向け。
-        static const UINT cf_svg = RegisterClipboardFormatW(L"image/svg+xml");
-        SetClipboardBytes(cf_svg, svg_utf8.c_str(), svg_utf8.size() + 1);
+        UniqueGlobalMem hSvg{ GlobalAlloc(GMEM_MOVEABLE, svg_utf8.size() + 1) };
+        if (hSvg) {
+            if (auto* dest = static_cast<char*>(GlobalLock(hSvg.get()))) {
+                std::char_traits<char>::copy(dest, svg_utf8.data(), svg_utf8.size());
+                dest[svg_utf8.size()] = '\0';
+                GlobalUnlock(hSvg.get());
+                static const UINT cf_svg = RegisterClipboardFormatW(L"image/svg+xml");
+                if (cf_svg != 0 && SetClipboardData(cf_svg, hSvg.get())) {
+                    hSvg.release();
+                }
+            }
+        }
     }
 
-    // CF_UNICODETEXT: SVG マークアップ原文（テキストエディタへの貼付用フォールバック）。
-    {
-        const size_t bytes = (svg_text.size() + 1) * sizeof(wchar_t);
-        UniqueGlobalMem hText{ GlobalAlloc(GMEM_MOVEABLE, bytes) };
-        if (hText) {
-            if (auto* dest = static_cast<wchar_t*>(GlobalLock(hText.get()))) {
-                std::char_traits<wchar_t>::copy(dest, svg_text.data(), svg_text.size());
-                dest[svg_text.size()] = L'\0';
-                GlobalUnlock(hText.get());
-                if (SetClipboardData(CF_UNICODETEXT, hText.get())) {
-                    hText.release();
-                }
+    const size_t bytes = (svg_text.size() + 1) * sizeof(wchar_t);
+    UniqueGlobalMem hText{ GlobalAlloc(GMEM_MOVEABLE, bytes) };
+    if (hText) {
+        if (auto* dest = static_cast<wchar_t*>(GlobalLock(hText.get()))) {
+            std::char_traits<wchar_t>::copy(dest, svg_text.data(), svg_text.size());
+            dest[svg_text.size()] = L'\0';
+            GlobalUnlock(hText.get());
+            if (SetClipboardData(CF_UNICODETEXT, hText.get())) {
+                hText.release();
             }
         }
     }

--- a/src/util/win_handle.h
+++ b/src/util/win_handle.h
@@ -155,6 +155,76 @@ inline std::string BuildCfHtmlPayload(std::string_view fragment_utf8)
     return payload;
 }
 
+// HGLOBAL を確保して任意のバイト列を SetClipboardData する内部ヘルパ。
+// 失敗時は何もしない。成功時はメモリ所有権がクリップボードへ移譲される。
+// クリップボードは事前に OpenClipboard / EmptyClipboard で開かれている前提。
+inline void SetClipboardBytes(UINT format, const void* data, size_t size) noexcept
+{
+    if (format == 0 || size == 0) {
+        return;
+    }
+    UniqueGlobalMem h{ GlobalAlloc(GMEM_MOVEABLE, size) };
+    if (!h) {
+        return;
+    }
+    if (auto* dest = static_cast<char*>(GlobalLock(h.get()))) {
+        std::char_traits<char>::copy(dest, static_cast<const char*>(data), size);
+        GlobalUnlock(h.get());
+        if (SetClipboardData(format, h.get())) {
+            h.release();
+        }
+    }
+}
+
+// SVG をクリップボードに書き込む。Office 系（Word / PowerPoint / Excel 2016+）が
+// 画像として貼り付けるには CF_HTML に <svg> タグを直接埋め込むのが最も互換性が高い
+// （Microsoft Edge / Chromium が採用する方式）。<img> data URI 経由は Office の
+// 一部バージョンでレンダリングが透明になる事象が報告されている。
+//
+// 書き込むフォーマット:
+//   - CF_HTML            : SVG タグそのもの（Office 系がベクタ画像として貼付）
+//   - "image/svg+xml"    : 生 SVG（UTF-8）（Inkscape などベクタ編集アプリ向け）
+//   - CF_UNICODETEXT     : SVG マークアップ原文（テキストエディタ向け）
+inline void WriteClipboardSvg(HWND hwnd, std::wstring_view svg_text) noexcept
+{
+    if (svg_text.empty() || !OpenClipboard(hwnd)) {
+        return;
+    }
+    EmptyClipboard();
+
+    const std::string svg_utf8 = string_convert::WideToUtf8(svg_text);
+
+    if (!svg_utf8.empty()) {
+        // CF_HTML: SVG タグを fragment にそのまま入れる。Office はインライン SVG を
+        // ベクタ画像として認識し、後で「グラフィックに変換」で個別図形に分解できる。
+        const std::string cf_html_payload = BuildCfHtmlPayload(svg_utf8);
+        static const UINT cf_html = RegisterClipboardFormatW(L"HTML Format");
+        SetClipboardBytes(cf_html, cf_html_payload.c_str(), cf_html_payload.size() + 1);
+
+        // "image/svg+xml": Inkscape など SVG ネイティブ対応アプリ向け。
+        static const UINT cf_svg = RegisterClipboardFormatW(L"image/svg+xml");
+        SetClipboardBytes(cf_svg, svg_utf8.c_str(), svg_utf8.size() + 1);
+    }
+
+    // CF_UNICODETEXT: SVG マークアップ原文（テキストエディタへの貼付用フォールバック）。
+    {
+        const size_t bytes = (svg_text.size() + 1) * sizeof(wchar_t);
+        UniqueGlobalMem hText{ GlobalAlloc(GMEM_MOVEABLE, bytes) };
+        if (hText) {
+            if (auto* dest = static_cast<wchar_t*>(GlobalLock(hText.get()))) {
+                std::char_traits<wchar_t>::copy(dest, svg_text.data(), svg_text.size());
+                dest[svg_text.size()] = L'\0';
+                GlobalUnlock(hText.get());
+                if (SetClipboardData(CF_UNICODETEXT, hText.get())) {
+                    hText.release();
+                }
+            }
+        }
+    }
+
+    CloseClipboard();
+}
+
 // クリップボードに CF_HTML（書式付き）と CF_UNICODETEXT（プレーンテキスト）を同時に書き込む。
 // fragment_html: <!--StartFragment--> と <!--EndFragment--> の間に入る HTML 断片（Wide 文字列）。
 // plain_text:    書式付きに対応していないアプリ向けのフォールバック。

--- a/tests/test_command_generator_frame.cpp
+++ b/tests/test_command_generator_frame.cpp
@@ -93,7 +93,7 @@ TEST_F(CmdGenFrameTest, TransformSnapsScrollToPixelWithDpi)
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 400.0f };
     const float scroll_y = 0.3f;
     const float dpi = 2.0f;
-    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, scroll_y, TextSelection{}, -1, -1, -1, dpi);
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, scroll_y, TextSelection{}, -1, -1, -1, -1, dpi);
 
     const auto* xform = FindFirst<SetTransformCmd>(cmds);
     ASSERT_NE(xform, nullptr);

--- a/tests/test_resource_manager.cpp
+++ b/tests/test_resource_manager.cpp
@@ -32,6 +32,13 @@ public:
         last_dark_mode = dark_mode;
     }
 
+    void RequestSvg(std::wstring_view /*code*/, bool /*dark_mode*/, SvgCallback callback) override
+    {
+        if (callback) {
+            callback(std::pmr::wstring{});
+        }
+    }
+
     void CancelPending() override { cancel_pending_count++; }
     void ClearCache() override { clear_cache_count++; }
 };

--- a/tests/test_resource_manager.cpp
+++ b/tests/test_resource_manager.cpp
@@ -32,10 +32,10 @@ public:
         last_dark_mode = dark_mode;
     }
 
-    void RequestSvg(std::wstring_view /*code*/, bool /*dark_mode*/, SvgCallback callback) override
+    void RequestSvg(std::wstring_view /*code*/, float /*max_width*/, bool /*dark_mode*/, SvgCallback callback) override
     {
         if (callback) {
-            callback(std::pmr::wstring{});
+            callback(std::pmr::wstring{}, false);
         }
     }
 


### PR DESCRIPTION
## Summary
- Mermaid ダイアグラム右上に「SVG コピー」ボタンを追加（保存ボタンの隣、Mermaid のみ対象）
- WebView2 ワーカーで mermaid.render の SVG 文字列を取得しクリップボードへ書き込み
- Excel 2016+ / Word / PowerPoint で「形式を選択して貼り付け → SVG」によりベクタ画像として貼付可能

## 実装詳細
- IMermaidRenderer に `RequestSvg` API を追加し、PNG レンダリングと同じワーカー枠を共有
- セッション内 LRU キャッシュ (最大 64 件) で同一図の再コピーを高速化
- 「コピー中…」「コピーしました」「失敗しました」のトースト表示で進捗を可視化
- クリップボードフォーマット: `image/svg+xml`（Office/Inkscape 用）+ `CF_UNICODETEXT`（テキストエディタ用）
- `IsSvgExportable(SyntaxLanguage)` を `core/syntax.h` に追加し言語判定を一元化
- `MermaidRenderer::CancelPending` で進行中の SVG コールバックを空 SVG で呼び出し、ドキュメント切替時にフラグが立ちっぱなしになる潜在バグを修正

## 経緯メモ
当初 `CF_HTML` 経由貼り付けと `<foreignObject>` → `<text>` 置換も実装したが、Excel での実機検証で「形式を選択 → SVG」が `image/svg+xml` を直接受け取り mermaid 生成 SVG を文字込みでオブジェクトとして正しくレンダリングすると確認できたため、シンプルな当初実装に戻した経緯がコミット履歴に残っている。

## Test plan
- [x] `cmake --build build --config Release` ビルド成功
- [x] `mendo_tests.exe --gtest_brief=1` 全 1955 テストパス
- [x] Excel で「形式を選択して貼り付け → SVG」でベクタ画像として貼付・「グラフィックに変換」で個別図形に分解できることを実機確認
- [x] Word / PowerPoint での貼付動作確認
- [ ] Inkscape など SVG ネイティブ対応アプリでの貼付動作確認
- [x] ドキュメント切替・テーマ変更を SVG コピー進行中に行ってもフラグハングしないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)