### PR TITLE
refactor: HoveredButtons 集約と std::to_underlying / concepts 制約への統一

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <utility>
 #include <variant>
 #include <filesystem>
 #include <dwmapi.h>
@@ -214,8 +215,7 @@ void App::OnPaint()
                 state_.document.doc.GetNodes(), state_.document.layout_cache,
                 state_.view.viewport.GetSelection(), layout.md_rect, sp, tb, gs, ts, sb,
                 state_.view.viewport.GetScrollY(), layout_service_->GetTotalHeight(),
-                static_cast<int>(state_.interaction.nav_hover), state_.interaction.hovered_copy_node, state_.interaction.hovered_save_node,
-                state_.interaction.hovered_svg_copy_node,
+                std::to_underlying(state_.interaction.nav_hover), state_.interaction.hovered,
                 state_.view.nav_history.CanGoBack(), state_.view.nav_history.CanGoForward(),
                 layout_service_->HasDirtyNodes()
                 });

--- a/src/app/app_events.h
+++ b/src/app/app_events.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "pane_layout.h"
 #include "nav_button.h"
+#include "hovered_buttons.h"
 #include "pane_controller.h"
 #include "tooltip_target.h"
 #include <variant>
@@ -102,9 +103,7 @@ struct MdPaneNavHoverAction {
     NavButtonHover nav_hover;
 };
 struct MdPaneButtonHoverChangedAction {
-    int hovered_copy_node;
-    int hovered_save_node;
-    int hovered_svg_copy_node = -1;
+    HoveredButtons hovered;
 };
 struct SplitterDragStartedAction {
     PaneController::DragTarget target;

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -8,6 +8,7 @@
 #include "profiler.h"
 #include "utility.h"
 #include <algorithm>
+#include <utility>
 
 // ============================================================
 // ファイル読み込み
@@ -148,7 +149,7 @@ void App::OnParseComplete()
 
         MENDO_TRACEF("OnParseComplete: reload node_count=%zu diff_pos=%zu old_size=%zu new_size=%zu op=%d",
             result->doc.GetNodes().size(), decision.diff_pos, old_view.size(), new_view.size(),
-            static_cast<int>(decision.op));
+            std::to_underlying(decision.op));
 
         switch (decision.op) {
         case ReloadOp::NoChange:
@@ -312,7 +313,7 @@ void App::DoReloadCurrentFile()
 
     MENDO_TRACEF("DoReload: diff_pos=%zu old_size=%zu new_size=%zu op=%d",
         decision.diff_pos, old_view.size(), new_view.size(),
-        static_cast<int>(decision.op));
+        std::to_underlying(decision.op));
 
     switch (decision.op) {
     case ReloadOp::NoChange:

--- a/src/app/app_mouse_helpers.h
+++ b/src/app/app_mouse_helpers.h
@@ -5,11 +5,20 @@
 #include "tooltip.h"
 #include "titlebar.h"
 #include "ui_constants.h"
+#include <concepts>
+#include <type_traits>
 
 namespace mendo::app_mouse {
 
+// ペインヘッダー内のボタン矩形を返す関数（NTTP）の型制約。
+template <auto Fn>
+concept PaneButtonRectFn =
+    std::invocable<decltype(Fn), float, float>
+    && std::convertible_to<std::invoke_result_t<decltype(Fn), float, float>, D2D1_RECT_F>;
+
 // ペインヘッダー内のボタンがクリックされたか判定する。
 template <auto ButtonRectFn>
+    requires PaneButtonRectFn<ButtonRectFn>
 bool HitPaneHeaderButton(float dip_x, float dip_y, const PaneRect& rect, float header_height)
 {
     const float local_x = dip_x - rect.x;
@@ -50,6 +59,12 @@ struct PaneHoverResult {
 // ヘッダーボタンのホバー状態を更新し、コンテンツ領域のアイテムヒットテストを行う。
 template<typename SetCloseHoveredFn, typename SetRefreshHoveredFn,
     typename HitTestFn, typename BuildTooltipFn>
+    requires std::predicate<SetCloseHoveredFn&, bool>
+          && std::predicate<SetRefreshHoveredFn&, bool>
+          && std::invocable<HitTestFn&, float, float>
+          && std::convertible_to<std::invoke_result_t<HitTestFn&, float, float>, int>
+          && std::invocable<BuildTooltipFn&, bool, bool, int>
+          && std::convertible_to<std::invoke_result_t<BuildTooltipFn&, bool, bool, int>, TooltipTarget>
 PaneHoverResult ProcessSidePaneHover(
     float dip_x, float dip_y,
     const PaneRect& rect, float header_h, float item_height,
@@ -86,6 +101,7 @@ PaneHoverResult ProcessSidePaneHover(
 // サイドペインのヘッダー領域のクリック処理を共通化。
 // ヘッダー領域内のクリックを消費した場合 true を返す（ボタン外も含む）。
 template<typename ToggleFn, typename RefreshFn>
+    requires std::invocable<ToggleFn&> && std::invocable<RefreshFn&>
 bool ProcessSidePaneHeaderClick(
     float dip_x, float dip_y,
     const PaneRect& rect, float header_h,

--- a/src/app/app_mouse_hover.cpp
+++ b/src/app/app_mouse_hover.cpp
@@ -109,32 +109,26 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
     // 1 回の可視ノード走査で 3 つを同時に判定する。
     const auto hit_ctx = BuildMdPaneHitContext(px, py, pane_layout);
     auto& ht = state_.interaction.hover_throttle;
-    int new_copy_hover = state_.interaction.hovered_copy_node;
-    int new_save_hover = state_.interaction.hovered_save_node;
-    int new_svg_copy_hover = state_.interaction.hovered_svg_copy_node;
+    HoveredButtons new_hover = state_.interaction.hovered;
     if (ht.TryMarkMoved(ht.last_copy_hit_pos, ht.last_copy_hit_tick, px, py)) {
         const auto btn_hit = hit_test_.CodeBlockButtonsHitTest(hit_ctx);
-        new_copy_hover = btn_hit.copy_node;
-        new_save_hover = btn_hit.save_node;
-        new_svg_copy_hover = btn_hit.svg_copy_node;
+        new_hover = { btn_hit.copy_node, btn_hit.save_node, btn_hit.svg_copy_node };
     }
-    if (new_copy_hover != state_.interaction.hovered_copy_node
-        || new_save_hover != state_.interaction.hovered_save_node
-        || new_svg_copy_hover != state_.interaction.hovered_svg_copy_node) {
-        Dispatch(MdPaneButtonHoverChangedAction{ new_copy_hover, new_save_hover, new_svg_copy_hover });
+    if (new_hover != state_.interaction.hovered) {
+        Dispatch(MdPaneButtonHoverChangedAction{ new_hover });
     }
 
-    if (new_copy_hover >= 0) {
+    if (new_hover.copy >= 0) {
         SetCursor(cursors_.Hand());
         Dispatch(UpdateTooltipAction{ TooltipTarget{ TooltipTarget::Zone::CopyButton, i18n::S().tooltip_copy }, px, py });
         return;
     }
-    if (new_svg_copy_hover >= 0) {
+    if (new_hover.svg_copy >= 0) {
         SetCursor(cursors_.Hand());
         Dispatch(UpdateTooltipAction{ TooltipTarget{ TooltipTarget::Zone::SvgCopyButton, i18n::S().tooltip_copy_svg }, px, py });
         return;
     }
-    if (new_save_hover >= 0) {
+    if (new_hover.save >= 0) {
         SetCursor(cursors_.Hand());
         Dispatch(UpdateTooltipAction{ TooltipTarget{ TooltipTarget::Zone::SaveButton, i18n::S().tooltip_save_image }, px, py });
         return;

--- a/src/app/app_state.h
+++ b/src/app/app_state.h
@@ -15,6 +15,7 @@
 #include "scroll_restoration.h"
 #include "context_menu.h"
 #include "hover_throttle.h"
+#include "hovered_buttons.h"
 #include "nav_button.h"
 #include "pane_layout.h"
 #include "theme_constants.h"
@@ -44,9 +45,7 @@ struct InteractionState {
     HoverThrottle hover_throttle;
     Tooltip tooltip;
     ToastNotifier toast;
-    int hovered_copy_node = -1;
-    int hovered_save_node = -1;
-    int hovered_svg_copy_node = -1;
+    HoveredButtons hovered;
     NavButtonHover nav_hover = NavButtonHover::None;
 };
 

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -378,23 +378,17 @@ void ReduceMdPaneNavHover(AppState& state, SideEffectList& effects, const MdPane
     state.interaction.nav_hover = a.nav_hover;
     // ナビボタンホバー時は、コピー/保存/SVGコピーボタンホバー状態をクリア（重ならないように）
     if (a.nav_hover != NavButtonHover::None) {
-        state.interaction.hovered_copy_node = -1;
-        state.interaction.hovered_save_node = -1;
-        state.interaction.hovered_svg_copy_node = -1;
+        state.interaction.hovered = HoveredButtons{};
     }
     PushEffect(effects, effect::InvalidateWindow{});
 }
 
 void ReduceMdPaneButtonHoverChanged(AppState& state, SideEffectList& effects, const MdPaneButtonHoverChangedAction& a)
 {
-    if (state.interaction.hovered_copy_node == a.hovered_copy_node
-        && state.interaction.hovered_save_node == a.hovered_save_node
-        && state.interaction.hovered_svg_copy_node == a.hovered_svg_copy_node) {
+    if (state.interaction.hovered == a.hovered) {
         return;
     }
-    state.interaction.hovered_copy_node = a.hovered_copy_node;
-    state.interaction.hovered_save_node = a.hovered_save_node;
-    state.interaction.hovered_svg_copy_node = a.hovered_svg_copy_node;
+    state.interaction.hovered = a.hovered;
     PushEffect(effects, effect::InvalidateWindow{});
 }
 

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <memory_resource>
 #include <algorithm>
+#include <utility>
 #include <variant>
 #include "syntax.h"
 #include "string_convert.h"
@@ -31,9 +32,9 @@ enum class AlertType : uint8_t {
     Caution
 };
 
-static_assert(static_cast<size_t>(AlertType::None) == 0, "AlertType::None must be 0");
-static_assert(static_cast<size_t>(AlertType::Note) == 1, "AlertType::Note must be 1");
-static_assert(static_cast<size_t>(AlertType::Caution) == 5, "AlertType::Caution must be 5");
+static_assert(std::to_underlying(AlertType::None) == 0, "AlertType::None must be 0");
+static_assert(std::to_underlying(AlertType::Note) == 1, "AlertType::Note must be 1");
+static_assert(std::to_underlying(AlertType::Caution) == 5, "AlertType::Caution must be 5");
 
 inline constexpr size_t ALERT_TYPE_COUNT = 5;
 
@@ -42,7 +43,7 @@ constexpr size_t AlertColorIndex(AlertType t) noexcept
     if (t == AlertType::None) {
         return ALERT_TYPE_COUNT;
     }
-    return static_cast<size_t>(t) - 1;
+    return static_cast<size_t>(std::to_underlying(t)) - 1;
 }
 
 // md4c の MD_ALIGN と値を一致させる（0=DEFAULT, 1=LEFT, 2=CENTER, 3=RIGHT）

--- a/src/core/syntax.cpp
+++ b/src/core/syntax.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <array>
 #include <span>
+#include <utility>
 
 using namespace std::literals;
 using syntax_keywords::KeywordTable;
@@ -528,7 +529,7 @@ static const LanguageDef LANGUAGE_DEFS[] = {
     }},
 };
 
-static_assert(std::size(LANGUAGE_DEFS) == static_cast<size_t>(SyntaxLanguage::Cmd) + 1, "LANGUAGE_DEFS must cover all SyntaxLanguage values");
+static_assert(std::size(LANGUAGE_DEFS) == std::to_underlying(SyntaxLanguage::Cmd) + 1, "LANGUAGE_DEFS must cover all SyntaxLanguage values");
 
 } // namespace
 
@@ -611,7 +612,7 @@ SyntaxLanguage DetectLanguage(std::wstring_view info_string)
 
 std::pmr::vector<SyntaxToken> Tokenize(std::wstring_view text, SyntaxLanguage language)
 {
-    const auto idx = static_cast<size_t>(language);
+    const auto idx = std::to_underlying(language);
     if (text.empty() || language == SyntaxLanguage::None ||
         IsDiagramLanguage(language) || idx >= std::size(LANGUAGE_DEFS)) {
         return {};

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -3,6 +3,7 @@
 #include "ui_constants.h"
 #include <cassert>
 #include <ranges>
+#include <utility>
 
 namespace {
 
@@ -277,7 +278,8 @@ int HitTestService::SaveButtonHitTest(const MdPaneHitContext& ctx) const noexcep
             const float x = ctx.theme.margin_left + indent;
             const float cw = ctx.content_width - indent;
             const auto bmp = MermaidBitmapRect(diagram.width, diagram.height, x, cw, entry.y_position);
-            const D2D1_RECT_F btn = OverlayButtonRect(bmp.right, bmp.top);
+            const D2D1_RECT_F btn = OverlayButtonRect(bmp.right, bmp.top,
+                std::to_underlying(DiagramButtonSlot::Save));
             return dip_x >= btn.left && dip_x <= btn.right
                 && dip_y >= btn.top && dip_y <= btn.bottom;
         });
@@ -334,14 +336,16 @@ HitTestService::CodeBlockButtonHit HitTestService::CodeBlockButtonsHitTest(
             if (diagram.bitmap) {
                 const auto bmp = MermaidBitmapRect(diagram.width, diagram.height, x, w, entry.y_position);
                 if (save_hit < 0) {
-                    const D2D1_RECT_F btn = OverlayButtonRect(bmp.right, bmp.top);
+                    const D2D1_RECT_F btn = OverlayButtonRect(bmp.right, bmp.top,
+                        std::to_underlying(DiagramButtonSlot::Save));
                     if (dip_x >= btn.left && dip_x <= btn.right
                         && dip_y >= btn.top && dip_y <= btn.bottom) {
                         save_hit = i;
                     }
                 }
                 if (svg_copy_hit < 0 && IsSvgExportable(node.code_language)) {
-                    const D2D1_RECT_F btn2 = OverlayButtonRect(bmp.right, bmp.top, 1);
+                    const D2D1_RECT_F btn2 = OverlayButtonRect(bmp.right, bmp.top,
+                        std::to_underlying(DiagramButtonSlot::SvgCopy));
                     if (dip_x >= btn2.left && dip_x <= btn2.right
                         && dip_y >= btn2.top && dip_y <= btn2.bottom) {
                         svg_copy_hit = i;

--- a/src/input/hit_test_service.h
+++ b/src/input/hit_test_service.h
@@ -5,6 +5,7 @@
 #include "pane.h"
 #include "theme.h"
 #include <climits>
+#include <concepts>
 #include <memory_resource>
 
 // MDペインのヒットテストに必要なコンテキスト情報。
@@ -94,10 +95,9 @@ private:
     };
 
     // CodeBlock ノードのオーバーレイボタン（Copy/Save）共通ヒットテスト。
-    // キャッシュ照合・座標変換・可視範囲走査を一元化する。Predicate は
-    // `(int index, const Node&, const NodeLayoutEntry&, float dip_x, float dip_y) -> bool`
-    // を返し、true を返したノードの index が結果となる。
+    // キャッシュ照合・座標変換・可視範囲走査を一元化し、matches が true を返したノードの index を返す。
     template <typename Predicate>
+        requires std::predicate<Predicate&, int, const Node&, const NodeLayoutEntry&, float, float>
     int HitTestCodeBlockButton(
         const MdPaneHitContext& ctx,
         HitCache<int>& cache,

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -4,6 +4,7 @@
 #include "syntax.h"
 #include "ui_constants.h"
 #include <algorithm>
+#include <concepts>
 #include <ranges>
 
 using Microsoft::WRL::ComPtr;
@@ -90,6 +91,8 @@ namespace {
 // 隣接する同属性ランを連続 range にマージして emit に渡す。
 // ラン配列は start 昇順で、直前ランの直後に始まる前提。
 template <typename Pred, typename Emit>
+    requires std::predicate<Pred&, const TextRun&>
+          && std::invocable<Emit&, DWRITE_TEXT_RANGE>
 void ForEachAttrRange(const std::pmr::vector<TextRun>& runs, Pred predicate, Emit emit)
 {
     const size_t n = runs.size();

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <format>
 #include <ranges>
+#include <utility>
 
 // h1/h2 見出し下線を描画するY座標を heading_spacing_below_h1h2 のこの比率で決める。
 // 値を小さくすると下線は見出し文字に近づき、下線と次行の間隔が広がる。
@@ -38,9 +39,7 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     const PaneRect& md_pane_rect, float scroll_y,
     const TextSelection& selection,
     int first_visible,
-    int hovered_copy_node,
-    int hovered_save_node,
-    int hovered_svg_copy_node,
+    HoveredButtons hovered,
     float dpi_scale)
 {
     // 古いコマンドを destruct してから resource をリセットする。
@@ -68,9 +67,7 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     frame_viewport_right_ = md_pane_rect.width - theme_->margin_left;
     frame_content_width_ = theme_->ContentWidth(md_pane_rect.width);
     frame_selection_ = &selection;
-    frame_hovered_copy_node_ = hovered_copy_node;
-    frame_hovered_save_node_ = hovered_save_node;
-    frame_hovered_svg_copy_node_ = hovered_svg_copy_node;
+    frame_hovered_ = hovered;
 
     // 最初の可視ノードを二分探索で検索（事前計算済みのインデックスがあればそれを使用）
     const int node_count = static_cast<int>(nodes.size());
@@ -144,9 +141,9 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
             if (diagram.bitmap) {
                 const auto bmp = MermaidBitmapRect(diagram.width, diagram.height, x, cw, entry.y_position);
                 cmds.emplace_back(DrawBitmapCmd{ diagram.bitmap.Get(), bmp });
-                GenSaveButton(cmds, bmp.right, bmp.top, node_index == frame_hovered_save_node_);
+                GenSaveButton(cmds, bmp.right, bmp.top, node_index == frame_hovered_.save);
                 if (IsSvgExportable(node.code_language)) {
-                    GenSvgCopyButton(cmds, bmp.right, bmp.top, node_index == frame_hovered_svg_copy_node_);
+                    GenSvgCopyButton(cmds, bmp.right, bmp.top, node_index == frame_hovered_.svg_copy);
                 }
             }
             else {
@@ -155,7 +152,7 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
             return;
         }
         GenCodeBlockBg(cmds, entry, x, cw);
-        GenCopyButton(cmds, entry, x, cw, node_index == frame_hovered_copy_node_);
+        GenCopyButton(cmds, entry, x, cw, node_index == frame_hovered_.copy);
         break;
 
     case NodeType::ListItem:
@@ -277,7 +274,8 @@ void CommandGenerator::GenSaveButton(DrawCommandList& cmds,
     if (!formats_.copy_btn_icon) {
         return;
     }
-    const D2D1_RECT_F btn = OverlayButtonRect(bitmap_right, bitmap_top);
+    const D2D1_RECT_F btn = OverlayButtonRect(bitmap_right, bitmap_top,
+        std::to_underlying(DiagramButtonSlot::Save));
     GenOverlayButton(cmds, btn, L'\uE896', is_hovered);
 }
 
@@ -287,7 +285,8 @@ void CommandGenerator::GenSvgCopyButton(DrawCommandList& cmds,
     if (!formats_.copy_btn_icon) {
         return;
     }
-    const D2D1_RECT_F btn = OverlayButtonRect(bitmap_right, bitmap_top, 1);
+    const D2D1_RECT_F btn = OverlayButtonRect(bitmap_right, bitmap_top,
+        std::to_underlying(DiagramButtonSlot::SvgCopy));
     GenOverlayButton(cmds, btn, L'\uE8C8', is_hovered);
 }
 

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -4,6 +4,7 @@
 #include "layout_cache.h"
 #include "theme.h"
 #include "pane.h"
+#include "hovered_buttons.h"
 #include "ui_constants.h"
 #include "memory_resource.h"
 #include "search_state.h"
@@ -93,9 +94,7 @@ public:
         const PaneRect& md_pane_rect, float scroll_y,
         const TextSelection& selection,
         int first_visible = -1,
-        int hovered_copy_node = -1,
-        int hovered_save_node = -1,
-        int hovered_svg_copy_node = -1,
+        HoveredButtons hovered = {},
         float dpi_scale = 1.0f);
 
 private:
@@ -169,7 +168,5 @@ private:
     float frame_viewport_right_ = 0.0f;
     float frame_content_width_ = 0.0f;
     const TextSelection* frame_selection_ = nullptr;
-    int frame_hovered_copy_node_ = -1;
-    int frame_hovered_save_node_ = -1;
-    int frame_hovered_svg_copy_node_ = -1;
+    HoveredButtons frame_hovered_;
 };

--- a/src/render/render_params.h
+++ b/src/render/render_params.h
@@ -6,6 +6,7 @@
 #include "toc.h"
 #include "titlebar.h"
 #include "pane.h"
+#include "hovered_buttons.h"
 #include "mouse_gesture.h"
 #include <d2d1.h>
 #include <wrl/client.h>
@@ -146,9 +147,7 @@ struct RenderParams {
     float scroll_y = 0.0f;
     float total_content_height = 0.0f;
     int nav_hovered = 0;
-    int hovered_copy_node = -1;
-    int hovered_save_node = -1;
-    int hovered_svg_copy_node = -1;
+    HoveredButtons hovered;
     // --- 1バイトアライメント ---
     bool can_go_back = false;
     bool can_go_forward = false;

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -4,6 +4,7 @@
 #include "profiler.h"
 #include <algorithm>
 #include <cmath>
+#include <utility>
 
 using Microsoft::WRL::ComPtr;
 
@@ -126,7 +127,7 @@ ID2D1SolidColorBrush* Renderer::GetSyntaxBrush(SyntaxTokenType type) const noexc
         BrushId::SyntaxPreprocessor,  // プリプロセッサ
         BrushId::SyntaxFunction,      // 関数
     };
-    const auto idx = static_cast<size_t>(type);
+    const auto idx = std::to_underlying(type);
     if (idx >= std::size(SYNTAX_MAP)) {
         return nullptr;
     }
@@ -378,7 +379,7 @@ void Renderer::Render(const RenderParams& p)
     const float dpi_scale = backend_.GetDpi() / DEFAULT_DPI;
     {
         MENDO_PROFILE("GenerateMdPane");
-        const auto& cmds = cmd_generator_.GenerateMdPane(p.nodes, p.cache, p.md_pane_rect, p.scroll_y, p.selection, first_visible, p.hovered_copy_node, p.hovered_save_node, p.hovered_svg_copy_node, dpi_scale);
+        const auto& cmds = cmd_generator_.GenerateMdPane(p.nodes, p.cache, p.md_pane_rect, p.scroll_y, p.selection, first_visible, p.hovered, dpi_scale);
         {
             MENDO_PROFILE("CommandExecutor::Execute");
             cmd_executor_.Execute(cmds, rt());

--- a/src/render/renderer.h
+++ b/src/render/renderer.h
@@ -15,6 +15,7 @@
 #include <array>
 #include <memory>
 #include <memory_resource>
+#include <utility>
 
 
 enum class BrushId : uint8_t {
@@ -110,10 +111,10 @@ private:
     ID2D1DeviceContext* rt() const noexcept { return backend_.GetRenderTarget(); }
     ID2D1Factory* d2d() const noexcept { return backend_.GetD2DFactory(); }
 
-    std::array<Microsoft::WRL::ComPtr<ID2D1SolidColorBrush>, static_cast<size_t>(BrushId::Count)> brushes_;
+    std::array<Microsoft::WRL::ComPtr<ID2D1SolidColorBrush>, std::to_underlying(BrushId::Count)> brushes_;
     ID2D1SolidColorBrush* Brush(BrushId id) const noexcept
     {
-        return brushes_[static_cast<size_t>(id)].Get();
+        return brushes_[std::to_underlying(id)].Get();
     }
 
     ID2D1SolidColorBrush* GetSyntaxBrush(SyntaxTokenType type) const noexcept;

--- a/src/render/renderer_pane.cpp
+++ b/src/render/renderer_pane.cpp
@@ -4,6 +4,7 @@
 #include "ui_constants.h"
 #include <algorithm>
 #include <cmath>
+#include <concepts>
 
 // PaneCacheのビットマップレンダーターゲットが必要なサイズと一致することを確認。
 // キャッシュが使用可能ならtrueを返す。
@@ -55,8 +56,8 @@ static void DrawPaneScrollbar(ID2D1RenderTarget* rt, ID2D1SolidColorBrush* thumb
 }
 
 // サイドペイン描画の共通スキャフォールド。
-// DrawItemFnのシグネチャ: void(ID2D1RenderTarget* rt, int index, float item_y, float pane_width)
 template<typename DrawItemFn>
+    requires std::invocable<DrawItemFn&, ID2D1RenderTarget*, int, float, float>
 static void DrawSidePaneImpl(
     PaneCache& cache,
     ID2D1RenderTarget* main_rt,

--- a/src/render/renderer_resources.cpp
+++ b/src/render/renderer_resources.cpp
@@ -2,6 +2,7 @@
 #include "resource.h"
 #include "ui_constants.h"
 #include "wic_util.h"
+#include <utility>
 
 using Microsoft::WRL::ComPtr;
 
@@ -101,7 +102,7 @@ void Renderer::RecreateBrushes()
     // 既存ブラシには SetColor のみ、未生成のものだけ CreateSolidColorBrush。
     // テーマ切替時の 40+ 個の COM オブジェクト再生成を回避する。
     for (const auto& s : specs) {
-        auto& brush = brushes_[static_cast<size_t>(s.id)];
+        auto& brush = brushes_[std::to_underlying(s.id)];
         if (brush) {
             brush->SetColor(s.color);
         }

--- a/src/ui/hovered_buttons.h
+++ b/src/ui/hovered_buttons.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// MD ペインのオーバーレイボタンのホバー状態。
+// 各フィールドはホバー対象のノードインデックスで、-1 は「該当なし」を表す。
+struct HoveredButtons {
+    int copy = -1;
+    int save = -1;
+    int svg_copy = -1;
+
+    bool operator==(const HoveredButtons&) const = default;
+};

--- a/src/ui/ui_constants.h
+++ b/src/ui/ui_constants.h
@@ -233,6 +233,13 @@ inline constexpr float TOAST_OVERLAY_BOTTOM_OFFSET = 16.0f;
 // ジェスチャー軌跡のスタイル
 inline constexpr float GESTURE_TRAIL_STROKE_WIDTH = 4.0f;
 
+// ダイアグラム（Mermaid 等）右上に並ぶオーバーレイボタンのスロット。
+// 値は OverlayButtonRect の button_index に対応し、0 が最も右、左隣に並ぶごとに +1。
+enum class DiagramButtonSlot : int {
+    Save = 0,
+    SvgCopy = 1,
+};
+
 // 要素の右上を基準にオーバーレイボタン（コピー/保存）の矩形を返す。
 // anchor_right: 基準領域の右端, anchor_top: 基準領域の上端
 // button_index: 0=最も右, 1 以降は左隣に COPY_BTN_GAP 分ずれる。

--- a/src/util/win_handle.h
+++ b/src/util/win_handle.h
@@ -82,6 +82,35 @@ struct GlobalMemTraits {
 };
 using UniqueGlobalMem = UniqueResource<GlobalMemTraits>;
 
+// 末尾 NUL 文字を付加した text を format 形式でクリップボードに登録する。
+// CharT は char または wchar_t を想定。OpenClipboard / EmptyClipboard /
+// CloseClipboard の呼び出しは呼び出し側の責務。
+// 戻り値: SetClipboardData まで成功したら true。
+template <typename CharT>
+inline bool SetClipboardZeroTerminated(UINT format, std::basic_string_view<CharT> text) noexcept
+{
+    if (format == 0) {
+        return false;
+    }
+    const size_t bytes = (text.size() + 1) * sizeof(CharT);
+    UniqueGlobalMem hMem{ GlobalAlloc(GMEM_MOVEABLE, bytes) };
+    if (!hMem) {
+        return false;
+    }
+    auto* dest = static_cast<CharT*>(GlobalLock(hMem.get()));
+    if (!dest) {
+        return false;
+    }
+    std::char_traits<CharT>::copy(dest, text.data(), text.size());
+    dest[text.size()] = CharT{};
+    GlobalUnlock(hMem.get());
+    if (!SetClipboardData(format, hMem.get())) {
+        return false;
+    }
+    hMem.release();
+    return true;
+}
+
 // クリップボードにテキストを書き込む共通ユーティリティ。
 // App::SetClipboardText と SideEffectExecutor の両方から使用される。
 inline void WriteClipboardText(HWND hwnd, std::wstring_view text) noexcept
@@ -90,18 +119,7 @@ inline void WriteClipboardText(HWND hwnd, std::wstring_view text) noexcept
         return;
     }
     EmptyClipboard();
-    const size_t bytes = (text.size() + 1) * sizeof(wchar_t);
-    UniqueGlobalMem hMem{ GlobalAlloc(GMEM_MOVEABLE, bytes) };
-    if (hMem) {
-        if (auto* dest = static_cast<wchar_t*>(GlobalLock(hMem.get()))) {
-            std::char_traits<wchar_t>::copy(dest, text.data(), text.size());
-            dest[text.size()] = L'\0';
-            GlobalUnlock(hMem.get());
-            if (SetClipboardData(CF_UNICODETEXT, hMem.get())) {
-                hMem.release();
-            }
-        }
-    }
+    SetClipboardZeroTerminated<wchar_t>(CF_UNICODETEXT, text);
     CloseClipboard();
 }
 
@@ -172,34 +190,11 @@ inline bool WriteClipboardSvg(HWND hwnd, std::wstring_view svg_text) noexcept
 
     const std::string svg_utf8 = string_convert::WideToUtf8(svg_text);
     if (!svg_utf8.empty()) {
-        UniqueGlobalMem hSvg{ GlobalAlloc(GMEM_MOVEABLE, svg_utf8.size() + 1) };
-        if (hSvg) {
-            if (auto* dest = static_cast<char*>(GlobalLock(hSvg.get()))) {
-                std::char_traits<char>::copy(dest, svg_utf8.data(), svg_utf8.size());
-                dest[svg_utf8.size()] = '\0';
-                GlobalUnlock(hSvg.get());
-                static const UINT cf_svg = RegisterClipboardFormatW(L"image/svg+xml");
-                if (cf_svg != 0 && SetClipboardData(cf_svg, hSvg.get())) {
-                    hSvg.release();
-                    any_set = true;
-                }
-            }
-        }
+        static const UINT cf_svg = RegisterClipboardFormatW(L"image/svg+xml");
+        any_set |= SetClipboardZeroTerminated<char>(cf_svg, svg_utf8);
     }
 
-    const size_t bytes = (svg_text.size() + 1) * sizeof(wchar_t);
-    UniqueGlobalMem hText{ GlobalAlloc(GMEM_MOVEABLE, bytes) };
-    if (hText) {
-        if (auto* dest = static_cast<wchar_t*>(GlobalLock(hText.get()))) {
-            std::char_traits<wchar_t>::copy(dest, svg_text.data(), svg_text.size());
-            dest[svg_text.size()] = L'\0';
-            GlobalUnlock(hText.get());
-            if (SetClipboardData(CF_UNICODETEXT, hText.get())) {
-                hText.release();
-                any_set = true;
-            }
-        }
-    }
+    any_set |= SetClipboardZeroTerminated<wchar_t>(CF_UNICODETEXT, svg_text);
 
     CloseClipboard();
     return any_set;
@@ -221,33 +216,12 @@ inline void WriteClipboardHtml(HWND hwnd, std::wstring_view fragment_html, std::
     if (!fragment_html.empty()) {
         const std::string fragment_utf8 = string_convert::WideToUtf8(fragment_html);
         const std::string payload = BuildCfHtmlPayload(fragment_utf8);
-        UniqueGlobalMem hHtml{ GlobalAlloc(GMEM_MOVEABLE, payload.size() + 1) };
-        if (hHtml) {
-            if (auto* dest = static_cast<char*>(GlobalLock(hHtml.get()))) {
-                std::char_traits<char>::copy(dest, payload.data(), payload.size());
-                dest[payload.size()] = '\0';
-                GlobalUnlock(hHtml.get());
-                const UINT cf_html = RegisterClipboardFormatW(L"HTML Format");
-                if (cf_html != 0 && SetClipboardData(cf_html, hHtml.get())) {
-                    hHtml.release();
-                }
-            }
-        }
+        const UINT cf_html = RegisterClipboardFormatW(L"HTML Format");
+        SetClipboardZeroTerminated<char>(cf_html, payload);
     }
 
     if (!plain_text.empty()) {
-        const size_t bytes = (plain_text.size() + 1) * sizeof(wchar_t);
-        UniqueGlobalMem hText{ GlobalAlloc(GMEM_MOVEABLE, bytes) };
-        if (hText) {
-            if (auto* dest = static_cast<wchar_t*>(GlobalLock(hText.get()))) {
-                std::char_traits<wchar_t>::copy(dest, plain_text.data(), plain_text.size());
-                dest[plain_text.size()] = L'\0';
-                GlobalUnlock(hText.get());
-                if (SetClipboardData(CF_UNICODETEXT, hText.get())) {
-                    hText.release();
-                }
-            }
-        }
+        SetClipboardZeroTerminated<wchar_t>(CF_UNICODETEXT, plain_text);
     }
 
     CloseClipboard();

--- a/tests/test_command_generator_frame.cpp
+++ b/tests/test_command_generator_frame.cpp
@@ -93,7 +93,7 @@ TEST_F(CmdGenFrameTest, TransformSnapsScrollToPixelWithDpi)
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 400.0f };
     const float scroll_y = 0.3f;
     const float dpi = 2.0f;
-    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, scroll_y, TextSelection{}, -1, -1, -1, -1, dpi);
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, scroll_y, TextSelection{}, -1, HoveredButtons{}, dpi);
 
     const auto* xform = FindFirst<SetTransformCmd>(cmds);
     ASSERT_NE(xform, nullptr);

--- a/tests/test_draw_command.cpp
+++ b/tests/test_draw_command.cpp
@@ -622,7 +622,7 @@ TEST_F(CmdGenTest, NestedListBulletCenteredOnFirstLine)
     EXPECT_EQ(idx, 2) << "親と子の箇条書き記号が1つずつ存在するべき";
 }
 
-// hovered_copy_node パラメータが GenerateMdPane に渡せることの検証
+// HoveredButtons パラメータが GenerateMdPane に渡せることの検証
 TEST_F(CmdGenTest, CodeBlockWithHoveredCopyNodeAccepted)
 {
     auto nodes = ParseMarkdown("```\ncode\n```").nodes;
@@ -630,8 +630,8 @@ TEST_F(CmdGenTest, CodeBlockWithHoveredCopyNodeAccepted)
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
     PaneRect md_pane{ 0, 0, 800.0f, 2000.0f };
-    // hovered_copy_node=0 を渡してもクラッシュしない
-    auto cmds = gen_.GenerateMdPane(nodes, cache, md_pane, 0.0f, TextSelection{}, -1, 0);
+    // hovered.copy=0 を渡してもクラッシュしない
+    auto cmds = gen_.GenerateMdPane(nodes, cache, md_pane, 0.0f, TextSelection{}, -1, HoveredButtons{ 0, -1, -1 });
     EXPECT_TRUE(std::holds_alternative<PushClipCmd>(cmds.front()));
     EXPECT_TRUE(std::holds_alternative<PopClipCmd>(cmds.back()));
 }

--- a/tests/test_reducer.cpp
+++ b/tests/test_reducer.cpp
@@ -374,78 +374,73 @@ TEST_F(ReducerTest, ParseComplete_EmitsHandleParseComplete) {
 TEST_F(ReducerTest, NavHover_NoneToBack_UpdatesStateAndInvalidates) {
     using Hover = NavButtonHover;
     state.interaction.nav_hover = Hover::None;
-    state.interaction.hovered_copy_node = 3;
-    state.interaction.hovered_save_node = 5;
+    state.interaction.hovered = { 3, 5, -1 };
 
     auto effects = Reduce(state, MdPaneNavHoverAction{ Hover::Back });
 
     EXPECT_EQ(state.interaction.nav_hover, Hover::Back);
     // ナビボタンホバー開始でコピー/保存ボタンのホバーはリセット
-    EXPECT_EQ(state.interaction.hovered_copy_node, -1);
-    EXPECT_EQ(state.interaction.hovered_save_node, -1);
+    EXPECT_EQ(state.interaction.hovered.copy, -1);
+    EXPECT_EQ(state.interaction.hovered.save, -1);
     EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
 }
 
 TEST_F(ReducerTest, NavHover_BackToNone_UpdatesStateAndInvalidates) {
     using Hover = NavButtonHover;
     state.interaction.nav_hover = Hover::Back;
-    state.interaction.hovered_copy_node = -1;
-    state.interaction.hovered_save_node = -1;
+    state.interaction.hovered = {};
 
     auto effects = Reduce(state, MdPaneNavHoverAction{ Hover::None });
 
     EXPECT_EQ(state.interaction.nav_hover, Hover::None);
     // ナビ離脱時はコピー/保存の状態は触らない
-    EXPECT_EQ(state.interaction.hovered_copy_node, -1);
-    EXPECT_EQ(state.interaction.hovered_save_node, -1);
+    EXPECT_EQ(state.interaction.hovered.copy, -1);
+    EXPECT_EQ(state.interaction.hovered.save, -1);
     EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
 }
 
 TEST_F(ReducerTest, NavHover_Unchanged_NoEffect) {
     using Hover = NavButtonHover;
     state.interaction.nav_hover = Hover::Forward;
-    state.interaction.hovered_copy_node = 7;
+    state.interaction.hovered.copy = 7;
 
     auto effects = Reduce(state, MdPaneNavHoverAction{ Hover::Forward });
 
     EXPECT_EQ(state.interaction.nav_hover, Hover::Forward);
     // 同値ならコピー/保存ホバーもそのまま
-    EXPECT_EQ(state.interaction.hovered_copy_node, 7);
+    EXPECT_EQ(state.interaction.hovered.copy, 7);
     EXPECT_TRUE(effects.empty());
 }
 
 // ---- MdPaneButtonHoverChangedAction テスト ----
 
 TEST_F(ReducerTest, ButtonHoverChanged_CopyUpdated_Invalidates) {
-    state.interaction.hovered_copy_node = -1;
-    state.interaction.hovered_save_node = -1;
+    state.interaction.hovered = {};
 
-    auto effects = Reduce(state, MdPaneButtonHoverChangedAction{ 3, -1 });
+    auto effects = Reduce(state, MdPaneButtonHoverChangedAction{ HoveredButtons{ 3, -1, -1 } });
 
-    EXPECT_EQ(state.interaction.hovered_copy_node, 3);
-    EXPECT_EQ(state.interaction.hovered_save_node, -1);
+    EXPECT_EQ(state.interaction.hovered.copy, 3);
+    EXPECT_EQ(state.interaction.hovered.save, -1);
     EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
 }
 
 TEST_F(ReducerTest, ButtonHoverChanged_SaveUpdated_Invalidates) {
-    state.interaction.hovered_copy_node = -1;
-    state.interaction.hovered_save_node = -1;
+    state.interaction.hovered = {};
 
-    auto effects = Reduce(state, MdPaneButtonHoverChangedAction{ -1, 5 });
+    auto effects = Reduce(state, MdPaneButtonHoverChangedAction{ HoveredButtons{ -1, 5, -1 } });
 
-    EXPECT_EQ(state.interaction.hovered_copy_node, -1);
-    EXPECT_EQ(state.interaction.hovered_save_node, 5);
+    EXPECT_EQ(state.interaction.hovered.copy, -1);
+    EXPECT_EQ(state.interaction.hovered.save, 5);
     EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
 }
 
 TEST_F(ReducerTest, ButtonHoverChanged_Unchanged_NoEffect) {
-    state.interaction.hovered_copy_node = 2;
-    state.interaction.hovered_save_node = 4;
+    state.interaction.hovered = { 2, 4, -1 };
 
-    auto effects = Reduce(state, MdPaneButtonHoverChangedAction{ 2, 4 });
+    auto effects = Reduce(state, MdPaneButtonHoverChangedAction{ HoveredButtons{ 2, 4, -1 } });
 
-    EXPECT_EQ(state.interaction.hovered_copy_node, 2);
-    EXPECT_EQ(state.interaction.hovered_save_node, 4);
+    EXPECT_EQ(state.interaction.hovered.copy, 2);
+    EXPECT_EQ(state.interaction.hovered.save, 4);
     EXPECT_TRUE(effects.empty());
 }
 

--- a/tests/test_titlebar.cpp
+++ b/tests/test_titlebar.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <iterator>
+#include <utility>
 #include "titlebar.h"
 
 class TitleBarTest : public ::testing::Test {
@@ -347,7 +348,7 @@ TEST_F(TitleBarTest, SetHoveredSetsExactlyOneButton)
     };
     for (auto zone : zones) {
         tb_.SetHovered(zone);
-        EXPECT_EQ(countHovered(), 1) << "zone=" << static_cast<int>(zone);
+        EXPECT_EQ(countHovered(), 1) << "zone=" << std::to_underlying(zone);
     }
 }
 


### PR DESCRIPTION
## Summary
- MD ペインのホバー状態 3 フィールド（`hovered_copy_node` / `hovered_save_node` / `hovered_svg_copy_node`）を `HoveredButtons` 構造体に集約し、State / Action / RenderParams / CommandGenerator にまたがる引き回しを 1 個の値で統一
- `static_cast<int/size_t>(enum)` を C++23 の `std::to_underlying` に置換し、`enum class` の整数変換意図をコード上で明示
- テンプレート関数（`HitPaneHeaderButton` / `ProcessSidePaneHover` / `HitTestCodeBlockButton` / `ForEachAttrRange` / `DrawSidePaneImpl` 等）に `requires` 句で concepts 制約を付与し、誤呼び出しをコンパイル時に検出
- クリップボード書き込みの定型コードを `SetClipboardZeroTerminated<CharT>` に共通化し、`WriteClipboardText` / `WriteClipboardSvg` / `WriteClipboardHtml` の重複を除去
- ダイアグラム右上ボタン位置のマジックナンバー (`0` / `1`) を `DiagramButtonSlot::Save` / `DiagramButtonSlot::SvgCopy` enum に置換

## Test plan
- [x] `cmake --build build --config Release` がエラー・警告なく完走
- [x] `mendo_tests.exe --gtest_brief=1` 全 1955 テストパス
- [ ] 実機で Mermaid 図のホバー（保存ボタン / SVG コピー）が以前同様に切り替わるか確認
- [ ] コードブロックのコピー時にクリップボードへ書き込めるか確認
- [ ] SVG コピー時に `image/svg+xml` と `CF_UNICODETEXT` の両方が書き込まれるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)