### PR TITLE
perf: parser.cpp の span ネスト追跡をカウンタ方式に置換

### DIFF
--- a/example/nested.md
+++ b/example/nested.md
@@ -1,0 +1,121 @@
+# Nested blockquote / list サンプル
+
+GitHub での表示を確認するための検証用サンプル。
+mendo の `blockquote_group_stack` / `list_counter` をカウンタ化した場合に
+影響しうるケースを並べる。
+
+---
+
+## 1. 単純なネスト blockquote
+
+> hoge
+> > huga
+
+---
+
+## 2. 外 → 内 → 外 に戻る blockquote
+
+外側を抜けずに内側に入り、内側を抜けて外側に戻るケース。
+`blockquote_group_stack` の top を使っている現状の挙動と、
+単純カウンタ化した場合に差が出る最重要ケース。
+
+> 外側 1 行目
+>
+> > 内側 1 行目
+> > 内側 2 行目
+>
+> 外側 2 行目 (内側を抜けて外側に戻った)
+> 外側 3 行目
+
+---
+
+## 3. 三段ネスト
+
+> 第 1 階層
+> > 第 2 階層
+> > > 第 3 階層
+> > 第 2 階層に戻る
+> 第 1 階層に戻る
+
+---
+
+## 4. 順序ありリストの番号
+
+1. one
+2. two
+3. three
+
+ネストを挟んでも親リストの番号が継続することの確認:
+
+1. parent A
+   1. child A-1
+   2. child A-2
+2. parent B (親の番号が継続するか)
+3. parent C
+
+---
+
+## 5. 順序なし → 順序あり混在
+
+- ul item 1
+  1. ol child 1
+  2. ol child 2
+- ul item 2
+  1. ol child 1 (新しい ol なので 1 から)
+  2. ol child 2
+
+---
+
+## 6. blockquote の中にリスト
+
+> 引用の中のリスト
+>
+> 1. 引用内 ol-1
+> 2. 引用内 ol-2
+>    - 入れ子の ul
+>    - 入れ子の ul
+> 3. 引用内 ol-3 (番号継続)
+
+---
+
+## 7. リストの中に blockquote
+
+1. リスト ol-1
+   > リスト内 blockquote 1 行目
+   > リスト内 blockquote 2 行目
+2. リスト ol-2
+   > 別の blockquote (新規 group になるか)
+
+---
+
+## 8. blockquote ネスト + リスト混在
+
+> 外側 引用
+>
+> 1. 外側 引用内 ol-1
+>    > 入れ子 引用
+>    > > 三段目 引用
+>    > 入れ子 引用に戻る
+> 2. 外側 引用内 ol-2 (番号継続するか)
+>
+> 外側 引用 末尾
+
+---
+
+## 9. GitHub Alert (ネスト blockquote)
+
+> [!NOTE]
+> Alert 親
+> > 内側 blockquote (Alert 伝播するか?)
+>
+> Alert 親の続き
+
+---
+
+## 10. 連続する別グループの blockquote
+
+> 1 つ目の引用
+
+段落で区切る
+
+> 2 つ目の引用 (group が変わるか)

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -20,14 +20,6 @@
 
 namespace {
 
-struct SpanState {
-    bool bold = false;
-    bool italic = false;
-    bool code = false;
-    bool strikethrough = false;
-    int link_url_index = -1; // -1 = リンクなし, >= 0 = link_urls へのインデックス
-};
-
 struct ParseContext {
     // パース用 monotonic リソース（一括確保→一括解放）
     MonotonicResource parse_resource{ 64 * 1024 };
@@ -41,9 +33,14 @@ struct ParseContext {
     std::pmr::vector<size_t> blockquote_indices;
     size_t current_node_index = 0;
 
-    // パース一時データには monotonic リソースを使用
-    std::stack<SpanState, std::pmr::deque<SpanState>> span_stack{ std::pmr::deque<SpanState>{parse_resource.resource()} };
-    SpanState current_span;
+    // span ネスト追跡は md4c 推奨のカウンタ方式。enter で +1, leave で -1。
+    // counter > 0 の間その属性が有効。CommonMark で link はネスト禁止のため
+    // link_url_index のみ単純フィールド (-1 = リンク外)。
+    uint8_t bold_count = 0;
+    uint8_t italic_count = 0;
+    uint8_t code_count = 0;
+    uint8_t strikethrough_count = 0;
+    int current_link_url_index = -1;
 
     // 現在ノード用の Wide 蓄積スクラッチ。FinalizeCurrentNode で
     // ノードの text_ にムーブする。
@@ -74,7 +71,6 @@ struct ParseContext {
     // 現在構築中のノード
     Node* current_node = nullptr;
 
-    // リンクURL格納: SpanStateではインデックスのみ保持し、push/popでの文字列コピーを回避
     std::pmr::vector<std::pmr::wstring> link_urls{ parse_resource.resource() };
 
     // BeginNode 毎にクリア。MakeRun から O(1) で重複 URL を検出する
@@ -130,12 +126,12 @@ struct ParseContext {
         TextRun run;
         run.start = start;
         run.length = length;
-        run.set_bold(current_span.bold);
-        run.set_italic(current_span.italic);
-        run.set_code(current_span.code);
-        run.set_strikethrough(current_span.strikethrough);
-        if (current_span.link_url_index >= 0 && current_node) {
-            const auto& url = link_urls[static_cast<size_t>(current_span.link_url_index)];
+        run.set_bold(static_cast<bool>(bold_count));
+        run.set_italic(static_cast<bool>(italic_count));
+        run.set_code(static_cast<bool>(code_count));
+        run.set_strikethrough(static_cast<bool>(strikethrough_count));
+        if (current_link_url_index >= 0 && current_node) {
+            const auto& url = link_urls[static_cast<size_t>(current_link_url_index)];
             int16_t node_idx;
             if (const auto it = current_node_url_map.find(url); it != current_node_url_map.end()) {
                 node_idx = it->second;
@@ -455,23 +451,22 @@ int OnEnterSpan(MD_SPANTYPE type, void* detail, void* userdata)
     auto* const ctx = static_cast<ParseContext*>(userdata);
 
     ctx->FlushPendingRun();
-    ctx->span_stack.push(ctx->current_span);
 
     switch (type) {
     case MD_SPAN_STRONG:
-        ctx->current_span.bold = true;
+        ++ctx->bold_count;
         ctx->paragraph_has_other_content = true;
         break;
     case MD_SPAN_EM:
-        ctx->current_span.italic = true;
+        ++ctx->italic_count;
         ctx->paragraph_has_other_content = true;
         break;
     case MD_SPAN_CODE:
-        ctx->current_span.code = true;
+        ++ctx->code_count;
         ctx->paragraph_has_other_content = true;
         break;
     case MD_SPAN_DEL:
-        ctx->current_span.strikethrough = true;
+        ++ctx->strikethrough_count;
         ctx->paragraph_has_other_content = true;
         break;
     case MD_SPAN_A: {
@@ -479,7 +474,7 @@ int OnEnterSpan(MD_SPANTYPE type, void* detail, void* userdata)
         if (a->href.text && a->href.size > 0) {
             ctx->link_urls.emplace_back();
             ctx->link_urls.back().assign(a->href.text, static_cast<size_t>(a->href.size));
-            ctx->current_span.link_url_index = static_cast<int>(ctx->link_urls.size()) - 1;
+            ctx->current_link_url_index = static_cast<int>(ctx->link_urls.size()) - 1;
         }
         ctx->paragraph_has_other_content = true;
         break;
@@ -522,24 +517,39 @@ int OnLeaveSpan(MD_SPANTYPE type, void* /*detail*/, void* userdata)
 
     ctx->FlushPendingRun();
 
-    if (type == MD_SPAN_IMG) {
+    // md4c は enter/leave が常にバランスする契約なのでアンダーフローは起きない。
+    switch (type) {
+    case MD_SPAN_STRONG:
+        --ctx->bold_count;
+        break;
+    case MD_SPAN_EM:
+        --ctx->italic_count;
+        break;
+    case MD_SPAN_CODE:
+        --ctx->code_count;
+        break;
+    case MD_SPAN_DEL:
+        --ctx->strikethrough_count;
+        break;
+    case MD_SPAN_A:
+        ctx->current_link_url_index = -1;
+        break;
+    case MD_SPAN_IMG:
         if (auto* cn = ctx->current_node; cn && !ctx->pending_image_src.empty()) {
             cn->ensure_image()->src = std::move(ctx->pending_image_src);
         }
         ctx->pending_image_src.clear();
-    }
-    else if (type == MD_SPAN_LATEXMATH_DISPLAY) {
+        break;
+    case MD_SPAN_LATEXMATH_DISPLAY:
         ctx->in_display_math = false;
         ctx->AppendWide(L"$$");
         ctx->paragraph_display_math_count++;
-    }
-    else if (type == MD_SPAN_LATEXMATH) {
+        break;
+    case MD_SPAN_LATEXMATH:
         ctx->AppendWide(L"$");
-    }
-
-    if (!ctx->span_stack.empty()) {
-        ctx->current_span = ctx->span_stack.top();
-        ctx->span_stack.pop();
+        break;
+    default:
+        break;
     }
 
     return 0;


### PR DESCRIPTION
## Summary

- md4c 公式 wiki ([Embedding-Parser:-Calling-MD4C](https://github.com/mity/md4c/wiki/Embedding-Parser:-Calling-MD4C)) で推奨されている **span はカウンタ方式** に従い、`SpanState` 構造体 + `std::stack<SpanState, pmr::deque>` を撤廃
- `bold_count` / `italic_count` / `code_count` / `strikethrough_count` (各 `uint8_t`) と `current_link_url_index` (`int`, -1 = リンク外) に置換
- span enter/leave 毎の 16B 構造体コピー + `pmr::deque` チャンク確保が消失。md4c コールバック (大規模 md で数千〜数万回) のオーバーヘッドを削減
- `example/nested.md` を追加: blockquote / list のネスト表示を GitHub レンダリングと比較するための検証用サンプル (本 PR とは独立に、別 PR でレンダリング差分を修正する用途)

## 設計メモ

- md4c は enter/leave が常にバランスする契約のためアンダーフローガードは不要 → 単純デクリメント
- CommonMark で link はネスト不可のため `current_link_url_index` のみ単純フィールド (リーブで -1 戻し)
- `blockquote_group_stack` / `list_counter` は **触らず**: それぞれ「インスタンス ID の保存・復元」「親リスト番号の継続」が必要で、単純カウンタ化では機能を満たせないため

## Test plan

- [x] `cmake --build build --config Release` 成功
- [x] `mendo_tests.exe` 全 2035 テスト PASS
- [x] `example/nested.md` を mendo / GitHub 双方で表示確認 (発見されたレンダリング差分は別 PR で対応)

🤖 Generated with [Claude Code](https://claude.com/claude-code)