### PR TITLE
fix(reload): issue#148 画像入りファイルでスクロール先がずれる問題を修正

### DIFF
--- a/src/app/app.h
+++ b/src/app/app.h
@@ -186,7 +186,7 @@ private:
     void FinishLoadMarkdownFile(bool heights_estimated = false);
     void HandleLoadFailureFallback();
     float CalcScrollForDiff(size_t diff_pos, float viewport_height) const;
-    void ApplyMermaidCacheHeights(float md_width);
+    bool ApplyMermaidCacheHeights(float md_width);
     void UpdateTitleBar();
 
     void FinishReload(size_t diff_pos);

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -178,8 +178,7 @@ void App::OnParseComplete()
     // 非同期のファイルオープンでも OnParseComplete() が使われるため、
     // 別ファイル読み込み時は差分ロジックをスキップする。
     if (_wcsicmp(result->doc.GetFilePath().c_str(), state_.document.doc.GetFilePath().c_str()) == 0) {
-        if (DeferIfPartialWrite(result->doc.GetFilePath(),
-                result->doc.GetRawUtf8().size())) {
+        if (DeferIfPartialWrite(result->doc.GetFilePath(), result->doc.GetRawUtf8().size())) {
             return;
         }
 
@@ -250,13 +249,21 @@ void App::FinishLoadMarkdownFile(bool heights_estimated)
     }
 
     // cache.Reset()直後は全ノードの高さが0のため、スクロール復元前に
-    // ノード高さを推定し、Mermaidキャッシュの実測値で補正する
+    // ノード高さを推定し、Mermaid/画像キャッシュの実測値で補正する
     if (has_reload_diff || state_.view.scroll_restore.HasNodeRestore()) {
         if (!heights_estimated) {
             MENDO_PROFILE("EstimateNodeHeights");
             EstimateNodeHeights(state_.document.doc.GetNodes(), state_.document.layout_cache, renderer_.GetTheme());
         }
-        ApplyMermaidCacheHeights(md_width);
+        const bool mermaid_applied = ApplyMermaidCacheHeights(md_width);
+        const bool image_applied = resource_manager_.ApplyCachedImagesForReload() > 0;
+        if (mermaid_applied || image_applied) {
+            RecomputeYPositions(
+                state_.document.doc.GetNodesMut(),
+                state_.document.layout_cache,
+                renderer_.GetTheme()
+            );
+        }
     }
 
     // CalcScrollForDiff は md_height (layout 値) に依存するため reducer に渡せず、
@@ -372,9 +379,17 @@ void App::FinishReload(size_t diff_pos)
     const float md_width = pane_layout.md_rect.width;
     const float md_height = pane_layout.md_rect.height;
 
-    // Mermaidブロックの推定高さをファイルキャッシュの実測値で上書きし、
-    // スクロール位置のずれを防ぐ
-    ApplyMermaidCacheHeights(md_width);
+    // Mermaid/LaTeX 図と通常画像の推定高さを実測値 (file_cache_ / image_loader メモリキャッシュ) で
+    // 上書きし、CalcScrollForDiff の Y 計算がずれないようにする。
+    const bool mermaid_applied = ApplyMermaidCacheHeights(md_width);
+    const bool image_applied = resource_manager_.ApplyCachedImagesForReload() > 0;
+    if (mermaid_applied || image_applied) {
+        RecomputeYPositions(
+            state_.document.doc.GetNodesMut(),
+            state_.document.layout_cache,
+            renderer_.GetTheme()
+        );
+    }
 
     const float desired_scroll = CalcScrollForDiff(diff_pos, md_height);
 
@@ -425,7 +440,7 @@ float App::CalcScrollForDiff(size_t diff_pos, float viewport_height) const
         diff_pos, viewport_height, state_.view.viewport.GetScrollY());
 }
 
-void App::ApplyMermaidCacheHeights(float md_width)
+bool App::ApplyMermaidCacheHeights(float md_width)
 {
     const float content_width = renderer_.GetTheme().ContentWidth(md_width);
     const bool dark_mode = theme_service_.IsDarkMode();
@@ -439,9 +454,7 @@ void App::ApplyMermaidCacheHeights(float md_width)
             any_applied = true;
         }
     }
-    if (any_applied) {
-        RecomputeYPositions(state_.document.doc.GetNodesMut(), state_.document.layout_cache, renderer_.GetTheme());
-    }
+    return any_applied;
 }
 
 void App::UpdateTitleBar()

