### PR TITLE
fix: ネスト blockquote の左バー連続描画と Alert 伝播

### DIFF
--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -105,13 +105,15 @@ struct Node {
     int list_number = 0;      // 0 = 順序なし, >0 = 順序付きリスト番号
     uint32_t alert_label_length = 0; // ラベル部分の文字数（描画エフェクト適用範囲）
     uint32_t source_offset = UINT32_MAX; // ソース wide テキスト内の UTF-16 コード単位オフセット（未設定時UINT32_MAX）
-    int blockquote_group = -1;       // 同一 MD_BLOCK_QUOTE 内のノードを識別するグループID
+    int blockquote_group = -1;       // 最外側 blockquote 単位のグループID（ネストしてもgroupは共有）
     int line_count = 0;              // テキスト内の改行数（パース時にカウント済み）
 
     NodeType type = NodeType::Paragraph;
     bool task_checked = false;
     AlertType alert_type = AlertType::None;
     SyntaxLanguage code_language = SyntaxLanguage::None;
+    int8_t quote_depth = 0;          // 現在の blockquote ネスト深さ（0 = 引用外, 1.. = ネストレベル）
+    int8_t quote_outer_indent = 0;   // 最外側 blockquote が居る indent_level（バー位置の起点）
 
     bool HasText() const noexcept { return !text_.empty(); }
 

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -101,15 +101,11 @@ struct ParseContext {
             current_node->SetTextWithLineCount(std::move(current_text), current_node->line_count);
         }
         // move 後 / 元から空 のいずれの経路でも、次ノード用に空状態へ揃える。
-        // monotonic resource なので clear() に追加コストはない。
         current_text.clear();
     }
 
     void BeginNode(NodeType type)
     {
-        // タイトリストではP blockのEnter/Leaveコールバックがスキップされるため、
-        // サブリスト開始時に蓄積テキストが未フラッシュのまま残る場合がある。
-        // 新しいノード作成前に確定させて、現在のノードにテキストを書き込む。
         FinalizeCurrentNode();
         nodes.emplace_back();
         current_node = &nodes.back();
@@ -118,8 +114,6 @@ struct ParseContext {
         current_node->indent_level = indent_level;
         if (blockquote_depth > 0) {
             current_node->blockquote_group = current_blockquote_group;
-            // INT8_MAX (127) でクランプ。実用 Markdown でこの深さに達することは無いが、
-            // 巨大入力での符号付きオーバーフローによる負数化（→描画スキップ）を防ぐ。
             current_node->quote_depth = static_cast<int8_t>(std::min(blockquote_depth, static_cast<int>(INT8_MAX)));
             current_node->quote_outer_indent = static_cast<int8_t>(std::min(outermost_quote_indent, static_cast<int>(INT8_MAX)));
         }

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -118,8 +118,10 @@ struct ParseContext {
         current_node->indent_level = indent_level;
         if (blockquote_depth > 0) {
             current_node->blockquote_group = current_blockquote_group;
-            current_node->quote_depth = static_cast<int8_t>(blockquote_depth);
-            current_node->quote_outer_indent = static_cast<int8_t>(outermost_quote_indent);
+            // INT8_MAX (127) でクランプ。実用 Markdown でこの深さに達することは無いが、
+            // 巨大入力での符号付きオーバーフローによる負数化（→描画スキップ）を防ぐ。
+            current_node->quote_depth = static_cast<int8_t>(std::min(blockquote_depth, static_cast<int>(INT8_MAX)));
+            current_node->quote_outer_indent = static_cast<int8_t>(std::min(outermost_quote_indent, static_cast<int>(INT8_MAX)));
         }
         current_node_url_map.clear();
     }
@@ -813,6 +815,11 @@ void DetectAlertAt(std::pmr::vector<Node>& nodes, size_t i)
     }
     auto& node = nodes[i];
     if (node.type != NodeType::BlockQuote || node.alert_type != AlertType::None) {
+        return;
+    }
+    // GitHub 仕様: Alert は最外側 blockquote (quote_depth==1) でのみ認識する。
+    // ネスト内 (`> > [!NOTE]`) は通常の引用として扱う。
+    if (node.quote_depth != 1) {
         return;
     }
     size_t marker_end = 0;

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -57,7 +57,8 @@ struct ParseContext {
     bool in_code_block = false;
     int blockquote_depth = 0;
     int blockquote_group_counter = 0;           // グループID生成用
-    std::stack<int, std::pmr::deque<int>> blockquote_group_stack{ std::pmr::deque<int>{ parse_resource.resource() } }; // ネスト追跡用
+    int current_blockquote_group = -1;          // 最外側 blockquote の group ID（ネスト中は共有）
+    int outermost_quote_indent = 0;             // 最外側 blockquote 進入時の indent_level（描画時のバー起点）
 
     // リスト追跡
     std::stack<int, std::pmr::deque<int>> list_counter{ std::pmr::deque<int>{ parse_resource.resource() } }; // 0 = 順序なしリスト, >0 = 順序ありリストのカウンター
@@ -115,8 +116,10 @@ struct ParseContext {
         current_node->type = type;
         current_node_index = nodes.size() - 1;
         current_node->indent_level = indent_level;
-        if (blockquote_depth > 0 && !blockquote_group_stack.empty()) {
-            current_node->blockquote_group = blockquote_group_stack.top();
+        if (blockquote_depth > 0) {
+            current_node->blockquote_group = current_blockquote_group;
+            current_node->quote_depth = static_cast<int8_t>(blockquote_depth);
+            current_node->quote_outer_indent = static_cast<int8_t>(outermost_quote_indent);
         }
         current_node_url_map.clear();
     }
@@ -266,9 +269,12 @@ int OnEnterBlock(MD_BLOCKTYPE type, void* detail, void* userdata)
     }
 
     case MD_BLOCK_QUOTE:
+        if (ctx->blockquote_depth == 0) {
+            ctx->current_blockquote_group = ++ctx->blockquote_group_counter;
+            ctx->outermost_quote_indent = ctx->indent_level + 1;
+        }
         ctx->blockquote_depth++;
         ctx->indent_level++;
-        ctx->blockquote_group_stack.push(++ctx->blockquote_group_counter);
         break;
 
     case MD_BLOCK_UL:
@@ -379,8 +385,9 @@ int OnLeaveBlock(MD_BLOCKTYPE type, void* /*detail*/, void* userdata)
         if (ctx->indent_level > 0) {
             ctx->indent_level--;
         }
-        if (!ctx->blockquote_group_stack.empty()) {
-            ctx->blockquote_group_stack.pop();
+        if (ctx->blockquote_depth == 0) {
+            ctx->current_blockquote_group = -1;
+            ctx->outermost_quote_indent = 0;
         }
         break;
 

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -385,14 +385,11 @@ void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds,
             break;
         }
 
-        // グループの範囲を特定
         const float group_top = cache[i].y_position;
         float group_bottom = cache[i].y_position + cache[i].height;
         const AlertType alert_type = nodes[i].alert_type;
-        int bar_indent = -1;
-        if (nodes[i].type == NodeType::BlockQuote) {
-            bar_indent = nodes[i].indent_level;
-        }
+        const int outer_indent = nodes[i].quote_outer_indent;
+        int max_depth = nodes[i].quote_depth;
 
         int j = i + 1;
         while (j < node_count && nodes[j].blockquote_group == group) {
@@ -400,50 +397,76 @@ void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds,
             if (bottom > group_bottom) {
                 group_bottom = bottom;
             }
-            if (bar_indent < 0 && nodes[j].type == NodeType::BlockQuote) {
-                bar_indent = nodes[j].indent_level;
+            if (nodes[j].quote_depth > max_depth) {
+                max_depth = nodes[j].quote_depth;
             }
             j++;
             // ビューポート外に大きく超えたグループ末尾の走査を打ち切る。
             // バーや背景はクリップ領域で切られるため、描画結果に影響しない。
             if (group_bottom > viewport_bottom) {
-                // グループ末尾までスキップ
                 while (j < node_count && nodes[j].blockquote_group == group) {
+                    if (nodes[j].quote_depth > max_depth) {
+                        max_depth = nodes[j].quote_depth;
+                    }
                     j++;
                 }
                 break;
             }
         }
 
-        if (bar_indent < 0) {
-            // BlockQuote ノードがないグループはスキップ
+        if (max_depth <= 0 || outer_indent <= 0) {
             i = j;
             continue;
         }
 
-        const float indent = static_cast<float>(bar_indent) * theme_->indent_width;
-        const float x = offset_x + indent;
-        const float bar_x = x - theme_->indent_width * 0.5f;
-
+        const float outer_x_indent = static_cast<float>(outer_indent) * theme_->indent_width;
+        const float outer_x = offset_x + outer_x_indent;
         if (alert_type != AlertType::None) {
             const auto idx = AlertColorIndex(alert_type);
             if (idx < ALERT_TYPE_COUNT) {
-                const float cw = content_width - indent;
+                const float cw = content_width - outer_x_indent;
                 const D2D1_RECT_F bg_rect = D2D1::RectF(
-                    x - ALERT_BG_PAD, group_top - ALERT_BG_PAD,
-                    x + cw, group_bottom + ALERT_BG_PAD);
+                    outer_x - ALERT_BG_PAD, group_top - ALERT_BG_PAD,
+                    outer_x + cw, group_bottom + ALERT_BG_PAD);
                 cmds.emplace_back(FillRoundedRectCmd{ bg_rect, ALERT_BG_CORNER, ALERT_BG_CORNER, theme_->alert_bg_color[idx] });
-                cmds.emplace_back(DrawLineCmd{
-                    D2D1::Point2F(bar_x, group_top - BAR_EXTEND),
-                    D2D1::Point2F(bar_x, group_bottom + BAR_EXTEND),
-                    theme_->alert_color[idx], theme_->blockquote_bar_width });
             }
         }
-        else {
-            cmds.emplace_back(DrawLineCmd{
-                D2D1::Point2F(bar_x, group_top - BAR_EXTEND),
-                D2D1::Point2F(bar_x, group_bottom + BAR_EXTEND),
-                theme_->blockquote_bar_color, theme_->blockquote_bar_width });
+
+        // GitHub と同様に、外側のバーはネストした範囲を貫通して連続描画する。
+        // 各 level ごとに quote_depth >= level の連続区間を求めてバーを発行。
+        for (int level = 1; level <= max_depth; ++level) {
+            const float bar_indent_x = static_cast<float>(outer_indent + level - 1) * theme_->indent_width;
+            const float bar_x = offset_x + bar_indent_x - theme_->indent_width * 0.5f;
+            const D2D1_COLOR_F bar_color = (level == 1 && alert_type != AlertType::None)
+                ? theme_->alert_color[AlertColorIndex(alert_type)]
+                : theme_->blockquote_bar_color;
+
+            const auto emit_bar = [&](float top, float bottom) {
+                cmds.emplace_back(DrawLineCmd{
+                    D2D1::Point2F(bar_x, top - BAR_EXTEND),
+                    D2D1::Point2F(bar_x, bottom + BAR_EXTEND),
+                    bar_color, theme_->blockquote_bar_width });
+            };
+
+            bool in_region = false;
+            float region_top = 0.0f;
+            float region_bottom = 0.0f;
+            for (int k = i; k < j; ++k) {
+                if (nodes[k].quote_depth >= level) {
+                    if (!in_region) {
+                        in_region = true;
+                        region_top = cache[k].y_position;
+                    }
+                    region_bottom = cache[k].y_position + cache[k].height;
+                }
+                else if (in_region) {
+                    emit_bar(region_top, region_bottom);
+                    in_region = false;
+                }
+            }
+            if (in_region) {
+                emit_bar(region_top, region_bottom);
+            }
         }
 
         i = j;

--- a/tests/test_command_generator_content.cpp
+++ b/tests/test_command_generator_content.cpp
@@ -6,6 +6,8 @@
 #include "cmd_gen_mock_test_base.h"
 #include "test_helpers.h"
 #include <algorithm>
+#include <map>
+#include <set>
 #include <variant>
 
 namespace {
@@ -93,6 +95,66 @@ TEST_F(CmdGenContentTest, BlockQuote_FullyAboveViewport_NoBar)
         return std::holds_alternative<DrawLineCmd>(c);
     });
     EXPECT_EQ(bar_lines, 0) << "viewport より上にあるグループは bar が描画されない";
+}
+
+// ネスト blockquote の各レベルを別 x 座標のバーで描画する (PR #156)
+TEST_F(CmdGenContentTest, NestedBlockQuote_EmitsBarPerLevel)
+{
+    Parse("> outer\n> > inner");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
+
+    std::set<float> bar_x_positions;
+    for (const auto& c : cmds) {
+        if (auto* l = std::get_if<DrawLineCmd>(&c)) {
+            if (l->stroke_width == theme_.blockquote_bar_width
+                && ColorEq(l->color, theme_.blockquote_bar_color)) {
+                bar_x_positions.insert(l->p0.x);
+            }
+        }
+    }
+    EXPECT_GE(bar_x_positions.size(), 2u)
+        << "2 段ネストではレベルごとに別 x 座標のバーが出る";
+}
+
+// 外→内→外の連続描画: 外側 (level=1) はネストを貫通して 1 本のバーになる
+TEST_F(CmdGenContentTest, NestedBlockQuote_OuterBarSpansAcrossInnerNesting)
+{
+    Parse("> outer\n> > inner\n>\n> back to outer");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
+
+    std::map<float, int> count_by_x;
+    for (const auto& c : cmds) {
+        if (auto* l = std::get_if<DrawLineCmd>(&c)) {
+            if (l->stroke_width == theme_.blockquote_bar_width
+                && ColorEq(l->color, theme_.blockquote_bar_color)) {
+                count_by_x[l->p0.x]++;
+            }
+        }
+    }
+    ASSERT_GE(count_by_x.size(), 2u);
+    // 最も左の x 座標が level=1 (外側) のバー。連続描画されているなら 1 本のみ。
+    EXPECT_EQ(count_by_x.begin()->second, 1)
+        << "外側バーはネストを貫通して 1 本連続描画される";
+}
+
+// Alert ネスト + 後段: 最外側バーは Alert 色で描画される
+TEST_F(CmdGenContentTest, AlertWithNested_OuterBarUsesAlertColor)
+{
+    Parse("> [!NOTE]\n> Alert head\n> > inner\n>\n> Alert continues");
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
+    auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
+
+    const auto note_color = theme_.alert_color[AlertColorIndex(AlertType::Note)];
+    const bool has_alert_bar = std::ranges::any_of(cmds, [&](const auto& c) {
+        if (auto* l = std::get_if<DrawLineCmd>(&c)) {
+            return ColorEq(l->color, note_color);
+        }
+        return false;
+    });
+    EXPECT_TRUE(has_alert_bar)
+        << "ネストありの Alert でも最外側バーは Note 色で描画される";
 }
 
 // ---- HorizontalRule カリング: 上方向 ----

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -246,6 +246,50 @@ TEST(Parser, SingleBlockquoteIsBlockQuoteType)
     EXPECT_EQ(nodes[0].GetText(), L"quoted text");
 }
 
+// ネスト blockquote の group/quote_depth 設計回帰防止
+// (PR #156 で blockquote_group をネスト中も最外側で共有する設計に変更)
+
+TEST(Parser, NestedBlockquote_SharesSameGroup)
+{
+    auto nodes = ParseMarkdown("> outer\n>\n> > inner\n>\n> still outer").nodes;
+    ASSERT_GE(nodes.size(), 3u);
+    const int group = nodes[0].blockquote_group;
+    EXPECT_GE(group, 0);
+    for (const auto& n : nodes) {
+        if (n.type == NodeType::BlockQuote) {
+            EXPECT_EQ(n.blockquote_group, group)
+                << "ネストの内外を問わず最外側 group を共有する";
+        }
+    }
+}
+
+TEST(Parser, NestedBlockquote_QuoteDepthReflectsNesting)
+{
+    auto nodes = ParseMarkdown("> outer\n> > inner\n> > > deep").nodes;
+    int max_depth = 0;
+    for (const auto& n : nodes) {
+        if (n.type == NodeType::BlockQuote && n.quote_depth > max_depth) {
+            max_depth = n.quote_depth;
+        }
+    }
+    EXPECT_EQ(max_depth, 3) << "3 段ネストの最大 quote_depth は 3";
+}
+
+TEST(Parser, NestedBlockquote_OuterReturnAfterInnerKeepsDepthOne)
+{
+    // 内側 quote の終了は空行 `>` が必要 (md4c の lazy continuation 挙動)
+    auto nodes = ParseMarkdown("> outer\n> > inner\n>\n> back to outer").nodes;
+    bool checked = false;
+    for (const auto& n : nodes) {
+        if (n.GetText().find(L"back to outer") != std::wstring::npos) {
+            EXPECT_EQ(n.quote_depth, 1)
+                << "ネストを抜けて外側に戻ったノードは quote_depth=1";
+            checked = true;
+        }
+    }
+    EXPECT_TRUE(checked);
+}
+
 // ---- バグ #11: Unicode追加面のエンティティ ----
 
 TEST(Parser, HtmlEntitySupplementaryPlane)
@@ -1149,6 +1193,44 @@ TEST(Parser, AlertFollowedByRegularBlockquote)
     }
     EXPECT_TRUE(has_alert);
     EXPECT_TRUE(has_normal);
