### PR TITLE
fix(reload): issue#146 ファイル変更場所スクロールが動かない問題を修正

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -164,7 +164,7 @@ void App::OnPaint()
     BeginPaint(hwnd_, &ps);
 
     const auto& layout = GetPaneLayout();
-    const bool show_loading = file_load_service_.IsLoading() && !state_.pending_prefix_shrink;
+    const bool show_loading = file_load_service_.IsLoading() && !state_.pending_reload_retry;
     if (!show_loading) {
         // 現在表示中のダーティなノードを現在の幅でレイアウトする
         EnsureScrollTarget();

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -202,7 +202,7 @@ private:
     void DeferReloadRetry();
 
     // partial-read を検出したら defer して true を返す。
-    bool DeferIfPartialWrite(const std::pmr::wstring& path, size_t read_size, const char* tag);
+    bool DeferIfPartialWrite(const std::pmr::wstring& path, size_t read_size);
 
     void CancelPendingResources();
     void ResetViewForNewDocument();

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -189,13 +189,20 @@ private:
     void ApplyMermaidCacheHeights(float md_width);
     void UpdateTitleBar();
 
-    void FinishReload(bool is_prefix_only, size_t diff_pos);
+    void FinishReload(size_t diff_pos);
 
-    // pending_prefix_shrink を確定し、NoChange / DeferPrefixShrink なら
+    // pending_reload_retry を確定し、NoChange / DeferPrefixShrink なら
     // ResumeFileWatch を発行して true (= 呼び出し元は早期 return) を返す。
     // PrefixGrowth / FullReload なら false を返し、呼び出し元が
     // decision.op で本格的な reload / load 処理を分岐する。
     bool ApplyReloadDecisionEarly(const ReloadDecision& decision);
+
+    // 短縮リトライで再リロードを予約する。エディタの truncate→rewrite 中や
+    // partial-read を検出した時に共通で使う。
+    void DeferReloadRetry();
+
+    // partial-read を検出したら defer して true を返す。
+    bool DeferIfPartialWrite(const std::pmr::wstring& path, size_t read_size, const char* tag);
 
     void CancelPendingResources();
     void ResetViewForNewDocument();

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -1,6 +1,7 @@
 #include "app.h"
 #include "app_constants.h"
 #include "file_loader.h"
+#include "file_io.h"
 #include "i18n.h"
 #include "document_utils.h"
 #include "mermaid_util.h"
@@ -9,26 +10,6 @@
 #include "utility.h"
 #include <algorithm>
 #include <utility>
-#include <windows.h>
-
-namespace {
-
-// 読み込み済みコンテンツの後にファイルがさらに伸びていれば、エディタ側が
-// 書き込み途中である可能性が高い。BOM の 3 バイトずれを吸収するため
-// 16 バイトの許容範囲を持たせる。
-[[nodiscard]] bool IsPartialWriteOngoing(const std::pmr::wstring& path, size_t result_size) noexcept
-{
-    WIN32_FILE_ATTRIBUTE_DATA attr{};
-    if (!GetFileAttributesExW(path.c_str(), GetFileExInfoStandard, &attr)) {
-        return false;
-    }
-    const uint64_t current_size = (static_cast<uint64_t>(attr.nFileSizeHigh) << 32)
-        | static_cast<uint64_t>(attr.nFileSizeLow);
-    constexpr uint64_t TOLERANCE = 16;
-    return current_size > static_cast<uint64_t>(result_size) + TOLERANCE;
-}
-
-} // namespace
 
 // ============================================================
 // ファイル読み込み
@@ -113,7 +94,7 @@ void App::DeferReloadRetry()
 
 bool App::DeferIfPartialWrite(const std::pmr::wstring& path, size_t read_size)
 {
-    if (!IsPartialWriteOngoing(path, read_size)) {
+    if (!IsFileLargerThan(path.c_str(), read_size)) {
         return false;
     }
     DeferReloadRetry();

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -105,14 +105,19 @@ bool App::ApplyReloadDecisionEarly(const ReloadDecision& decision)
 
 void App::DeferReloadRetry()
 {
+    // FileWatcher は paused のままにする。resume すると、リトライ待機中に
+    // 新しいファイル変更通知が来た時に on_change_ が発火して
+    // FILE_RELOAD_DEBOUNCE タイマーを 200ms に上書きしてしまい、短縮リトライの
+    // 意図が失われる。pending_change_ は次回の正常 reload 完了時の
+    // ResumeFileWatch で消費される (一度だけ NoChange の追加サイクルが走る)。
     state_.pending_reload_retry = true;
-    EmitEffect(effect::ResumeFileWatch{});
     EmitEffect(effect::SetTimer{ app_timer::FILE_RELOAD_DEBOUNCE, app_timer::FILE_RELOAD_RETRY_MS });
 }
 
 // IsPartialWriteOngoing が真なら DeferReloadRetry を発火し true を返す。
 // OnParseComplete / DoReloadCurrentFile の重複排除用。
-bool App::DeferIfPartialWrite(const std::pmr::wstring& path, size_t read_size, const char* tag)
+bool App::DeferIfPartialWrite(const std::pmr::wstring& path, size_t read_size,
+    [[maybe_unused]] const char* tag)
 {
     if (!IsPartialWriteOngoing(path, read_size)) {
         return false;

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -111,13 +111,11 @@ void App::DeferReloadRetry()
     EmitEffect(effect::SetTimer{ app_timer::FILE_RELOAD_DEBOUNCE, app_timer::FILE_RELOAD_RETRY_MS });
 }
 
-bool App::DeferIfPartialWrite(const std::pmr::wstring& path, size_t read_size,
-    [[maybe_unused]] const char* tag)
+bool App::DeferIfPartialWrite(const std::pmr::wstring& path, size_t read_size)
 {
     if (!IsPartialWriteOngoing(path, read_size)) {
         return false;
     }
-    MENDO_TRACEF("%hs: partial write ongoing, deferring (read_size=%zu)", tag, read_size);
     DeferReloadRetry();
     return true;
 }
@@ -200,7 +198,7 @@ void App::OnParseComplete()
     // 別ファイル読み込み時は差分ロジックをスキップする。
     if (_wcsicmp(result->doc.GetFilePath().c_str(), state_.document.doc.GetFilePath().c_str()) == 0) {
         if (DeferIfPartialWrite(result->doc.GetFilePath(),
-                result->doc.GetRawUtf8().size(), "OnParseComplete")) {
+                result->doc.GetRawUtf8().size())) {
             return;
         }
 
@@ -360,7 +358,7 @@ void App::DoReloadCurrentFile()
     }
     std::pmr::string new_utf8 = std::move(*load_result);
 
-    if (DeferIfPartialWrite(state_.document.doc.GetFilePath(), new_utf8.size(), "DoReload")) {
+    if (DeferIfPartialWrite(state_.document.doc.GetFilePath(), new_utf8.size())) {
         return;
     }
 

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -9,6 +9,26 @@
 #include "utility.h"
 #include <algorithm>
 #include <utility>
+#include <windows.h>
+
+namespace {
+
+// 読み込み済みコンテンツの後にファイルがさらに伸びていれば、エディタ側が
+// 書き込み途中である可能性が高い。BOM の 3 バイトずれを吸収するため
+// 16 バイトの許容範囲を持たせる。
+[[nodiscard]] bool IsPartialWriteOngoing(const std::pmr::wstring& path, size_t result_size) noexcept
+{
+    WIN32_FILE_ATTRIBUTE_DATA attr{};
+    if (!GetFileAttributesExW(path.c_str(), GetFileExInfoStandard, &attr)) {
+        return false;
+    }
+    const uint64_t current_size = (static_cast<uint64_t>(attr.nFileSizeHigh) << 32)
+        | static_cast<uint64_t>(attr.nFileSizeLow);
+    constexpr uint64_t TOLERANCE = 16;
+    return current_size > static_cast<uint64_t>(result_size) + TOLERANCE;
+}
+
+} // namespace
 
 // ============================================================
 // ファイル読み込み
@@ -56,7 +76,7 @@ void App::LoadHelpDocument()
 void App::BeginAsyncLoad(const std::pmr::wstring& path)
 {
     file_load_service_.SetLoadingPath(path);
-    if (DocumentService::NeedsLoadingAnimation(path) && !state_.pending_prefix_shrink) {
+    if (DocumentService::NeedsLoadingAnimation(path) && !state_.pending_reload_retry) {
         file_load_service_.StartLoading(path);
         EmitEffect(effect::SetTimer{ app_timer::LOADING_ANIM, app_timer::FRAME_INTERVAL_MS });
         Invalidate();
@@ -69,15 +89,37 @@ void App::BeginAsyncLoad(const std::pmr::wstring& path)
 // state_.document.doc を更新せず保持して、次のリロードで正確な差分を取り直す。
 bool App::ApplyReloadDecisionEarly(const ReloadDecision& decision)
 {
-    state_.pending_prefix_shrink = (decision.op == ReloadOp::DeferPrefixShrink);
-    if (decision.op == ReloadOp::NoChange || decision.op == ReloadOp::DeferPrefixShrink) {
+    if (decision.op == ReloadOp::NoChange) {
+        state_.pending_reload_retry = false;
         EmitEffect(effect::ResumeFileWatch{});
-        if (decision.op == ReloadOp::NoChange) {
-            Invalidate();
-        }
+        Invalidate();
         return true;
     }
+    if (decision.op == ReloadOp::DeferPrefixShrink) {
+        DeferReloadRetry();
+        return true;
+    }
+    state_.pending_reload_retry = false;
     return false;
+}
+
+void App::DeferReloadRetry()
+{
+    state_.pending_reload_retry = true;
+    EmitEffect(effect::ResumeFileWatch{});
+    EmitEffect(effect::SetTimer{ app_timer::FILE_RELOAD_DEBOUNCE, app_timer::FILE_RELOAD_RETRY_MS });
+}
+
+// IsPartialWriteOngoing が真なら DeferReloadRetry を発火し true を返す。
+// OnParseComplete / DoReloadCurrentFile の重複排除用。
+bool App::DeferIfPartialWrite(const std::pmr::wstring& path, size_t read_size, const char* tag)
+{
+    if (!IsPartialWriteOngoing(path, read_size)) {
+        return false;
+    }
+    MENDO_TRACEF("%hs: partial write ongoing, deferring (read_size=%zu)", tag, read_size);
+    DeferReloadRetry();
+    return true;
 }
 
 // reducer を経由せず App 層で直接実行する。ファイル I/O + 同期/非同期ロード分岐 +
@@ -87,7 +129,7 @@ bool App::ApplyReloadDecisionEarly(const ReloadDecision& decision)
 void App::LoadMarkdownFile(std::wstring_view path)
 {
     EmitEffect(effect::KillTimer{ app_timer::FILE_RELOAD_DEBOUNCE });
-    state_.pending_prefix_shrink = false;
+    state_.pending_reload_retry = false;
     // 仮想パスは NeedsAsyncLoad が true を返し非同期ロードが失敗するため、
     // 先に検出して同期ロードに回す。
     if (IsHelpPath(path)) {
@@ -157,6 +199,11 @@ void App::OnParseComplete()
     // 非同期のファイルオープンでも OnParseComplete() が使われるため、
     // 別ファイル読み込み時は差分ロジックをスキップする。
     if (_wcsicmp(result->doc.GetFilePath().c_str(), state_.document.doc.GetFilePath().c_str()) == 0) {
+        if (DeferIfPartialWrite(result->doc.GetFilePath(),
+                result->doc.GetRawUtf8().size(), "OnParseComplete")) {
+            return;
+        }
+
         const std::string_view old_view(state_.document.doc.GetRawUtf8());
         const std::string_view new_view(result->doc.GetRawUtf8());
         const auto decision = AnalyzeReloadDiff(old_view, new_view);
@@ -169,10 +216,9 @@ void App::OnParseComplete()
             return;
         }
         if (decision.op == ReloadOp::PrefixGrowth) {
-            // 末尾伸張のみ。FinishReload が ResizePreservingPrefix で旧キャッシュの実測高さを保持する。
             resource_manager_.CancelMermaidBatch();
             state_.document.doc = std::move(result->doc);
-            FinishReload(true, decision.diff_pos);
+            FinishReload(decision.diff_pos);
             return;
         }
         state_.reload_diff_pos = decision.diff_pos;
@@ -243,7 +289,8 @@ void App::FinishLoadMarkdownFile(bool heights_estimated)
     Dispatch(RestoreScrollAfterLoadAction{ has_reload_diff, reload_diff_scroll_y });
     scroll_y = state_.view.viewport.GetScrollY();
 
-    MENDO_TRACEF("FinishLoad: scroll_y=%.1f (0=top of file)", scroll_y);
+    MENDO_TRACEF("FinishLoad: after-restore scroll_y=%.1f reload_diff_scroll_y=%.1f",
+        scroll_y, reload_diff_scroll_y);
 
     {
         MENDO_PROFILE("ViewportLayout(Initial)");
@@ -251,6 +298,10 @@ void App::FinishLoadMarkdownFile(bool heights_estimated)
     }
 
     FinalizeLayout(md_height);
+
+    MENDO_TRACEF("FinishLoad: after-finalize scroll_y=%.1f max_scroll=%.1f",
+        state_.view.viewport.GetScrollY(),
+        state_.view.viewport.GetMaxScroll());
 
     UpdateTitleBar();
 
@@ -308,6 +359,11 @@ void App::DoReloadCurrentFile()
         return;
     }
     std::pmr::string new_utf8 = std::move(*load_result);
+
+    if (DeferIfPartialWrite(state_.document.doc.GetFilePath(), new_utf8.size(), "DoReload")) {
+        return;
+    }
+
     const std::string_view old_view(state_.document.doc.GetRawUtf8());
     const std::string_view new_view(new_utf8);
     const auto decision = AnalyzeReloadDiff(old_view, new_view);
@@ -321,22 +377,15 @@ void App::DoReloadCurrentFile()
     }
     MENDO_PROFILE("Reload::ReplaceFromMarkdown");
     state_.document.doc.ReplaceFromMarkdown(std::move(new_utf8));
-    FinishReload(decision.op == ReloadOp::PrefixGrowth, decision.diff_pos);
+    FinishReload(decision.diff_pos);
 }
 
 // DoReloadCurrentFile / OnParseComplete 共通のリロード後処理。
 // ドキュメントは更新済みの状態で呼ばれる。
-void App::FinishReload(bool is_prefix_only, size_t diff_pos)
+void App::FinishReload(size_t diff_pos)
 {
-    const float old_scroll = state_.view.viewport.GetScrollY();
-
-    if (is_prefix_only) {
-        state_.document.layout_cache.ResizePreservingPrefix(state_.document.doc.GetNodes().size());
-    }
-    else {
-        state_.document.layout_cache.Reset(state_.document.doc.GetNodes().size(), false);
-        EstimateNodeHeights(state_.document.doc.GetNodes(), state_.document.layout_cache, renderer_.GetTheme());
-    }
+    state_.document.layout_cache.Reset(state_.document.doc.GetNodes().size(), false);
+    EstimateNodeHeights(state_.document.doc.GetNodes(), state_.document.layout_cache, renderer_.GetTheme());
 
     renderer_.InvalidateTocPaneCache();
 
@@ -344,18 +393,14 @@ void App::FinishReload(bool is_prefix_only, size_t diff_pos)
     const float md_width = pane_layout.md_rect.width;
     const float md_height = pane_layout.md_rect.height;
 
-    if (!is_prefix_only) {
-        // Mermaidブロックの推定高さをファイルキャッシュの実測値で上書きし、
-        // スクロール位置のずれを防ぐ
-        ApplyMermaidCacheHeights(md_width);
-    }
+    // Mermaidブロックの推定高さをファイルキャッシュの実測値で上書きし、
+    // スクロール位置のずれを防ぐ
+    ApplyMermaidCacheHeights(md_width);
 
-    const float desired_scroll = is_prefix_only
-        ? old_scroll
-        : CalcScrollForDiff(diff_pos, md_height);
+    const float desired_scroll = CalcScrollForDiff(diff_pos, md_height);
 
-    MENDO_TRACEF("FinishReload: desired_scroll=%.1f old_scroll=%.1f is_prefix_only=%d",
-        desired_scroll, old_scroll, is_prefix_only ? 1 : 0);
+    MENDO_TRACEF("FinishReload: desired_scroll=%.1f diff_pos=%zu",
+        desired_scroll, diff_pos);
 
     // スクロール位置を設定してからViewportLayoutを呼ぶことで、
     // 変更箇所周辺の可視ノードが優先的に計測される。
@@ -369,6 +414,10 @@ void App::FinishReload(bool is_prefix_only, size_t diff_pos)
     }
 
     FinalizeLayout(md_height);
+
+    MENDO_TRACEF("FinishReload: after-finalize scroll_y=%.1f max_scroll=%.1f",
+        state_.view.viewport.GetScrollY(),
+        state_.view.viewport.GetMaxScroll());
 
     if (state_.search.search_state.IsVisible()) {
         // PMR プール再利用で (nodes.data(), size) が一致すると古いキャッシュを

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -105,17 +105,12 @@ bool App::ApplyReloadDecisionEarly(const ReloadDecision& decision)
 
 void App::DeferReloadRetry()
 {
-    // FileWatcher は paused のままにする。resume すると、リトライ待機中に
-    // 新しいファイル変更通知が来た時に on_change_ が発火して
-    // FILE_RELOAD_DEBOUNCE タイマーを 200ms に上書きしてしまい、短縮リトライの
-    // 意図が失われる。pending_change_ は次回の正常 reload 完了時の
-    // ResumeFileWatch で消費される (一度だけ NoChange の追加サイクルが走る)。
+    // FileWatcher は paused のまま維持する。resume すると待機中の変更通知が
+    // FILE_RELOAD_DEBOUNCE を 200ms に上書きし、短縮リトライが効かなくなる。
     state_.pending_reload_retry = true;
     EmitEffect(effect::SetTimer{ app_timer::FILE_RELOAD_DEBOUNCE, app_timer::FILE_RELOAD_RETRY_MS });
 }
 
-// IsPartialWriteOngoing が真なら DeferReloadRetry を発火し true を返す。
-// OnParseComplete / DoReloadCurrentFile の重複排除用。
 bool App::DeferIfPartialWrite(const std::pmr::wstring& path, size_t read_size,
     [[maybe_unused]] const char* tag)
 {

--- a/src/app/app_state.h
+++ b/src/app/app_state.h
@@ -80,7 +80,9 @@ struct AppState {
 
     // ---- リロード管理 ----
     size_t reload_diff_pos = std::string_view::npos;
-    bool pending_prefix_shrink = false;
+    // 短縮タイマーで再リロード予約済み (DeferPrefixShrink / partial-read race)。
+    // ローディングアニメーションを抑制するために参照される。
+    bool pending_reload_retry = false;
 
     // ---- ペインレイアウトキャッシュ ----
     std::pmr::wstring cached_title_text = L"mendo";

--- a/src/app/timer_ids.h
+++ b/src/app/timer_ids.h
@@ -21,5 +21,6 @@ inline constexpr UINT_PTR FILE_RELOAD_DEBOUNCE = 13;
 // タイマー間隔 (ms)
 inline constexpr UINT FRAME_INTERVAL_MS = 16;              // ~60fps アニメーション用
 inline constexpr UINT FILE_RELOAD_DEBOUNCE_MS = 200;       // ファイル変更通知のデバウンス
+inline constexpr UINT FILE_RELOAD_RETRY_MS = 50;           // truncate→rewrite 検出後の短縮リトライ
 
 } // namespace app_timer

--- a/src/util/file_io.h
+++ b/src/util/file_io.h
@@ -78,6 +78,21 @@ struct OpenedFile {
     return { std::move(buf), r.size };
 }
 
+// 読み込み済みコンテンツの後にファイルがさらに伸びていれば、エディタ側が
+// 書き込み途中である可能性が高い。BOM の 3 バイトずれ等を吸収するため
+// 16 バイトの許容範囲を持たせる。
+[[nodiscard]] inline bool IsFileLargerThan(const std::filesystem::path& path,
+    size_t reference_size, size_t tolerance = 16) noexcept
+{
+    WIN32_FILE_ATTRIBUTE_DATA attr{};
+    if (!GetFileAttributesExW(path.c_str(), GetFileExInfoStandard, &attr)) {
+        return false;
+    }
+    const uint64_t current_size = (static_cast<uint64_t>(attr.nFileSizeHigh) << 32)
+        | static_cast<uint64_t>(attr.nFileSizeLow);
+    return current_size > static_cast<uint64_t>(reference_size) + tolerance;
+}
+
 // ファイルに全て書き込む。成功時はtrueを返す。
 [[nodiscard]] inline bool WriteAllBytes(const std::filesystem::path& path, const void* data, size_t size)
 {

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -1659,6 +1659,55 @@ TEST(CalcScrollYForDiff, ParsedMarkdownIntegration)
     EXPECT_GE(result, 0.0f);
 }
 
+// issue#146 回帰テスト:
+// 末尾追記 (PrefixGrowth) で旧コードが old_scroll を保持していたため、
+// ユーザの編集場所にスクロールしなかった。AnalyzeReloadDiff と
+// CalcScrollYForDiff の組合せで「fallback ではなく diff_pos に対応する
+// 位置を返す」ことを担保する。
+TEST(CalcScrollYForDiff, PrefixGrowthScrollsTowardAppendedTail)
+{
+    // 旧 doc: 3 段落
+    const std::string old_md = "para_one\n\npara_two\n\npara_three";
+    // 新 doc: 末尾に 1 段落追記
+    const std::string new_md = old_md + "\n\npara_four_added";
+
+    // AnalyzeReloadDiff で PrefixGrowth と判定されること
+    const auto decision = AnalyzeReloadDiff(old_md, new_md);
+    ASSERT_EQ(decision.op, ReloadOp::PrefixGrowth);
+    ASSERT_EQ(decision.diff_pos, old_md.size());
+
+    // 新 doc を pipeline で扱うイメージで cache を構築
+    auto nodes = ParseMarkdown(new_md).nodes;
+    ASSERT_GE(nodes.size(), 4u);
+
+    LayoutCache cache;
+    cache.Resize(nodes.size());
+    float y = 0.0f;
+    for (size_t i = 0; i < nodes.size(); ++i) {
+        cache[i].y_position = y;
+        cache[i].height = 100.0f;
+        y += 100.0f;
+    }
+    const float last_old_node_y = cache[nodes.size() - 2].y_position;
+    const float appended_node_y = cache[nodes.size() - 1].y_position;
+
+    // ユーザが先頭付近 (scroll_y=0) を見ている状態で末尾追記が起きたシナリオ。
+    // 旧コード (is_prefix_only ? old_scroll : ...) では desired_scroll が
+    // current_scroll(=0) のまま fallback されていた。これが issue#146 の症状。
+    constexpr float viewport_height = 500.0f;
+    constexpr float current_scroll = 0.0f;
+    const float result = CalcScrollYForDiff(nodes, cache, new_md,
+        decision.diff_pos, viewport_height, current_scroll);
+
+    // 修正後: 追記境界 (旧 doc 末尾) 近辺にスクロール。current_scroll とは
+    // 顕著に異なる値が返ること。旧コードでは current_scroll(=0) がそのまま
+    // 返っていたので、「margin 分以上」上回ることで回帰を検出できる。
+    EXPECT_GT(result, current_scroll + viewport_height * 0.2f);
+    // 着地点は最後の旧ノード〜追記ノードの境界付近 (margin で多少上)。
+    EXPECT_GE(result, last_old_node_y - viewport_height * 0.2f);
+    EXPECT_LE(result, appended_node_y);
+}
+
 // ============================================================
 // ToLowerAscii
 // ============================================================

--- a/tests/test_file_io.cpp
+++ b/tests/test_file_io.cpp
@@ -122,3 +122,75 @@ TEST_F(FileIoTest, WriteZeroBytesProducesEmptyFile)
     EXPECT_TRUE(fs::exists(path));
     EXPECT_EQ(fs::file_size(path), 0u);
 }
+
+// ═══════════════════════════════════════════════
+// IsFileLargerThan: エディタの書き込み中検知
+// ═══════════════════════════════════════════════
+
+TEST_F(FileIoTest, IsFileLargerThan_FileMatchesReadSize_ReturnsFalse)
+{
+    const auto path = temp_dir_ / L"match.bin";
+    const std::string payload(1000, 'a');
+    ASSERT_TRUE(WriteAllBytes(path, payload.data(), payload.size()));
+
+    EXPECT_FALSE(IsFileLargerThan(path, 1000));
+}
+
+TEST_F(FileIoTest, IsFileLargerThan_FileLargerByMoreThanTolerance_ReturnsTrue)
+{
+    // partial-read race の中核ケース: 17MB 読んだ後にファイルが 32MB ある
+    const auto path = temp_dir_ / L"growing.bin";
+    const std::string payload(2000, 'b');
+    ASSERT_TRUE(WriteAllBytes(path, payload.data(), payload.size()));
+
+    EXPECT_TRUE(IsFileLargerThan(path, 1000));
+}
+
+TEST_F(FileIoTest, IsFileLargerThan_BomTolerance_ReturnsFalse)
+{
+    // BOM 3 バイト分のずれは partial-write ではなく BOM 由来として扱う。
+    const auto path = temp_dir_ / L"bom.bin";
+    const std::string payload(1003, 'c');
+    ASSERT_TRUE(WriteAllBytes(path, payload.data(), payload.size()));
+
+    EXPECT_FALSE(IsFileLargerThan(path, 1000));
+}
+
+TEST_F(FileIoTest, IsFileLargerThan_JustBeyondTolerance_ReturnsTrue)
+{
+    // tolerance ぴったり (16 バイト) の境界: 17 バイトの差で true
+    const auto path = temp_dir_ / L"edge.bin";
+    const std::string payload(1017, 'd');
+    ASSERT_TRUE(WriteAllBytes(path, payload.data(), payload.size()));
+
+    EXPECT_TRUE(IsFileLargerThan(path, 1000));
+}
+
+TEST_F(FileIoTest, IsFileLargerThan_FileSmallerThanRead_ReturnsFalse)
+{
+    // 削除直後の truncate 状態: 読んだ size より現在のファイルが小さい場合は
+    // partial-write race ではない (別パスの DeferPrefixShrink が処理する)
+    const auto path = temp_dir_ / L"shrunk.bin";
+    const std::string payload(500, 'e');
+    ASSERT_TRUE(WriteAllBytes(path, payload.data(), payload.size()));
+
+    EXPECT_FALSE(IsFileLargerThan(path, 1000));
+}
+
+TEST_F(FileIoTest, IsFileLargerThan_MissingFile_ReturnsFalse)
+{
+    const auto path = temp_dir_ / L"does_not_exist.bin";
+    EXPECT_FALSE(IsFileLargerThan(path, 1000));
+}
+
+TEST_F(FileIoTest, IsFileLargerThan_CustomTolerance)
+{
+    const auto path = temp_dir_ / L"custom_tol.bin";
+    const std::string payload(1100, 'f');
+    ASSERT_TRUE(WriteAllBytes(path, payload.data(), payload.size()));
+
+    // tolerance=50: 100 バイト差は超過 → true
+    EXPECT_TRUE(IsFileLargerThan(path, 1000, 50));
+    // tolerance=200: 100 バイト差は範囲内 → false
+    EXPECT_FALSE(IsFileLargerThan(path, 1000, 200));
+}


### PR DESCRIPTION
## Summary

issue #146 で報告された「ファイル変更場所にスクロールする機能がファイル行数が増加した際に動かない事がある」を修正。sakura エディタ等の truncate→rewrite 2段階保存で発生する 3 つの症状を解消し、リロード処理を整理しました。

closes #146

## 修正内容

### 機能修正
- **PrefixGrowth (末尾追記) でスクロールしない問題**: `FinishReload` が `is_prefix_only=true` の場合に旧スクロール位置を保持していた。常に `CalcScrollForDiff` で diff 位置へスクロールするよう統一。
- **「2回更新したような挙動」の軽減**: `DeferPrefixShrink` 検出後の 200ms デバウンスを 50ms 短縮リトライに変更 (` FILE_RELOAD_RETRY_MS`)。truncate→rewrite の総待ち時間を ~400ms → ~250ms に。
- **partial-content read race の解消**: 32MB クラスのファイルで sakura の書き込み途中に読み込みが発生し、partial content を ` state_.document.doc` に commit してしまう問題。読み込み直後に ` GetFileAttributesEx` でファイルサイズを再確認し、まだ伸びていれば defer + 短縮リトライする (`IsPartialWriteOngoing`)。

### リファクタリング
- `pending_prefix_shrink` → `pending_reload_retry` にリネーム (partial-read race でも立てるため、実態に合わせる)
- `DeferReloadRetry` / `DeferIfPartialWrite` ヘルパーで `ApplyReloadDecisionEarly` / `OnParseComplete` / `DoReloadCurrentFile` の defer 処理重複を解消
- `FinishReload(bool is_prefix_only, size_t diff_pos)` → `FinishReload(size_t diff_pos)` に簡略化。`ResizePreservingPrefix` の最適化経路を撤廃し、常に Reset+Estimate で cache を作り直す

### 診断トレース拡充
- `FinishLoadMarkdownFile` / `FinishReload` に `after-restore` / `after-finalize` の scroll_y / max_scroll を出力する `MENDO_TRACEF` を追加。`MENDO_PROFILE_ENABLED=0` のリリースビルドではゼロコスト。

## 検証

- 32MB ファイル (~89000 ノード) で各シナリオを動作確認:
  - 下方追記 (PrefixGrowth) → 編集箇所にスクロール ✓
  - 上方編集 (FullReload) → 編集箇所にスクロール ✓
  - 上方削除 (FullReload) → 編集箇所にスクロール ✓
- DebugView で partial-write 検出が機能していることを確認:
  ```
  [mendo-reload] OnParseComplete: partial write ongoing, deferring (read_size=17502208)
  [mendo-reload] OnParseComplete: reload op=3 diff_pos=13246472 old_size=33863942 new_size=33863944
  [mendo-reload] FinishLoad: after-finalize scroll_y=8894985.0 max_scroll=22737972.0
  ```

## Test plan

- [x] Release ビルド成功
- [x] 既存テスト 1998 件全 PASS (`mendo_tests.exe --gtest_brief=1`)
- [x] 32MB MD ファイルで sakura エディタからの保存で各位置の編集 (上方/中央/下方) が正しい位置にスクロールすることを再確認
- [x] 通常サイズのファイル (~64KB) での `DoReloadCurrentFile` 同期経路でも回帰がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)