### PR TITLE
refactor: パース・描画パスの細かなパフォーマンス改善

### DIFF
--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -131,15 +131,21 @@ struct Node {
         FinalizeSetText();
     }
 
-    // SetText と異なり line_count を再計算しない。呼び出し側で line_count を維持済みの場合に使う。
-    void SetTextPreservingLineCount(std::wstring_view s)
+    // text_ と line_count を一括更新する。SetText のような再走査は行わず、
+    // 呼び出し側が既に求めてある line_count をそのまま採用する。
+    // text と line_count を同時に渡す API になっているため、片側だけ更新して
+    // 不整合状態を残す事故が起こりにくい（パーサのように改行数を逐次積算する
+    // 文脈で利用することを想定）。
+    void SetTextWithLineCount(std::wstring_view s, int line_count_value) noexcept
     {
         text_.assign(s);
+        line_count = line_count_value;
     }
 
-    void SetTextPreservingLineCount(std::pmr::wstring&& s) noexcept
+    void SetTextWithLineCount(std::pmr::wstring&& s, int line_count_value) noexcept
     {
         text_ = std::move(s);
+        line_count = line_count_value;
     }
 
     // ---- 拡張データへのアクセサ ----

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -131,6 +131,17 @@ struct Node {
         FinalizeSetText();
     }
 
+    // SetText と異なり line_count を再計算しない。呼び出し側で line_count を維持済みの場合に使う。
+    void SetTextPreservingLineCount(std::wstring_view s)
+    {
+        text_.assign(s);
+    }
+
+    void SetTextPreservingLineCount(std::pmr::wstring&& s) noexcept
+    {
+        text_ = std::move(s);
+    }
+
     // ---- 拡張データへのアクセサ ----
     // get_if 風に *_data() でポインタを返す。所持していなければ nullptr。
     NodeTableData* table_data() noexcept { return std::get_if<NodeTableData>(&extra); }

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -131,11 +131,8 @@ struct Node {
         FinalizeSetText();
     }
 