--- a/src/app/resource_manager.cpp
+++ b/src/app/resource_manager.cpp
@@ -39,9 +39,12 @@ struct VisibleRange {
 VisibleRange ComputeVisibleNodeRange(const LayoutCache& cache, size_t node_count,
     float range_top, float range_bottom)
 {
-    const size_t first = static_cast<size_t>(FindFirstVisibleNodeIndex(cache, node_count, range_top));
+    // 過渡状態で node_count > cache.size() のとき cache[i] が OOB になるため、
+    // FindFirstVisibleNodeIndex と同じ方針で内部クランプする。
+    const size_t effective = std::min(node_count, cache.size());
+    const size_t first = static_cast<size_t>(FindFirstVisibleNodeIndex(cache, effective, range_top));
     size_t last_plus_1 = first;
-    for (size_t i = first; i < node_count; ++i) {
+    for (size_t i = first; i < effective; ++i) {
         if (cache[i].y_position > range_bottom) {
             break;
         }

--- a/src/app/resource_manager.cpp
+++ b/src/app/resource_manager.cpp
@@ -70,7 +70,7 @@ void ResourceManager::Init(Document& doc, LayoutCache& cache, ViewportManager& v
 // 画像リソース
 // ============================================================
 
-int ResourceManager::ApplyCachedImages()
+int ResourceManager::ApplyCachedImages(bool respect_viewport)
 {
     const std::wstring doc_dir{ doc_->GetDirectory() };
     if (doc_dir.empty()) {
@@ -82,22 +82,24 @@ int ResourceManager::ApplyCachedImages()
         return 0;
     }
 
-    const float viewport_top = viewport_->GetScrollY();
-    const float viewport_height = cb_.get_viewport_height();
-    const float buffer = viewport_height * PREFETCH_BUFFER_SCREENS;
-    const float range_top = viewport_top - buffer;
-    const float range_bottom = viewport_top + viewport_height + buffer;
     const float indent_width = cb_.get_indent_width();
-
     auto& nodes = doc_->GetNodesMut();
     const auto& image_indices = doc_->GetImageNodeIndices();
 
-    // 全件走査ではなく、可視範囲に intersect する image index のみを走査。
+    // 通常描画は可視範囲に intersect する image index のみを走査。
+    // リロード時 (respect_viewport=false) は CalcScrollForDiff の Y 計算用に全件処理する。
     // viewport_height <= 0.0f の時は初期化中等なのでレイアウト範囲無視（全件）で従来挙動を保つ。
     IndexSlice slice{ image_indices.begin(), image_indices.end() };
-    if (viewport_height > 0.0f) {
-        const auto vr = ComputeVisibleNodeRange(*cache_, nodes.size(), range_top, range_bottom);
-        slice = VisibleSlice(image_indices, vr.first, vr.last_plus_1);
+    if (respect_viewport) {
+        const float viewport_height = cb_.get_viewport_height();
+        if (viewport_height > 0.0f) {
+            const float viewport_top = viewport_->GetScrollY();
+            const float buffer = viewport_height * PREFETCH_BUFFER_SCREENS;
+            const float range_top = viewport_top - buffer;
+            const float range_bottom = viewport_top + viewport_height + buffer;
+            const auto vr = ComputeVisibleNodeRange(*cache_, nodes.size(), range_top, range_bottom);
+            slice = VisibleSlice(image_indices, vr.first, vr.last_plus_1);
+        }
     }
 
     int applied = 0;
@@ -148,7 +150,9 @@ int ResourceManager::ApplyCachedImages()
             (*cache_)[i].layout_dirty = false;
             ++applied;
         }
-        else {
+        else if (respect_viewport) {
+            // 通常運用時のみ未キャッシュ画像を非同期ロード起動。
+            // リロード時は後続の LoadImages effect で起動するためスキップ。
             image_loader_->RequestLoadAsync(abs_str, [this] { OnImageLoadComplete(); });
         }
     }

--- a/src/app/resource_manager.h
+++ b/src/app/resource_manager.h
@@ -40,7 +40,10 @@ public:
         Callbacks cb);
 
     // --- 画像リソース ---
-    int ApplyCachedImages();
+    // respect_viewport=true: 可視範囲のみ走査し、未キャッシュは非同期ロード起動。通常描画用。
+    // respect_viewport=false: 全画像を走査、未キャッシュは無視。リロード時のスクロール計算前用。
+    int ApplyCachedImages(bool respect_viewport = true);
+    int ApplyCachedImagesForReload() { return ApplyCachedImages(false); }
     void LoadImages();
     void OnAppImageLoaded();
     void OnImageLoadComplete();

--- a/tests/test_resource_manager.cpp
+++ b/tests/test_resource_manager.cpp
@@ -182,7 +182,7 @@ TEST_F(ResourceManagerTest, ApplyCachedImagesForReloadReturnsZeroWhenCacheMisses
     EXPECT_EQ(rm_.ApplyCachedImagesForReload(), 0);
 
     const size_t img_idx = doc_.GetImageNodeIndices()[0];
-    EXPECT_FLOAT_EQ(cache_[img_idx].height, 100.0f); // placeholder のまま
+    EXPECT_FLOAT_EQ(cache_[img_idx].height, 100.0f); // SeedLayoutCache の block_height のまま
 }
 
 TEST_F(ResourceManagerTest, ApplyCachedImagesForReloadAppliesBeyondVisibleRange)
@@ -202,7 +202,7 @@ TEST_F(ResourceManagerTest, ApplyCachedImagesForReloadAppliesBeyondVisibleRange)
     const int visible_applied = rm_.ApplyCachedImages();
     EXPECT_EQ(visible_applied, 1);
 
-    // 2個目の高さはまだ placeholder のまま。
+    // 2個目の高さはまだ SeedLayoutCache の block_height=3000 のまま。
     EXPECT_FLOAT_EQ(cache_[image_indices[1]].height, 3000.0f);
 
     // ApplyCachedImagesForReload は範囲制限を持たないので残りの 1 件も適用する。

--- a/tests/test_resource_manager.cpp
+++ b/tests/test_resource_manager.cpp
@@ -142,6 +142,92 @@ TEST_F(ResourceManagerTest, ApplyCachedImagesReturnsZeroForRemoteImages)
     EXPECT_EQ(rm_.ApplyCachedImages(), 0);
 }
 
+// ---- 画像経路: ApplyCachedImagesForReload (issue #148) ----
+
+TEST_F(ResourceManagerTest, ApplyCachedImagesForReloadAppliesHeightFromCache)
+{
+    LoadMarkdown("# heading\n\n![alt](foo.png)\n");
+    image_loader_.InsertCacheEntry(L"C:\\dir\\foo.png", 1000.0f, 800.0f);
+
+    // 適用前: SeedLayoutCache が block_height=100 で初期化している。
+    const auto& image_indices = doc_.GetImageNodeIndices();
+    ASSERT_EQ(image_indices.size(), 1u);
+    const size_t img_idx = image_indices[0];
+    EXPECT_FLOAT_EQ(cache_[img_idx].height, 100.0f);
+
+    EXPECT_EQ(rm_.ApplyCachedImagesForReload(), 1);
+
+    // content_width=800, image_width=1000 → スケール係数 800/1000、
+    // height=800 * 0.8 = 640
+    EXPECT_FLOAT_EQ(cache_[img_idx].height, 640.0f);
+    EXPECT_FALSE(cache_[img_idx].layout_dirty);
+}
+
+TEST_F(ResourceManagerTest, ApplyCachedImagesForReloadKeepsHeightWhenWithinContentWidth)
+{
+    LoadMarkdown("![alt](small.png)\n");
+    // content_width=800 より小さい画像はスケール無し。
+    image_loader_.InsertCacheEntry(L"C:\\dir\\small.png", 400.0f, 300.0f);
+
+    EXPECT_EQ(rm_.ApplyCachedImagesForReload(), 1);
+
+    const size_t img_idx = doc_.GetImageNodeIndices()[0];
+    EXPECT_FLOAT_EQ(cache_[img_idx].height, 300.0f);
+}
+
+TEST_F(ResourceManagerTest, ApplyCachedImagesForReloadReturnsZeroWhenCacheMisses)
+{
+    LoadMarkdown("![alt](missing.png)\n");
+    // image_loader_ にキャッシュ未挿入 → 0 件。
+    EXPECT_EQ(rm_.ApplyCachedImagesForReload(), 0);
+
+    const size_t img_idx = doc_.GetImageNodeIndices()[0];
+    EXPECT_FLOAT_EQ(cache_[img_idx].height, 100.0f); // placeholder のまま
+}
+
+TEST_F(ResourceManagerTest, ApplyCachedImagesForReloadAppliesBeyondVisibleRange)
+{
+    // issue #148 の本質: 可視範囲外の画像も全件走査して height を更新する。
+    // 画像を 2 個配置し、2 個目を viewport から大きく外して ApplyCachedImages との差を出す。
+    LoadMarkdown("![one](one.png)\n\n![two](two.png)\n", /*block_height=*/3000.0f);
+
+    const auto& image_indices = doc_.GetImageNodeIndices();
+    ASSERT_EQ(image_indices.size(), 2u);
+
+    image_loader_.InsertCacheEntry(L"C:\\dir\\one.png", 400.0f, 300.0f);
+    image_loader_.InsertCacheEntry(L"C:\\dir\\two.png", 400.0f, 250.0f);
+
+    // viewport_height=600, PREFETCH_BUFFER=3 → 範囲は ~[-1800, 2400]。
+    // 2個目は y=3000+ にあり可視範囲外。ApplyCachedImages は 1 件のみ適用。
+    const int visible_applied = rm_.ApplyCachedImages();
+    EXPECT_EQ(visible_applied, 1);
+
+    // 2個目の高さはまだ placeholder のまま。
+    EXPECT_FLOAT_EQ(cache_[image_indices[1]].height, 3000.0f);
+
+    // ApplyCachedImagesForReload は範囲制限を持たないので残りの 1 件も適用する。
+    // 1 個目は ApplyCachedImages で diagram.bitmap がセットされていないのでもう一度適用される。
+    const int reload_applied = rm_.ApplyCachedImagesForReload();
+    EXPECT_EQ(reload_applied, 2);
+    EXPECT_FLOAT_EQ(cache_[image_indices[1]].height, 250.0f);
+    EXPECT_FALSE(cache_[image_indices[1]].layout_dirty);
+}
+
+TEST_F(ResourceManagerTest, ApplyCachedImagesForReloadIgnoresRemoteImages)
+{
+    LoadMarkdown("![alt](https://example.com/foo.png)\n");
+    // リモート画像はキャッシュ参照しない。
+    EXPECT_EQ(rm_.ApplyCachedImagesForReload(), 0);
+}
+
+TEST_F(ResourceManagerTest, ApplyCachedImagesForReloadReturnsZeroWhenContentWidthIsZero)
+{
+    LoadMarkdown("![alt](foo.png)\n");
+    image_loader_.InsertCacheEntry(L"C:\\dir\\foo.png", 1000.0f, 800.0f);
+    tracker_.content_width = 0.0f;
+    EXPECT_EQ(rm_.ApplyCachedImagesForReload(), 0);
+}
+
 // ---- Mermaid 経路 ----
 
 TEST_F(ResourceManagerTest, RequestMermaidRendersInvokesRendererForVisibleDiagram)


### PR DESCRIPTION
## Summary

issue #148 で報告された「ファイル変更場所スクロールが画像を含む md ファイルで誤った位置に飛ぶ」を修正。画像の高さが全て placeholder (~60px) のまま `CalcScrollForDiff` が Y を計算してしまっていた。

closes #148

## 根本原因

`FinishReload` (`src/app/app_file.cpp`) は次の順で動作:

1. `layout_cache.Reset()` → 全 cache 破棄
2. `EstimateNodeHeights()` → **通常画像は placeholder ~60px**
3. `ApplyMermaidCacheHeights()` → Mermaid/LaTeX のみ `file_cache_` の実測値で上書き
4. `CalcScrollForDiff(diff_pos, ...)` ← **通常画像は placeholder のまま**
5. `SetScrollY` → `ViewportLayout` (この後ようやく `MeasureNode` で可視範囲だけ実測)

Mermaid/LaTeX (`is_diagram_language` true) には実測値復元ステップがあるのに、通常画像にはなかった。PR #147 で `ResizePreservingPrefix` を撤廃したことでこの欠落が顕在化した形。

## 修正内容

### `ResourceManager::ApplyCachedImages` の二経路統合

`bool respect_viewport` 引数を追加し、既存の可視範囲限定経路と新規のリロード用全件走査経路を 1 関数に統合。

- `respect_viewport=true` (既定): 通常描画用。可視範囲のみ走査、未キャッシュは `RequestLoadAsync` 起動。
- `respect_viewport=false`: リロード用。全画像を走査、未キャッシュは無視 (後続の `LoadImages` effect に委ねる)。副作用として `diagram.bitmap` も復元され、描画初回の取得を省略できる。

`ApplyCachedImagesForReload()` はヘッダ内の inline ラッパ。

### `App::ApplyMermaidCacheHeights` の戻り値 bool 化

内部の `RecomputeYPositions` 呼び出しを撤廃し、`any_applied` を bool で返す。`FinishReload` / `FinishLoadMarkdownFile` で `mermaid_applied || image_applied` の OR 結果で 1 回だけ再計算するよう統一。Mermaid/画像 両方ヒットしても O(N) 走査は 1 回。

### LaTeX 数式について

`is_diagram_language(SyntaxLanguage::LatexMath)==true` のため Mermaid と同経路で動作しており、従来から問題なし。issue の確認項目は新規テストで消し込み。

## Test plan

- [x] Release ビルド成功
- [x] 既存 + 新規テスト 2012 件全 PASS (`mendo_tests.exe --gtest_brief=1`)
- [x] 新規テスト 6 件追加 (`ResourceManagerTest.ApplyCachedImagesForReload*`)
  - cache 反映 / スケール無し / キャッシュミス / 可視範囲外適用 / リモート除外 / `content_width=0`
- [x] 画像入り 32MB クラス md で sakura エディタからの保存で各位置の編集 (上方/中央/下方) が編集箇所にスクロールすることを実機確認
- [x] LaTeX 数式入り md で同上の確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)