### PR TITLE
refactor: テスト共通化と /simplify レビュー反映

### DIFF
--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -67,7 +67,8 @@ void Document::BuildHeadingIndices(const std::pmr::vector<size_t>& heading_indic
         toc_.AddEntry(node, static_cast<int>(i));
         const auto sv = node.anchor_id();
         if (!sv.empty()) {
-            anchor_index_.emplace(sv, static_cast<int>(i));
+            std::pmr::wstring key{ sv, anchor_index_.get_allocator().resource() };
+            anchor_index_.try_emplace(std::move(key), static_cast<int>(i));
         }
     }
 }

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -34,14 +34,27 @@ public:
 private:
     void BuildHeadingIndices(const std::pmr::vector<size_t>& heading_indices);
 
+    // anchor_index_ のキー用の透過ハッシュ。wstring_view / pmr::wstring 双方で
+    // 同じハッシュになるよう wstring_view 経由で計算する。
+    struct AnchorKeyHash {
+        using is_transparent = void;
+        [[nodiscard]] size_t operator()(std::wstring_view sv) const noexcept
+        {
+            return std::hash<std::wstring_view>{}(sv);
+        }
+        [[nodiscard]] size_t operator()(const std::pmr::wstring& s) const noexcept
+        {
+            return std::hash<std::wstring_view>{}(s);
+        }
+    };
+
     std::pmr::vector<Node> nodes_;
     std::pmr::wstring file_path_;
     std::pmr::string raw_utf8_;
     TableOfContents toc_;
-    // キーは nodes_ 内 NodeHeadingData::anchor_id への view。
-    // BuildHeadingIndices 以降は nodes_ のサイズを変更しないこと（要素アドレスを安定させる）。
-    std::pmr::unordered_map<std::wstring_view, int,
-        std::hash<std::wstring_view>, std::equal_to<>> anchor_index_;
+    // キーは所有 wstring。nodes_ の再アロケート/構造変更でも索引が dangling しない。
+    std::pmr::unordered_map<std::pmr::wstring, int,
+        AnchorKeyHash, std::equal_to<>> anchor_index_;
     std::pmr::vector<size_t> image_node_indices_;
     std::pmr::vector<size_t> diagram_node_indices_;
 };

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -381,22 +381,11 @@ HitTestService::CodeBlockButtonHit HitTestService::CodeBlockButtonsHitTest(
 NavButtonHover HitTestService::NavButtonHitTest(
     float dip_x, float dip_y, const PaneRect& md_rect) const noexcept
 {
-    const float base_x = md_rect.x + md_rect.width - NAV_BTN_MARGIN - NAV_BTN_SIZE * 2 - NAV_BTN_GAP - NAV_BTN_SCROLLBAR_OFFSET;
-    const float base_y = md_rect.y + md_rect.height - NAV_BTN_MARGIN - NAV_BTN_SIZE;
-
-    if (dip_y < base_y || dip_y > base_y + NAV_BTN_SIZE) {
-        return NavButtonHover::None;
-    }
-
-    // 戻るボタン
-    if (dip_x >= base_x && dip_x <= base_x + NAV_BTN_SIZE) {
+    if (NavBackButtonRect(md_rect).Contains(dip_x, dip_y)) {
         return NavButtonHover::Back;
     }
-    // 進むボタン
-    const float fwd_x = base_x + NAV_BTN_SIZE + NAV_BTN_GAP;
-    if (dip_x >= fwd_x && dip_x <= fwd_x + NAV_BTN_SIZE) {
+    if (NavForwardButtonRect(md_rect).Contains(dip_x, dip_y)) {
         return NavButtonHover::Forward;
     }
-
     return NavButtonHover::None;
 }

--- a/src/input/hit_test_service.h
+++ b/src/input/hit_test_service.h
@@ -4,9 +4,36 @@
 #include "nav_button.h"
 #include "pane.h"
 #include "theme.h"
+#include "ui_constants.h"
 #include <climits>
 #include <concepts>
 #include <memory_resource>
+
+// ボタン矩形の純粋表現。テスト側が実装の式を再構築せずに済むよう、
+// 各ボタンの矩形を返す API は本ヘッダから提供する。
+struct ButtonRect {
+    float x = 0.0f, y = 0.0f, w = 0.0f, h = 0.0f;
+    [[nodiscard]] constexpr bool Contains(float px, float py) const noexcept
+    {
+        return px >= x && px <= x + w && py >= y && py <= y + h;
+    }
+};
+
+// 戻るボタンの矩形。実装側の NavButtonHitTest と同一の式を使う。
+[[nodiscard]] inline ButtonRect NavBackButtonRect(const PaneRect& md_rect) noexcept
+{
+    const float x = md_rect.x + md_rect.width
+        - NAV_BTN_MARGIN - NAV_BTN_SIZE * 2.0f - NAV_BTN_GAP - NAV_BTN_SCROLLBAR_OFFSET;
+    const float y = md_rect.y + md_rect.height - NAV_BTN_MARGIN - NAV_BTN_SIZE;
+    return { x, y, NAV_BTN_SIZE, NAV_BTN_SIZE };
+}
+
+// 進むボタンの矩形。Back の右に NAV_BTN_GAP の隙間を空けて並ぶ。
+[[nodiscard]] inline ButtonRect NavForwardButtonRect(const PaneRect& md_rect) noexcept
+{
+    const ButtonRect back = NavBackButtonRect(md_rect);
+    return { back.x + NAV_BTN_SIZE + NAV_BTN_GAP, back.y, NAV_BTN_SIZE, NAV_BTN_SIZE };
+}
 
 // MDペインのヒットテストに必要なコンテキスト情報。
 // ドキュメントデータ、ビューポート状態、マウス位置をまとめる。

--- a/src/io/config_service.cpp
+++ b/src/io/config_service.cpp
@@ -95,9 +95,9 @@ void ConfigService::Flush()
     }
 
     if (!MoveFileExW(tmp_path.c_str(), ini_path.c_str(), MOVEFILE_REPLACE_EXISTING)) {
-        // renameが失敗した場合（クロスボリューム等）、直接書き込み
+        // renameが失敗した場合（クロスボリューム等）、直接書き込み（更なる失敗の救済手段はないので戻り値は破棄）
         DeleteFileW(tmp_path.c_str());
-        WriteAllBytes(ini_path, content.data(), content.size());
+        (void)WriteAllBytes(ini_path, content.data(), content.size());
     }
 }
 

--- a/src/io/config_service.h
+++ b/src/io/config_service.h
@@ -15,9 +15,9 @@ public:
 
     // テスト用に既定の AppData パスをオーバーライドする。
     void SetConfigDirOverride(const std::filesystem::path& dir);
-    std::filesystem::path GetConfigDir() const;
+    [[nodiscard]] std::filesystem::path GetConfigDir() const;
     // 設定ディレクトリ配下のファイルパスを返す。区切り文字や ".." を含む名前は拒否する。
-    std::filesystem::path GetConfigPath(std::wstring_view filename) const;
+    [[nodiscard]] std::filesystem::path GetConfigPath(std::wstring_view filename) const;
 
     // ---- ディスク永続化 ----
 
@@ -29,16 +29,16 @@ public:
     // ---- 型付きアクセサ（メモリ上のマップを読み書き） ----
 
     void SaveBool(std::string_view section, std::string_view key, bool value);
-    bool LoadBool(std::string_view section, std::string_view key, bool default_value = false) const;
+    [[nodiscard]] bool LoadBool(std::string_view section, std::string_view key, bool default_value = false) const;
 
     void SaveInt(std::string_view section, std::string_view key, int value);
-    int LoadInt(std::string_view section, std::string_view key, int def, int min_v, int max_v) const;
+    [[nodiscard]] int LoadInt(std::string_view section, std::string_view key, int def, int min_v, int max_v) const;
 
     void SaveWString(std::string_view section, std::string_view key, std::wstring_view value);
-    std::pmr::wstring LoadWString(std::string_view section, std::string_view key) const;
+    [[nodiscard]] std::pmr::wstring LoadWString(std::string_view section, std::string_view key) const;
 
 private:
-    const std::string* FindValue(std::string_view section, std::string_view key) const;
+    [[nodiscard]] const std::string* FindValue(std::string_view section, std::string_view key) const;
 
     std::filesystem::path config_dir_override_;
     // SHGetKnownFolderPath の結果キャッシュ。override 未設定時の問い合わせを 1 回に抑える。

--- a/src/io/image_loader.cpp
+++ b/src/io/image_loader.cpp
@@ -89,20 +89,14 @@ bool ImageLoader::LoadImage(const std::wstring& abs_path, DiagramEntry& out)
         return false;
     }
 