-    // text_ と line_count を一括更新する。SetText のような再走査は行わず、
-    // 呼び出し側が既に求めてある line_count をそのまま採用する。
-    // text と line_count を同時に渡す API になっているため、片側だけ更新して
-    // 不整合状態を残す事故が起こりにくい（パーサのように改行数を逐次積算する
-    // 文脈で利用することを想定）。
+    // text_ と line_count を一括更新する（呼び出し側が積算済みの line_count を渡す）。
+    // 改行を逐次カウントしておけるパーサ向けの最適化バリアント。
     void SetTextWithLineCount(std::wstring_view s, int line_count_value) noexcept
     {
         text_.assign(s);

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -39,11 +39,11 @@ struct ParseContext {
     std::pmr::vector<size_t> heading_indices;
     std::pmr::vector<size_t> image_indices;
     std::pmr::vector<size_t> diagram_indices;
+    std::pmr::vector<size_t> blockquote_indices;
     size_t current_node_index = 0;
 
     // パース一時データには monotonic リソースを使用
-    std::stack<SpanState, std::pmr::deque<SpanState>> span_stack{
-        std::pmr::deque<SpanState>{parse_resource.resource()} };
+    std::stack<SpanState, std::pmr::deque<SpanState>> span_stack{ std::pmr::deque<SpanState>{parse_resource.resource()} };
     SpanState current_span;
 
     // UTF-8 → Wide変換用の再利用可能バッファ
@@ -52,10 +52,6 @@ struct ParseContext {
     std::pmr::string utf8_accum{ parse_resource.resource() };
 
     // 現在ノード用の UTF-8 蓄積スクラッチ。
-    // 旧設計では Node::text_utf8 として永続フィールドに置いていたが、
-    // パース完了後は不要なメモリが Node に残り続けるため ParseContext 側に移動した。
-    // ノード切り替え時に FinalizeCurrentNode() で Wide 化して current_node->text_ に書き、
-    // クリアして次ノードに使い回す。
     std::pmr::string current_utf8{ parse_resource.resource() };
 
     // ブロックコンテキスト追跡
@@ -106,7 +102,8 @@ struct ParseContext {
         FlushUtf8();
         if (current_node && !current_utf8.empty()) {
             Utf8ToWide(current_utf8, text_buffer);
-            current_node->SetText(std::wstring_view{ text_buffer });
+            // line_count は AppendText / AppendUtf8 で積算済みなので再走査を避ける。
+            current_node->SetTextPreservingLineCount(text_buffer);
         }
         current_utf8.clear();
     }
@@ -317,6 +314,9 @@ int OnEnterBlock(MD_BLOCKTYPE type, void* detail, void* userdata)
         if (!ctx->in_code_block) {
             const auto node_type = (ctx->blockquote_depth > 0) ? NodeType::BlockQuote : NodeType::Paragraph;
             ctx->BeginNode(node_type);
+            if (node_type == NodeType::BlockQuote) {
+                ctx->blockquote_indices.emplace_back(ctx->current_node_index);
+            }
         }
         ctx->paragraph_display_math_count = 0;
         ctx->paragraph_has_other_content = false;
@@ -695,6 +695,7 @@ ParseResult ParseMarkdown(std::string_view markdown_text)
     ctx.heading_indices.reserve(std::clamp(markdown_text.size() / 256, size_t{ 8 }, size_t{ 512 }));
     ctx.image_indices.reserve(std::clamp(markdown_text.size() / 512, size_t{ 4 }, size_t{ 256 }));
     ctx.diagram_indices.reserve(std::clamp(markdown_text.size() / 1024, size_t{ 4 }, size_t{ 128 }));
+    ctx.blockquote_indices.reserve(std::clamp(markdown_text.size() / 512, size_t{ 4 }, size_t{ 256 }));
 
     MD_PARSER parser{};
     parser.abi_version = 0;
@@ -711,7 +712,7 @@ ParseResult ParseMarkdown(std::string_view markdown_text)
     // 安全のため）テキストを確定する。
     ctx.FinalizeCurrentNode();
 
-    DetectAlerts(ctx.nodes);
+    DetectAlerts(ctx.nodes, std::span<const size_t>{ ctx.blockquote_indices });
 
     ParseResult result;
     result.nodes = std::move(ctx.nodes);
@@ -857,37 +858,47 @@ void TransformAlertNode(Node& node, AlertType type, size_t marker_end)
     node.alert_label_length = static_cast<uint32_t>(full_label_len);
 }
 
-} // namespace
-
-void DetectAlerts(std::pmr::vector<Node>& nodes)
+// 単一の BlockQuote ノードに対して Alert マーカーを検出・適用し、
+// 同一 blockquote_group の後続ノードに alert_type を伝播する。
+// 既に alert_type が設定されているノードはスキップする（伝播で当たった先頭等）。
+void DetectAlertAt(std::pmr::vector<Node>& nodes, size_t i)
 {
     const auto node_count = nodes.size();
-    for (size_t i = 0; i < node_count; i++) {
-        if (nodes[i].type != NodeType::BlockQuote) {
-            continue;
-        }
-        size_t marker_end = 0;
-        const AlertType type = DetectAlertMarker(nodes[i].GetText(), marker_end);
-        if (type == AlertType::None) {
-            continue;
-        }
-        const int group = nodes[i].blockquote_group;
-        TransformAlertNode(nodes[i], type, marker_end);
+    if (i >= node_count) {
+        return;
+    }
+    auto& node = nodes[i];
+    if (node.type != NodeType::BlockQuote || node.alert_type != AlertType::None) {
+        return;
+    }
+    size_t marker_end = 0;
+    const AlertType type = DetectAlertMarker(node.GetText(), marker_end);
+    if (type == AlertType::None) {
+        return;
+    }
+    const int group = node.blockquote_group;
+    TransformAlertNode(node, type, marker_end);
 
-        // 同一 blockquote_group の後続ノードにも同じ alert_type を伝播
-        // ノード種別に依存せず、グループIDで判定する（リスト等も含む）
-        size_t j = i + 1;
-        for (; j < node_count; j++) {
-            if (nodes[j].blockquote_group != group) {
-                break;
-            }
-            nodes[j].alert_type = type;
+    // 同一 blockquote_group の後続ノードにも同じ alert_type を伝播。
+    // ノード種別に依存せず、グループIDで判定する（リスト等も含む）。
+    for (size_t j = i + 1; j < node_count; j++) {
+        if (nodes[j].blockquote_group != group) {
+            break;
         }
-        i = j - 1; // 伝播済みノードをスキップ
+        nodes[j].alert_type = type;
     }
 }
 
-std::optional<std::wstring_view> ResolveHtmlEntity(std::string_view entity, wchar_t (&buffer)[2])
+} // namespace
+
+void DetectAlerts(std::pmr::vector<Node>& nodes, std::span<const size_t> blockquote_indices)
+{
+    for (const size_t i : blockquote_indices) {
+        DetectAlertAt(nodes, i);
+    }
+}
+
+std::optional<std::wstring_view> ResolveHtmlEntity(std::string_view entity, wchar_t(&buffer)[2])
 {
     const wchar_t* literal = nullptr;
     if (entity == "&amp;") {

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -102,7 +102,6 @@ struct ParseContext {
         FlushUtf8();
         if (current_node && !current_utf8.empty()) {
             Utf8ToWide(current_utf8, text_buffer);
-            // line_count は AppendText / AppendUtf8 で積算済みなので再走査を避ける。
             current_node->SetTextWithLineCount(text_buffer, current_node->line_count);
         }
         current_utf8.clear();

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -103,7 +103,7 @@ struct ParseContext {
         if (current_node && !current_utf8.empty()) {
             Utf8ToWide(current_utf8, text_buffer);
             // line_count は AppendText / AppendUtf8 で積算済みなので再走査を避ける。
-            current_node->SetTextPreservingLineCount(text_buffer);
+            current_node->SetTextWithLineCount(text_buffer, current_node->line_count);
         }
         current_utf8.clear();
     }

--- a/src/core/parser.h
+++ b/src/core/parser.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "document_types.h"
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -16,8 +17,9 @@ struct ParseResult {
 
 ParseResult ParseMarkdown(std::string_view markdown_text);
 
-// BlockQuoteノードからGitHub Alertsを検出し、マーカー除去・ラベル挿入・グルーピングを行う（テスト用に公開）
-void DetectAlerts(std::pmr::vector<Node>& nodes);
+// BlockQuoteノードからGitHub Alertsを検出し、マーカー除去・ラベル挿入・グルーピングを行う（テスト用に公開）。
+// blockquote_indices は ParseMarkdown が収集した BlockQuote ノードのインデックス。
+void DetectAlerts(std::pmr::vector<Node>& nodes, std::span<const size_t> blockquote_indices);
 
 // AlertTypeに対応するラベル文字列を返す（テスト用に公開）
 const wchar_t* GetAlertLabel(AlertType type) noexcept;

--- a/src/core/reload.cpp
+++ b/src/core/reload.cpp
@@ -92,8 +92,7 @@ float CalcScrollYForDiff(
             }
         }
         if (next_start > node_start) {
-            const float fraction = static_cast<float>(diff_pos - node_start)
-                / static_cast<float>(next_start - node_start);
+            const float fraction = static_cast<float>(diff_pos - node_start) / static_cast<float>(next_start - node_start);
             node_y += node_h * std::min(fraction, 1.0f);
         }
     }

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -75,11 +75,10 @@ void ComputeColumnWidths(std::pmr::vector<float>& out,
 
 std::pmr::wstring BuildLinearizedTableText(const std::pmr::vector<TableRow>& rows)
 {
-    const auto row_count = rows.size();
-    // 概算でreserveし、1パスで構築する（二重走査を回避）
     std::pmr::wstring text;
-    text.reserve(row_count * 64); // 行あたり平均64文字の概算
+    const auto row_count = rows.size();
     const auto last_row = static_cast<ptrdiff_t>(row_count) - 1;
+    text.reserve(row_count * 128); // 行あたり平均128文字の概算
     for (const auto& [r, row] : rows | std::views::enumerate) {
         for (const auto& [c, cell] : row.cells | std::views::enumerate) {
             if (c > 0) {

--- a/src/render/command_executor.h
+++ b/src/render/command_executor.h
@@ -47,9 +47,7 @@ private:
         uint64_t last_used = 0;
     };
 
-    // UI スレッド専用のためロック不要。グローバル sync pool を経由しないように
-    // 標準 unordered_map を使う（pmr::unordered_map ではアロケーション毎に
-    // synchronized_pool_resource のミューテックスを取得していた）。
+    // UI スレッド専用なので pmr の sync pool を経由せず標準アロケータを使う。
     std::unordered_map<uint32_t, BrushEntry> brush_pool_;
     uint64_t use_counter_ = 0;
     ID2D1RenderTarget* bound_rt_ = nullptr;

--- a/src/render/command_executor.h
+++ b/src/render/command_executor.h
@@ -3,7 +3,6 @@
 #include <d2d1.h>
 #include <wrl/client.h>
 #include <cstdint>
-#include <memory_resource>
 #include <unordered_map>
 
 namespace command_executor_internal {
@@ -48,7 +47,10 @@ private:
         uint64_t last_used = 0;
     };
 
-    std::pmr::unordered_map<uint32_t, BrushEntry> brush_pool_;
+    // UI スレッド専用のためロック不要。グローバル sync pool を経由しないように
+    // 標準 unordered_map を使う（pmr::unordered_map ではアロケーション毎に
+    // synchronized_pool_resource のミューテックスを取得していた）。
+    std::unordered_map<uint32_t, BrushEntry> brush_pool_;
     uint64_t use_counter_ = 0;
     ID2D1RenderTarget* bound_rt_ = nullptr;
 };

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -486,14 +486,12 @@ void CommandGenerator::GenSearchHighlights(DrawCommandList& cmds, const NodeLayo
     }
 
     const std::span<const SearchMatch> matches = *search_matches_;
-    const auto first_it = std::ranges::lower_bound(matches, node_index, {}, &SearchMatch::node_index);
-    if (first_it == matches.end() || first_it->node_index != node_index) {
+    const auto range = std::ranges::equal_range(matches, node_index, {}, &SearchMatch::node_index);
+    if (range.empty()) {
         return;
     }
-    // matches は node_index 昇順なので upper_bound で末尾も O(log N) で求める。
-    const auto last_it = std::ranges::upper_bound(matches, node_index, {}, &SearchMatch::node_index);
-    const size_t first_global = static_cast<size_t>(first_it - matches.begin());
-    const size_t node_match_count = static_cast<size_t>(last_it - first_it);
+    const size_t first_global = static_cast<size_t>(range.begin() - matches.begin());
+    const size_t node_match_count = static_cast<size_t>(range.size());
 
     auto& cache = entry.ensure_search_hl_cache();
     RebuildSearchHlCache(cache, entry, matches, first_global, node_match_count);

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1175,7 +1175,7 @@ TEST(Parser, AlertLabelContents)
 TEST(Parser, DetectAlertsOnEmptyVector)
 {
     std::pmr::vector<Node> nodes;
-    DetectAlerts(nodes); // クラッシュしないべき
+    DetectAlerts(nodes, {}); // クラッシュしないべき
     EXPECT_TRUE(nodes.empty());
 }
 

--- a/tests/test_side_effect_executor.cpp
+++ b/tests/test_side_effect_executor.cpp
@@ -37,7 +37,8 @@ public:
     std::vector<bool> apply_dark_mode_calls;
 
     void Invalidate() override { invalidate_count++; }
-    void InvalidateTitleBarArea(int width_px, int height_px) override {
+    void InvalidateTitleBarArea(int width_px, int height_px) override
+    {
         invalidate_titlebar_calls.emplace_back(width_px, height_px);
     }
     void SetTimer(UINT_PTR id, UINT ms) override { set_timer_calls.emplace_back(id, ms); }
@@ -46,19 +47,23 @@ public:
     void ReleaseCapture() override { release_capture_count++; }
     void SetCursor(effect::CursorType type) override { set_cursor_calls.push_back(type); }
     void WriteClipboardText(std::wstring_view text) override { clipboard_text_calls.emplace_back(text); }
-    void WriteClipboardHtml(std::wstring_view html, std::wstring_view plain) override {
-        clipboard_html_calls.emplace_back(std::wstring{html}, std::wstring{plain});
+    void WriteClipboardHtml(std::wstring_view html, std::wstring_view plain) override
+    {
+        clipboard_html_calls.emplace_back(std::wstring{ html }, std::wstring{ plain });
     }
-    void ShellOpen(const std::pmr::wstring& url) override { shell_open_calls.emplace_back(std::wstring_view{url}); }
+    void ShellOpen(const std::pmr::wstring& url) override { shell_open_calls.emplace_back(std::wstring_view{ url }); }
     void ShowWindowCmd(int cmd) override { show_window_cmd_calls.push_back(cmd); }
-    void PostWindowMessage(UINT msg, WPARAM wp, LPARAM lp) override {
+    void PostWindowMessage(UINT msg, WPARAM wp, LPARAM lp) override
+    {
         post_message_calls.emplace_back(msg, wp, lp);
     }
-    void SetWindowTitle(const std::pmr::wstring& title) override { set_window_title_calls.emplace_back(std::wstring_view{title}); }
-    void SetWindowPosition(int x, int y, int cx, int cy) override {
+    void SetWindowTitle(const std::pmr::wstring& title) override { set_window_title_calls.emplace_back(std::wstring_view{ title }); }
+    void SetWindowPosition(int x, int y, int cx, int cy) override
+    {
         set_window_position_calls.emplace_back(x, y, cx, cy);
     }
-    POINT ClientToScreen(POINT client_pt) override {
+    POINT ClientToScreen(POINT client_pt) override
+    {
         client_to_screen_inputs.push_back(client_pt);
         return { client_pt.x + client_to_screen_translation.x,
                  client_pt.y + client_to_screen_translation.y };
@@ -73,12 +78,12 @@ protected:
     // --- 依存クラスの実体（default-construct） ---
     RecordingWin32Host host_;
     FileWatcher watcher_;
-    DocumentService doc_service_{watcher_};
+    DocumentService doc_service_{ watcher_ };
     ConfigService config_;
     ResourceManager resource_manager_;
     AppState state_;
     LayoutEngine engine_;
-    LayoutService layout_service_{engine_, state_.view.viewport};
+    LayoutService layout_service_{ engine_, state_.view.viewport };
     SideEffectExecutor exec_;
 
     // --- スパイ記録 ---
@@ -87,7 +92,7 @@ protected:
     int open_file_dialog_count_ = 0;
     std::vector<PaneZone> invalidate_pane_cache_calls_;
     int refresh_pane_layout_count_ = 0;
-    std::pair<UINT, UINT> last_renderer_resize_{0, 0};
+    std::pair<UINT, UINT> last_renderer_resize_{ 0, 0 };
     int renderer_resize_count_ = 0;
     float last_renderer_dpi_ = 0.0f;
     int renderer_set_dpi_count_ = 0;
@@ -103,7 +108,7 @@ protected:
     int mermaid_init_retry_count_ = 0;
     int destroy_count_ = 0;
     int handle_parse_complete_count_ = 0;
-    std::pair<int, int> last_context_menu_pos_{0, 0};
+    std::pair<int, int> last_context_menu_pos_{ 0, 0 };
     int show_context_menu_count_ = 0;
 
     SideEffectExecutor::Callbacks MakeCallbacks()
@@ -149,8 +154,7 @@ protected:
 
     void SetUp() override
     {
-        exec_.Init(host_, resource_manager_, doc_service_,
-                   state_, layout_service_, MakeCallbacks());
+        exec_.Init(host_, resource_manager_, doc_service_, state_, layout_service_, MakeCallbacks());
     }
 };
 
@@ -160,7 +164,7 @@ protected:
 
 TEST_F(SideEffectExecutorTest, LoadFileDispatchesToCallback)
 {
-    exec_.ExecuteOne(effect::LoadFile{std::pmr::wstring{L"C:/doc.md"}});
+    exec_.ExecuteOne(effect::LoadFile{ std::pmr::wstring{L"C:/doc.md"} });
     ASSERT_EQ(load_file_paths_.size(), 1u);
     EXPECT_EQ(load_file_paths_[0], L"C:/doc.md");
 }
@@ -179,8 +183,8 @@ TEST_F(SideEffectExecutorTest, OpenFileDialogDispatchesToCallback)
 
 TEST_F(SideEffectExecutorTest, InvalidatePaneCacheForwardsPaneZone)
 {
-    exec_.ExecuteOne(effect::InvalidatePaneCache{PaneZone::MdPane});
-    exec_.ExecuteOne(effect::InvalidatePaneCache{PaneZone::FilePane});
+    exec_.ExecuteOne(effect::InvalidatePaneCache{ PaneZone::MdPane });
+    exec_.ExecuteOne(effect::InvalidatePaneCache{ PaneZone::FilePane });
     ASSERT_EQ(invalidate_pane_cache_calls_.size(), 2u);
     EXPECT_EQ(invalidate_pane_cache_calls_[0], PaneZone::MdPane);
     EXPECT_EQ(invalidate_pane_cache_calls_[1], PaneZone::FilePane);
@@ -194,14 +198,14 @@ TEST_F(SideEffectExecutorTest, RefreshPaneLayoutDispatchesToCallback)
 
 TEST_F(SideEffectExecutorTest, RendererResizeForwardsDimensions)
 {
-    exec_.ExecuteOne(effect::RendererResize{1920, 1080});
+    exec_.ExecuteOne(effect::RendererResize{ 1920, 1080 });
     EXPECT_EQ(renderer_resize_count_, 1);
-    EXPECT_EQ(last_renderer_resize_, std::make_pair(UINT{1920}, UINT{1080}));
+    EXPECT_EQ(last_renderer_resize_, std::make_pair(UINT{ 1920 }, UINT{ 1080 }));
 }
 
 TEST_F(SideEffectExecutorTest, RendererSetDpiForwardsDpiValue)
 {
-    exec_.ExecuteOne(effect::RendererSetDpi{144.0f});
+    exec_.ExecuteOne(effect::RendererSetDpi{ 144.0f });
     EXPECT_EQ(renderer_set_dpi_count_, 1);
     EXPECT_FLOAT_EQ(last_renderer_dpi_, 144.0f);
 }
@@ -281,7 +285,7 @@ TEST_F(SideEffectExecutorTest, HandleParseCompleteDispatchesToCallback)
 
 TEST_F(SideEffectExecutorTest, ShowContextMenuForwardsScreenPosition)
 {
-    exec_.ExecuteOne(effect::ShowContextMenu{150, 200});
+    exec_.ExecuteOne(effect::ShowContextMenu{ 150, 200 });
     EXPECT_EQ(show_context_menu_count_, 1);
     EXPECT_EQ(last_context_menu_pos_, std::make_pair(150, 200));
 }
@@ -292,15 +296,15 @@ TEST_F(SideEffectExecutorTest, ShowContextMenuForwardsScreenPosition)
 
 TEST_F(SideEffectExecutorTest, ShowToastUpdatesToastState)
 {
-    exec_.ExecuteOne(effect::ShowToast{L"Copied"});
+    exec_.ExecuteOne(effect::ShowToast{ L"Copied" });
     EXPECT_TRUE(state_.interaction.toast.IsVisible());
     EXPECT_EQ(state_.interaction.toast.GetMessage(), L"Copied");
 }
 
 TEST_F(SideEffectExecutorTest, ShowToastOverwritesPreviousMessage)
 {
-    exec_.ExecuteOne(effect::ShowToast{L"First"});
-    exec_.ExecuteOne(effect::ShowToast{L"Second"});
+    exec_.ExecuteOne(effect::ShowToast{ L"First" });
+    exec_.ExecuteOne(effect::ShowToast{ L"Second" });
     EXPECT_EQ(state_.interaction.toast.GetMessage(), L"Second");
 }
 
@@ -312,8 +316,8 @@ TEST_F(SideEffectExecutorTest, ExecuteRunsAllEffectsInOrder)
 {
     std::pmr::vector<SideEffect> list;
     list.emplace_back(effect::ReloadFile{});
-    list.emplace_back(effect::LoadFile{std::pmr::wstring{L"A"}});
-    list.emplace_back(effect::LoadFile{std::pmr::wstring{L"B"}});
+    list.emplace_back(effect::LoadFile{ std::pmr::wstring{L"A"} });
+    list.emplace_back(effect::LoadFile{ std::pmr::wstring{L"B"} });
     list.emplace_back(effect::Destroy{});
 
     exec_.Execute(list);
@@ -345,12 +349,12 @@ TEST_F(SideEffectExecutorTest, InvalidateWindowCallsHostInvalidate)
 
 TEST_F(SideEffectExecutorTest, SetTimerAndKillTimerForwardToHost)
 {
-    exec_.ExecuteOne(effect::SetTimer{42, 100});
-    exec_.ExecuteOne(effect::KillTimer{42});
+    exec_.ExecuteOne(effect::SetTimer{ 42, 100 });
+    exec_.ExecuteOne(effect::KillTimer{ 42 });
     ASSERT_EQ(host_.set_timer_calls.size(), 1u);
-    EXPECT_EQ(host_.set_timer_calls[0], std::make_pair(UINT_PTR{42}, UINT{100}));
+    EXPECT_EQ(host_.set_timer_calls[0], std::make_pair(UINT_PTR{ 42 }, UINT{ 100 }));
     ASSERT_EQ(host_.kill_timer_calls.size(), 1u);
-    EXPECT_EQ(host_.kill_timer_calls[0], UINT_PTR{42});
+    EXPECT_EQ(host_.kill_timer_calls[0], UINT_PTR{ 42 });
 }
 
 TEST_F(SideEffectExecutorTest, SetCaptureAndReleaseCaptureForwardToHost)
@@ -363,10 +367,10 @@ TEST_F(SideEffectExecutorTest, SetCaptureAndReleaseCaptureForwardToHost)
 
 TEST_F(SideEffectExecutorTest, SetCursorForwardsTypeToHost)
 {
-    exec_.ExecuteOne(effect::SetCursor{effect::CursorType::Arrow});
-    exec_.ExecuteOne(effect::SetCursor{effect::CursorType::Hand});
-    exec_.ExecuteOne(effect::SetCursor{effect::CursorType::IBeam});
-    exec_.ExecuteOne(effect::SetCursor{effect::CursorType::SizeWE});
+    exec_.ExecuteOne(effect::SetCursor{ effect::CursorType::Arrow });
+    exec_.ExecuteOne(effect::SetCursor{ effect::CursorType::Hand });
+    exec_.ExecuteOne(effect::SetCursor{ effect::CursorType::IBeam });
+    exec_.ExecuteOne(effect::SetCursor{ effect::CursorType::SizeWE });
     ASSERT_EQ(host_.set_cursor_calls.size(), 4u);
     EXPECT_EQ(host_.set_cursor_calls[0], effect::CursorType::Arrow);
     EXPECT_EQ(host_.set_cursor_calls[1], effect::CursorType::Hand);
@@ -376,9 +380,9 @@ TEST_F(SideEffectExecutorTest, SetCursorForwardsTypeToHost)
 
 TEST_F(SideEffectExecutorTest, ClipboardEffectsForwardToHost)
 {
-    exec_.ExecuteOne(effect::ClipboardWrite{std::pmr::wstring{L"hello"}});
-    exec_.ExecuteOne(effect::ClipboardWriteHtml{std::pmr::wstring{L"<p>html</p>"},
-                                                std::pmr::wstring{L"plain"}});
+    exec_.ExecuteOne(effect::ClipboardWrite{ std::pmr::wstring{L"hello"} });
+    exec_.ExecuteOne(effect::ClipboardWriteHtml{ std::pmr::wstring{L"<p>html</p>"},
+                                                std::pmr::wstring{L"plain"} });
     ASSERT_EQ(host_.clipboard_text_calls.size(), 1u);
     EXPECT_EQ(host_.clipboard_text_calls[0], L"hello");
     ASSERT_EQ(host_.clipboard_html_calls.size(), 1u);
@@ -388,45 +392,45 @@ TEST_F(SideEffectExecutorTest, ClipboardEffectsForwardToHost)
 
 TEST_F(SideEffectExecutorTest, ShellOpenForwardsUrlToHost)
 {
-    exec_.ExecuteOne(effect::ShellOpen{std::pmr::wstring{L"https://example.com"}});
+    exec_.ExecuteOne(effect::ShellOpen{ std::pmr::wstring{L"https://example.com"} });
     ASSERT_EQ(host_.shell_open_calls.size(), 1u);
     EXPECT_EQ(host_.shell_open_calls[0], L"https://example.com");
 }
 
 TEST_F(SideEffectExecutorTest, ShowWindowCmdForwardsValueToHost)
 {
-    exec_.ExecuteOne(effect::ShowWindowCmd{SW_MAXIMIZE});
+    exec_.ExecuteOne(effect::ShowWindowCmd{ SW_MAXIMIZE });
     ASSERT_EQ(host_.show_window_cmd_calls.size(), 1u);
     EXPECT_EQ(host_.show_window_cmd_calls[0], SW_MAXIMIZE);
 }
 
 TEST_F(SideEffectExecutorTest, PostWindowMessageForwardsToHost)
 {
-    exec_.ExecuteOne(effect::PostWindowMessage{WM_USER + 1, 7, 13});
+    exec_.ExecuteOne(effect::PostWindowMessage{ WM_USER + 1, 7, 13 });
     ASSERT_EQ(host_.post_message_calls.size(), 1u);
-    EXPECT_EQ(std::get<0>(host_.post_message_calls[0]), UINT{WM_USER + 1});
-    EXPECT_EQ(std::get<1>(host_.post_message_calls[0]), WPARAM{7});
-    EXPECT_EQ(std::get<2>(host_.post_message_calls[0]), LPARAM{13});
+    EXPECT_EQ(std::get<0>(host_.post_message_calls[0]), UINT{ WM_USER + 1 });
+    EXPECT_EQ(std::get<1>(host_.post_message_calls[0]), WPARAM{ 7 });
+    EXPECT_EQ(std::get<2>(host_.post_message_calls[0]), LPARAM{ 13 });
 }
 
 TEST_F(SideEffectExecutorTest, SetWindowTitleForwardsToHost)
 {
-    exec_.ExecuteOne(effect::SetWindowTitle{std::pmr::wstring{L"mendo — doc.md"}});
+    exec_.ExecuteOne(effect::SetWindowTitle{ std::pmr::wstring{L"mendo — doc.md"} });
     ASSERT_EQ(host_.set_window_title_calls.size(), 1u);
     EXPECT_EQ(host_.set_window_title_calls[0], L"mendo — doc.md");
 }
 
 TEST_F(SideEffectExecutorTest, SetWindowPositionForwardsToHost)
 {
-    exec_.ExecuteOne(effect::SetWindowPosition{10, 20, 800, 600});
+    exec_.ExecuteOne(effect::SetWindowPosition{ 10, 20, 800, 600 });
     ASSERT_EQ(host_.set_window_position_calls.size(), 1u);
     EXPECT_EQ(host_.set_window_position_calls[0], std::make_tuple(10, 20, 800, 600));
 }
 
 TEST_F(SideEffectExecutorTest, ApplyDarkModeForwardsFlagToHost)
 {
-    exec_.ExecuteOne(effect::ApplyDarkMode{true});
-    exec_.ExecuteOne(effect::ApplyDarkMode{false});
+    exec_.ExecuteOne(effect::ApplyDarkMode{ true });
+    exec_.ExecuteOne(effect::ApplyDarkMode{ false });
     ASSERT_EQ(host_.apply_dark_mode_calls.size(), 2u);
     EXPECT_TRUE(host_.apply_dark_mode_calls[0]);
     EXPECT_FALSE(host_.apply_dark_mode_calls[1]);
@@ -456,8 +460,8 @@ TEST_F(SideEffectExecutorTest, InvalidateTitleBarFallsBackToFullInvalidateWhenWi
 
 TEST_F(SideEffectExecutorTest, ShowToastSchedulesTimerAndInvalidates)
 {
-    exec_.ExecuteOne(effect::ShowToast{L"Copied"});
+    exec_.ExecuteOne(effect::ShowToast{ L"Copied" });
     ASSERT_EQ(host_.set_timer_calls.size(), 1u);
-    EXPECT_EQ(host_.set_timer_calls[0].first, UINT_PTR{app_timer::TOAST});
+    EXPECT_EQ(host_.set_timer_calls[0].first, UINT_PTR{ app_timer::TOAST });
     EXPECT_EQ(host_.invalidate_count, 1);
 }


### PR DESCRIPTION
## Summary

ホットパスの小さな最適化と、それに伴う軽微なリファクタを束ねたPRです。動作変更はなく、既存テスト 2022 件すべてパスを確認済み。

- **DetectAlerts の走査削減**: ParseContext に `blockquote_indices` を追加し、パース中に BlockQuote ノードの位置を収集。`DetectAlerts` は全ノード走査せず、収集済みインデックスだけを処理する形に変更。
- **`Node::SetTextPreservingLineCount` を追加**: UTF-8 蓄積時に `AppendText` / `AppendUtf8` で積算済みの `line_count` を再走査しないバリアントを用意し、`FinalizeCurrentNode` から利用。
- **`D2DBrushPool` のロック回避**: `pmr::unordered_map` → `std::unordered_map`。UI スレッド専用なのでロック不要にもかかわらず、毎回 `synchronized_pool_resource` のミューテックスを取得していた点を解消。
- **`GenSearchHighlights` の検索統合**: `lower_bound` + `upper_bound` を `equal_range` 一回呼び出しに置き換え。
- **`BuildLinearizedTableText` の reserve 調整**: 行あたり 64 文字 → 128 文字に。
- **テスト整形**: `test_side_effect_executor.cpp` のブレース内スペーススタイルをプロジェクト方針に揃えた。

## Test plan

- [x] `cmake --build build --config Release` ビルド成功
- [x] `build/tests/Release/mendo_tests.exe --gtest_brief=1` で 2022 tests PASSED
- [ ] 実機でアラート付き Markdown / 検索ハイライト / テーブルの描画に regression がないか目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)