### PR TITLE
perf: md4c を UTF-16 入力モードに切替えてパース処理を高速化

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,9 @@ set(WIL_INCLUDE "${wil_SOURCE_DIR}/include")
 # ---- md4c（サードパーティ） ----
 add_library(md4c STATIC third_party/md4c/md4c.c)
 target_include_directories(md4c PUBLIC third_party/md4c)
+# UTF-16 入力モードを有効化（MD_CHAR=WCHAR）。
+# md4c.h を取り込む側（mendo_core 等）にも伝播させるため PUBLIC で定義。
+target_compile_definitions(md4c PUBLIC MD4C_USE_UTF16)
 if(MSVC)
     target_compile_options(md4c PRIVATE /W0)
     set_target_properties(md4c PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -7,6 +7,7 @@
 #include "mermaid_util.h"
 #include "layout.h"
 #include "profiler.h"
+#include "string_convert.h"
 #include "utility.h"
 #include <algorithm>
 #include <utility>
@@ -181,12 +182,12 @@ void App::OnParseComplete()
     // 非同期のファイルオープンでも OnParseComplete() が使われるため、
     // 別ファイル読み込み時は差分ロジックをスキップする。
     if (path_util::iequal(result->doc.GetFilePath(), state_.document.doc.GetFilePath())) {
-        if (DeferIfPartialWrite(result->doc.GetFilePath(), result->doc.GetRawUtf8().size())) {
+        if (DeferIfPartialWrite(result->doc.GetFilePath(), result->doc.GetLoadedByteSize())) {
             return;
         }
 
-        const std::string_view old_view(state_.document.doc.GetRawUtf8());
-        const std::string_view new_view(result->doc.GetRawUtf8());
+        const std::wstring_view old_view(state_.document.doc.GetRawText());
+        const std::wstring_view new_view(result->doc.GetRawText());
         const auto decision = AnalyzeReloadDiff(old_view, new_view);
 
         MENDO_TRACEF("OnParseComplete: reload node_count=%zu diff_pos=%zu old_size=%zu new_size=%zu op=%d",
@@ -206,7 +207,7 @@ void App::OnParseComplete()
     }
     else {
         // 別ファイルの非同期ロードではリロード用の差分スクロールを使わない
-        state_.reload_diff_pos = std::string_view::npos;
+        state_.reload_diff_pos = std::wstring_view::npos;
     }
 
     state_.document.doc = std::move(result->doc);
@@ -236,7 +237,7 @@ void App::FinishLoadMarkdownFile(bool heights_estimated)
     // スクロール位置の復元
     float scroll_y = 0.0f;
 
-    const bool has_reload_diff = (state_.reload_diff_pos != std::string_view::npos);
+    const bool has_reload_diff = (state_.reload_diff_pos != std::wstring_view::npos);
 
     if (state_.view.scroll_restore.HasNodeRestore()) {
         MENDO_TRACEF("FinishLoad: has_reload_diff=%d node=%d offset=%d heights_estimated=%d",
@@ -353,8 +354,15 @@ void App::DoReloadCurrentFile()
         return;
     }
 
-    const std::string_view old_view(state_.document.doc.GetRawUtf8());
-    const std::string_view new_view(new_utf8);
+    const size_t byte_size = new_utf8.size();
+    std::pmr::wstring new_wide;
+    {
+        MENDO_PROFILE("Reload::Utf8ToWide");
+        string_convert::Utf8ToWide(new_utf8, new_wide);
+    }
+
+    const std::wstring_view old_view(state_.document.doc.GetRawText());
+    const std::wstring_view new_view(new_wide);
     const auto decision = AnalyzeReloadDiff(old_view, new_view);
 
     MENDO_TRACEF("DoReload: diff_pos=%zu old_size=%zu new_size=%zu op=%d",
@@ -365,7 +373,7 @@ void App::DoReloadCurrentFile()
         return;
     }
     MENDO_PROFILE("Reload::ReplaceFromMarkdown");
-    state_.document.doc.ReplaceFromMarkdown(std::move(new_utf8));
+    state_.document.doc.ReplaceFromMarkdown(std::move(new_wide), byte_size);
     FinishReload(decision.diff_pos);
 }
 
@@ -439,7 +447,7 @@ float App::CalcScrollForDiff(size_t diff_pos, float viewport_height) const
     MENDO_TRACEF("CalcScrollForDiff: diff_pos=%zu node_count=%zu", diff_pos, state_.document.doc.GetNodes().size());
     return CalcScrollYForDiff(
         state_.document.doc.GetNodes(), state_.document.layout_cache,
-        state_.document.doc.GetRawUtf8(),
+        std::wstring_view{ state_.document.doc.GetRawText() },
         diff_pos, viewport_height, state_.view.viewport.GetScrollY());
 }
 

--- a/src/app/app_state.h
+++ b/src/app/app_state.h
@@ -77,7 +77,9 @@ struct AppState {
     int active_toc_index = -1;
 
     // ---- リロード管理 ----
-    size_t reload_diff_pos = std::string_view::npos;
+    // wstring_view::npos と string_view::npos は同じ値（static_cast<size_t>(-1)）だが、
+    // 意味的に wide テキストへのオフセットなので wstring_view 側で揃える。
+    size_t reload_diff_pos = std::wstring_view::npos;
     // 短縮タイマーで再リロード予約済み (DeferPrefixShrink / partial-read race)。
     // ローディングアニメーションを抑制するために参照される。
     bool pending_reload_retry = false;

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -747,7 +747,7 @@ void ReduceRestoreScrollAfterLoad(AppState& state, SideEffectList& /*effects*/, 
     state.view.viewport.ClearScrollTarget();
     if (a.has_reload_diff) {
         state.view.viewport.SetScrollY(a.reload_diff_scroll_y);
-        state.reload_diff_pos = std::string_view::npos;
+        state.reload_diff_pos = std::wstring_view::npos;
     }
     else if (state.view.scroll_restore.HasNodeRestore()) {
         state.view.viewport.SetScrollTarget(

--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -2,23 +2,36 @@
 #include "document_utils.h"
 #include "parser.h"
 #include "profiler.h"
+#include "string_convert.h"
 #include <filesystem>
 
-Document Document::FromMarkdown(std::pmr::string utf8, std::wstring_view path)
+Document Document::FromMarkdown(std::pmr::wstring wide, size_t byte_size, std::wstring_view path)
 {
     Document doc;
     doc.file_path_ = path;
-    doc.raw_utf8_ = std::move(utf8);
+    doc.raw_wide_ = std::move(wide);
+    doc.loaded_byte_size_ = byte_size;
     ParseResult result;
     {
         MENDO_PROFILE("ParseMarkdown");
-        result = ParseMarkdown(doc.raw_utf8_);
+        result = ParseMarkdown(std::wstring_view{ doc.raw_wide_ });
     }
     {
         MENDO_PROFILE("BuildIndices");
         doc.ReplaceContent(std::move(result));
     }
     return doc;
+}
+
+Document Document::FromMarkdown(std::pmr::string utf8, std::wstring_view path)
+{
+    const size_t byte_size = utf8.size();
+    std::pmr::wstring wide;
+    {
+        MENDO_PROFILE("Utf8ToWide");
+        string_convert::Utf8ToWide(utf8, wide);
+    }
+    return FromMarkdown(std::move(wide), byte_size, path);
 }
 
 std::pmr::wstring Document::GetDirectory() const
@@ -39,10 +52,22 @@ void Document::ReplaceContent(ParseResult&& result)
     BuildHeadingIndices(result.heading_indices);
 }
 
+void Document::ReplaceFromMarkdown(std::pmr::wstring wide, size_t byte_size)
+{
+    raw_wide_ = std::move(wide);
+    loaded_byte_size_ = byte_size;
+    ReplaceContent(ParseMarkdown(std::wstring_view{ raw_wide_ }));
+}
+
 void Document::ReplaceFromMarkdown(std::pmr::string utf8)
 {
-    raw_utf8_ = std::move(utf8);
-    ReplaceContent(ParseMarkdown(raw_utf8_));
+    const size_t byte_size = utf8.size();
+    std::pmr::wstring wide;
+    {
+        MENDO_PROFILE("Utf8ToWide");
+        string_convert::Utf8ToWide(utf8, wide);
+    }
+    ReplaceFromMarkdown(std::move(wide), byte_size);
 }
 
 int Document::FindAnchorIndex(std::wstring_view anchor) const

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -12,7 +12,8 @@ class Document {
 public:
     constexpr Document() noexcept = default;
 
-    // ファクトリ
+    // ファクトリ。本物は wide 入力版。utf8 入力版はテスト・既存呼び出し互換シム。
+    static Document FromMarkdown(std::pmr::wstring wide, size_t byte_size, std::wstring_view path);
     static Document FromMarkdown(std::pmr::string utf8, std::wstring_view path);
 
     // アクセサ
@@ -21,11 +22,15 @@ public:
     constexpr const std::pmr::wstring& GetFilePath() const noexcept { return file_path_; }
     constexpr const TableOfContents& GetToc() const noexcept { return toc_; }
     constexpr bool IsEmpty() const noexcept { return nodes_.empty(); }
-    const std::pmr::string& GetRawUtf8() const noexcept { return raw_utf8_; }
+    // パース入力の wide テキストへの参照。AnalyzeReloadDiff の比較用。
+    const std::pmr::wstring& GetRawText() const noexcept { return raw_wide_; }
+    // 元ファイル(UTF-8)バイト数。エディタの中間書き込み検出（IsFileLargerThan）で参照する。
+    constexpr size_t GetLoadedByteSize() const noexcept { return loaded_byte_size_; }
     std::pmr::wstring GetDirectory() const;
 
     constexpr void SetFilePath(std::wstring_view path) { file_path_ = path; }
     void ReplaceContent(ParseResult&& result);
+    void ReplaceFromMarkdown(std::pmr::wstring wide, size_t byte_size);
     void ReplaceFromMarkdown(std::pmr::string utf8);
     int FindAnchorIndex(std::wstring_view anchor) const;
     // 既に anchor_id 形式（小文字 ASCII 正規化済み）と判明している入力向け。
@@ -53,7 +58,8 @@ private:
 
     std::pmr::vector<Node> nodes_;
     std::pmr::wstring file_path_;
-    std::pmr::string raw_utf8_;
+    std::pmr::wstring raw_wide_;
+    size_t loaded_byte_size_ = 0;
     TableOfContents toc_;
     // キーは所有 wstring。nodes_ の再アロケート/構造変更でも索引が dangling しない。
     std::pmr::unordered_map<std::pmr::wstring, int,

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -12,7 +12,8 @@ class Document {
 public:
     constexpr Document() noexcept = default;
 
-    // ファクトリ。本物は wide 入力版。utf8 入力版はテスト・既存呼び出し互換シム。
+    // ファクトリ。本体は wide 入力版。utf8 入力版は FileLoader からの UTF-8
+    // バイト列（または埋め込みリソース）を直接受け取るための変換ラッパー。
     static Document FromMarkdown(std::pmr::wstring wide, size_t byte_size, std::wstring_view path);
     static Document FromMarkdown(std::pmr::string utf8, std::wstring_view path);
 

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -104,7 +104,7 @@ struct Node {
     int indent_level = 0;
     int list_number = 0;      // 0 = 順序なし, >0 = 順序付きリスト番号
     uint32_t alert_label_length = 0; // ラベル部分の文字数（描画エフェクト適用範囲）
-    uint32_t source_offset = UINT32_MAX; // ソースUTF-8内のバイトオフセット（未設定時UINT32_MAX）
+    uint32_t source_offset = UINT32_MAX; // ソース wide テキスト内の UTF-16 コード単位オフセット（未設定時UINT32_MAX）
     int blockquote_group = -1;       // 同一 MD_BLOCK_QUOTE 内のノードを識別するグループID
     int line_count = 0;              // テキスト内の改行数（パース時にカウント済み）
 

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -13,13 +13,12 @@
 #include <format>
 #include <iterator>
 #include <algorithm>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <system_error>
 
 namespace {
-
-using string_convert::Utf8ToWide;
 
 struct SpanState {
     bool bold = false;
@@ -46,13 +45,15 @@ struct ParseContext {
     std::stack<SpanState, std::pmr::deque<SpanState>> span_stack{ std::pmr::deque<SpanState>{parse_resource.resource()} };
     SpanState current_span;
 
-    // UTF-8 → Wide変換用の再利用可能バッファ
-    std::pmr::wstring text_buffer;
+    // 現在ノード用の Wide 蓄積スクラッチ。FinalizeCurrentNode で
+    // ノードの text_ にムーブする。
+    std::pmr::wstring current_text{ parse_resource.resource() };
 
-    std::pmr::string utf8_accum{ parse_resource.resource() };
-
-    // 現在ノード用の UTF-8 蓄積スクラッチ。
-    std::pmr::string current_utf8{ parse_resource.resource() };
+    // current_text 内の「未確定 TextRun」の開始位置 (wide unit)。
+    // 同じ span 状態で連続する AppendWide は 1 つの TextRun に統合される。
+    // span 切替 / ブロック退出時に FlushPendingRun が呼ばれて確定する。
+    uint32_t pending_run_start = 0;
+    bool has_pending_run = false;
 
     // ブロックコンテキスト追跡
     int indent_level = 0;
@@ -72,7 +73,6 @@ struct ParseContext {
 
     // 現在構築中のノード
     Node* current_node = nullptr;
-    uint32_t node_wide_offset = 0; // 現在ノードのWide文字オフセット（TextRun用）
 
     // リンクURL格納: SpanStateではインデックスのみ保持し、push/popでの文字列コピーを回避
     std::pmr::vector<std::pmr::wstring> link_urls{ parse_resource.resource() };
@@ -90,35 +90,35 @@ struct ParseContext {
     bool in_display_math = false;
     int paragraph_display_math_count = 0;
     bool paragraph_has_other_content = false;
-    std::pmr::string display_math_buf{ parse_resource.resource() };
+    std::pmr::wstring display_math_buf{ parse_resource.resource() };
 
-    // md_parse() に渡した入力バッファ先頭ポインタ（source_offset 計算用）
-    const char* markdown_base = nullptr;
+    // md_parse() に渡した入力バッファ先頭ポインタ（source_offset 計算用、UTF-16 コード単位オフセット）
+    const wchar_t* markdown_base = nullptr;
 
-    // 現在ノードの UTF-8 スクラッチを Wide 化して text_ に書き込み、スクラッチを空にする。
+    // 現在ノードの Wide スクラッチを text_ に書き込み、スクラッチを空にする。
     // BeginNode 直前と各 OnLeaveBlock の current_node 解除直前に呼ぶ。
     void FinalizeCurrentNode()
     {
-        FlushUtf8();
-        if (current_node && !current_utf8.empty()) {
-            Utf8ToWide(current_utf8, text_buffer);
-            current_node->SetTextWithLineCount(text_buffer, current_node->line_count);
+        FlushPendingRun();
+        if (current_node && !current_text.empty()) {
+            current_node->SetTextWithLineCount(std::move(current_text), current_node->line_count);
         }
-        current_utf8.clear();
+        // move 後 / 元から空 のいずれの経路でも、次ノード用に空状態へ揃える。
+        // monotonic resource なので clear() に追加コストはない。
+        current_text.clear();
     }
 
     void BeginNode(NodeType type)
     {
         // タイトリストではP blockのEnter/Leaveコールバックがスキップされるため、
         // サブリスト開始時に蓄積テキストが未フラッシュのまま残る場合がある。
-        // 新しいノード作成前に Wide 化を確定させて、現在のノードにテキストを書き込む。
+        // 新しいノード作成前に確定させて、現在のノードにテキストを書き込む。
         FinalizeCurrentNode();
         nodes.emplace_back();
         current_node = &nodes.back();
         current_node->type = type;
         current_node_index = nodes.size() - 1;
         current_node->indent_level = indent_level;
-        node_wide_offset = 0;
         if (blockquote_depth > 0 && !blockquote_group_stack.empty()) {
             current_node->blockquote_group = blockquote_group_stack.top();
         }
@@ -150,7 +150,8 @@ struct ParseContext {
         return run;
     }
 
-    // テーブルセルにWideテキストを追加（AppendText/AppendUtf8から委譲される）
+    // テーブルセルにWideテキストを追加（AppendWideから委譲される）。
+    // セルは pending run 方式を使わず、即時 TextRun を生成する。
     void AppendTextToCell(std::wstring_view text)
     {
         const uint32_t start = static_cast<uint32_t>(current_cell->text.size());
@@ -158,98 +159,36 @@ struct ParseContext {
         current_cell->runs.emplace_back(MakeRun(start, static_cast<uint32_t>(text.size())));
     }
 
-    // Wideテキストを現在のノードまたはセルに追加する。
+    // Wide テキストを現在のノードまたはセルに追加する。
     // セル内なら AppendTextToCell に委譲。
-    // ノードなら Wide→UTF-8 変換して current_utf8 スクラッチに蓄積する（BR/SOFTBR/Entity用）。
-    void AppendText(std::wstring_view text)
+    // ノードなら current_text スクラッチに直接 append し、未確定 TextRun として保留する。
+    // 同じ span 状態で連続して呼ばれると 1 つの TextRun に統合される。
+    void AppendWide(std::wstring_view text)
     {
         if (current_cell) {
             AppendTextToCell(text);
             return;
         }
-        if (!current_node) {
+        if (!current_node || text.empty()) {
             return;
         }
-        const uint32_t start = node_wide_offset;
-        // AppendText は BR/SOFTBR/Entity 用で短い入力前提。INT_MAX/3 超は安全のためスキップ
-        if (!text.empty() && text.size() <= static_cast<size_t>(INT_MAX) / 3) {
-            const size_t old_size = current_utf8.size();
-            const size_t max_bytes = text.size() * 3;
-            current_utf8.resize_and_overwrite(old_size + max_bytes, [&](char* buf, size_t count) -> size_t {
-                const int n = WideCharToMultiByte(CP_UTF8, 0, text.data(), static_cast<int>(text.size()), buf + old_size, static_cast<int>(count - old_size), nullptr, nullptr);
-                return old_size + (n > 0 ? static_cast<size_t>(n) : 0);
-            });
+        if (!has_pending_run) {
+            pending_run_start = static_cast<uint32_t>(current_text.size());
+            has_pending_run = true;
         }
-        node_wide_offset += static_cast<uint32_t>(text.size());
-        current_node->runs.emplace_back(MakeRun(start, static_cast<uint32_t>(text.size())));
-        for (const wchar_t c : text) {
-            if (c == L'\n') {
-                current_node->line_count++;
-            }
-        }
+        current_text.append(text);
+        current_node->line_count += static_cast<int>(std::ranges::count(text, L'\n'));
     }
 
-    // 蓄積UTF-8をフラッシュ
-    void FlushUtf8()
+    // 未確定 TextRun を確定して current_node->runs に push する。
+    // span 状態が変わる直前 (OnEnter/Leave Span) と OnLeaveBlock の冒頭で呼ぶ。
+    void FlushPendingRun()
     {
-        if (!utf8_accum.empty()) {
-            AppendUtf8(utf8_accum);
-            utf8_accum.clear();
+        if (has_pending_run && current_node && current_text.size() > pending_run_start) {
+            const uint32_t length = static_cast<uint32_t>(current_text.size() - pending_run_start);
+            current_node->runs.emplace_back(MakeRun(pending_run_start, length));
         }
-    }
-
-    // テーブルセルにUTF-8テキストをWide変換して追加（AppendUtf8から委譲される）
-    void AppendUtf8ToCell(std::string_view text)
-    {
-        Utf8ToWide(text, text_buffer);
-        if (!text_buffer.empty()) {
-            AppendTextToCell(text_buffer);
-        }
-    }
-
-    // UTF-8テキストを現在のノードまたはセルに追加する。
-    // セル内なら AppendUtf8ToCell に委譲（Wide変換が必要）。
-    // ノードなら current_utf8 スクラッチに直接蓄積し、Wide長のみ計算する（遅延変換で高速化）。
-    void AppendUtf8(std::string_view text)
-    {
-        if (current_cell) {
-            AppendUtf8ToCell(text);
-            return;
-        }
-        if (!current_node) {
-            return;
-        }
-        // ノード: Wide長のみ計算して current_utf8 に蓄積
-        // ASCII高速パス: 非ASCII（0x80以上）バイトが無ければバイト長＝ワイド長
-        int wlen;
-        int newline_count = 0;
-        size_t scan = 0;
-        for (; scan < text.size(); ++scan) {
-            if (static_cast<unsigned char>(text[scan]) >= 0x80) {
-                break;
-            }
-            if (text[scan] == '\n') {
-                newline_count++;
-            }
-        }
-        if (scan == text.size()) {
-            wlen = static_cast<int>(text.size());
-        }
-        else {
-            wlen = MultiByteToWideChar(CP_UTF8, 0, text.data(), static_cast<int>(text.size()), nullptr, 0);
-            for (; scan < text.size(); ++scan) {
-                if (text[scan] == '\n') {
-                    newline_count++;
-                }
-            }
-        }
-        if (wlen > 0) {
-            const uint32_t start = node_wide_offset;
-            current_utf8.append(text);
-            node_wide_offset += static_cast<uint32_t>(wlen);
-            current_node->runs.emplace_back(MakeRun(start, static_cast<uint32_t>(wlen)));
-            current_node->line_count += newline_count;
-        }
+        has_pending_run = false;
     }
 };
 
@@ -284,12 +223,9 @@ bool TryPromoteParagraphToDisplayMath(ParseContext* ctx)
     }
     node->type = NodeType::CodeBlock;
     node->code_language = SyntaxLanguage::LatexMath;
-    // current_utf8 スクラッチに math 内容を直接書き込み、後段の FinalizeCurrentNode で
-    // Wide 化される。
-    ctx->current_utf8.assign(ctx->display_math_buf.data(), ctx->display_math_buf.size());
+    ctx->current_text.assign(ctx->display_math_buf.data(), ctx->display_math_buf.size());
     node->runs.clear();
-    node->line_count = static_cast<int>(std::ranges::count(ctx->current_utf8, '\n'));
-    ctx->node_wide_offset = 0;
+    node->line_count = static_cast<int>(std::ranges::count(ctx->current_text, L'\n'));
     ctx->diagram_indices.emplace_back(ctx->current_node_index);
     return true;
 }
@@ -328,7 +264,7 @@ int OnEnterBlock(MD_BLOCKTYPE type, void* detail, void* userdata)
         ctx->BeginNode(NodeType::CodeBlock);
         auto* const code_detail = static_cast<MD_BLOCK_CODE_DETAIL*>(detail);
         if (code_detail && code_detail->lang.text && code_detail->lang.size > 0) {
-            ctx->current_node->code_language = DetectLanguage(std::string_view{ code_detail->lang.text, static_cast<size_t>(code_detail->lang.size) });
+            ctx->current_node->code_language = DetectLanguage(std::wstring_view{ code_detail->lang.text, static_cast<size_t>(code_detail->lang.size) });
         }
         break;
     }
@@ -355,7 +291,7 @@ int OnEnterBlock(MD_BLOCKTYPE type, void* detail, void* userdata)
         auto* const li = static_cast<MD_BLOCK_LI_DETAIL*>(detail);
         if (li->is_task) {
             ctx->BeginNode(NodeType::TaskListItem);
-            ctx->current_node->task_checked = (li->task_mark == 'x' || li->task_mark == 'X');
+            ctx->current_node->task_checked = (li->task_mark == L'x' || li->task_mark == L'X');
         }
         else {
             ctx->BeginNode(NodeType::ListItem);
@@ -418,17 +354,16 @@ int OnLeaveBlock(MD_BLOCKTYPE type, void* /*detail*/, void* userdata)
 {
     auto* const ctx = static_cast<ParseContext*>(userdata);
 
-    ctx->FlushUtf8();
+    ctx->FlushPendingRun();
 
     switch (type) {
     case MD_BLOCK_CODE: {
         auto* cn = ctx->current_node;
         ctx->in_code_block = false;
-        // 末尾の改行があれば除去（current_utf8 スクラッチに対して操作）
-        if (cn && !ctx->current_utf8.empty() && ctx->current_utf8.back() == '\n') {
-            ctx->current_utf8.pop_back();
+        // 末尾の改行があれば除去（current_text スクラッチに対して操作）
+        if (cn && !ctx->current_text.empty() && ctx->current_text.back() == L'\n') {
+            ctx->current_text.pop_back();
             cn->line_count--;
-            ctx->node_wide_offset--;
             if (!cn->runs.empty()) {
                 auto& last = cn->runs.back();
                 if (last.length > 0) {
@@ -519,7 +454,7 @@ int OnEnterSpan(MD_SPANTYPE type, void* detail, void* userdata)
 {
     auto* const ctx = static_cast<ParseContext*>(userdata);
 
-    ctx->FlushUtf8();
+    ctx->FlushPendingRun();
     ctx->span_stack.push(ctx->current_span);
 
     switch (type) {
@@ -543,9 +478,7 @@ int OnEnterSpan(MD_SPANTYPE type, void* detail, void* userdata)
         auto* const a = static_cast<MD_SPAN_A_DETAIL*>(detail);
         if (a->href.text && a->href.size > 0) {
             ctx->link_urls.emplace_back();
-            Utf8ToWide(
-                std::string_view{ a->href.text, static_cast<size_t>(a->href.size) },
-                ctx->link_urls.back());
+            ctx->link_urls.back().assign(a->href.text, static_cast<size_t>(a->href.size));
             ctx->current_span.link_url_index = static_cast<int>(ctx->link_urls.size()) - 1;
         }
         ctx->paragraph_has_other_content = true;
@@ -554,17 +487,15 @@ int OnEnterSpan(MD_SPANTYPE type, void* detail, void* userdata)
     case MD_SPAN_IMG: {
         auto* const img = static_cast<MD_SPAN_IMG_DETAIL*>(detail);
         if (img->src.text && img->src.size > 0) {
-            Utf8ToWide(
-                std::string_view{ img->src.text, static_cast<size_t>(img->src.size) },
-                ctx->pending_image_src);
+            ctx->pending_image_src.assign(img->src.text, static_cast<size_t>(img->src.size));
         }
         ctx->paragraph_has_other_content = true;
         break;
     }
     case MD_SPAN_LATEXMATH_DISPLAY:
-        // "$$" はフォールバックテキスト用。昇格対象でなくなった時点で has_other_content を立てる
+        // L"$$" はフォールバックテキスト用。昇格対象でなくなった時点で has_other_content を立てる
         ctx->in_display_math = true;
-        ctx->AppendUtf8(std::string_view{ "$$", 2 });
+        ctx->AppendWide(std::wstring_view{ L"$$", 2 });
         if (ctx->paragraph_display_math_count == 0 && !ctx->paragraph_has_other_content) {
             ctx->display_math_buf.clear();
         }
@@ -574,7 +505,7 @@ int OnEnterSpan(MD_SPANTYPE type, void* detail, void* userdata)
         break;
     case MD_SPAN_LATEXMATH:
         // インライン $...$ は昇格対象外。元の "$" を復元してテキストとして残す
-        ctx->AppendUtf8(std::string_view{ "$", 1 });
+        ctx->AppendWide(std::wstring_view{ L"$", 1 });
         ctx->paragraph_has_other_content = true;
         break;
     default:
@@ -589,7 +520,7 @@ int OnLeaveSpan(MD_SPANTYPE type, void* /*detail*/, void* userdata)
 {
     auto* const ctx = static_cast<ParseContext*>(userdata);
 
-    ctx->FlushUtf8();
+    ctx->FlushPendingRun();
 
     if (type == MD_SPAN_IMG) {
         if (auto* cn = ctx->current_node; cn && !ctx->pending_image_src.empty()) {
@@ -599,11 +530,11 @@ int OnLeaveSpan(MD_SPANTYPE type, void* /*detail*/, void* userdata)
     }
     else if (type == MD_SPAN_LATEXMATH_DISPLAY) {
         ctx->in_display_math = false;
-        ctx->AppendUtf8(std::string_view{ "$$", 2 });
+        ctx->AppendWide(std::wstring_view{ L"$$", 2 });
         ctx->paragraph_display_math_count++;
     }
     else if (type == MD_SPAN_LATEXMATH) {
-        ctx->AppendUtf8(std::string_view{ "$", 1 });
+        ctx->AppendWide(std::wstring_view{ L"$", 1 });
     }
 
     if (!ctx->span_stack.empty()) {
@@ -622,10 +553,12 @@ int OnText(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, void* userdata)
         return 0;
     }
 
-    // 各ノードの最初のテキストコールバックでソースオフセットを記録
+    // 各ノードの最初のテキストコールバックでソースオフセットを記録（UTF-16 コード単位）
     if (ctx->current_node->source_offset == UINT32_MAX && ctx->markdown_base) {
         ctx->current_node->source_offset = static_cast<uint32_t>(text - ctx->markdown_base);
     }
+
+    const std::wstring_view chunk{ text, static_cast<size_t>(size) };
 
     switch (type) {
     case MD_TEXT_NORMAL:
@@ -633,14 +566,14 @@ int OnText(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, void* userdata)
         if (!ctx->in_display_math) {
             ctx->paragraph_has_other_content = true;
         }
-        ctx->utf8_accum.append(text, static_cast<size_t>(size));
+        ctx->AppendWide(chunk);
         break;
 
     case MD_TEXT_LATEXMATH:
-        ctx->utf8_accum.append(text, static_cast<size_t>(size));
+        ctx->AppendWide(chunk);
         if (ctx->in_display_math && ctx->paragraph_display_math_count == 0 &&
             !ctx->paragraph_has_other_content) {
-            ctx->display_math_buf.append(text, static_cast<size_t>(size));
+            ctx->display_math_buf.append(chunk);
         }
         break;
 
@@ -648,14 +581,12 @@ int OnText(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, void* userdata)
         if (!ctx->in_display_math) {
             ctx->paragraph_has_other_content = true;
         }
-        ctx->FlushUtf8();
-        const std::string_view entity{ text, static_cast<size_t>(size) };
         wchar_t entity_buf[2];
-        if (const auto resolved = ResolveHtmlEntity(entity, entity_buf)) {
-            ctx->AppendText(*resolved);
+        if (const auto resolved = ResolveHtmlEntity(chunk, entity_buf)) {
+            ctx->AppendWide(*resolved);
         }
         else {
-            ctx->AppendUtf8(entity);
+            ctx->AppendWide(chunk);
         }
         break;
     }
@@ -664,16 +595,14 @@ int OnText(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, void* userdata)
         if (!ctx->in_display_math) {
             ctx->paragraph_has_other_content = true;
         }
-        ctx->FlushUtf8();
-        ctx->AppendText(std::wstring_view{ L"\n", 1 });
+        ctx->AppendWide(std::wstring_view{ L"\n", 1 });
         break;
 
     case MD_TEXT_SOFTBR:
         if (!ctx->in_display_math) {
             ctx->paragraph_has_other_content = true;
         }
-        ctx->FlushUtf8();
-        ctx->AppendText(std::wstring_view{ L" ", 1 });
+        ctx->AppendWide(std::wstring_view{ L" ", 1 });
         break;
 
     default:
@@ -685,11 +614,12 @@ int OnText(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, void* userdata)
 
 } // namespace
 
-ParseResult ParseMarkdown(std::string_view markdown_text)
+ParseResult ParseMarkdown(std::wstring_view markdown_text)
 {
     ParseContext ctx;
     ctx.markdown_base = markdown_text.data();
-    ctx.utf8_accum.reserve(4096);
+    // ノード単位のスクラッチを 1 回確保しておくと、長段落・コードブロックでの再確保を抑えられる。
+    ctx.current_text.reserve(4096);
     ctx.nodes.reserve(std::clamp(markdown_text.size() / 64, size_t{ 64 }, size_t{ 8192 }));
     ctx.heading_indices.reserve(std::clamp(markdown_text.size() / 256, size_t{ 8 }, size_t{ 512 }));
     ctx.image_indices.reserve(std::clamp(markdown_text.size() / 512, size_t{ 4 }, size_t{ 256 }));
@@ -719,6 +649,13 @@ ParseResult ParseMarkdown(std::string_view markdown_text)
     result.image_indices = std::move(ctx.image_indices);
     result.diagram_indices = std::move(ctx.diagram_indices);
     return result;
+}
+
+ParseResult ParseMarkdown(std::string_view utf8_markdown_text)
+{
+    std::pmr::wstring wide;
+    string_convert::Utf8ToWide(utf8_markdown_text, wide);
+    return ParseMarkdown(std::wstring_view{ wide });
 }
 
 std::wstring_view GetAlertLabel(AlertType type) noexcept
@@ -888,44 +825,57 @@ void DetectAlerts(std::pmr::vector<Node>& nodes, std::span<const size_t> blockqu
     }
 }
 
-std::optional<std::wstring_view> ResolveHtmlEntity(std::string_view entity, wchar_t(&buffer)[2])
+std::optional<std::wstring_view> ResolveHtmlEntity(std::wstring_view entity, wchar_t(&buffer)[2])
 {
     const wchar_t* literal = nullptr;
-    if (entity == "&amp;") {
+    if (entity == L"&amp;") {
         literal = L"&";
     }
-    else if (entity == "&lt;") {
+    else if (entity == L"&lt;") {
         literal = L"<";
     }
-    else if (entity == "&gt;") {
+    else if (entity == L"&gt;") {
         literal = L">";
     }
-    else if (entity == "&quot;") {
+    else if (entity == L"&quot;") {
         literal = L"\"";
     }
-    else if (entity == "&apos;") {
+    else if (entity == L"&apos;") {
         literal = L"'";
     }
-    else if (entity == "&nbsp;") {
-        literal = L"\u00A0";
+    else if (entity == std::wstring_view{ L"&nbsp;" }) {
+        literal = L" ";
     }
     if (literal) {
         return std::wstring_view{ literal, 1 };
     }
 
-    if (entity.size() >= 4 && entity[0] == '&' && entity[1] == '#') {
+    if (entity.size() >= 4 && entity[0] == L'&' && entity[1] == L'#') {
+        // 数値文字参照は ASCII 数字のみで構成される。from_chars は narrow しか
+        // 受け付けないため、スタックの小バッファに narrow 化してから渡す。
+        char ascii[16];
+        if (entity.size() > sizeof(ascii)) {
+            return std::nullopt;
+        }
+        for (size_t i = 0; i < entity.size(); ++i) {
+            const wchar_t c = entity[i];
+            if (c > 0x7F) {
+                return std::nullopt;
+            }
+            ascii[i] = static_cast<char>(c);
+        }
         unsigned long codepoint = 0;
         bool valid = false;
-        if (entity[2] == 'x' || entity[2] == 'X') {
-            const auto r = std::from_chars(entity.data() + 3, entity.data() + entity.size() - 1, codepoint, 16);
+        if (ascii[2] == 'x' || ascii[2] == 'X') {
+            const auto r = std::from_chars(ascii + 3, ascii + entity.size() - 1, codepoint, 16);
             valid = (r.ec == std::errc());
         }
         else {
-            const auto r = std::from_chars(entity.data() + 2, entity.data() + entity.size() - 1, codepoint, 10);
+            const auto r = std::from_chars(ascii + 2, ascii + entity.size() - 1, codepoint, 10);
             valid = (r.ec == std::errc());
         }
         // サロゲート範囲 (U+D800-U+DFFF) は単独で UTF-16 として不正なので除外し、
-        // 呼び出し側で元の utf-8 をそのまま再投入させる。
+        // 呼び出し側で元の入力をそのままテキストとして再投入させる。
         if (valid && codepoint > 0 && codepoint <= 0xFFFF &&
             !(codepoint >= 0xD800 && codepoint <= 0xDFFF)) {
             buffer[0] = static_cast<wchar_t>(codepoint);

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -493,9 +493,9 @@ int OnEnterSpan(MD_SPANTYPE type, void* detail, void* userdata)
         break;
     }
     case MD_SPAN_LATEXMATH_DISPLAY:
-        // L"$$" はフォールバックテキスト用。昇格対象でなくなった時点で has_other_content を立てる
+        // "$$" はフォールバックテキスト用。昇格対象でなくなった時点で has_other_content を立てる
         ctx->in_display_math = true;
-        ctx->AppendWide(std::wstring_view{ L"$$", 2 });
+        ctx->AppendWide(L"$$");
         if (ctx->paragraph_display_math_count == 0 && !ctx->paragraph_has_other_content) {
             ctx->display_math_buf.clear();
         }
@@ -505,7 +505,7 @@ int OnEnterSpan(MD_SPANTYPE type, void* detail, void* userdata)
         break;
     case MD_SPAN_LATEXMATH:
         // インライン $...$ は昇格対象外。元の "$" を復元してテキストとして残す
-        ctx->AppendWide(std::wstring_view{ L"$", 1 });
+        ctx->AppendWide(L"$");
         ctx->paragraph_has_other_content = true;
         break;
     default:
@@ -530,11 +530,11 @@ int OnLeaveSpan(MD_SPANTYPE type, void* /*detail*/, void* userdata)
     }
     else if (type == MD_SPAN_LATEXMATH_DISPLAY) {
         ctx->in_display_math = false;
-        ctx->AppendWide(std::wstring_view{ L"$$", 2 });
+        ctx->AppendWide(L"$$");
         ctx->paragraph_display_math_count++;
     }
     else if (type == MD_SPAN_LATEXMATH) {
-        ctx->AppendWide(std::wstring_view{ L"$", 1 });
+        ctx->AppendWide(L"$");
     }
 
     if (!ctx->span_stack.empty()) {
@@ -595,14 +595,14 @@ int OnText(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, void* userdata)
         if (!ctx->in_display_math) {
             ctx->paragraph_has_other_content = true;
         }
-        ctx->AppendWide(std::wstring_view{ L"\n", 1 });
+        ctx->AppendWide(L"\n");
         break;
 
     case MD_TEXT_SOFTBR:
         if (!ctx->in_display_math) {
             ctx->paragraph_has_other_content = true;
         }
-        ctx->AppendWide(std::wstring_view{ L" ", 1 });
+        ctx->AppendWide(L" ");
         break;
 
     default:
@@ -827,27 +827,29 @@ void DetectAlerts(std::pmr::vector<Node>& nodes, std::span<const size_t> blockqu
 
 std::optional<std::wstring_view> ResolveHtmlEntity(std::wstring_view entity, wchar_t(&buffer)[2])
 {
-    const wchar_t* literal = nullptr;
-    if (entity == L"&amp;") {
-        literal = L"&";
-    }
-    else if (entity == L"&lt;") {
-        literal = L"<";
-    }
-    else if (entity == L"&gt;") {
-        literal = L">";
-    }
-    else if (entity == L"&quot;") {
-        literal = L"\"";
-    }
-    else if (entity == L"&apos;") {
-        literal = L"'";
-    }
-    else if (entity == std::wstring_view{ L"&nbsp;" }) {
-        literal = L" ";
-    }
-    if (literal) {
-        return std::wstring_view{ literal, 1 };
+    {
+        std::wstring_view literal;
+        if (entity == L"&amp;") {
+            literal = L"&";
+        }
+        else if (entity == L"&lt;") {
+            literal = L"<";
+        }
+        else if (entity == L"&gt;") {
+            literal = L">";
+        }
+        else if (entity == L"&quot;") {
+            literal = L"\"";
+        }
+        else if (entity == L"&apos;") {
+            literal = L"'";
+        }
+        else if (entity == L"&nbsp;") {
+            literal = L" ";
+        }
+        if (!literal.empty()) {
+            return literal;
+        }
     }
 
     if (entity.size() >= 4 && entity[0] == L'&' && entity[1] == L'#') {

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -853,37 +853,21 @@ std::optional<std::wstring_view> ResolveHtmlEntity(std::wstring_view entity, wch
     }
 
     if (entity.size() >= 4 && entity[0] == L'&' && entity[1] == L'#') {
-        // 数値文字参照は ASCII 数字のみで構成される。from_chars は narrow しか
-        // 受け付けないため、スタックの小バッファに narrow 化してから渡す。
-        char ascii[16];
-        if (entity.size() > sizeof(ascii)) {
-            return std::nullopt;
-        }
-        for (size_t i = 0; i < entity.size(); ++i) {
-            const wchar_t c = entity[i];
-            if (c > 0x7F) {
-                return std::nullopt;
-            }
-            ascii[i] = static_cast<char>(c);
-        }
         unsigned long codepoint = 0;
-        bool valid = false;
-        if (ascii[2] == 'x' || ascii[2] == 'X') {
-            const auto r = std::from_chars(ascii + 3, ascii + entity.size() - 1, codepoint, 16);
-            valid = (r.ec == std::errc());
+        if (entity[2] == L'x' || entity[2] == L'X') {
+            (void)ascii_util::from_chars(entity.data() + 3, entity.size(), codepoint, 16ul);
         }
         else {
-            const auto r = std::from_chars(ascii + 2, ascii + entity.size() - 1, codepoint, 10);
-            valid = (r.ec == std::errc());
+            (void)ascii_util::from_chars(entity.data() + 2, entity.size(), codepoint, 10ul);
         }
         // サロゲート範囲 (U+D800-U+DFFF) は単独で UTF-16 として不正なので除外し、
         // 呼び出し側で元の入力をそのままテキストとして再投入させる。
-        if (valid && codepoint > 0 && codepoint <= 0xFFFF &&
+        if (codepoint > 0 && codepoint <= 0xFFFF &&
             !(codepoint >= 0xD800 && codepoint <= 0xDFFF)) {
             buffer[0] = static_cast<wchar_t>(codepoint);
             return std::wstring_view{ buffer, 1 };
         }
-        if (valid && codepoint > 0xFFFF && codepoint <= 0x10FFFF) {
+        if (codepoint > 0xFFFF && codepoint <= 0x10FFFF) {
             // 補助面: UTF-16 サロゲートペア
             const unsigned long adj = codepoint - 0x10000;
             buffer[0] = static_cast<wchar_t>(0xD800 + (adj >> 10));

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -852,22 +852,33 @@ std::optional<std::wstring_view> ResolveHtmlEntity(std::wstring_view entity, wch
         }
     }
 
-    if (entity.size() >= 4 && entity[0] == L'&' && entity[1] == L'#') {
+    if (entity.size() >= 4 && entity[0] == L'&' && entity[1] == L'#' && entity.back() == L';') {
         unsigned long codepoint = 0;
+        const wchar_t* digits;
+        size_t digit_len;
+        unsigned long base;
         if (entity[2] == L'x' || entity[2] == L'X') {
-            (void)ascii_util::from_chars(entity.data() + 3, entity.size(), codepoint, 16ul);
+            digits = entity.data() + 3;
+            digit_len = entity.size() - 4; // "&#x" と末尾 ';' を除いた残り長
+            base = 16;
         }
         else {
-            (void)ascii_util::from_chars(entity.data() + 2, entity.size(), codepoint, 10ul);
+            digits = entity.data() + 2;
+            digit_len = entity.size() - 3; // "&#" と末尾 ';' を除いた残り長
+            base = 10;
         }
+        const wchar_t* const stop = ascii_util::from_chars(digits, digit_len, codepoint, base);
+        // 全桁消費 (stop == digits + digit_len) かつ 1 桁以上 (stop > digits) のみ受理。
+        // "&#65x;" のように途中で停止した入力は不正として弾く。
+        const bool fully_consumed = (stop == digits + digit_len) && (stop > digits);
         // サロゲート範囲 (U+D800-U+DFFF) は単独で UTF-16 として不正なので除外し、
         // 呼び出し側で元の入力をそのままテキストとして再投入させる。
-        if (codepoint > 0 && codepoint <= 0xFFFF &&
+        if (fully_consumed && codepoint > 0 && codepoint <= 0xFFFF &&
             !(codepoint >= 0xD800 && codepoint <= 0xDFFF)) {
             buffer[0] = static_cast<wchar_t>(codepoint);
             return std::wstring_view{ buffer, 1 };
         }
-        if (codepoint > 0xFFFF && codepoint <= 0x10FFFF) {
+        if (fully_consumed && codepoint > 0xFFFF && codepoint <= 0x10FFFF) {
             // 補助面: UTF-16 サロゲートペア
             const unsigned long adj = codepoint - 0x10000;
             buffer[0] = static_cast<wchar_t>(0xD800 + (adj >> 10));

--- a/src/core/parser.h
+++ b/src/core/parser.h
@@ -15,7 +15,12 @@ struct ParseResult {
     std::pmr::vector<size_t> diagram_indices;
 };
 
-ParseResult ParseMarkdown(std::string_view markdown_text);
+// 本物の Markdown パーサ。md4c を MD4C_USE_UTF16 モードで起動するため入力は wide。
+ParseResult ParseMarkdown(std::wstring_view markdown_text);
+
+// テスト・便宜用の UTF-8 入力シム。内部で wide 化してから wstring_view 版へ委譲する。
+// 本番コードでは使わない（FileLoader 経由で wide が直接渡る）。
+ParseResult ParseMarkdown(std::string_view utf8_markdown_text);
 
 // BlockQuoteノードからGitHub Alertsを検出し、マーカー除去・ラベル挿入・グルーピングを行う（テスト用に公開）。
 // blockquote_indices は ParseMarkdown が収集した BlockQuote ノードのインデックス。
@@ -27,9 +32,9 @@ std::wstring_view GetAlertLabel(AlertType type) noexcept;
 // AlertTypeに対応するアイコン文字列を返す（テスト用に公開）
 std::wstring_view GetAlertIcon(AlertType type) noexcept;
 
-// HTML エンティティ (例: "&amp;", "&#x1F600;") を解決する。
-// 戻り値: 解決成功なら wide 文字列の view、失敗なら nullopt (呼び出し側で元の utf-8 を
+// HTML エンティティ (例: L"&amp;", L"&#x1F600;") を解決する。
+// 戻り値: 解決成功なら wide 文字列の view、失敗なら nullopt (呼び出し側で元の入力を
 // そのままテキストとして再投入することを示す)。
 // view が指す領域は (a) static なリテラル または (b) 呼び出し側が渡した buffer のいずれか。
 // buffer のスコープ内でのみ valid。
-[[nodiscard]] std::optional<std::wstring_view> ResolveHtmlEntity(std::string_view entity, wchar_t(&buffer)[2]);
+[[nodiscard]] std::optional<std::wstring_view> ResolveHtmlEntity(std::wstring_view entity, wchar_t(&buffer)[2]);

--- a/src/core/reload.cpp
+++ b/src/core/reload.cpp
@@ -4,23 +4,23 @@
 #include <cstdint>
 #include <ranges>
 
-size_t FindFirstDifference(std::string_view old_text, std::string_view new_text) noexcept
+size_t FindFirstDifference(std::wstring_view old_text, std::wstring_view new_text) noexcept
 {
     const auto [it_old, it_new] = std::ranges::mismatch(old_text, new_text);
     if (it_old == old_text.end() && it_new == new_text.end()) {
-        return std::string_view::npos;
+        return std::wstring_view::npos;
     }
     return static_cast<size_t>(it_old - old_text.begin());
 }
 
-ReloadDecision AnalyzeReloadDiff(std::string_view old_utf8, std::string_view new_utf8) noexcept
+ReloadDecision AnalyzeReloadDiff(std::wstring_view old_wide, std::wstring_view new_wide) noexcept
 {
-    const size_t diff_pos = FindFirstDifference(old_utf8, new_utf8);
-    if (diff_pos == std::string_view::npos) {
-        return { ReloadOp::NoChange, std::string_view::npos };
+    const size_t diff_pos = FindFirstDifference(old_wide, new_wide);
+    if (diff_pos == std::wstring_view::npos) {
+        return { ReloadOp::NoChange, std::wstring_view::npos };
     }
-    if (IsPrefixOnlyDiff(diff_pos, old_utf8.size(), new_utf8.size())) {
-        if (new_utf8.size() < old_utf8.size()) {
+    if (IsPrefixOnlyDiff(diff_pos, old_wide.size(), new_wide.size())) {
+        if (new_wide.size() < old_wide.size()) {
             return { ReloadOp::DeferPrefixShrink, diff_pos };
         }
         return { ReloadOp::PrefixGrowth, diff_pos };
@@ -68,7 +68,7 @@ int FindNodeBySourceOffset(const std::pmr::vector<Node>& nodes, uint32_t diff_of
 float CalcScrollYForDiff(
     const std::pmr::vector<Node>& nodes,
     const LayoutCache& cache,
-    std::string_view content,
+    std::wstring_view content,
     size_t diff_pos,
     float viewport_height,
     float fallback_scroll) noexcept

--- a/src/core/reload.h
+++ b/src/core/reload.h
@@ -1,7 +1,7 @@
 #pragma once
 // 同一ファイルのリロード判定ロジック。
-// 旧/新コンテンツの UTF-8 バイト列を比較し、リロード方針を決定する純粋関数群と、
-// 差分位置 (UTF-8 バイトオフセット) を対応するノード / スクロール Y 座標へ写像する
+// 旧/新コンテンツの wide 文字列を比較し、リロード方針を決定する純粋関数群と、
+// 差分位置 (UTF-16 コード単位オフセット) を対応するノード / スクロール Y 座標へ写像する
 // ルックアップを提供する。OnParseComplete / DoReloadCurrentFile の同一ファイル
 // 再読み込み時の分岐を統一するために 1 か所に集約している。
 #include "document_types.h"
@@ -14,8 +14,8 @@
 
 class LayoutCache;
 
-// 新旧コンテンツの最初の差分バイトオフセットを返す。同一の場合は npos。
-size_t FindFirstDifference(std::string_view old_text, std::string_view new_text) noexcept;
+// 新旧コンテンツの最初の差分 UTF-16 コード単位位置を返す。同一の場合は npos。
+size_t FindFirstDifference(std::wstring_view old_text, std::wstring_view new_text) noexcept;
 
 // diff_pos が短い方の末尾と一致するかを判定する。
 // 片方がもう片方の prefix であり、ファイルの伸縮（エディタの中間書き込み状態）を示す。
@@ -34,11 +34,11 @@ enum class ReloadOp : uint8_t {
 
 struct ReloadDecision {
     ReloadOp op;
-    size_t diff_pos;    // NoChange のとき std::string_view::npos、それ以外は差分開始位置。
+    size_t diff_pos;    // NoChange のとき std::wstring_view::npos、それ以外は差分開始位置。
 };
 
-// 旧/新コンテンツの UTF-8 バイト列を比較し、リロード方針を決定する純粋関数。
-ReloadDecision AnalyzeReloadDiff(std::string_view old_utf8, std::string_view new_utf8) noexcept;
+// 旧/新コンテンツの wide 文字列を比較し、リロード方針を決定する純粋関数。
+ReloadDecision AnalyzeReloadDiff(std::wstring_view old_wide, std::wstring_view new_wide) noexcept;
 
 // source_offset が diff_offset 以下の最後のノードを返す。該当なしの場合は -1。
 [[nodiscard]] int FindNodeBySourceOffset(const std::pmr::vector<Node>& nodes, uint32_t diff_offset) noexcept;
@@ -48,7 +48,7 @@ ReloadDecision AnalyzeReloadDiff(std::string_view old_utf8, std::string_view new
 float CalcScrollYForDiff(
     const std::pmr::vector<Node>& nodes,
     const LayoutCache& cache,
-    std::string_view content,
+    std::wstring_view content,
     size_t diff_pos,
     float viewport_height,
     float fallback_scroll) noexcept;

--- a/src/util/ascii_util.h
+++ b/src/util/ascii_util.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <cwchar>
 #include <cwctype>
+#include <concepts>
 #include <emmintrin.h>
 #include <intrin.h>
 #include <string_view>
@@ -227,6 +228,35 @@ constexpr bool iless(std::wstring_view a, std::wstring_view b) noexcept
 constexpr bool istarts_with(std::wstring_view s, std::wstring_view prefix) noexcept
 {
     return s.size() >= prefix.size() && iequal(s.substr(0, prefix.size()), prefix);
+}
+
+template <typename T, std::unsigned_integral U>
+constexpr const T* from_chars(const T* start, std::size_t len, U& value, U base = 10) noexcept
+{
+    const auto end = start + len;
+    U b;
+
+    value = 0;
+    if (base <= 10) {
+        for (; (start < end) && ((b = *start - static_cast<T>('0')) < base); ++start) {
+            value = (value * base) + b;
+        }
+    }
+    else {
+        for (; start < end; ++start) {
+            const U c = static_cast<std::make_unsigned_t<T>>(*start);
+            b = c - static_cast<T>('0');
+            if (b >= 10) {
+                b = (c | 0x20) - static_cast<T>('a');
+                if (b >= (base - 10)) {
+                    break;
+                }
+                b += 10;
+            }
+            value = (value * base) + b;
+        }
+    }
+    return start;
 }
 
 } // namespace ascii_util

--- a/src/util/ascii_util.h
+++ b/src/util/ascii_util.h
@@ -8,6 +8,7 @@
 #include <emmintrin.h>
 #include <intrin.h>
 #include <string_view>
+#include <type_traits>
 
 // ASCII 文字列ヘルパ。バルク処理は SSE2 で wchar_t (UTF-16 code unit) を 8 文字並列に扱い、
 // 非 ASCII (>= U+0080) を含むチャンクは std::towlower や逐次比較にフォールバックするので、

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -88,76 +88,81 @@ TEST(DocumentTest, GetNodesMut)
     EXPECT_EQ(doc.GetNodes()[0].GetText(), L"modified");
 }
 
-// ---- GetRawUtf8 ----
+// ---- GetRawText / GetLoadedByteSize ----
 
-TEST(DocumentTest, GetRawUtf8FromMarkdown)
+TEST(DocumentTest, GetRawTextFromMarkdown)
 {
     auto doc = Document::FromMarkdown("# Hello\nworld", L"test.md");
-    EXPECT_EQ(doc.GetRawUtf8(), "# Hello\nworld");
+    EXPECT_EQ(doc.GetRawText(), L"# Hello\nworld");
+    EXPECT_EQ(doc.GetLoadedByteSize(), 13u);
 }
 
-TEST(DocumentTest, GetRawUtf8Empty)
+TEST(DocumentTest, GetRawTextEmpty)
 {
     auto doc = Document::FromMarkdown("", L"test.md");
-    EXPECT_TRUE(doc.GetRawUtf8().empty());
+    EXPECT_TRUE(doc.GetRawText().empty());
+    EXPECT_EQ(doc.GetLoadedByteSize(), 0u);
 }
 
-TEST(DocumentTest, GetRawUtf8Default)
+TEST(DocumentTest, GetRawTextDefault)
 {
     Document doc;
-    EXPECT_TRUE(doc.GetRawUtf8().empty());
+    EXPECT_TRUE(doc.GetRawText().empty());
+    EXPECT_EQ(doc.GetLoadedByteSize(), 0u);
 }
 
-TEST(DocumentTest, GetRawUtf8AfterReplace)
+TEST(DocumentTest, GetRawTextAfterReplace)
 {
     auto doc = Document::FromMarkdown("old content", L"test.md");
-    EXPECT_EQ(doc.GetRawUtf8(), "old content");
+    EXPECT_EQ(doc.GetRawText(), L"old content");
 
     doc.ReplaceFromMarkdown("new content");
-    EXPECT_EQ(doc.GetRawUtf8(), "new content");
+    EXPECT_EQ(doc.GetRawText(), L"new content");
 }
 
-TEST(DocumentTest, GetRawUtf8Utf8Content)
+TEST(DocumentTest, GetRawTextUtf8Content)
 {
     std::pmr::string utf8 = "# 日本語テスト\n\nこんにちは";
     auto doc = Document::FromMarkdown(utf8, L"test.md");
-    EXPECT_EQ(doc.GetRawUtf8(), utf8);
+    // UTF-8 と Wide で同じ論理テキストが得られる
+    EXPECT_EQ(doc.GetRawText(), L"# 日本語テスト\n\nこんにちは");
+    // バイトサイズは UTF-8 のサイズ（CJK は 3 byte/char）
+    EXPECT_EQ(doc.GetLoadedByteSize(), utf8.size());
 }
 
-TEST(DocumentTest, GetRawUtf8PreservedAcrossMultipleReplaces)
+TEST(DocumentTest, GetRawTextPreservedAcrossMultipleReplaces)
 {
     auto doc = Document::FromMarkdown("v1", L"test.md");
-    EXPECT_EQ(doc.GetRawUtf8(), "v1");
+    EXPECT_EQ(doc.GetRawText(), L"v1");
 
     doc.ReplaceFromMarkdown("v2");
-    EXPECT_EQ(doc.GetRawUtf8(), "v2");
+    EXPECT_EQ(doc.GetRawText(), L"v2");
 
     doc.ReplaceFromMarkdown("v3");
-    EXPECT_EQ(doc.GetRawUtf8(), "v3");
+    EXPECT_EQ(doc.GetRawText(), L"v3");
 }
 
-TEST(DocumentTest, GetRawUtf8IndependentOfNodes)
+TEST(DocumentTest, GetRawTextIndependentOfNodes)
 {
-    // ノードの変更が raw_utf8_ に影響しないことを確認
+    // ノードの変更が raw_wide_ に影響しないことを確認
     auto doc = Document::FromMarkdown("hello", L"test.md");
     doc.GetNodesMut()[0].SetText(L"modified");
-    // raw_utf8_ はパース入力のまま
-    EXPECT_EQ(doc.GetRawUtf8(), "hello");
+    // raw_wide_ はパース入力のまま
+    EXPECT_EQ(doc.GetRawText(), L"hello");
 }
 
-TEST(DocumentTest, RawUtf8SourceOffsetConsistency)
+TEST(DocumentTest, RawTextSourceOffsetConsistency)
 {
-    // raw_utf8_ 内のオフセットがノードの source_offset と一致することを確認
+    // raw_wide_ 内のオフセット（UTF-16 コード単位）がノードの source_offset と一致することを確認
     std::pmr::string md = "# Title\n\nBody text";
     auto doc = Document::FromMarkdown(md, L"test.md");
     const auto& nodes = doc.GetNodes();
-    const auto& raw = doc.GetRawUtf8();
+    const auto& raw = doc.GetRawText();
     ASSERT_GE(nodes.size(), 2u);
 
     // source_offset 位置の文字がノードのテキスト先頭と対応する
     for (const auto& n : nodes) {
         if (n.source_offset != UINT32_MAX && n.source_offset < raw.size()) {
-            // ソース位置のバイトがノードテキストの最初の文字のUTF-8エンコーディングと一致
             EXPECT_LT(n.source_offset, static_cast<uint32_t>(raw.size()));
         }
     }

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -5,6 +5,7 @@
 #include "document_test_helpers.h"
 #include "test_helpers.h"
 #include "parser.h"
+#include "string_convert.h"
 #include "syntax.h"
 
 // ============================================================
@@ -1024,61 +1025,61 @@ TEST(ExtractFilename, MixedSeparators)
 }
 
 // ============================================================
-// FindFirstDifference
+// FindFirstDifference (UTF-16 コード単位の差分検出)
 // ============================================================
 
 TEST(FindFirstDifference, IdenticalStrings)
 {
-    EXPECT_EQ(FindFirstDifference("hello", "hello"), std::string_view::npos);
+    EXPECT_EQ(FindFirstDifference(L"hello", L"hello"), std::wstring_view::npos);
 }
 
 TEST(FindFirstDifference, BothEmpty)
 {
-    EXPECT_EQ(FindFirstDifference("", ""), std::string_view::npos);
+    EXPECT_EQ(FindFirstDifference(L"", L""), std::wstring_view::npos);
 }
 
-TEST(FindFirstDifference, DifferentFirstByte)
+TEST(FindFirstDifference, DifferentFirstUnit)
 {
-    EXPECT_EQ(FindFirstDifference("abc", "xbc"), 0u);
+    EXPECT_EQ(FindFirstDifference(L"abc", L"xbc"), 0u);
 }
 
 TEST(FindFirstDifference, DifferentMiddle)
 {
-    EXPECT_EQ(FindFirstDifference("abcdef", "abcXef"), 3u);
+    EXPECT_EQ(FindFirstDifference(L"abcdef", L"abcXef"), 3u);
 }
 
-TEST(FindFirstDifference, DifferentLastByte)
+TEST(FindFirstDifference, DifferentLastUnit)
 {
-    EXPECT_EQ(FindFirstDifference("abc", "abX"), 2u);
+    EXPECT_EQ(FindFirstDifference(L"abc", L"abX"), 2u);
 }
 
 TEST(FindFirstDifference, NewLongerThanOld)
 {
-    EXPECT_EQ(FindFirstDifference("abc", "abcdef"), 3u);
+    EXPECT_EQ(FindFirstDifference(L"abc", L"abcdef"), 3u);
 }
 
 TEST(FindFirstDifference, OldLongerThanNew)
 {
-    EXPECT_EQ(FindFirstDifference("abcdef", "abc"), 3u);
+    EXPECT_EQ(FindFirstDifference(L"abcdef", L"abc"), 3u);
 }
 
 TEST(FindFirstDifference, EmptyOld)
 {
-    EXPECT_EQ(FindFirstDifference("", "new"), 0u);
+    EXPECT_EQ(FindFirstDifference(L"", L"new"), 0u);
 }
 
 TEST(FindFirstDifference, EmptyNew)
 {
-    EXPECT_EQ(FindFirstDifference("old", ""), 0u);
+    EXPECT_EQ(FindFirstDifference(L"old", L""), 0u);
 }
 
-TEST(FindFirstDifference, Utf8Content)
+TEST(FindFirstDifference, CjkContent)
 {
-    // UTF-8: "う"=E3 81 86, "え"=E3 81 88 → 先頭2バイト共通、3バイト目で差分
-    std::string a = "あいう";
-    std::string b = "あいえ";
+    // BMP 内の CJK は 1 wchar_t/char。"う"(U+3046)/"え"(U+3048) は 1 unit 違い。
+    std::wstring a = L"あいう";
+    std::wstring b = L"あいえ";
     size_t diff = FindFirstDifference(a, b);
-    EXPECT_EQ(diff, 8u); // "あいう"/"あいえ" の最後のバイトで差分
+    EXPECT_EQ(diff, 2u); // 3 文字目で差分（インデックス 2）
 }
 
 // ============================================================
@@ -1087,22 +1088,22 @@ TEST(FindFirstDifference, Utf8Content)
 
 TEST(AnalyzeReloadDiff, IdenticalContentReturnsNoChange)
 {
-    const auto d = AnalyzeReloadDiff("hello world", "hello world");
+    const auto d = AnalyzeReloadDiff(L"hello world", L"hello world");
     EXPECT_EQ(d.op, ReloadOp::NoChange);
-    EXPECT_EQ(d.diff_pos, std::string_view::npos);
+    EXPECT_EQ(d.diff_pos, std::wstring_view::npos);
 }
 
 TEST(AnalyzeReloadDiff, BothEmptyReturnsNoChange)
 {
-    const auto d = AnalyzeReloadDiff("", "");
+    const auto d = AnalyzeReloadDiff(L"", L"");
     EXPECT_EQ(d.op, ReloadOp::NoChange);
-    EXPECT_EQ(d.diff_pos, std::string_view::npos);
+    EXPECT_EQ(d.diff_pos, std::wstring_view::npos);
 }
 
 TEST(AnalyzeReloadDiff, AppendedSuffixIsPrefixGrowth)
 {
     // 末尾に追記 → prefix-only growth（スクロール維持）
-    const auto d = AnalyzeReloadDiff("abc", "abcdef");
+    const auto d = AnalyzeReloadDiff(L"abc", L"abcdef");
     EXPECT_EQ(d.op, ReloadOp::PrefixGrowth);
     EXPECT_EQ(d.diff_pos, 3u);
 }
@@ -1110,7 +1111,7 @@ TEST(AnalyzeReloadDiff, AppendedSuffixIsPrefixGrowth)
 TEST(AnalyzeReloadDiff, EmptyToContentIsPrefixGrowth)
 {
     // 空ファイル → 何か書いた。prefix-only growth として扱う。
-    const auto d = AnalyzeReloadDiff("", "new content");
+    const auto d = AnalyzeReloadDiff(L"", L"new content");
     EXPECT_EQ(d.op, ReloadOp::PrefixGrowth);
     EXPECT_EQ(d.diff_pos, 0u);
 }
@@ -1118,7 +1119,7 @@ TEST(AnalyzeReloadDiff, EmptyToContentIsPrefixGrowth)
 TEST(AnalyzeReloadDiff, TruncatedSuffixIsDeferPrefixShrink)
 {
     // 末尾が消えた = truncate。エディタの truncate→rewrite 前半の可能性があるため defer。
-    const auto d = AnalyzeReloadDiff("abcdef", "abc");
+    const auto d = AnalyzeReloadDiff(L"abcdef", L"abc");
     EXPECT_EQ(d.op, ReloadOp::DeferPrefixShrink);
     EXPECT_EQ(d.diff_pos, 3u);
 }
@@ -1126,23 +1127,23 @@ TEST(AnalyzeReloadDiff, TruncatedSuffixIsDeferPrefixShrink)
 TEST(AnalyzeReloadDiff, ContentToEmptyIsDeferPrefixShrink)
 {
     // 全消去も truncate → rewrite の前半とみなして defer する
-    const auto d = AnalyzeReloadDiff("old content", "");
+    const auto d = AnalyzeReloadDiff(L"old content", L"");
     EXPECT_EQ(d.op, ReloadOp::DeferPrefixShrink);
     EXPECT_EQ(d.diff_pos, 0u);
 }
 
 TEST(AnalyzeReloadDiff, MiddleChangeIsFullReload)
 {
-    // 中間バイトが変わった。prefix-only ではないので全体リロード。
-    const auto d = AnalyzeReloadDiff("abcdef", "abcXef");
+    // 中間で変化した。prefix-only ではないので全体リロード。
+    const auto d = AnalyzeReloadDiff(L"abcdef", L"abcXef");
     EXPECT_EQ(d.op, ReloadOp::FullReload);
     EXPECT_EQ(d.diff_pos, 3u);
 }
 
-TEST(AnalyzeReloadDiff, FirstByteChangeIsFullReload)
+TEST(AnalyzeReloadDiff, FirstUnitChangeIsFullReload)
 {
     // 先頭で差分があれば必ず FullReload（同一長さなので prefix-only にならない）。
-    const auto d = AnalyzeReloadDiff("abc", "Xbc");
+    const auto d = AnalyzeReloadDiff(L"abc", L"Xbc");
     EXPECT_EQ(d.op, ReloadOp::FullReload);
     EXPECT_EQ(d.diff_pos, 0u);
 }
@@ -1150,19 +1151,19 @@ TEST(AnalyzeReloadDiff, FirstByteChangeIsFullReload)
 TEST(AnalyzeReloadDiff, LengthChangedWithMiddleDiffIsFullReload)
 {
     // 途中で差分があり、かつ長さも変わる → prefix-only ではなく FullReload。
-    const auto d = AnalyzeReloadDiff("abcdef", "abcYYYz");
+    const auto d = AnalyzeReloadDiff(L"abcdef", L"abcYYYz");
     EXPECT_EQ(d.op, ReloadOp::FullReload);
     EXPECT_EQ(d.diff_pos, 3u);
 }
 
-TEST(AnalyzeReloadDiff, Utf8SuffixAppendedIsPrefixGrowth)
+TEST(AnalyzeReloadDiff, CjkSuffixAppendedIsPrefixGrowth)
 {
-    // UTF-8 バイト列での末尾追記も prefix-only growth として扱える
-    const std::string old_text = "あいう";
-    const std::string new_text = "あいうえお";
+    // CJK 末尾追記も prefix-only growth として扱える
+    const std::wstring old_text = L"あいう";
+    const std::wstring new_text = L"あいうえお";
     const auto d = AnalyzeReloadDiff(old_text, new_text);
     EXPECT_EQ(d.op, ReloadOp::PrefixGrowth);
-    EXPECT_EQ(d.diff_pos, 9u); // "あいう" = 9 バイト
+    EXPECT_EQ(d.diff_pos, 3u); // "あいう" = 3 wchar_t
 }
 
 // ============================================================
@@ -1278,11 +1279,15 @@ TEST(FindNodeBySourceOffset, MixedWithHorizontalRules)
 // 統合テスト: diff検出 → ノード特定
 // ============================================================
 
-// ヘルパー: old→new の編集をシミュレートし、変更箇所のノードを特定する
+// ヘルパー: old→new の編集をシミュレートし、変更箇所のノードを特定する。
+// 入力 UTF-8 を wide 化して FindFirstDifference を呼ぶ（source_offset は wide 単位）。
 static int SimulateEditAndFindNode(std::string_view old_md, std::string_view new_md)
 {
-    size_t diff_pos = FindFirstDifference(old_md, new_md);
-    if (diff_pos == std::string_view::npos) {
+    std::pmr::wstring old_w, new_w;
+    string_convert::Utf8ToWide(old_md, old_w);
+    string_convert::Utf8ToWide(new_md, new_w);
+    size_t diff_pos = FindFirstDifference(old_w, new_w);
+    if (diff_pos == std::wstring_view::npos) {
         return -1;
     }
     auto nodes = ParseMarkdown(new_md).nodes;
@@ -1500,14 +1505,14 @@ TEST(IsPrefixOnlyDiff, BothEmpty)
 TEST(IsPrefixOnlyDiff, IntegrationWithFindFirstDifference)
 {
     // FindFirstDifference と組み合わせた実際のユースケース
-    std::string_view old_text = "Hello World";
-    std::string_view new_text = "Hello World, more text";
+    std::wstring_view old_text = L"Hello World";
+    std::wstring_view new_text = L"Hello World, more text";
     size_t diff = FindFirstDifference(old_text, new_text);
     EXPECT_TRUE(IsPrefixOnlyDiff(diff, old_text.size(), new_text.size()));
 
     // 内容が異なる場合
-    std::string_view old_text2 = "Hello World";
-    std::string_view new_text2 = "Hello Xxxxx";
+    std::wstring_view old_text2 = L"Hello World";
+    std::wstring_view new_text2 = L"Hello Xxxxx";
     size_t diff2 = FindFirstDifference(old_text2, new_text2);
     EXPECT_FALSE(IsPrefixOnlyDiff(diff2, old_text2.size(), new_text2.size()));
 }
@@ -1530,7 +1535,7 @@ TEST(CalcScrollYForDiff, FallbackWhenNoNodes)
 {
     std::pmr::vector<Node> nodes;
     LayoutCache cache;
-    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, "content", 0, 500.0f, 42.0f), 42.0f);
+    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, L"content", 0, 500.0f, 42.0f), 42.0f);
 }
 
 TEST(CalcScrollYForDiff, FallbackWhenNodeNotFound)
@@ -1540,7 +1545,7 @@ TEST(CalcScrollYForDiff, FallbackWhenNodeNotFound)
     nodes[0].source_offset = 50;
     auto cache = MakeUniformCache(3);
     // diff_pos=10 < 全ノードの最小 offset(50) → -1 → fallback
-    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, "content", 10, 500.0f, 99.0f), 99.0f);
+    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, L"content", 10, 500.0f, 99.0f), 99.0f);
 }
 
 TEST(CalcScrollYForDiff, ScrollsToNodeStartWithMargin)
@@ -1548,7 +1553,7 @@ TEST(CalcScrollYForDiff, ScrollsToNodeStartWithMargin)
     // 3ノード: offset=0,100,200 / y=0,100,200 / height=100
     auto nodes = MakeNodes(3, 100);
     auto cache = MakeUniformCache(3, 100.0f);
-    std::string content(300, 'x');
+    std::wstring content(300, L'x');
 
     // diff_pos=0 → node 0, y=0, margin=500*0.2=100 → max(0, 0-100)=0
     EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, content, 0, 500.0f, 0.0f), 0.0f);
@@ -1565,7 +1570,7 @@ TEST(CalcScrollYForDiff, IntraNodeFractionInterpolation)
     // 2ノード: offset=0,100 / y=0,1000 / height=1000
     auto nodes = MakeNodes(2, 100);
     auto cache = MakeUniformCache(2, 1000.0f);
-    std::string content(200, 'x');
+    std::wstring content(200, L'x');
 
     // diff_pos=50 → node 0 (offset=0), next_start=100
     // fraction = (50-0)/(100-0) = 0.5
@@ -1580,7 +1585,7 @@ TEST(CalcScrollYForDiff, FractionClampsToOne)
     // diff_pos がノード範囲を超える場合でも fraction は 1.0 でクランプ
     auto nodes = MakeNodes(2, 100);
     auto cache = MakeUniformCache(2, 1000.0f);
-    std::string content(200, 'x');
+    std::wstring content(200, L'x');
 
     // diff_pos=99 → node 0, fraction=99/100=0.99
     // y = 0 + 1000*0.99 = 990, scroll = 990-20 = 970
@@ -1597,7 +1602,7 @@ TEST(CalcScrollYForDiff, SkipsUnsetSourceOffsets)
     nodes[1].source_offset = UINT32_MAX; // 未設定（HorizontalRule等）
     nodes[2].source_offset = 200;
     auto cache = MakeUniformCache(3, 100.0f);
-    std::string content(300, 'x');
+    std::wstring content(300, L'x');
 
     // diff_pos=100 → node 0 (offset=0), next valid = node 2 (offset=200)
     // fraction = (100-0)/(200-0) = 0.5
@@ -1613,7 +1618,7 @@ TEST(CalcScrollYForDiff, LastNodeUsesContentSizeAsNextStart)
     auto nodes = MakeNodes(1, 0);
     nodes[0].source_offset = 0;
     auto cache = MakeUniformCache(1, 1000.0f);
-    std::string content(100, 'x');
+    std::wstring content(100, L'x');
 
     // diff_pos=50, next_start=content.size()=100
     // fraction = 50/100 = 0.5
@@ -1630,14 +1635,14 @@ TEST(CalcScrollYForDiff, CacheSizeMismatchFallback)
     auto cache = MakeUniformCache(3, 100.0f); // キャッシュは3つだけ
 
     // diff_pos=400 → node 4 だがキャッシュは3つ → fallback
-    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, std::string(500, 'x'), 400, 500.0f, 77.0f), 77.0f);
+    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, std::wstring(500, L'x'), 400, 500.0f, 77.0f), 77.0f);
 }
 
 TEST(CalcScrollYForDiff, ParsedMarkdownIntegration)
 {
     // 実際のMarkdownをパースして差分スクロール位置を計算する統合テスト
-    std::string md = "# Title\n\nFirst paragraph\n\nSecond paragraph\n\nThird paragraph";
-    auto nodes = ParseMarkdown(md).nodes;
+    std::wstring md = L"# Title\n\nFirst paragraph\n\nSecond paragraph\n\nThird paragraph";
+    auto nodes = ParseMarkdown(std::wstring_view{ md }).nodes;
     ASSERT_GE(nodes.size(), 4u);
 
     // ノード高さを設定
@@ -1650,9 +1655,9 @@ TEST(CalcScrollYForDiff, ParsedMarkdownIntegration)
         y += 50.0f;
     }
 
-    // "Second paragraph" の先頭バイトで diff
-    size_t diff_pos = static_cast<size_t>(md.find("Second"));
-    ASSERT_NE(diff_pos, std::string::npos);
+    // "Second paragraph" の先頭で diff
+    size_t diff_pos = static_cast<size_t>(md.find(L"Second"));
+    ASSERT_NE(diff_pos, std::wstring::npos);
 
     float result = CalcScrollYForDiff(nodes, cache, md, diff_pos, 500.0f, 0.0f);
     // スクロール位置は 0 以上で、fallback(0) とは異なる値が期待される
@@ -1667,9 +1672,9 @@ TEST(CalcScrollYForDiff, ParsedMarkdownIntegration)
 TEST(CalcScrollYForDiff, PrefixGrowthScrollsTowardAppendedTail)
 {
     // 旧 doc: 3 段落
-    const std::string old_md = "para_one\n\npara_two\n\npara_three";
+    const std::wstring old_md = L"para_one\n\npara_two\n\npara_three";
     // 新 doc: 末尾に 1 段落追記
-    const std::string new_md = old_md + "\n\npara_four_added";
+    const std::wstring new_md = old_md + L"\n\npara_four_added";
 
     // AnalyzeReloadDiff で PrefixGrowth と判定されること
     const auto decision = AnalyzeReloadDiff(old_md, new_md);
@@ -1677,7 +1682,7 @@ TEST(CalcScrollYForDiff, PrefixGrowthScrollsTowardAppendedTail)
     ASSERT_EQ(decision.diff_pos, old_md.size());
 
     // 新 doc を pipeline で扱うイメージで cache を構築
-    auto nodes = ParseMarkdown(new_md).nodes;
+    auto nodes = ParseMarkdown(std::wstring_view{ new_md }).nodes;
     ASSERT_GE(nodes.size(), 4u);
 
     LayoutCache cache;

--- a/tests/test_html_entity.cpp
+++ b/tests/test_html_entity.cpp
@@ -3,7 +3,7 @@
 
 namespace {
 
-std::optional<std::wstring> Resolve(std::string_view entity)
+std::optional<std::wstring> Resolve(std::wstring_view entity)
 {
     wchar_t buf[2];
     const auto view = ResolveHtmlEntity(entity, buf);
@@ -17,32 +17,32 @@ std::optional<std::wstring> Resolve(std::string_view entity)
 
 TEST(HtmlEntity, NamedLiterals)
 {
-    EXPECT_EQ(Resolve("&amp;"), L"&");
-    EXPECT_EQ(Resolve("&lt;"), L"<");
-    EXPECT_EQ(Resolve("&gt;"), L">");
-    EXPECT_EQ(Resolve("&quot;"), L"\"");
-    EXPECT_EQ(Resolve("&apos;"), L"'");
-    EXPECT_EQ(Resolve("&nbsp;"), L" ");
+    EXPECT_EQ(Resolve(L"&amp;"), L"&");
+    EXPECT_EQ(Resolve(L"&lt;"), L"<");
+    EXPECT_EQ(Resolve(L"&gt;"), L">");
+    EXPECT_EQ(Resolve(L"&quot;"), L"\"");
+    EXPECT_EQ(Resolve(L"&apos;"), L"'");
+    EXPECT_EQ(Resolve(L"&nbsp;"), L" ");
 }
 
 TEST(HtmlEntity, NumericDecimal)
 {
-    EXPECT_EQ(Resolve("&#65;"), L"A");
-    EXPECT_EQ(Resolve("&#9;"), L"\t");
+    EXPECT_EQ(Resolve(L"&#65;"), L"A");
+    EXPECT_EQ(Resolve(L"&#9;"), L"\t");
 }
 
 TEST(HtmlEntity, NumericHex)
 {
-    EXPECT_EQ(Resolve("&#x41;"), L"A");
-    EXPECT_EQ(Resolve("&#X41;"), L"A");
-    EXPECT_EQ(Resolve("&#x4E00;"), L"一");
-    EXPECT_EQ(Resolve("&#xFFFF;"), L"￿");
+    EXPECT_EQ(Resolve(L"&#x41;"), L"A");
+    EXPECT_EQ(Resolve(L"&#X41;"), L"A");
+    EXPECT_EQ(Resolve(L"&#x4E00;"), L"一");
+    EXPECT_EQ(Resolve(L"&#xFFFF;"), L"￿");
 }
 
 TEST(HtmlEntity, SupplementaryPlaneSurrogatePair)
 {
     // U+1F600 GRINNING FACE → サロゲートペア (D83D, DE00)
-    const auto result = Resolve("&#x1F600;");
+    const auto result = Resolve(L"&#x1F600;");
     ASSERT_TRUE(result.has_value());
     ASSERT_EQ(result->size(), 2u);
     EXPECT_EQ((*result)[0], static_cast<wchar_t>(0xD83D));
@@ -52,33 +52,33 @@ TEST(HtmlEntity, SupplementaryPlaneSurrogatePair)
 TEST(HtmlEntity, RejectsLoneSurrogateHigh)
 {
     // U+D800-U+DBFF (high surrogate) は単独で UTF-16 として不正
-    EXPECT_EQ(Resolve("&#xD800;"), std::nullopt);
-    EXPECT_EQ(Resolve("&#xDBFF;"), std::nullopt);
+    EXPECT_EQ(Resolve(L"&#xD800;"), std::nullopt);
+    EXPECT_EQ(Resolve(L"&#xDBFF;"), std::nullopt);
 }
 
 TEST(HtmlEntity, RejectsLoneSurrogateLow)
 {
     // U+DC00-U+DFFF (low surrogate) は単独で UTF-16 として不正
-    EXPECT_EQ(Resolve("&#xDC00;"), std::nullopt);
-    EXPECT_EQ(Resolve("&#xDFFF;"), std::nullopt);
+    EXPECT_EQ(Resolve(L"&#xDC00;"), std::nullopt);
+    EXPECT_EQ(Resolve(L"&#xDFFF;"), std::nullopt);
 }
 
 TEST(HtmlEntity, RejectsZero)
 {
-    EXPECT_EQ(Resolve("&#0;"), std::nullopt);
-    EXPECT_EQ(Resolve("&#x0;"), std::nullopt);
+    EXPECT_EQ(Resolve(L"&#0;"), std::nullopt);
+    EXPECT_EQ(Resolve(L"&#x0;"), std::nullopt);
 }
 
 TEST(HtmlEntity, RejectsOutOfRange)
 {
-    EXPECT_EQ(Resolve("&#x110000;"), std::nullopt);
-    EXPECT_EQ(Resolve("&#x7FFFFFFF;"), std::nullopt);
+    EXPECT_EQ(Resolve(L"&#x110000;"), std::nullopt);
+    EXPECT_EQ(Resolve(L"&#x7FFFFFFF;"), std::nullopt);
 }
 
 TEST(HtmlEntity, RejectsMalformed)
 {
-    EXPECT_EQ(Resolve("&unknown;"), std::nullopt);
-    EXPECT_EQ(Resolve("&#xZZ;"), std::nullopt);
-    EXPECT_EQ(Resolve("&#;"), std::nullopt);
-    EXPECT_EQ(Resolve(""), std::nullopt);
+    EXPECT_EQ(Resolve(L"&unknown;"), std::nullopt);
+    EXPECT_EQ(Resolve(L"&#xZZ;"), std::nullopt);
+    EXPECT_EQ(Resolve(L"&#;"), std::nullopt);
+    EXPECT_EQ(Resolve(L""), std::nullopt);
 }

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1282,13 +1282,14 @@ TEST(Parser, SourceOffsetHorizontalRule)
     EXPECT_EQ(nodes[0].source_offset, UINT32_MAX);
 }
 
-TEST(Parser, SourceOffsetUtf8Multibyte)
+TEST(Parser, SourceOffsetCjkMultiCodeUnit)
 {
-    // "あいう\n\ntest" → "あいう"=9バイト, "\n\n"=2バイト
+    // "あいう\n\ntest" → wide で "あいう" = 3 wchar_t, "\n\n" = 2 wchar_t
+    // source_offset は UTF-16 コード単位
     auto nodes = ParseMarkdown("あいう\n\ntest").nodes;
     ASSERT_EQ(nodes.size(), 2u);
     EXPECT_EQ(nodes[0].source_offset, 0u);
-    EXPECT_EQ(nodes[1].source_offset, 11u); // 9 + 2
+    EXPECT_EQ(nodes[1].source_offset, 5u); // 3 + 2
 }
 
 TEST(Parser, SourceOffsetUnorderedList)

--- a/tests/test_string_convert.cpp
+++ b/tests/test_string_convert.cpp
@@ -185,3 +185,132 @@ TEST(StringConvert, ThreeByteBoundary)
     EXPECT_EQ(result, L"\u3042");
     EXPECT_EQ(result.size(), 1u);
 }
+
+// \u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550
+// 16 \u30d0\u30a4\u30c8\u5883\u754c / \u5404\u7a2e\u9577\u3055\u30fb\u6df7\u5728\u30d1\u30bf\u30fc\u30f3\u306e\u56de\u5e30\u30c6\u30b9\u30c8
+// \u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550
+
+TEST(StringConvert, Utf8ToWide16ByteExact)
+{
+    std::string utf8 = "0123456789ABCDEF";
+    EXPECT_EQ(utf8.size(), 16u);
+    auto result = Utf8ToWide(utf8);
+    EXPECT_EQ(result, L"0123456789ABCDEF");
+    EXPECT_EQ(result.size(), 16u);
+}
+
+TEST(StringConvert, Utf8ToWide32ByteExact)
+{
+    std::string utf8 = "0123456789ABCDEFghijklmnopqrstuv";
+    EXPECT_EQ(utf8.size(), 32u);
+    auto result = Utf8ToWide(utf8);
+    EXPECT_EQ(result.size(), 32u);
+    EXPECT_EQ(result, L"0123456789ABCDEFghijklmnopqrstuv");
+}
+
+TEST(StringConvert, Utf8ToWide15ByteJustUnderBoundary)
+{
+    std::string utf8 = "0123456789ABCDE";
+    EXPECT_EQ(utf8.size(), 15u);
+    auto result = Utf8ToWide(utf8);
+    EXPECT_EQ(result, L"0123456789ABCDE");
+}
+
+TEST(StringConvert, Utf8ToWide17ByteJustOverBoundary)
+{
+    std::string utf8 = "0123456789ABCDEFG";
+    auto result = Utf8ToWide(utf8);
+    EXPECT_EQ(result, L"0123456789ABCDEFG");
+}
+
+TEST(StringConvert, Utf8ToWide31ByteJustUnderTwoChunks)
+{
+    std::string utf8 = "0123456789ABCDEFghijklmnopqrstu";
+    auto result = Utf8ToWide(utf8);
+    EXPECT_EQ(result.size(), 31u);
+    EXPECT_EQ(result, L"0123456789ABCDEFghijklmnopqrstu");
+}
+
+TEST(StringConvert, Utf8ToWide1024Byte)
+{
+    std::string utf8(1024, 'A');
+    auto result = Utf8ToWide(utf8);
+    EXPECT_EQ(result.size(), 1024u);
+    for (size_t i = 0; i < result.size(); ++i) {
+        EXPECT_EQ(result[i], L'A');
+    }
+}
+
+TEST(StringConvert, Utf8ToWideNonAsciiAtBoundaryStart)
+{
+    // \u5148\u982d\u30d0\u30a4\u30c8\u5373\u975e ASCII\u3002U+3042 (\xE3\x81\x82) + ASCII 15 byte
+    std::string utf8 = "\xE3\x81\x82" "0123456789ABCDE";
+    auto result = Utf8ToWide(utf8);
+    EXPECT_EQ(result, L"\u3042" L"0123456789ABCDE");
+}
+
+TEST(StringConvert, Utf8ToWideNonAsciiInMiddle)
+{
+    // "abc" + U+3042 + "def" + U+4E16 + "ghi"
+    std::string utf8 = "abc\xE3\x81\x82" "def" "\xE4\xB8\x96" "ghi";
+    auto result = Utf8ToWide(utf8);
+    EXPECT_EQ(result, L"abc\u3042" L"def\u4e16" L"ghi");
+}
+
+TEST(StringConvert, Utf8ToWideNonAsciiAtBoundaryEnd)
+{
+    // 13 byte ASCII + 3 byte CJK = 16 byte (1 \u30c1\u30e3\u30f3\u30af)
+    std::string utf8 = "0123456789ABC" "\xE3\x81\x82";
+    auto result = Utf8ToWide(utf8);
+    EXPECT_EQ(result, L"0123456789ABC\u3042");
+}
+
+TEST(StringConvert, Utf8ToWideNonAsciiSpansBoundary)
+{
+    // 15 byte ASCII + 3 byte CJK = 18 byte\u3002\u5883\u754c\u306b leading byte \u304c\u6765\u308b\u3002
+    std::string utf8 = "0123456789ABCDE" "\xE3\x81\x82";
+    auto result = Utf8ToWide(utf8);
+    EXPECT_EQ(result, L"0123456789ABCDE\u3042");
+}
+
+TEST(StringConvert, Utf8ToWideAlternatingAsciiCjk)
+{
+    // U+3053 U+3093 U+306B U+3061 U+306F = "\u3053\u3093\u306b\u3061\u306f"
+    std::string utf8;
+    std::pmr::wstring expected;
+    for (int i = 0; i < 50; ++i) {
+        utf8 += "Hello world! ";
+        utf8 += "\xE3\x81\x93\xE3\x82\x93\xE3\x81\xAB\xE3\x81\xA1\xE3\x81\xAF ";
+        expected += L"Hello world! ";
+        expected += L"\u3053\u3093\u306b\u3061\u306f ";
+    }
+    auto result = Utf8ToWide(utf8);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(StringConvert, Utf8ToWideEmojiAtBoundary)
+{
+    // \u88dc\u52a9\u9762\u6587\u5b57\u3092 16 byte \u5883\u754c\u306b\u7f6e\u3044\u3066\u30b5\u30ed\u30b2\u30fc\u30c8\u30da\u30a2\u304c\u6b63\u3057\u304f\u51fa\u529b\u3055\u308c\u308b\u3053\u3068
+    std::string utf8(15, 'x');
+    utf8 += "\xF0\x9F\x98\x80"; // U+1F600 (4 byte UTF-8 \u2192 2 wchar surrogate pair)
+    auto result = Utf8ToWide(utf8);
+    EXPECT_EQ(result.size(), 17u);
+    EXPECT_EQ(result.substr(0, 15), std::pmr::wstring(15, L'x'));
+    EXPECT_EQ(result[15], static_cast<wchar_t>(0xD83D));
+    EXPECT_EQ(result[16], static_cast<wchar_t>(0xDE00));
+}
+
+TEST(StringConvert, Utf8ToWideAllAsciiCodepoints)
+{
+    // 0x00 \u301c 0x7F \u306e\u5168 ASCII \u7bc4\u56f2\u3092\u542b\u3080\u6587\u5b57\u5217\u3092\u5909\u63db\u3057\u3066\u3082 1:1 \u3067\u5bfe\u5fdc
+    std::string utf8;
+    utf8.reserve(128);
+    for (int c = 0; c < 128; ++c) {
+        utf8.push_back(static_cast<char>(c));
+    }
+    auto result = Utf8ToWide(utf8);
+    EXPECT_EQ(result.size(), 128u);
+    for (int c = 0; c < 128; ++c) {
+        EXPECT_EQ(result[static_cast<size_t>(c)], static_cast<wchar_t>(c));
+    }
+}

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -9,7 +9,8 @@
 			"UNICODE",
 			"_UNICODE",
 			"NOMINMAX",
-			"WIN32_LEAN_AND_MEAN"
+			"WIN32_LEAN_AND_MEAN",
+			"MD4C_USE_UTF16"
 		],
 		"chat.tools.terminal.autoApprove": {
 			"ctest": true,


### PR DESCRIPTION
## Summary

- `MD4C_USE_UTF16` を有効化し、md4c が wide テキストを直接受け取るように変更。`parser.cpp` の UTF-8 蓄積バッファ＋ per-node Wide 化変換を廃止し、`current_text` への直接 append と `pending_run_start` による TextRun バッチング方式へ統合。ノードあたりの `wchar_t` コピー回数が 2→1 回に削減。
- `Document::raw_utf8_` を `raw_wide_` + `loaded_byte_size_` に置換し、`ParseMarkdown` / `AnalyzeReloadDiff` / `FindFirstDifference` / `CalcScrollYForDiff` を `wstring_view` ベースに統一（`source_offset` も UTF-16 コード単位の意味に変更）。`ResolveHtmlEntity` も wide ベースに刷新し、ASCII 数値文字参照は `ascii_util::from_chars` で処理。
- 実測: `ParseMarkdown` が giga(大量構文) -25.4% (895→669ms)、test(通常仕様書) -19.1% (293→237ms)。Utf8ToWide 込みトータルでも giga -16.4%, test -11.5%。

## Test plan

- [x] `cmake --build build --config Release` が警告なく通る
- [x] `mendo_tests.exe --gtest_brief=1` が全パス（特に `test_parser` / `test_document` / `test_html_entity` / `test_string_convert`）
- [x] 実ファイル(giga / 通常仕様書)を開いてレンダリング・スクロール・リロード差分検出に retrogression が無いことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)