-    const auto decoded = wic_util::DecodeFromStream(wic_factory_.Get(), stream.Get());
-    if (!decoded) {
-        return false;
-    }
-
-    Microsoft::WRL::ComPtr<ID2D1Bitmap> bitmap;
-    const HRESULT hr = render_target_->CreateBitmapFromWicBitmap(decoded->converter.Get(), &bitmap);
-    if (FAILED(hr)) {
+    auto created = wic_util::CreateD2DBitmapFromStream(wic_factory_.Get(), render_target_, stream.Get());
+    if (!created) {
         return false;
     }
 
     // ピクセルサイズを DIP に変換してキャッシュに登録
-    const auto [width, height] = CreateAndCacheImage(abs_path, bitmap, decoded->pixel_width, decoded->pixel_height);
-    out.bitmap = bitmap;
+    const auto [width, height] = CreateAndCacheImage(abs_path, created->bitmap, created->pixel_width, created->pixel_height);
+    out.bitmap = std::move(created->bitmap);
     out.width = width;
     out.height = height;
     return true;

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -367,11 +367,13 @@ constexpr bool IsOffscreen(float y, float h, float range_top, float range_bottom
 }
 
 // 下端が viewport_top 以上の最初のノードを二分探索で見つける。
-// 最初の可視候補ノードのインデックスを返す。該当なしの場合は node_count を返す。
+// 最初の可視候補ノードのインデックスを返す。該当なしの場合は effective node count を返す。
+// 過渡状態で node_count > cache.size() でも UB にならないよう内部でクランプする。
 constexpr int FindFirstVisibleNodeIndex(const LayoutCache& cache, size_t node_count, float viewport_top) noexcept
 {
+    const size_t effective = std::min(node_count, cache.size());
     const auto first = cache.cbegin();
-    const auto last = first + static_cast<ptrdiff_t>(node_count);
+    const auto last = first + static_cast<ptrdiff_t>(effective);
     const auto it = std::ranges::partition_point(first, last, [viewport_top](const NodeLayoutEntry& e) noexcept {
         return e.y_position + e.height <= viewport_top;
     });

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -724,24 +724,20 @@ void MermaidRenderer::OnCaptureComplete(int worker_idx, uint64_t code_hash, IStr
 HRESULT MermaidRenderer::CreateBitmapFromPngStream(IStream* stream, ID2D1Bitmap** bitmap,
     float* width, float* height)
 {
-    if (!wic_factory_ || !render_target_ || !stream) {
+    if (!stream || !bitmap) {
         return E_FAIL;
     }
 
     const LARGE_INTEGER zero = {};
     stream->Seek(zero, STREAM_SEEK_SET, nullptr);
 
-    const auto decoded = wic_util::DecodeFromStream(wic_factory_.Get(), stream);
-    if (!decoded) {
+    auto created = wic_util::CreateD2DBitmapFromStream(wic_factory_.Get(), render_target_, stream);
+    if (!created) {
         return E_FAIL;
     }
 
-    const HRESULT hr = render_target_->CreateBitmapFromWicBitmap(decoded->converter.Get(), bitmap);
-    if (FAILED(hr)) {
-        return hr;
-    }
-
-    *width = static_cast<float>(decoded->pixel_width);
-    *height = static_cast<float>(decoded->pixel_height);
+    *bitmap = created->bitmap.Detach();
+    *width = static_cast<float>(created->pixel_width);
+    *height = static_cast<float>(created->pixel_height);
     return S_OK;
 }

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -724,7 +724,7 @@ void MermaidRenderer::OnCaptureComplete(int worker_idx, uint64_t code_hash, IStr
 HRESULT MermaidRenderer::CreateBitmapFromPngStream(IStream* stream, ID2D1Bitmap** bitmap,
     float* width, float* height)
 {
-    if (!stream || !bitmap) {
+    if (!stream || !bitmap || !width || !height) {
         return E_FAIL;
     }
 

--- a/src/mermaid/mermaid_file_cache.cpp
+++ b/src/mermaid/mermaid_file_cache.cpp
@@ -192,9 +192,9 @@ void MermaidFileCache::SaveIndex()
     }
 
     if (!MoveFileExW(tmp_path.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING)) {
-        // renameが失敗した場合、直接書き込み
+        // renameが失敗した場合、直接書き込み（更なる失敗の救済手段はないので戻り値は破棄）
         DeleteFileW(tmp_path.c_str());
-        WriteAllBytes(path, buf.get(), buf_size);
+        (void)WriteAllBytes(path, buf.get(), buf_size);
     }
 }
 
@@ -325,7 +325,8 @@ void MermaidFileCache::StoreAsync(uint64_t key, float css_width, float css_heigh
             return;
         }
 
-        WriteAllBytes(path, data.data(), data.size());
+        // 書き込み失敗時はキャッシュ未保存のままになるが、再生成可能なので致命的ではない
+        (void)WriteAllBytes(path, data.data(), data.size());
     });
     if (!posted) {
         // Post 失敗時はラムダが走らないので PendingGuard も走らない。

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -175,23 +175,34 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
         break;
     }
 
+    GenNodeTextDecorations(cmds, node, entry, node_index, x, text_x);
+}
+
+D2D1_COLOR_F CommandGenerator::GetNodeBaseColor(const Node& node) const noexcept
+{
+    switch (node.type) {
+    case NodeType::Heading:
+        return theme_->heading_color;
+    case NodeType::BlockQuote:
+        return (node.alert_type != AlertType::None)
+            ? theme_->text_color
+            : theme_->blockquote_text_color;
+    case NodeType::CodeBlock:
+        return theme_->code_text_color;
+    default:
+        return theme_->text_color;
+    }
+}
+
+void CommandGenerator::GenNodeTextDecorations(DrawCommandList& cmds,
+    const Node& node, const NodeLayoutEntry& entry, int node_index,
+    float x, float text_x)
+{
     if (!entry.text_layout) {
         return;
     }
 
-    // ノードタイプに応じたベースカラーを決定
-    D2D1_COLOR_F base_color = theme_->text_color;
-    if (node.type == NodeType::Heading) {
-        base_color = theme_->heading_color;
-    }
-    else if (node.type == NodeType::BlockQuote) {
-        base_color = (node.alert_type != AlertType::None)
-            ? theme_->text_color
-            : theme_->blockquote_text_color;
-    }
-    else if (node.type == NodeType::CodeBlock) {
-        base_color = theme_->code_text_color;
-    }
+    const D2D1_COLOR_F base_color = GetNodeBaseColor(node);
 
     // インラインコードの背景
     GenInlineCodeBgs(cmds, entry.inline_code_bgs, text_x, entry.y_position, theme_->code_bg_color);
@@ -474,55 +485,66 @@ void CommandGenerator::GenSearchHighlights(DrawCommandList& cmds, const NodeLayo
         return;
     }
 
-    const auto& matches = *search_matches_;
-    auto it = std::ranges::lower_bound(matches, node_index, {}, &SearchMatch::node_index);
-    const size_t first_global = static_cast<size_t>(it - matches.begin());
-    if (first_global >= matches.size() || matches[first_global].node_index != node_index) {
+    const std::span<const SearchMatch> matches = *search_matches_;
+    const auto first_it = std::ranges::lower_bound(matches, node_index, {}, &SearchMatch::node_index);
+    if (first_it == matches.end() || first_it->node_index != node_index) {
         return;
     }
+    // matches は node_index 昇順なので upper_bound で末尾も O(log N) で求める。
+    const auto last_it = std::ranges::upper_bound(matches, node_index, {}, &SearchMatch::node_index);
+    const size_t first_global = static_cast<size_t>(first_it - matches.begin());
+    const size_t node_match_count = static_cast<size_t>(last_it - first_it);
 
+    auto& cache = entry.ensure_search_hl_cache();
+    RebuildSearchHlCache(cache, entry, matches, first_global, node_match_count);
+    EmitSearchHlCommands(cmds, cache, matches, first_global, origin_x, origin_y, table_row, table_col);
+}
+
+void CommandGenerator::RebuildSearchHlCache(SearchHlCache& cache, const NodeLayoutEntry& entry,
+    std::span<const SearchMatch> matches, size_t first_global, size_t node_match_count)
+{
     // キャッシュミス時のみ HitTestTextRange を一括発行。layout 変更時は
     // invalidate_search_hl_cache() でキャッシュ自体が破棄されており、SearchState の
     // generation は 1 から始まるため、cache.gen == search_generation_ のみで
     // キャッシュ有効性を完全判定できる。
-    auto& cache = entry.ensure_search_hl_cache();
-    if (cache.gen != search_generation_) {
-        size_t node_match_count = 0;
-        for (size_t mi = first_global; mi < matches.size(); ++mi) {
-            if (matches[mi].node_index != node_index) {
-                break;
-            }
-            ++node_match_count;
-        }
-
-        cache.rects.clear();
-        cache.rect_ends.clear();
-        cache.rect_ends.reserve(node_match_count);
-
-        auto& buf = GetHitTestBuffer();
-        for (size_t mi = first_global; mi < first_global + node_match_count; ++mi) {
-            const auto& m = matches[mi];
-            IDWriteTextLayout* l = nullptr;
-            if (m.table_row >= 0 && entry.has_table_layout()) {
-                l = entry.table_layout->GetCellLayout(static_cast<size_t>(m.table_row), static_cast<size_t>(m.table_col));
-            }
-            else if (m.table_row < 0) {
-                l = entry.text_layout.Get();
-            }
-            if (l && m.length > 0) {
-                const UINT32 count = FetchHitTestMetrics(l, m.start, m.length, buf);
-                for (UINT32 k = 0; k < count; ++k) {
-                    cache.rects.emplace_back(RectFromHitTest(buf[k]));
-                }
-            }
-            cache.rect_ends.push_back(static_cast<uint32_t>(cache.rects.size()));
-        }
-        cache.gen = search_generation_;
+    if (cache.gen == search_generation_) {
+        return;
     }
 
-    // キャッシュ済みの矩形を origin 加算してコマンド化する。
+    cache.rects.clear();
+    cache.rect_ends.clear();
+    cache.rect_ends.reserve(node_match_count);
+
+    auto& buf = GetHitTestBuffer();
+    for (size_t mi = first_global; mi < first_global + node_match_count; ++mi) {
+        const auto& m = matches[mi];
+        IDWriteTextLayout* l = nullptr;
+        if (m.table_row >= 0 && entry.has_table_layout()) {
+            l = entry.table_layout->GetCellLayout(static_cast<size_t>(m.table_row), static_cast<size_t>(m.table_col));
+        }
+        else if (m.table_row < 0) {
+            l = entry.text_layout.Get();
+        }
+        // m.table_row >= 0 && !has_table_layout() のケースは layout 失効中の
+        // 暫定状態で、l は nullptr のまま空 rect として記録する（次回再構築時に修復）。
+        if (l && m.length > 0) {
+            const UINT32 count = FetchHitTestMetrics(l, m.start, m.length, buf);
+            for (UINT32 k = 0; k < count; ++k) {
+                cache.rects.emplace_back(RectFromHitTest(buf[k]));
+            }
+        }
+        cache.rect_ends.push_back(static_cast<uint32_t>(cache.rects.size()));
+    }
+    cache.gen = search_generation_;
+}
+
+void CommandGenerator::EmitSearchHlCommands(DrawCommandList& cmds, const SearchHlCache& cache,
+    std::span<const SearchMatch> matches, size_t first_global,
+    float origin_x, float origin_y, int table_row, int table_col)
+{
     // 呼び出し側（セル/ノード本体）に属する match のみ描画する。
     const size_t node_match_count = cache.rect_ends.size();
+
     for (size_t node_mi = 0; node_mi < node_match_count; ++node_mi) {
         const size_t mi = first_global + node_mi;
         const auto& m = matches[mi];

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -9,6 +9,7 @@
 #include "memory_resource.h"
 #include "search_state.h"
 #include <cassert>
+#include <span>
 
 // HitTestTextRange 初期バッファ容量。1 行中の inline code run が
 // 折り返される想定最大数に合わせる。描画 hot path 中の resize を避けるのが目的。
@@ -100,6 +101,14 @@ public:
 private:
     void GenerateNode(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, const DiagramEntry& diagram, int node_index);
 
+    // ベースカラー、インラインコード背景、検索/選択ハイライト、本文テキスト、
+    // タスクリストチェックボックスを描画する。
+    void GenNodeTextDecorations(DrawCommandList& cmds, const Node& node,
+        const NodeLayoutEntry& entry, int node_index, float x, float text_x);
+
+    // ノードタイプに応じた本文ベースカラーを返す。
+    [[nodiscard]] D2D1_COLOR_F GetNodeBaseColor(const Node& node) const noexcept;
+
     void GenHorizontalRule(DrawCommandList& cmds, const NodeLayoutEntry& entry, float x, float w);
     void GenTable(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, int node_index, float x);
     void GenTableRowBg(DrawCommandList& cmds, bool is_header, bool is_even_row, float x, float y, float table_width, float row_h, float border);
@@ -115,6 +124,17 @@ private:
     void EmitHighlightRects(DrawCommandList& cmds, IDWriteTextLayout* layout, uint32_t start, uint32_t length, float origin_x, float origin_y, D2D1_COLOR_F color);
     void GenSelectionHighlight(DrawCommandList& cmds, IDWriteTextLayout* layout, uint32_t start, uint32_t length, float origin_x, float origin_y);
     void GenSearchHighlights(DrawCommandList& cmds, const NodeLayoutEntry& entry, int node_index, float origin_x, float origin_y, int table_row = -1, int table_col = -1);
+
+    // 検索ハイライトのキャッシュが古い場合に再構築する。
+    // matches[first_global, first_global + node_match_count) が当該ノードのマッチ。
+    void RebuildSearchHlCache(SearchHlCache& cache, const NodeLayoutEntry& entry,
+        std::span<const SearchMatch> matches, size_t first_global, size_t node_match_count);
+
+    // 構築済みキャッシュから FillRectCmd を発行する。
+    // table_row / table_col に該当するマッチのみ origin に加算して描画。
+    void EmitSearchHlCommands(DrawCommandList& cmds, const SearchHlCache& cache,
+        std::span<const SearchMatch> matches, size_t first_global,
+        float origin_x, float origin_y, int table_row, int table_col);
 
     const Theme* theme_ = nullptr;
     Formats formats_;

--- a/src/theme/theme.cpp
+++ b/src/theme/theme.cpp
@@ -234,13 +234,15 @@ static Theme BuildDarkTheme()
     return t;
 }
 
-Theme GetLightTheme()
+// 静的初期化はプロセス終了時に1回だけ走る。Magic statics の保護コストは
+// 関数呼び出しごとの atomic ロードのみで、ホットパスでもほぼ無視できる。
+const Theme& GetLightTheme()
 {
     static const Theme kLight = BuildLightTheme();
     return kLight;
 }
 
-Theme GetDarkTheme()
+const Theme& GetDarkTheme()
 {
     static const Theme kDark = BuildDarkTheme();
     return kDark;

--- a/src/theme/theme.h
+++ b/src/theme/theme.h
@@ -108,5 +108,7 @@ inline constexpr float ZOOM_STEPS[] = {
 inline constexpr int ZOOM_STEP_COUNT = sizeof(ZOOM_STEPS) / sizeof(ZOOM_STEPS[0]);
 inline constexpr int ZOOM_DEFAULT_INDEX = 7; // 1.00f
 
-[[nodiscard]] Theme GetLightTheme();
-[[nodiscard]] Theme GetDarkTheme();
+// プロセス内で 1 度だけ初期化される定数テーマへの参照を返す。
+// 値変更が必要な場合は呼び出し側でコピーして ApplyZoom 等を行うこと。
+[[nodiscard]] const Theme& GetLightTheme();
+[[nodiscard]] const Theme& GetDarkTheme();

--- a/src/ui/viewport_manager.h
+++ b/src/ui/viewport_manager.h
@@ -90,11 +90,9 @@ public:
         if (scroll_target_.IsValid()) {
             return;
         }
-        // 呼び出し側の node_count が過渡状態で cache.size() を超える可能性に備えてクランプ
+        // node_count > cache.size() の過渡状態に備えて effective に揃えてから渡す。
+        // 「該当なし」のときは FindFirstVisibleNodeIndex が effective を返す契約。
         const size_t effective = std::min(node_count, cache.size());
-        if (effective == 0) {
-            return;
-        }
         const int idx = FindFirstVisibleNodeIndex(cache, effective, scroll_y_);
         if (idx < static_cast<int>(effective)) {
             scroll_target_ = { idx, scroll_y_ - cache[idx].y_position };

--- a/src/util/file_io.h
+++ b/src/util/file_io.h
@@ -30,7 +30,7 @@ struct OpenedFile {
     OpenFileError error = OpenFileError::None;
 };
 
-inline OpenedFile OpenFileForReadShared(const std::filesystem::path& path,
+[[nodiscard]] inline OpenedFile OpenFileForReadShared(const std::filesystem::path& path,
     DWORD share_mode, LONGLONG max_size, DWORD* out_error = nullptr) noexcept
 {
     if (out_error) {
@@ -62,7 +62,7 @@ inline OpenedFile OpenFileForReadShared(const std::filesystem::path& path,
 
 // ファイルを全て読み込む。失敗時は{nullptr, 0}を返す。
 // out_errorが非nullの場合、CreateFileW失敗時のGetLastError()を格納する。
-inline std::pair<std::unique_ptr<uint8_t[]>, size_t> ReadAllBytes(
+[[nodiscard]] inline std::pair<std::unique_ptr<uint8_t[]>, size_t> ReadAllBytes(
     const std::filesystem::path& path, DWORD* out_error = nullptr)
 {
     auto r = OpenFileForReadShared(path, FILE_SHARE_READ, UINT32_MAX, out_error);
@@ -79,7 +79,7 @@ inline std::pair<std::unique_ptr<uint8_t[]>, size_t> ReadAllBytes(
 }
 
 // ファイルに全て書き込む。成功時はtrueを返す。
-inline bool WriteAllBytes(const std::filesystem::path& path, const void* data, size_t size)
+[[nodiscard]] inline bool WriteAllBytes(const std::filesystem::path& path, const void* data, size_t size)
 {
     if (size > UINT32_MAX) {
         return false;

--- a/src/util/wic_util.h
+++ b/src/util/wic_util.h
@@ -61,6 +61,32 @@ inline std::optional<DecodeResult> DecodeFromStream(
     return DecodeResult{ std::move(converter), w, h };
 }
 
+struct CreatedBitmap {
+    Microsoft::WRL::ComPtr<ID2D1Bitmap> bitmap;
+    UINT pixel_width = 0;
+    UINT pixel_height = 0;
+};
+
+// IStream から WIC デコード -> D2D ビットマップ生成までを一括で行う。
+// image_loader（同期）と mermaid（PNGキャッシュ復元）の同型処理を共通化するためのヘルパー。
+inline std::optional<CreatedBitmap> CreateD2DBitmapFromStream(
+    IWICImagingFactory* wic, ID2D1RenderTarget* rt, IStream* stream)
+{
+    if (!wic || !rt || !stream) {
+        return std::nullopt;
+    }
+    auto decoded = DecodeFromStream(wic, stream);
+    if (!decoded) {
+        return std::nullopt;
+    }
+    Microsoft::WRL::ComPtr<ID2D1Bitmap> bitmap;
+    const HRESULT hr = rt->CreateBitmapFromWicBitmap(decoded->converter.Get(), &bitmap);
+    if (FAILED(hr)) {
+        return std::nullopt;
+    }
+    return CreatedBitmap{ std::move(bitmap), decoded->pixel_width, decoded->pixel_height };
+}
+
 // IWICBitmapSource を GUID_WICPixelFormat32bppPBGRA に変換する。
 // HICON 由来の IWICBitmap など、デコーダを経由しないソースに使用する。
 inline Microsoft::WRL::ComPtr<IWICFormatConverter> ConvertBitmapSource(

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -219,76 +219,89 @@ LRESULT Win32Window::OnNcHitTest(LPARAM lParam)
     POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
     ScreenToClient(hwnd_, &pt);
 
-    // 非最大化時のリサイズ枠判定（細めの枠でスクロールバーと干渉しないようにする）
-    if (!IsZoomed(hwnd_)) {
-        const int border = cached_nchit_border_;
-        const int frame_y = cached_nchit_frame_y_;
-        const int right_border = cached_nchit_right_border_;
+    if (const LRESULT frame_hit = HitTestResizeFrame(pt); frame_hit != HTNOWHERE) {
+        return frame_hit;
+    }
+    return HitTestTitleBar(pt);
+}
 
-        RECT rc;
-        GetClientRect(hwnd_, &rc);
-
-        if (pt.y < frame_y) {
-            if (pt.x < border) {
-                return HTTOPLEFT;
-            }
-            if (pt.x >= rc.right - right_border) {
-                return HTTOPRIGHT;
-            }
-            return HTTOP;
-        }
-        if (pt.y >= rc.bottom - border) {
-            if (pt.x < border) {
-                return HTBOTTOMLEFT;
-            }
-            if (pt.x >= rc.right - right_border) {
-                return HTBOTTOMRIGHT;
-            }
-            return HTBOTTOM;
-        }
-        if (pt.x < border) {
-            return HTLEFT;
-        }
-        if (pt.x >= rc.right - right_border) {
-            // 内側部分のみスクロールバーを優先、最外側borderはリサイズを優先
-            if (pt.x < rc.right - border) {
-                const float dpi_scale = app_->GetDpiScale();
-                if (app_->IsOverMdScrollbar(pt.x / dpi_scale, pt.y / dpi_scale)) {
-                    return HTCLIENT;
-                }
-            }
-            return HTRIGHT;
-        }
+LRESULT Win32Window::HitTestResizeFrame(POINT pt) const noexcept
+{
+    // 最大化時はリサイズ不可
+    if (IsZoomed(hwnd_)) {
+        return HTNOWHERE;
     }
 
-    // タイトルバー領域のヒットテスト
+    const int border = cached_nchit_border_;
+    const int frame_y = cached_nchit_frame_y_;
+    const int right_border = cached_nchit_right_border_;
+
+    RECT rc;
+    GetClientRect(hwnd_, &rc);
+
+    if (pt.y < frame_y) {
+        if (pt.x < border) {
+            return HTTOPLEFT;
+        }
+        if (pt.x >= rc.right - right_border) {
+            return HTTOPRIGHT;
+        }
+        return HTTOP;
+    }
+    if (pt.y >= rc.bottom - border) {
+        if (pt.x < border) {
+            return HTBOTTOMLEFT;
+        }
+        if (pt.x >= rc.right - right_border) {
+            return HTBOTTOMRIGHT;
+        }
+        return HTBOTTOM;
+    }
+    if (pt.x < border) {
+        return HTLEFT;
+    }
+    // 右辺: スクロールバー領域は HTCLIENT を優先するが、最外側 border はリサイズを優先
+    if (pt.x >= rc.right - right_border) {
+        if (pt.x < rc.right - border) {
+            const float dpi_scale = app_->GetDpiScale();
+            if (app_->IsOverMdScrollbar(pt.x / dpi_scale, pt.y / dpi_scale)) {
+                return HTCLIENT;
+            }
+        }
+        return HTRIGHT;
+    }
+
+    return HTNOWHERE;
+}
+
+LRESULT Win32Window::HitTestTitleBar(POINT pt) const noexcept
+{
     const float dpi_scale = app_->GetDpiScale();
     const float dip_x = pt.x / dpi_scale;
     const float dip_y = pt.y / dpi_scale;
     const float titlebar_height = app_->GetTitleBarHeightDip();
 
-    if (dip_y < titlebar_height) {
-        const auto zone = app_->TitleBarHitTest(dip_x, dip_y);
-        switch (zone) {
-        case TitleBarHitZone::Icon:
-            return HTSYSMENU;  // システムメニュー表示（ダブルクリックで閉じる）
-        case TitleBarHitZone::OpenFile:
-        case TitleBarHitZone::Help:
-        case TitleBarHitZone::ThemeToggle:
-        case TitleBarHitZone::Search:
-        case TitleBarHitZone::FileToggle:
-        case TitleBarHitZone::TocToggle:
-        case TitleBarHitZone::Minimize:
-        case TitleBarHitZone::Maximize:
-        case TitleBarHitZone::Close:
-            return HTCLIENT;  // カスタムボタンはWM_LBUTTONDOWNで処理
-        case TitleBarHitZone::Caption:
-        default:
-            return HTCAPTION;
-        }
+    if (dip_y >= titlebar_height) {
+        return HTCLIENT;
     }
 
-    return HTCLIENT;
+    switch (app_->TitleBarHitTest(dip_x, dip_y)) {
+    case TitleBarHitZone::Icon:
+        return HTSYSMENU;  // システムメニュー表示（ダブルクリックで閉じる）
+    case TitleBarHitZone::OpenFile:
+    case TitleBarHitZone::Help:
+    case TitleBarHitZone::ThemeToggle:
+    case TitleBarHitZone::Search:
+    case TitleBarHitZone::FileToggle:
+    case TitleBarHitZone::TocToggle:
+    case TitleBarHitZone::Minimize:
+    case TitleBarHitZone::Maximize:
+    case TitleBarHitZone::Close:
+        return HTCLIENT;  // カスタムボタンはWM_LBUTTONDOWNで処理
+    case TitleBarHitZone::Caption:
+    default:
+        return HTCAPTION;
+    }
 }
 
 LRESULT Win32Window::HandleMouseMessage(UINT msg, WPARAM wParam, LPARAM lParam)

--- a/src/window/window.h
+++ b/src/window/window.h
@@ -29,6 +29,10 @@ private:
     LRESULT HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam);
     LRESULT OnNcCalcSize(WPARAM wParam, LPARAM lParam);
     LRESULT OnNcHitTest(LPARAM lParam);
+    // リサイズ枠領域のヒットテスト。最大化時は HTNOWHERE を返し、呼び出し元で次の判定へ進む。
+    LRESULT HitTestResizeFrame(POINT pt) const noexcept;
+    // タイトルバー領域のヒットテスト。タイトルバー外なら HTCLIENT を返す。
+    LRESULT HitTestTitleBar(POINT pt) const noexcept;
     LRESULT HandleMouseMessage(UINT msg, WPARAM wParam, LPARAM lParam);
     LRESULT HandleAppNotification(UINT msg, WPARAM wParam, LPARAM lParam);
     void UpdateDwmFrame();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(mendo_tests
     test_layout_cache.cpp
     test_copy_button.cpp
     test_hit_test_service.cpp
+    test_hit_test_service_dwrite.cpp
     test_swipe_detector.cpp
     test_titlebar.cpp
     test_ui_constants.cpp
@@ -56,6 +57,8 @@ add_executable(mendo_tests
     test_task_scheduler.cpp
     test_side_effect_executor.cpp
     test_command_generator_frame.cpp
+    test_command_generator_content.cpp
+    test_command_generator_highlight.cpp
     test_measurer_parity.cpp
     test_command_executor.cpp
     test_resource_manager.cpp

--- a/tests/cmd_gen_mock_test_base.h
+++ b/tests/cmd_gen_mock_test_base.h
@@ -1,0 +1,49 @@
+#pragma once
+// MockTextMeasurer + LayoutEngine + CommandGenerator のフィクスチャ基底。
+// IDWriteTextLayout を必要としないコマンド生成テスト用。DirectWrite 経路を踏む
+// テストは別途 dwrite_test_base.h を使う。
+#include <gtest/gtest.h>
+#include "command_generator.h"
+#include "draw_command.h"
+#include "layout.h"
+#include "mock_text_measurer.h"
+#include "parser.h"
+#include "theme.h"
+#include <memory_resource>
+#include <variant>
+
+class CmdGenMockTestBase : public ::testing::Test {
+protected:
+    MockTextMeasurer mock_;
+    LayoutEngine engine_;
+    CommandGenerator gen_;
+    Theme theme_;
+    LayoutCache cache_;
+    std::pmr::vector<Node> nodes_;
+
+    void SetUp() override
+    {
+        theme_ = GetLightTheme();
+        ASSERT_TRUE(engine_.Init(&mock_, theme_));
+        gen_.SetTheme(&theme_);
+        gen_.SetFormats({ nullptr, nullptr, nullptr, nullptr });
+    }
+
+    void Parse(const std::string& md, float viewport_w = 800.0f)
+    {
+        nodes_ = ParseMarkdown(md).nodes;
+        cache_.Resize(nodes_.size());
+        engine_.ComputeLayout(nodes_, cache_, viewport_w);
+    }
+};
+
+template <typename T>
+const T* FindFirst(const DrawCommandList& cmds)
+{
+    for (const auto& c : cmds) {
+        if (auto* p = std::get_if<T>(&c)) {
+            return p;
+        }
+    }
+    return nullptr;
+}

--- a/tests/dwrite_test_base.h
+++ b/tests/dwrite_test_base.h
@@ -1,0 +1,55 @@
+#pragma once
+// DirectWrite を使うテスト用の共通フィクスチャ。
+// MockTextMeasurer 経路では到達できない `text_layout != nullptr` の経路
+// （ハイライト矩形、本文 hit test 等）を踏むテストで使用する。
+//
+// test_helpers.h に DWrite を含めると DWrite 不要のテストにも include コストが
+// 載るため、本ヘッダは独立させて使うテストだけが include する設計とする。
+#include "test_helpers.h"
+#include "dwrite_measurer.h"
+#include "layout.h"
+#include "layout_cache.h"
+#include "parser.h"
+#include "theme.h"
+#include <dwrite.h>
+#include <wrl/client.h>
+#include <iomanip>
+#include <ios>
+
+class DWriteTestBase : public ComApartmentTest {
+protected:
+    Microsoft::WRL::ComPtr<IDWriteFactory> dwrite_factory_;
+    DWriteTextMeasurer measurer_;
+    Theme theme_;
+    LayoutEngine engine_;
+
+    void SetUp() override
+    {
+        const HRESULT hr = DWriteCreateFactory(
+            DWRITE_FACTORY_TYPE_SHARED,
+            __uuidof(IDWriteFactory),
+            reinterpret_cast<IUnknown**>(dwrite_factory_.GetAddressOf()));
+        ASSERT_TRUE(SUCCEEDED(hr))
+            << "DWriteCreateFactory failed: 0x" << std::hex << hr;
+
+        theme_ = GetLightTheme();
+        measurer_.SetFactory(dwrite_factory_.Get());
+        ASSERT_TRUE(measurer_.Init(theme_));
+        ASSERT_TRUE(engine_.Init(&measurer_, theme_));
+    }
+
+    struct ParsedLayout {
+        std::pmr::vector<Node> nodes;
+        LayoutCache cache;
+    };
+
+    // パース → レイアウト計測まで一括実施。多くのテストで定型的に使う。
+    ParsedLayout ParseAndLayout(const std::string& md, float viewport_w = 800.0f)
+    {
+        ParsedLayout r;
+        r.nodes = ParseMarkdown(md).nodes;
+        r.cache.Resize(r.nodes.size());
+        engine_.ComputeLayout(r.nodes, r.cache, viewport_w);
+        return r;
+    }
+};

--- a/tests/test_command_generator_content.cpp
+++ b/tests/test_command_generator_content.cpp
@@ -1,0 +1,133 @@
+// CommandGenerator の内容系（Heading 下線 / blockquote 装飾 / カリング境界）。
+// MockTextMeasurer 経路で踏める範囲のみ。ハイライトや button 配置は
+// IDWriteTextFormat / IDWriteTextLayout が必要なため別ファイル
+// (test_command_generator_highlight.cpp) で扱う。
+#include <gtest/gtest.h>
+#include "cmd_gen_mock_test_base.h"
+#include "test_helpers.h"
+#include <algorithm>
+#include <variant>
+
+namespace {
+
+class CmdGenContentTest : public CmdGenMockTestBase {};
+
+} // namespace
+
+// ---- Heading 下線 ----
+// h1 / h2 のみ entry.height の下に下線が描画される（hr_color）。
+// h3 以降では下線が出ない。
+
+TEST_F(CmdGenContentTest, HeadingH1_EmitsUnderlineWithHrColor)
+{
+    Parse("# Title");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
+
+    const auto hr_lines = std::ranges::count_if(cmds, [&](const auto& c) {
+        if (auto* l = std::get_if<DrawLineCmd>(&c)) {
+            return ColorEq(l->color, theme_.hr_color);
+        }
+        return false;
+    });
+    EXPECT_GE(hr_lines, 1) << "h1 では hr_color の下線が 1 本以上出るはず";
+}
+
+TEST_F(CmdGenContentTest, HeadingH2_EmitsUnderlineWithCorrectThickness)
+{
+    Parse("## Subtitle");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
+
+    bool found = false;
+    for (const auto& c : cmds) {
+        if (auto* l = std::get_if<DrawLineCmd>(&c)) {
+            if (ColorEq(l->color, theme_.hr_color)
+                && l->stroke_width == theme_.h2_underline_thickness) {
+                found = true;
+                break;
+            }
+        }
+    }
+    EXPECT_TRUE(found) << "h2 下線は h2_underline_thickness を使うはず";
+}
+
+TEST_F(CmdGenContentTest, HeadingH3_DoesNotEmitUnderline)
+{
+    Parse("### Sub");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
+
+    const auto draw_lines = std::ranges::count_if(cmds, [](const auto& c) {
+        return std::holds_alternative<DrawLineCmd>(c);
+    });
+    EXPECT_EQ(draw_lines, 0) << "h3 は下線を発行しない";
+}
+
+// ---- blockquote グループ装飾 ----
+
+TEST_F(CmdGenContentTest, BlockQuote_EmitsBarLine)
+{
+    Parse("> Quoted");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
+
+    const auto bar_lines = std::ranges::count_if(cmds, [&](const auto& c) {
+        if (auto* l = std::get_if<DrawLineCmd>(&c)) {
+            return l->stroke_width == theme_.blockquote_bar_width
+                && ColorEq(l->color, theme_.blockquote_bar_color);
+        }
+        return false;
+    });
+    EXPECT_GE(bar_lines, 1) << "blockquote には bar_color の縦バーが 1 本以上出る";
+}
+
+TEST_F(CmdGenContentTest, BlockQuote_FullyAboveViewport_NoBar)
+{
+    Parse("> Quoted");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 50.0f };
+    // viewport_top を blockquote の下端より十分大きくする
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 100000.0f, TextSelection{});
+
+    const auto bar_lines = std::ranges::count_if(cmds, [](const auto& c) {
+        return std::holds_alternative<DrawLineCmd>(c);
+    });
+    EXPECT_EQ(bar_lines, 0) << "viewport より上にあるグループは bar が描画されない";
+}
+
+// ---- HorizontalRule カリング: 上方向 ----
+// 既存の test_command_generator_frame.cpp に「下方向」カリングはあるが
+// 「上方向」（大量スクロールで全 hr が viewport 上にある）は未網羅。
+
+TEST_F(CmdGenContentTest, HorizontalRule_AllAboveViewport_NoLines)
+{
+    Parse("---\n\n---\n\n---");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 100.0f };
+    // 全 hr ノードより十分下にスクロール → 上方向カリングを踏む
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 100000.0f, TextSelection{});
+
+    const auto draw_lines = std::ranges::count_if(cmds, [](const auto& c) {
+        return std::holds_alternative<DrawLineCmd>(c);
+    });
+    EXPECT_EQ(draw_lines, 0);
+}
+
+// ---- 複数 hr のうち先頭だけ可視なケース ----
+// 上方向カリングと下方向カリングが両端で同時に効くケース。
+
+TEST_F(CmdGenContentTest, HorizontalRule_PartialViewportLimitsToVisible)
+{
+    Parse("---\n\n---\n\n---\n\n---\n\n---");
+    ASSERT_FALSE(nodes_.empty());
+
+    // 1 本目の hr の下端より少し大きい viewport を用意する。
+    const float first_hr_bottom = cache_[0].y_position + cache_[0].height;
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, first_hr_bottom + 1.0f };
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
+
+    const auto draw_lines = std::ranges::count_if(cmds, [](const auto& c) {
+        return std::holds_alternative<DrawLineCmd>(c);
+    });
+    EXPECT_GE(draw_lines, 1) << "1 本目は確実に可視範囲内";
+    EXPECT_LT(draw_lines, 5) << "全 5 本は描画されない（後続はカリングされる）";
+}

--- a/tests/test_command_generator_frame.cpp
+++ b/tests/test_command_generator_frame.cpp
@@ -1,56 +1,13 @@
 #include <gtest/gtest.h>
-#include "command_generator.h"
-#include "layout.h"
-#include "mock_text_measurer.h"
-#include "parser.h"
+#include "cmd_gen_mock_test_base.h"
 #include "search_state.h"
+#include <algorithm>
 #include <optional>
 #include <variant>
 
 namespace {
 
-class CmdGenFrameTest : public ::testing::Test {
-protected:
-    MockTextMeasurer mock_;
-    LayoutEngine engine_;
-    CommandGenerator gen_;
-    Theme theme_;
-    LayoutCache cache_;
-    std::pmr::vector<Node> nodes_;
-
-    void SetUp() override
-    {
-        theme_ = GetLightTheme();
-        ASSERT_TRUE(engine_.Init(&mock_, theme_));
-        gen_.SetTheme(&theme_);
-        gen_.SetFormats({ nullptr, nullptr, nullptr, nullptr });
-    }
-
-    void Parse(const std::string& md, float viewport_w = 800.0f)
-    {
-        nodes_ = ParseMarkdown(md).nodes;
-        cache_.Resize(nodes_.size());
-        engine_.ComputeLayout(nodes_, cache_, viewport_w);
-    }
-
-    int CountCmd(const DrawCommandList& cmds, auto predicate)
-    {
-        int n = 0;
-        for (const auto& c : cmds) {
-            if (predicate(c)) n++;
-        }
-        return n;
-    }
-};
-
-template <typename T>
-const T* FindFirst(const DrawCommandList& cmds)
-{
-    for (const auto& c : cmds) {
-        if (auto* p = std::get_if<T>(&c)) return p;
-    }
-    return nullptr;
-}
+class CmdGenFrameTest : public CmdGenMockTestBase {};
 
 } // namespace
 
@@ -112,7 +69,7 @@ TEST_F(CmdGenFrameTest, ScrolledBeyondBottomProducesOnlyFrameCommands)
     // 全ノードより下にスクロール → DrawLineCmd なし
     auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 10000.0f, TextSelection{});
 
-    int draw_lines = CountCmd(cmds, [](const auto& c) {
+    auto draw_lines = std::ranges::count_if(cmds, [](const auto& c) {
         return std::holds_alternative<DrawLineCmd>(c);
     });
     EXPECT_EQ(draw_lines, 0) << "すべてのノードがビューポート下ならDrawLineCmdは生成されない";
@@ -156,7 +113,7 @@ TEST_F(CmdGenFrameTest, FirstVisibleBeyondEndProducesNoContent)
 
     // first_visible がノード数以上 → 本体ループに入らない
     auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{}, 999);
-    int draw_lines = CountCmd(cmds, [](const auto& c) {
+    auto draw_lines = std::ranges::count_if(cmds, [](const auto& c) {
         return std::holds_alternative<DrawLineCmd>(c);
     });
     EXPECT_EQ(draw_lines, 0);
@@ -209,7 +166,7 @@ TEST_F(CmdGenFrameTest, SetSearchMatchesWithEmptyProducesNoHighlight)
     auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
     // マッチ空のため FillRectCmd は選択ハイライト経路以外は生成されない
     // (paragraph text_layout=null なので選択経路も走らない)
-    int fill_rects = CountCmd(cmds, [](const auto& c) {
+    auto fill_rects = std::ranges::count_if(cmds, [](const auto& c) {
         return std::holds_alternative<FillRectCmd>(c);
     });
     EXPECT_EQ(fill_rects, 0);

--- a/tests/test_command_generator_highlight.cpp
+++ b/tests/test_command_generator_highlight.cpp
@@ -1,0 +1,172 @@
+// CommandGenerator の DirectWrite 必須経路（ハイライト系）のテスト。
+// MockTextMeasurer では entry.text_layout が nullptr になるため、検索/選択
+// ハイライトの矩形発行と「検索→選択→本文」の順序は検証できない。本ファイルは
+// 実 IDWriteFactory を使う DWriteTestBase の上で、その経路を踏む。
+#include <gtest/gtest.h>
+#include "command_generator.h"
+#include "draw_command.h"
+#include "dwrite_test_base.h"
+#include "search_state.h"
+#include "text_types.h"
+#include <variant>
+#include <vector>
+
+namespace {
+
+// DrawCommand の variant index を順に並べたものを返す。
+// 失敗時のメッセージで「コマンド型の並び」が読みやすくなることを目的とする。
+std::vector<size_t> ExtractCmdKinds(const DrawCommandList& cmds)
+{
+    std::vector<size_t> kinds;
+    kinds.reserve(cmds.size());
+    for (const auto& c : cmds) {
+        kinds.push_back(c.index());
+    }
+    return kinds;
+}
+
+class HighlightOrderTest : public DWriteTestBase {
+protected:
+    CommandGenerator gen_;
+
+    void SetUp() override
+    {
+        DWriteTestBase::SetUp();
+        gen_.SetTheme(&theme_);
+        gen_.SetFormats({ nullptr, nullptr, nullptr, nullptr });
+    }
+};
+
+} // namespace
+
+// 検索ハイライト → 選択ハイライト → 本文（DrawTextLayoutCmd）の順序を検証する。
+// この順序が崩れると、選択中のテキストが検索ハイライトに塗り潰される、または
+// 本文が両ハイライトの下に隠れる、という視覚的不具合が発生する。
+TEST_F(HighlightOrderTest, SearchThenSelectionThenText)
+{
+    auto pl = ParseAndLayout("Hello World");
+    ASSERT_FALSE(pl.nodes.empty());
+
+    // node 0 の "Hello" を検索マッチに、"World" を選択範囲に設定する。
+    // 範囲が重ならないことで、ハイライト矩形が独立に発行されることを保証する。
+    std::pmr::vector<SearchMatch> matches;
+    matches.push_back({ 0, 0, 5, -1, -1 });
+    gen_.SetSearchMatches(&matches, 0, 1);
+
+    TextSelection sel = TextSelection::MakeOrdered(0, 6, 0, 11);
+    sel.active = true;
+
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
+    const auto& cmds = gen_.GenerateMdPane(pl.nodes, pl.cache, pane, 0.0f, sel);
+
+    // 検索色・選択色・本文 の各最小 index を見つける。
+    std::optional<size_t> first_search;
+    std::optional<size_t> first_selection;
+    std::optional<size_t> first_text_layout;
+    for (size_t i = 0; i < cmds.size(); ++i) {
+        if (auto* fr = std::get_if<FillRectCmd>(&cmds[i])) {
+            if (!first_search && (ColorEq(fr->color, theme_.search_highlight_color)
+                || ColorEq(fr->color, theme_.search_highlight_current_color))) {
+                first_search = i;
+            }
+            else if (!first_selection && ColorEq(fr->color, SELECTION_COLOR)) {
+                first_selection = i;
+            }
+        }
+        else if (std::holds_alternative<DrawTextLayoutCmd>(cmds[i])) {
+            if (!first_text_layout) {
+                first_text_layout = i;
+            }
+        }
+    }
+
+    ASSERT_TRUE(first_search.has_value()) << "検索ハイライトの FillRectCmd が見つからない";
+    ASSERT_TRUE(first_selection.has_value()) << "選択ハイライトの FillRectCmd が見つからない";
+    ASSERT_TRUE(first_text_layout.has_value()) << "本文 DrawTextLayoutCmd が見つからない";
+    EXPECT_LT(*first_search, *first_selection)
+        << "検索ハイライトは選択ハイライトより先に発行されるべき。kinds=[..]";
+    EXPECT_LT(*first_selection, *first_text_layout)
+        << "選択ハイライトは本文 DrawTextLayoutCmd より先に発行されるべき";
+}
+
+// 検索マッチが空・選択も無い場合は、ハイライト系 FillRectCmd は発行されないこと。
+// 失敗時に「ノイズ FillRect が出ている」=どの装飾が漏れているかが分かる。
+TEST_F(HighlightOrderTest, NoHighlightsWhenNeitherActive)
+{
+    auto pl = ParseAndLayout("Hello World");
+    gen_.SetSearchMatches(nullptr, -1, 0);
+    const TextSelection sel{};
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
+    const auto& cmds = gen_.GenerateMdPane(pl.nodes, pl.cache, pane, 0.0f, sel);
+
+    for (const auto& c : cmds) {
+        if (auto* fr = std::get_if<FillRectCmd>(&c)) {
+            EXPECT_FALSE(ColorEq(fr->color, theme_.search_highlight_color));
+            EXPECT_FALSE(ColorEq(fr->color, theme_.search_highlight_current_color));
+            EXPECT_FALSE(ColorEq(fr->color, SELECTION_COLOR));
+        }
+    }
+}
+
+// 現在マッチは search_highlight_current_color、それ以外は search_highlight_color
+// で塗られる。current_match_index がインデックス指定 → そのマッチだけ別色。
+// 失敗するとユーザー視点で「現在マッチがどこにあるか分からない」状態になる。
+TEST_F(HighlightOrderTest, CurrentMatchUsesCurrentColor)
+{
+    auto pl = ParseAndLayout("Hello Hello");
+    std::pmr::vector<SearchMatch> matches;
+    matches.push_back({ 0, 0, 5, -1, -1 });
+    matches.push_back({ 0, 6, 5, -1, -1 });
+    gen_.SetSearchMatches(&matches, 1, 1);  // 2 番目を current にする
+
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
+    const auto& cmds = gen_.GenerateMdPane(pl.nodes, pl.cache, pane, 0.0f, TextSelection{});
+
+    int n_default = 0;
+    int n_current = 0;
+    for (const auto& c : cmds) {
+        if (auto* fr = std::get_if<FillRectCmd>(&c)) {
+            if (ColorEq(fr->color, theme_.search_highlight_color)) {
+                n_default++;
+            }
+            else if (ColorEq(fr->color, theme_.search_highlight_current_color)) {
+                n_current++;
+            }
+        }
+    }
+    EXPECT_GE(n_default, 1) << "非カレントの検索マッチが少なくとも 1 つあるはず";
+    EXPECT_GE(n_current, 1) << "カレントマッチが 1 つあるはず";
+}
+
+// start == end の選択範囲は描画ハイライトを発行しない。
+// SetScrollSelectionMoved 等で起きうる空選択で余計な FillRectCmd が出ないことの確認。
+TEST_F(HighlightOrderTest, EmptySelectionProducesNoSelectionRect)
+{
+    auto pl = ParseAndLayout("Hello World");
+    gen_.SetSearchMatches(nullptr, -1, 0);
+    TextSelection sel = TextSelection::MakeOrdered(0, 5, 0, 5);
+    sel.active = true;
+
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
+    const auto& cmds = gen_.GenerateMdPane(pl.nodes, pl.cache, pane, 0.0f, sel);
+
+    for (const auto& c : cmds) {
+        if (auto* fr = std::get_if<FillRectCmd>(&c)) {
+            EXPECT_FALSE(ColorEq(fr->color, SELECTION_COLOR))
+                << "空選択で SELECTION_COLOR の FillRectCmd は出ない";
+        }
+    }
+}
+
+// kinds 抽出ヘルパーが順序を正しく取り出すこと（ヘルパー自身のスモーク）。
+TEST_F(HighlightOrderTest, ExtractCmdKindsIsOrdered)
+{
+    auto pl = ParseAndLayout("Hello");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
+    const auto& cmds = gen_.GenerateMdPane(pl.nodes, pl.cache, pane, 0.0f, TextSelection{});
+    const auto kinds = ExtractCmdKinds(cmds);
+    ASSERT_EQ(kinds.size(), cmds.size());
+    for (size_t i = 0; i < cmds.size(); ++i) {
+        EXPECT_EQ(kinds[i], cmds[i].index());
+    }
+}

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -1,7 +1,9 @@
 #pragma once
 #include <gtest/gtest.h>
+#include <d2d1.h>
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <system_error>
@@ -9,6 +11,13 @@
 #include <windows.h>
 #include "document_types.h"
 #include "layout_cache.h"
+#include "side_effect.h"
+
+// 同色判定。完全一致のみ（テストで使う色はテーマ定数なので浮動小数点誤差は問題にならない）。
+constexpr bool ColorEq(D2D1_COLOR_F a, D2D1_COLOR_F b) noexcept
+{
+    return a.r == b.r && a.g == b.g && a.b == b.b && a.a == b.a;
+}
 
 // テキスト持ちの Paragraph ノードを作るテスト用ヘルパー。
 inline Node MakeTextNode(const wchar_t* text)
@@ -94,6 +103,54 @@ protected:
         return path;
     }
 };
+
+// SideEffectList の中で型 T が最初に現れる位置を返す。
+// 型 T はいずれかのドメイン variant のメンバである必要がある。
+template <typename T>
+inline std::optional<size_t> IndexOfEffect(const SideEffectList& effects) noexcept
+{
+    for (size_t i = 0; i < effects.size(); ++i) {
+        if (GetEffect<T>(effects[i]) != nullptr) {
+            return i;
+        }
+    }
+    return std::nullopt;
+}
+
+enum class EffectOrdering {
+    Before,   // A が先、B が後
+    After,    // B が先、A が後
+    OnlyA,    // A だけ存在
+    OnlyB,    // B だけ存在
+    Neither   // どちらも無し
+};
+
+// effects 内で A が B より先に現れるか判定する。
+// 順序の意味づけが分岐ごとに違う場合があるので、Before / After 以外も
+// 失敗時に何が起きたかを呼び出し側が EXPECT_EQ で識別できるよう列挙する。
+template <typename A, typename B>
+inline EffectOrdering EffectOrder(const SideEffectList& effects) noexcept
+{
+    const auto a = IndexOfEffect<A>(effects);
+    const auto b = IndexOfEffect<B>(effects);
+    if (!a && !b) {
+        return EffectOrdering::Neither;
+    }
+    if (a && !b) {
+        return EffectOrdering::OnlyA;
+    }
+    if (!a && b) {
+        return EffectOrdering::OnlyB;
+    }
+    return *a < *b ? EffectOrdering::Before : EffectOrdering::After;
+}
+
+// effects 内で A が存在し、かつ B が存在し、A が B より先に現れる場合のみ true。
+template <typename A, typename B>
+inline bool HasEffectInOrder(const SideEffectList& effects) noexcept
+{
+    return EffectOrder<A, B>(effects) == EffectOrdering::Before;
+}
 
 // COM apartment 初期化を管理する基底フィクスチャ。
 // 既に他スイートで別モードで初期化済みのケース (RPC_E_CHANGED_MODE) では

--- a/tests/test_hit_test_service.cpp
+++ b/tests/test_hit_test_service.cpp
@@ -40,108 +40,87 @@ protected:
 };
 
 // ---- NavButtonHitTest: 純粋な座標計算のみ ----
-
-// 実装と同じ式で Back ボタンの基点 X を算出する。
-static float NavBackButtonX(const PaneRect& md)
-{
-    return md.x + md.width - NAV_BTN_MARGIN - NAV_BTN_SIZE * 2.0f
-        - NAV_BTN_GAP - NAV_BTN_SCROLLBAR_OFFSET;
-}
-
-static float NavButtonY(const PaneRect& md)
-{
-    return md.y + md.height - NAV_BTN_MARGIN - NAV_BTN_SIZE;
-}
+// 矩形は src 側の NavBackButtonRect / NavForwardButtonRect を使う。
+// 「式を二重実装するとリファクタ時にテストもズレる」問題を避けるため。
 
 TEST_F(HitTestServiceTest, NavButton_HitBackCenter)
 {
     PaneRect md{ 0.0f, 0.0f, 800.0f, 600.0f };
-    const float bx = NavBackButtonX(md);
-    const float by = NavButtonY(md);
-    EXPECT_EQ(hit_test_.NavButtonHitTest(bx + NAV_BTN_SIZE * 0.5f,
-        by + NAV_BTN_SIZE * 0.5f, md),
+    const ButtonRect back = NavBackButtonRect(md);
+    EXPECT_EQ(hit_test_.NavButtonHitTest(back.x + back.w * 0.5f,
+        back.y + back.h * 0.5f, md),
         NavButtonHover::Back);
 }
 
 TEST_F(HitTestServiceTest, NavButton_HitForwardCenter)
 {
     PaneRect md{ 0.0f, 0.0f, 800.0f, 600.0f };
-    const float bx = NavBackButtonX(md);
-    const float by = NavButtonY(md);
-    const float fwd_x = bx + NAV_BTN_SIZE + NAV_BTN_GAP;
-    EXPECT_EQ(hit_test_.NavButtonHitTest(fwd_x + NAV_BTN_SIZE * 0.5f,
-        by + NAV_BTN_SIZE * 0.5f, md),
+    const ButtonRect fwd = NavForwardButtonRect(md);
+    EXPECT_EQ(hit_test_.NavButtonHitTest(fwd.x + fwd.w * 0.5f,
+        fwd.y + fwd.h * 0.5f, md),
         NavButtonHover::Forward);
 }
 
 TEST_F(HitTestServiceTest, NavButton_GapBetweenButtonsIsNone)
 {
     PaneRect md{ 0.0f, 0.0f, 800.0f, 600.0f };
-    const float bx = NavBackButtonX(md);
-    const float by = NavButtonY(md);
+    const ButtonRect back = NavBackButtonRect(md);
     // Back の右端より NAV_BTN_GAP/2 右（Forward 左端より NAV_BTN_GAP/2 左）
-    const float gx = bx + NAV_BTN_SIZE + NAV_BTN_GAP * 0.5f;
-    EXPECT_EQ(hit_test_.NavButtonHitTest(gx, by + NAV_BTN_SIZE * 0.5f, md),
+    const float gx = back.x + back.w + NAV_BTN_GAP * 0.5f;
+    EXPECT_EQ(hit_test_.NavButtonHitTest(gx, back.y + back.h * 0.5f, md),
         NavButtonHover::None);
 }
 
 TEST_F(HitTestServiceTest, NavButton_AboveRangeIsNone)
 {
     PaneRect md{ 0.0f, 0.0f, 800.0f, 600.0f };
-    const float bx = NavBackButtonX(md);
-    const float by = NavButtonY(md);
-    EXPECT_EQ(hit_test_.NavButtonHitTest(bx + NAV_BTN_SIZE * 0.5f, by - 1.0f, md),
+    const ButtonRect back = NavBackButtonRect(md);
+    EXPECT_EQ(hit_test_.NavButtonHitTest(back.x + back.w * 0.5f, back.y - 1.0f, md),
         NavButtonHover::None);
 }
 
 TEST_F(HitTestServiceTest, NavButton_BelowRangeIsNone)
 {
     PaneRect md{ 0.0f, 0.0f, 800.0f, 600.0f };
-    const float bx = NavBackButtonX(md);
-    const float by = NavButtonY(md);
-    EXPECT_EQ(hit_test_.NavButtonHitTest(bx + NAV_BTN_SIZE * 0.5f,
-        by + NAV_BTN_SIZE + 1.0f, md),
+    const ButtonRect back = NavBackButtonRect(md);
+    EXPECT_EQ(hit_test_.NavButtonHitTest(back.x + back.w * 0.5f,
+        back.y + back.h + 1.0f, md),
         NavButtonHover::None);
 }
 
 TEST_F(HitTestServiceTest, NavButton_LeftOfBackIsNone)
 {
     PaneRect md{ 0.0f, 0.0f, 800.0f, 600.0f };
-    const float bx = NavBackButtonX(md);
-    const float by = NavButtonY(md);
-    EXPECT_EQ(hit_test_.NavButtonHitTest(bx - 1.0f, by + NAV_BTN_SIZE * 0.5f, md),
+    const ButtonRect back = NavBackButtonRect(md);
+    EXPECT_EQ(hit_test_.NavButtonHitTest(back.x - 1.0f, back.y + back.h * 0.5f, md),
         NavButtonHover::None);
 }
 
 TEST_F(HitTestServiceTest, NavButton_RightOfForwardIsNone)
 {
     PaneRect md{ 0.0f, 0.0f, 800.0f, 600.0f };
-    const float bx = NavBackButtonX(md);
-    const float by = NavButtonY(md);
-    const float fwd_x = bx + NAV_BTN_SIZE + NAV_BTN_GAP;
-    EXPECT_EQ(hit_test_.NavButtonHitTest(fwd_x + NAV_BTN_SIZE + 1.0f,
-        by + NAV_BTN_SIZE * 0.5f, md),
+    const ButtonRect fwd = NavForwardButtonRect(md);
+    EXPECT_EQ(hit_test_.NavButtonHitTest(fwd.x + fwd.w + 1.0f,
+        fwd.y + fwd.h * 0.5f, md),
         NavButtonHover::None);
 }
 
 TEST_F(HitTestServiceTest, NavButton_BackLeftEdgeIsInclusive)
 {
-    // dip_x == base_x は >= 条件なので Back
+    // dip_x == back.x は ButtonRect::Contains の >= 条件なので Back
     PaneRect md{ 0.0f, 0.0f, 800.0f, 600.0f };
-    const float bx = NavBackButtonX(md);
-    const float by = NavButtonY(md);
-    EXPECT_EQ(hit_test_.NavButtonHitTest(bx, by + NAV_BTN_SIZE * 0.5f, md),
+    const ButtonRect back = NavBackButtonRect(md);
+    EXPECT_EQ(hit_test_.NavButtonHitTest(back.x, back.y + back.h * 0.5f, md),
         NavButtonHover::Back);
 }
 
 TEST_F(HitTestServiceTest, NavButton_BackRightEdgeIsInclusive)
 {
-    // dip_x == base_x + NAV_BTN_SIZE も <= 条件なので Back
+    // dip_x == back.x + back.w も <= 条件なので Back
     PaneRect md{ 0.0f, 0.0f, 800.0f, 600.0f };
-    const float bx = NavBackButtonX(md);
-    const float by = NavButtonY(md);
-    EXPECT_EQ(hit_test_.NavButtonHitTest(bx + NAV_BTN_SIZE,
-        by + NAV_BTN_SIZE * 0.5f, md),
+    const ButtonRect back = NavBackButtonRect(md);
+    EXPECT_EQ(hit_test_.NavButtonHitTest(back.x + back.w,
+        back.y + back.h * 0.5f, md),
         NavButtonHover::Back);
 }
 
@@ -149,10 +128,9 @@ TEST_F(HitTestServiceTest, NavButton_PositionsWithNonZeroPaneOrigin)
 {
     // MD ペインが原点以外にある場合でも正しく算出されること
     PaneRect md{ 200.0f, 40.0f, 600.0f, 500.0f };
-    const float bx = NavBackButtonX(md);
-    const float by = NavButtonY(md);
-    EXPECT_EQ(hit_test_.NavButtonHitTest(bx + NAV_BTN_SIZE * 0.5f,
-        by + NAV_BTN_SIZE * 0.5f, md),
+    const ButtonRect back = NavBackButtonRect(md);
+    EXPECT_EQ(hit_test_.NavButtonHitTest(back.x + back.w * 0.5f,
+        back.y + back.h * 0.5f, md),
         NavButtonHover::Back);
 }
 

--- a/tests/test_hit_test_service_dwrite.cpp
+++ b/tests/test_hit_test_service_dwrite.cpp
@@ -1,0 +1,132 @@
+// HitTestService の DirectWrite 経路テスト。
+// MockTextMeasurer では `entry.text_layout` が nullptr になるため、
+// HitTest 内の `if (entry.text_layout)` 経路や HitTestTable の cell_layout
+// 経由の text_pos 計算は到達できない。本ファイルでは実 IDWriteFactory を
+// 使う DWriteTestBase の上で、その経路を踏む。
+#include <gtest/gtest.h>
+#include "dwrite_test_base.h"
+#include "hit_test_service.h"
+#include "ui_constants.h"
+#include <utility>
+
+namespace {
+
+class HitTestDWriteTest : public DWriteTestBase {
+protected:
+    HitTestService hit_;
+
+    float ContentWidth(float pane_w) const noexcept
+    {
+        return pane_w - theme_.margin_left - theme_.margin_right;
+    }
+};
+
+} // namespace
+
+// 段落の text_layout 経路: paragraph 上の中央付近をクリックすると、当該ノードと
+// 0 でない text_pos が返される。MockTextMeasurer 経路では text_pos = 0 のまま
+// 返されてしまうため、DirectWrite を通したことの直接的な検証になる。
+TEST_F(HitTestDWriteTest, ParagraphHitReturnsTextPositionFromTextLayout)
+{
+    auto pl = ParseAndLayout("Hello, this is a long paragraph for hit testing.");
+    ASSERT_FALSE(pl.nodes.empty());
+
+    // 段落の中央付近 (margin_left + 数文字分) をクリックする想定。
+    // dpi=1, md_pane_left=0, scroll_y=0 で screen 座標 == DIP。
+    const float content_width = ContentWidth(800.0f);
+    const int screen_x = static_cast<int>(theme_.margin_left + 50.0f);
+    const int screen_y = static_cast<int>(pl.cache[0].y_position + 4.0f);
+
+    const MdPaneHitContext ctx{
+        pl.nodes, pl.cache, theme_, 0.0f, 0.0f, 1.0f,
+        screen_x, screen_y, content_width, 600.0f
+    };
+    const auto r = hit_.HitTest(ctx);
+
+    EXPECT_EQ(r.node_index, 0);
+    EXPECT_GT(r.text_pos, 0u)
+        << "DirectWrite 経路では HitTestPoint で text_pos が 0 より大きく解決されるはず";
+}
+
+// テーブル row_cum_y / col_cum_x 経由の hit test。
+// LayoutEngine + DWriteTextMeasurer を通した cache の table_layout には
+// row_cum_y / col_cum_x が積まれる。HitTestTable はそれを upper_bound で参照する。
+TEST_F(HitTestDWriteTest, TableHitDetectsRowAndColumn)
+{
+    auto pl = ParseAndLayout("| H1 | H2 |\n|---|---|\n| 11 | 12 |\n| 21 | 22 |");
+
+    int table_idx = -1;
+    for (size_t i = 0; i < pl.nodes.size(); ++i) {
+        if (pl.nodes[i].type == NodeType::Table) {
+            table_idx = static_cast<int>(i);
+            break;
+        }
+    }
+    ASSERT_GE(table_idx, 0);
+    ASSERT_TRUE(pl.cache[table_idx].has_table_layout());
+
+    // テーブル中央あたりに hit する位置。
+    const auto& entry = pl.cache[table_idx];
+    const int sx = static_cast<int>(theme_.margin_left + 30.0f);
+    const int sy = static_cast<int>(entry.y_position + entry.height * 0.5f);
+
+    const float content_width = ContentWidth(800.0f);
+    const MdPaneHitContext ctx{
+        pl.nodes, pl.cache, theme_, 0.0f, 0.0f, 1.0f,
+        sx, sy, content_width, 600.0f
+    };
+    const auto r = hit_.HitTest(ctx);
+
+    EXPECT_EQ(r.node_index, table_idx)
+        << "テーブル領域内の click は table ノードを返すはず";
+}
+
+// CodeBlockButtonsHitTest: Copy ボタンの上を click すると copy_node にコードブロック
+// インデックスが入ること。共有 cache の matches も正しく動くかを軽く確認する。
+TEST_F(HitTestDWriteTest, CodeBlockButtonsHitTest_CopyHitReturnsNode)
+{
+    auto pl = ParseAndLayout("```\nint main() { return 0; }\n```");
+
+    int code_idx = -1;
+    for (size_t i = 0; i < pl.nodes.size(); ++i) {
+        if (pl.nodes[i].type == NodeType::CodeBlock) {
+            code_idx = static_cast<int>(i);
+            break;
+        }
+    }
+    ASSERT_GE(code_idx, 0);
+
+    const auto& entry = pl.cache[code_idx];
+    const float content_width = ContentWidth(800.0f);
+    const float block_right = theme_.margin_left + content_width;
+    const float block_top = entry.y_position - theme_.code_block_padding;
+    const D2D1_RECT_F btn = OverlayButtonRect(block_right, block_top);
+    const int sx = static_cast<int>((btn.left + btn.right) * 0.5f);
+    const int sy = static_cast<int>((btn.top + btn.bottom) * 0.5f);
+
+    const MdPaneHitContext ctx{
+        pl.nodes, pl.cache, theme_, 0.0f, 0.0f, 1.0f,
+        sx, sy, content_width, 600.0f
+    };
+    const auto hits = hit_.CodeBlockButtonsHitTest(ctx);
+    EXPECT_EQ(hits.copy_node, code_idx);
+    EXPECT_EQ(hits.save_node, -1);
+    EXPECT_EQ(hits.svg_copy_node, -1);
+}
+
+// CodeBlockButtonsHitTest はキャッシュ機構を持つ: 同じ ctx + 同じ effects_generation
+// の繰り返し呼び出しでは結果が再利用される。書き換えしないことを 2 回呼んで確認する。
+TEST_F(HitTestDWriteTest, CodeBlockButtonsHitTest_RepeatCallReturnsSameResult)
+{
+    auto pl = ParseAndLayout("```\nfoo\n```");
+    const float content_width = ContentWidth(800.0f);
+    const MdPaneHitContext ctx{
+        pl.nodes, pl.cache, theme_, 0.0f, 0.0f, 1.0f,
+        100, 100, content_width, 600.0f
+    };
+    const auto a = hit_.CodeBlockButtonsHitTest(ctx);
+    const auto b = hit_.CodeBlockButtonsHitTest(ctx);
+    EXPECT_EQ(a.copy_node, b.copy_node);
+    EXPECT_EQ(a.save_node, b.save_node);
+    EXPECT_EQ(a.svg_copy_node, b.svg_copy_node);
+}

--- a/tests/test_navigation_service.cpp
+++ b/tests/test_navigation_service.cpp
@@ -63,3 +63,73 @@ TEST(HandleLinkClickTest, HandleEmptyLink)
     auto result = HandleLinkClick(L"");
     EXPECT_EQ(result.type, LinkClickResult::Type::None);
 }
+
+// ---- 大小文字混在の URL スキーム ----
+// ShellExecute に渡す URL のスキームは RFC 上 case-insensitive。
+// 実装は IsSafeUrlScheme で to_lower 比較しているが、混在ケースの
+// 回帰がないか直接的に検証する。
+TEST(HandleLinkClickTest, HttpsMixedCaseRecognized)
+{
+    auto r = HandleLinkClick(L"HtTpS://example.com");
+    EXPECT_EQ(r.type, LinkClickResult::Type::ExternalUrl);
+}
+
+TEST(HandleLinkClickTest, HttpMixedCaseRecognized)
+{
+    auto r = HandleLinkClick(L"HTTP://example.com");
+    EXPECT_EQ(r.type, LinkClickResult::Type::ExternalUrl);
+}
+
+TEST(HandleLinkClickTest, MailtoUpperCaseRecognized)
+{
+    auto r = HandleLinkClick(L"MAILTO:user@example.com");
+    EXPECT_EQ(r.type, LinkClickResult::Type::ExternalUrl);
+}
+
+TEST(HandleLinkClickTest, MailtoMixedCaseRecognized)
+{
+    auto r = HandleLinkClick(L"MailTo:user@example.com");
+    EXPECT_EQ(r.type, LinkClickResult::Type::ExternalUrl);
+}
+
+// ---- アンカーリンクの境界 ----
+
+TEST(HandleLinkClickTest, BareHashTreatedAsAnchorWithEmptyTarget)
+{
+    // "#" 単体は anchor 扱いだが target は空文字列。
+    auto r = HandleLinkClick(L"#");
+    EXPECT_EQ(r.type, LinkClickResult::Type::Anchor);
+    EXPECT_EQ(r.target, L"");
+}
+
+TEST(HandleLinkClickTest, AnchorWithUnicodeTarget)
+{
+    auto r = HandleLinkClick(L"#見出し");
+    EXPECT_EQ(r.type, LinkClickResult::Type::Anchor);
+    EXPECT_EQ(r.target, L"見出し");
+}
+
+// ---- 偽装されたスキームを弾く ----
+
+TEST(HandleLinkClickTest, LeadingSpaceBeforeHttpIsBlocked)
+{
+    // 先頭にスペースを入れて IsSafeUrlScheme の比較をすり抜けようとする攻撃を弾く。
+    auto r = HandleLinkClick(L" http://example.com");
+    EXPECT_EQ(r.type, LinkClickResult::Type::None);
+}
+
+TEST(HandleLinkClickTest, HttpWithoutSlashesIsBlocked)
+{
+    // "http:example.com" のように // が無い場合は IsSafeUrlScheme が false を返す。
+    auto r = HandleLinkClick(L"http:example.com");
+    EXPECT_EQ(r.type, LinkClickResult::Type::None);
+}
+
+TEST(HandleLinkClickTest, JustSchemePrefixWithoutContentIsAllowed)
+{
+    // "http://" だけでも prefix マッチで通る。これは現状の仕様。
+    // 万が一実装が「prefix 後に少なくとも 1 文字」を要求するように変わったら
+    // このテストを更新する。
+    auto r = HandleLinkClick(L"http://");
+    EXPECT_EQ(r.type, LinkClickResult::Type::ExternalUrl);
+}

--- a/tests/test_reducer.cpp
+++ b/tests/test_reducer.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 #include "reducer.h"
 #include "document.h"
+#include "app_state.h"
+#include "test_helpers.h"
 
 class ReducerTest : public ::testing::Test {
 protected:
@@ -951,4 +953,131 @@ TEST_F(ReducerTest, TocItemClicked_ValidAnchor_ScrollsAndInvalidates) {
     EXPECT_TRUE(state.view.nav_history.CanGoBack());
     EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
     EXPECT_TRUE(HasEffect<effect::BitmapManage>(effects));
+}
+
+// ---- 副作用順序ヘルパーの利用例 (test_helpers.h::HasEffectInOrder) ----
+// EmitScrollEffects は InvalidateWindow → BitmapManage の順で push する契約。
+// 順序が逆転すると BitmapManage 側が古い viewport で動くなどの実害があるため、
+// 並びそのものを検証する。
+TEST_F(ReducerTest, KeyScrollLineDown_EmitsInvalidateBeforeBitmapManage) {
+    auto effects = Reduce(state, KeyScrollAction{ ScrollType::LineDown });
+    EXPECT_TRUE((HasEffectInOrder<effect::InvalidateWindow, effect::BitmapManage>(effects)));
+}
+
+TEST_F(ReducerTest, DirectScrollBy_EmitsInvalidateBeforeBitmapManage) {
+    auto effects = Reduce(state, DirectScrollByAction{ 100.0f });
+    EXPECT_TRUE((HasEffectInOrder<effect::InvalidateWindow, effect::BitmapManage>(effects)));
+}
+
+TEST_F(ReducerTest, Resize_EmitsRendererResizeBeforeSizingUpdate) {
+    state.window.is_sizing = true;
+    auto effects = Reduce(state, ResizeAction{ 1024, 768 });
+    EXPECT_TRUE((HasEffectInOrder<effect::RendererResize, effect::PerformSizingUpdate>(effects)));
+}
+
+// ---- RestoreScrollAfterLoadAction: 3 分岐 ----
+// 仕様 (reducer.cpp::ReduceRestoreScrollAfterLoad):
+//   1. has_reload_diff -> SetScrollY(reload_diff_scroll_y)
+//   2. (else) HasNodeRestore -> SetScrollTarget(node, offset)
+//   3. (else) -> SetScrollY(0)
+// 1 が 2 に優先することも合わせて検証する。
+
+TEST_F(ReducerTest, RestoreScrollAfterLoad_HasReloadDiff_SetsScrollY) {
+    state.reload_diff_pos = 12;  // npos 以外なら何でもよい
+    state.view.viewport.ScrollTo(50.0f);
+
+    Reduce(state, RestoreScrollAfterLoadAction{ true, 250.0f });
+
+    EXPECT_FLOAT_EQ(state.view.viewport.GetScrollY(), 250.0f);
+    EXPECT_EQ(state.reload_diff_pos, std::string_view::npos);  // 消費されてクリアされる
+    EXPECT_FALSE(state.view.viewport.HasScrollTarget());
+}
+
+TEST_F(ReducerTest, RestoreScrollAfterLoad_HasNodeRestore_SetsScrollTarget) {
+    state.document.doc = Document::FromMarkdown(
+        std::pmr::string("# A\n\n# B\n\n# C"), L"test.md");
+    auto& cache = state.document.layout_cache;
+    cache.Resize(state.document.doc.GetNodes().size());
+    cache[0].y_position = 0.0f;
+    cache[1].y_position = 100.0f;
+    cache[2].y_position = 200.0f;
+    state.view.scroll_restore.SetNodeRestore(1, 7);
+
+    Reduce(state, RestoreScrollAfterLoadAction{ false, 0.0f });
+
+    // ApplyScrollTarget 後は scroll_target が消費される実装になり得るため
+    // ScrollY 側で検証する (cache[1].y_position + offset)。
+    EXPECT_FLOAT_EQ(state.view.viewport.GetScrollY(), 107.0f);
+    EXPECT_FALSE(state.view.scroll_restore.HasNodeRestore());  // 消費される
+}
+
+TEST_F(ReducerTest, RestoreScrollAfterLoad_NoRestoreInfo_ScrollsToTop) {
+    state.view.viewport.ScrollTo(300.0f);
+
+    Reduce(state, RestoreScrollAfterLoadAction{ false, 0.0f });
+
+    EXPECT_FLOAT_EQ(state.view.viewport.GetScrollY(), 0.0f);
+}
+
+TEST_F(ReducerTest, RestoreScrollAfterLoad_HasReloadDiff_TakesPrecedenceOverNodeRestore) {
+    // reload_diff と node_restore が同時に立っている場合は reload_diff が勝つ仕様。
+    state.reload_diff_pos = 5;
+    state.view.scroll_restore.SetNodeRestore(2, 0);
+
+    Reduce(state, RestoreScrollAfterLoadAction{ true, 75.0f });
+
+    EXPECT_FLOAT_EQ(state.view.viewport.GetScrollY(), 75.0f);
+    // node_restore は has_reload_diff 分岐では触られないため残る
+    EXPECT_TRUE(state.view.scroll_restore.HasNodeRestore());
+}
+
+// ---- Zoom / ToggleDarkMode: 可視位置の anchor 保持 ----
+// 期待動作: 可視先頭ノードを SnapshotVisibleTarget で取り、ズーム/モード切替後に
+// SetScrollTarget で同じノードへ戻れるようにする。これが落ちると、ズーム後に
+// 全く別の場所までスクロールが飛ぶという可視的な不具合になる。
+
+TEST_F(ReducerTest, ZoomIn_PreservesScrollAnchorOnVisibleNode) {
+    state.window.cached_theme.zoom = 1.0f;
+    state.document.doc = Document::FromMarkdown(
+        std::pmr::string("# A\n\n# B\n\n# C"), L"test.md");
+    auto& cache = state.document.layout_cache;
+    cache.Resize(state.document.doc.GetNodes().size());
+    for (size_t i = 0; i < cache.size(); ++i) {
+        cache[i].y_position = static_cast<float>(i * 100);
+    }
+    state.view.viewport.ScrollTo(120.0f);  // node 1 が可視先頭
+
+    const auto pre = SnapshotVisibleTarget(state);
+    ASSERT_TRUE(pre.IsValid());
+
+    Reduce(state, ZoomAction{ ZoomDirection::In });
+
+    // ZoomIn 後、可視先頭ノードが scroll_target として保存されている
+    ASSERT_TRUE(state.view.viewport.HasScrollTarget());
+    EXPECT_EQ(state.view.viewport.GetScrollTarget().node, pre.node);
+}
+
+TEST_F(ReducerTest, ZoomReset_AtDefaultIndex_NoEffect) {
+    // ZoomReset は既にデフォルト位置なら 0 を返し、early return する。
+    auto effects = Reduce(state, ZoomAction{ ZoomDirection::Reset });
+    EXPECT_FALSE(HasEffect<effect::ApplyThemeChange>(effects));
+}
+
+TEST_F(ReducerTest, ToggleDarkMode_PreservesScrollAnchorOnVisibleNode) {
+    state.document.doc = Document::FromMarkdown(
+        std::pmr::string("# A\n\n# B\n\n# C"), L"test.md");
+    auto& cache = state.document.layout_cache;
+    cache.Resize(state.document.doc.GetNodes().size());
+    for (size_t i = 0; i < cache.size(); ++i) {
+        cache[i].y_position = static_cast<float>(i * 100);
+    }
+    state.view.viewport.ScrollTo(120.0f);
+
+    const auto pre = SnapshotVisibleTarget(state);
+    ASSERT_TRUE(pre.IsValid());
+
+    Reduce(state, ToggleDarkModeAction{});
+
+    ASSERT_TRUE(state.view.viewport.HasScrollTarget());
+    EXPECT_EQ(state.view.viewport.GetScrollTarget().node, pre.node);
 }

--- a/tests/test_session_service.cpp
+++ b/tests/test_session_service.cpp
@@ -88,3 +88,70 @@ TEST_F(SessionServiceTest, LoadLastFilePathRejectsUncPaths)
     auto path = session_.LoadLastFilePath();
     EXPECT_TRUE(path.empty());
 }
+
+// ---- LoadLastFilePath の境界: デバイスパス / 拡張パス / 存在しないファイル ----
+
+TEST_F(SessionServiceTest, LoadLastFilePathRejectsExtendedPathPrefix)
+{
+    // \\?\ 拡張パスは UNC パスと同じ \\ 始まりとして弾かれる。
+    config_.SaveWString("Session", "LastFile", L"\\\\?\\C:\\file.md");
+    auto path = session_.LoadLastFilePath();
+    EXPECT_TRUE(path.empty());
+}
+
+TEST_F(SessionServiceTest, LoadLastFilePathRejectsDevicePathPrefix)
+{
+    // \\.\ デバイスパスも \\ 始まりとして弾かれる。
+    config_.SaveWString("Session", "LastFile", L"\\\\.\\PhysicalDrive0");
+    auto path = session_.LoadLastFilePath();
+    EXPECT_TRUE(path.empty());
+}
+
+TEST_F(SessionServiceTest, LoadLastFilePathRejectsNonexistentLocalPath)
+{
+    // GetFileAttributesW がパス無効を返す通常パスは弾かれる。
+    config_.SaveWString("Session", "LastFile",
+        L"C:\\__mendo_nonexistent_dir__\\__never__.md");
+    auto path = session_.LoadLastFilePath();
+    EXPECT_TRUE(path.empty());
+}
+
+TEST_F(SessionServiceTest, LoadLastFilePathReturnsEmptyWhenNothingSaved)
+{
+    auto path = session_.LoadLastFilePath();
+    EXPECT_TRUE(path.empty());
+}
+
+// ---- SaveScrollPosition / LoadScrollPosition の境界 ----
+
+TEST_F(SessionServiceTest, SaveScrollPosition_NegativeOffsetRoundtrips)
+{
+    // 反転スクロール（node_y > scroll_y）で offset が負になるケース。
+    session_.SaveScrollPosition(3, 100.0f, 250.0f);
+    const auto pos = session_.LoadScrollPosition();
+    EXPECT_EQ(pos.node, 3);
+    EXPECT_EQ(pos.offset, -150);
+}
+
+TEST_F(SessionServiceTest, LoadScrollPosition_DefaultsWhenNothingSaved)
+{
+    const auto pos = session_.LoadScrollPosition();
+    EXPECT_EQ(pos.node, -1);
+    EXPECT_EQ(pos.offset, 0);
+}
+
+TEST_F(SessionServiceTest, LoadScrollPosition_OutOfRangeNodeFallsBackToDefault)
+{
+    // LoadInt の min/max は -1 / 1000000。範囲外は default(-1) を返すはず。
+    config_.SaveInt("Session", "ScrollNode", 10000000);
+    const auto pos = session_.LoadScrollPosition();
+    EXPECT_EQ(pos.node, -1);
+}
+
+TEST_F(SessionServiceTest, LoadScrollPosition_OutOfRangeOffsetFallsBackToDefault)
+{
+    // offset は ±1000000 を超えると default(0) になる。
+    config_.SaveInt("Session", "ScrollOffset", 99999999);
+    const auto pos = session_.LoadScrollPosition();
+    EXPECT_EQ(pos.offset, 0);
+}

--- a/tests/test_session_service.cpp
+++ b/tests/test_session_service.cpp
@@ -1,8 +1,9 @@
 #include <gtest/gtest.h>
 #include "session_service.h"
 #include "config_service.h"
+#include "test_helpers.h"
 
-class SessionServiceTest : public ::testing::Test {
+class SessionServiceTest : public TempDirTestBase {
 protected:
     ConfigService config_;
     SessionService session_{ config_ };
@@ -110,8 +111,9 @@ TEST_F(SessionServiceTest, LoadLastFilePathRejectsDevicePathPrefix)
 TEST_F(SessionServiceTest, LoadLastFilePathRejectsNonexistentLocalPath)
 {
     // GetFileAttributesW がパス無効を返す通常パスは弾かれる。
-    config_.SaveWString("Session", "LastFile",
-        L"C:\\__mendo_nonexistent_dir__\\__never__.md");
+    // TempDirTestBase 配下の作成しないファイル名を使い、絶対パスへのフレークを避ける。
+    const auto missing = (temp_dir_ / L"never_created.md").wstring();
+    config_.SaveWString("Session", "LastFile", missing);
     auto path = session_.LoadLastFilePath();
     EXPECT_TRUE(path.empty());
 }


### PR DESCRIPTION
## Summary

- **テストフィクスチャ共通化**: DirectWrite 必須経路用 `DWriteTestBase`、MockTextMeasurer 経路用 `CmdGenMockTestBase` を抽出。CmdGen 系テストの重複セットアップ・`ColorEq`・`CountCmd` を共通ヘルパに集約し、`std::ranges::count_if` に置換。
- **小規模リファクタ**: `command_generator` を機能ごとに分解（`GenNodeTextDecorations` / `GenSearchHighlights` / `RebuildSearchHlCache` / `EmitSearchHlCommands`）、`window::OnNcHitTest` を `HitTestResizeFrame` / `HitTestTitleBar` に分割、`HitTestService` のナビボタン矩形を公開、`viewport_manager::EnsureScrollTarget` の二重 clamp を解消、`wic_util::CreateD2DBitmapFromStream` で `image_loader` / `mermaid` のビットマップ生成を共通化、`Document::anchor_index_` を所有 `pmr::wstring` キーに変更し dangling 耐性を確保。
- **新規テスト**: CmdGen 内容系（Heading 下線 / blockquote / カリング）、ハイライト発行順序、HitTestService DirectWrite 経路、Navigation Service / Reducer / Session Service の補強。

## Test plan

- [x] `cmake --build build --config Release` でビルド成功
- [x] `mendo_tests.exe` 全 1998 テストパス
- [x] レビュアーによる UI 動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)