+}
+
+// ネストを跨いだ Alert 伝播 (PR #156)
+
+TEST(Parser, Alert_PropagatesAcrossNestedBlockquote)
+{
+    // example/nested.md #9 相当: 親 -> ネスト -> 親の続き
+    auto nodes = ParseMarkdown(
+        "> [!NOTE]\n"
+        "> Alert head\n"
+        "> > nested\n"
+        ">\n"
+        "> Alert continues"
+    ).nodes;
+    bool checked_continuation = false;
+    for (const auto& n : nodes) {
+        if (n.GetText().find(L"Alert continues") != std::wstring::npos) {
+            EXPECT_EQ(n.alert_type, AlertType::Note)
+                << "ネストを抜けた後段でも Alert が継続する";
+            checked_continuation = true;
+        }
+    }
+    EXPECT_TRUE(checked_continuation);
+}
+
+TEST(Parser, Alert_IgnoredWhenStartedInsideNestedBlockquote)
+{
+    // GitHub 仕様: ネスト内 (`> > [!NOTE]`) の Alert マーカーは認識しない
+    auto nodes = ParseMarkdown(
+        "> outer\n"
+        "> > [!NOTE]\n"
+        "> > inner note text"
+    ).nodes;
+    for (const auto& n : nodes) {
+        EXPECT_EQ(n.alert_type, AlertType::None)
+            << "ネスト内の Alert マーカーは無効化される";
+        EXPECT_EQ(n.alert_label_length, 0u);
+    }
 }
 
 TEST(Parser, AlertUnknownTypeIgnored)


### PR DESCRIPTION
## Summary
- `example/nested.md` の No.1〜No.3 のような多段ネスト blockquote で、外側のバーがネストした内側の左を貫通せず空白になっていた問題を修正。GitHub と同じく外側ラインがネスト範囲全体を貫通して描画されるようにした。
- `example/nested.md` の No.9 のような Alert blockquote で、ネストから抜けた後段に Alert スタイルが伝播しない問題を修正。

## Changes
- `Node` に `quote_depth` / `quote_outer_indent` (`int8_t`) を追加
- `blockquote_group_stack` を廃止し、ネスト中も最外側の `blockquote_group` を共有する設計に変更
- `GenBlockQuoteGroupDecorations` を、グループ内の各 quote level ごとに `quote_depth >= level` の連続区間でバーを描画するロジックに書き換え
- Alert は最外側 (level=1) のバー・背景にのみ適用、内側 (level>=2) は通常の灰色バー（GitHub の挙動）

## 既知の制限
- リストと blockquote が混在する `example/nested.md` の No.8 のようなケースでは、内側 quote のバー位置は等差仮定で計算されるため多少ずれる可能性がある（修正前から完全には正しくなかったケース）。完全対応には Node に各 level の indent 配列を持たせる必要があり、メモリ増のトレードオフがあるため別 PR で検討。

## Test plan
- [x] `cmake --build build --config Release` 成功
- [x] `mendo_tests.exe` 全 2035 テスト pass
- [x] `example/nested.md` を mendo で開き、No.1〜No.3 の多段ネスト blockquote の左バーが連続して描画されることを目視確認
- [x] `example/nested.md` の No.9 で Alert がネスト後段にも伝播することを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)