### PR TITLE
refactor: 型サイズ縮小と constexpr 化、センチネル整理

### DIFF
--- a/src/app/app.h
+++ b/src/app/app.h
@@ -67,7 +67,7 @@ public:
     void OnXButtonForward() { Dispatch(NavigateForwardAction{}); }
 
     // ファイル変更イベント（メッセージループから呼ばれる）
-    HANDLE GetFileWatchEvent() const noexcept { return doc_service_.GetFileWatchEvent(); }
+    constexpr HANDLE GetFileWatchEvent() const noexcept { return doc_service_.GetFileWatchEvent(); }
     void OnFileWatchEvent();
 
     // タイマーコールバック
@@ -84,14 +84,14 @@ public:
     void OnSearchClose() { Dispatch(CloseSearchBarAction{}); }
     void OnSearchNext() { Dispatch(SearchNextAction{}); }
     void OnSearchPrev() { Dispatch(SearchPrevAction{}); }
-    bool IsSearchBarVisible() const noexcept { return state_.search.search_state.IsVisible(); }
+    constexpr bool IsSearchBarVisible() const noexcept { return state_.search.search_state.IsVisible(); }
     void OnToggleCaseSensitive() { Dispatch(ToggleCaseSensitiveAction{}); }
     void OnToggleHighlight() { Dispatch(ToggleHighlightAction{}); }
     void SetSearchSelection(int sel_start, int sel_end) { Dispatch(SearchSelectionAction{ sel_start, sel_end }); }
     void SetImeComposition(std::pmr::wstring comp) { Dispatch(ImeCompositionAction{ std::move(comp) }); }
     RECT GetSearchEditRect();
 
-    void SetPendingRestoreNode(int node, int offset) noexcept
+    constexpr void SetPendingRestoreNode(int node, int offset) noexcept
     {
         state_.view.scroll_restore.SetNodeRestore(node, offset);
     }
@@ -107,7 +107,7 @@ public:
     constexpr float GetDpiScale() const noexcept { return state_.window.cached_dpi_scale; }
 
     // カスタムタイトルバー
-    float GetTitleBarHeightDip() const noexcept { return state_.window.titlebar.GetHeight(); }
+    constexpr float GetTitleBarHeightDip() const noexcept { return state_.window.titlebar.GetHeight(); }
     TitleBarHitZone TitleBarHitTest(float dip_x, float dip_y) const noexcept { return state_.window.titlebar.HitTest(dip_x, dip_y); }
     bool IsOverMdScrollbar(float dip_x, float dip_y);
     bool IsOverMdScrollbar(float dip_x, float dip_y, const ::PaneLayout& layout) const noexcept;

--- a/src/app/app_events.h
+++ b/src/app/app_events.h
@@ -35,7 +35,7 @@ struct MouseWheelEvent {
 
 // ──── アクション: コマンド系 (アプリが実行すべき操作) ────
 
-enum class ScrollType {
+enum class ScrollType : uint8_t {
     LineUp,
     LineDown,
     PageUp,
@@ -66,7 +66,7 @@ struct SelectAllAction {};
 struct ClearSelectionAction {};
 
 // サイドペインの切り替え
-enum class PaneTarget {
+enum class PaneTarget : uint8_t {
     File,
     Toc
 };
@@ -92,7 +92,7 @@ constexpr PaneZone ToPaneZone(PaneTarget target) noexcept
 }
 
 // ズーム操作
-enum class ZoomDirection {
+enum class ZoomDirection : uint8_t {
     In,
     Out,
     Reset

--- a/src/app/app_mouse_click.cpp
+++ b/src/app/app_mouse_click.cpp
@@ -132,10 +132,10 @@ void App::HandleFilePaneClick(float dip_x, float dip_y, const PaneLayout& layout
     const int idx = state_.file_explorer.HitTest(local_y, theme.pane_item_height);
     if (idx >= 0 && idx < static_cast<int>(state_.file_explorer.GetEntries().size())) {
         const auto& file_entry = state_.file_explorer.GetEntries()[idx];
-        if (file_entry.is_directory) {
+        if (file_entry.is_directory()) {
             Dispatch(FilePaneDirectoryClickedAction{ file_entry.full_path });
         }
-        else if (!file_entry.is_current) {
+        else if (!file_entry.is_current()) {
             if (GetFileAttributesW(file_entry.full_path.c_str()) == INVALID_FILE_ATTRIBUTES) {
                 RefreshFilePane();
                 ShowToast(i18n::S().toast_file_not_found);

--- a/src/app/app_mouse_helpers.h
+++ b/src/app/app_mouse_helpers.h
@@ -20,7 +20,7 @@ concept PaneButtonRectFn =
 // ペインヘッダー内のボタンがクリックされたか判定する。
 template <auto ButtonRectFn>
     requires PaneButtonRectFn<ButtonRectFn>
-bool HitPaneHeaderButton(float dip_x, float dip_y, const PaneRect& rect, float header_height)
+constexpr bool HitPaneHeaderButton(float dip_x, float dip_y, const PaneRect& rect, float header_height)
 {
     const float local_x = dip_x - rect.x;
     const float local_y = dip_y - rect.y;
@@ -31,7 +31,7 @@ bool HitPaneHeaderButton(float dip_x, float dip_y, const PaneRect& rect, float h
 }
 
 // タイトルバーボタンに対応するツールチップを返す。
-inline TooltipTarget BuildTitleBarTooltip(TitleBarHitZone zone, bool is_maximized) noexcept
+constexpr TooltipTarget BuildTitleBarTooltip(TitleBarHitZone zone, bool is_maximized) noexcept
 {
     const auto& ls = i18n::S();
     switch (zone) {
@@ -49,7 +49,7 @@ inline TooltipTarget BuildTitleBarTooltip(TitleBarHitZone zone, bool is_maximize
 }
 
 // 検索バーのボタンに対応するツールチップを返す。
-inline TooltipTarget BuildSearchBarTooltip(SearchBarHitZone zone) noexcept
+constexpr TooltipTarget BuildSearchBarTooltip(SearchBarHitZone zone) noexcept
 {
     const auto& ls = i18n::S();
     switch (zone) {
@@ -63,7 +63,7 @@ inline TooltipTarget BuildSearchBarTooltip(SearchBarHitZone zone) noexcept
 }
 
 // MD ペインのナビゲーションボタンに対応するツールチップを返す。
-inline TooltipTarget BuildNavButtonTooltip(NavButtonHover hit) noexcept
+constexpr TooltipTarget BuildNavButtonTooltip(NavButtonHover hit) noexcept
 {
     const auto& ls = i18n::S();
     switch (hit) {

--- a/src/app/app_navigate.cpp
+++ b/src/app/app_navigate.cpp
@@ -58,7 +58,7 @@ void App::HandleApplyThemeChange(const effect::ApplyThemeChange& e)
 {
     if (e.type == effect::ApplyThemeChange::Type::Zoom) {
         const Theme base = theme_service_.CreateTheme();
-        renderer_.ApplyZoomFromBase(base, e.new_zoom);
+        renderer_.ApplyZoomFromBase(base, ZOOM_STEPS[e.zoom_index]);
         FinishThemeOrZoomChange();
         UpdateTitleBar();
         theme_service_.SaveZoomLevel(e.zoom_index);

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -244,23 +244,26 @@ void ReduceCopyFormattedClipboard(const AppState& state, SideEffectList& effects
 
 void ReduceZoom(AppState& state, SideEffectList& effects, const ZoomAction& a)
 {
-    float new_zoom = 0.0f;
-    switch (a.direction) {
-    case ZoomDirection::In:
-        new_zoom = state.view.viewport.ZoomIn();
-        break;
-    case ZoomDirection::Out:
-        new_zoom = state.view.viewport.ZoomOut();
-        break;
-    case ZoomDirection::Reset:
-        new_zoom = state.view.viewport.ZoomReset();
-        break;
-    }
-    if (new_zoom <= 0.0f) {
-        return;
+    {
+        bool changed = false;
+        switch (a.direction) {
+        case ZoomDirection::In:
+            changed = state.view.viewport.ZoomIn();
+            break;
+        case ZoomDirection::Out:
+            changed = state.view.viewport.ZoomOut();
+            break;
+        case ZoomDirection::Reset:
+            changed = state.view.viewport.ZoomReset();
+            break;
+        }
+        if (!changed) {
+            return;
+        }
     }
     const auto anchor = SnapshotVisibleTarget(state);
     state.pane_layout_valid = false;
+    const float new_zoom = state.view.viewport.GetCurrentZoom();
     const float zoom_ratio = new_zoom / state.window.cached_theme.zoom;
     state.view.panes.ApplyZoom(zoom_ratio);
     state.document.layout_cache.InvalidateAllLayouts();
@@ -270,8 +273,7 @@ void ReduceZoom(AppState& state, SideEffectList& effects, const ZoomAction& a)
     }
     PushEffect(effects, effect::ApplyThemeChange{
         .type = effect::ApplyThemeChange::Type::Zoom,
-        .new_zoom = new_zoom,
-        .zoom_index = state.view.viewport.GetZoomIndex(),
+        .zoom_index = static_cast<uint8_t>(state.view.viewport.GetZoomIndex()),
         });
 }
 
@@ -287,8 +289,7 @@ void ReduceToggleDarkMode(AppState& state, SideEffectList& effects)
     }
     PushEffect(effects, effect::ApplyThemeChange{
         .type = effect::ApplyThemeChange::Type::DarkMode,
-        .new_zoom = 0.0f,
-        .zoom_index = state.view.viewport.GetZoomIndex(),
+        .zoom_index = static_cast<uint8_t>(state.view.viewport.GetZoomIndex()),
         });
 }
 

--- a/src/app/render_composer.cpp
+++ b/src/app/render_composer.cpp
@@ -50,6 +50,7 @@ TitleBarRenderState BuildTitleBarState(const AppState& state,
     tb.icon_rect = state.window.titlebar.GetIconRect();
     tb.title_text_rect = state.window.titlebar.GetTitleTextRect();
     tb.title_text = state.cached_title_text;
+    tb.hovered_zone = state.window.titlebar.GetHovered();
     tb.is_dark_mode = is_dark_mode;
     tb.search_active = state.search.search_state.IsVisible();
     tb.file_pane_visible = state.view.panes.IsFilePaneVisible();

--- a/src/app/side_effect.h
+++ b/src/app/side_effect.h
@@ -19,7 +19,7 @@ struct InvalidateWindow {};
 struct InvalidateTitleBar {};
 struct SetCapture {};
 struct ReleaseCapture {};
-enum class CursorType { Arrow, Hand, IBeam, SizeWE };
+enum class CursorType : uint8_t { Arrow, Hand, IBeam, SizeWE };
 struct SetCursor { CursorType type; };
 struct ClipboardWrite { std::pmr::wstring text; };
 struct ClipboardWriteHtml { std::pmr::wstring html; std::pmr::wstring plain; };
@@ -35,10 +35,9 @@ struct SetWindowTitle { std::pmr::wstring title; };
 struct SetWindowPosition { int x; int y; int cx; int cy; };
 struct ApplyDarkMode { bool dark; };
 struct ApplyThemeChange {
-    enum class Type { Zoom, DarkMode };
+    enum class Type : uint8_t { Zoom, DarkMode };
     Type type;
-    float new_zoom;
-    int zoom_index;
+    uint8_t zoom_index;  // Zoom 値は ZOOM_STEPS[zoom_index] で復元する。
 };
 struct PerformResizeEnd {};
 struct PerformSizingUpdate {};

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -24,7 +24,7 @@ public:
     constexpr const TableOfContents& GetToc() const noexcept { return toc_; }
     constexpr bool IsEmpty() const noexcept { return nodes_.empty(); }
     // パース入力の wide テキストへの参照。AnalyzeReloadDiff の比較用。
-    const std::pmr::wstring& GetRawText() const noexcept { return raw_wide_; }
+    constexpr const std::pmr::wstring& GetRawText() const noexcept { return raw_wide_; }
     // 元ファイル(UTF-8)バイト数。エディタの中間書き込み検出（IsFileLargerThan）で参照する。
     constexpr size_t GetLoadedByteSize() const noexcept { return loaded_byte_size_; }
     std::pmr::wstring GetDirectory() const;

--- a/src/core/document_service.h
+++ b/src/core/document_service.h
@@ -13,7 +13,7 @@ public:
     void StopWatching() noexcept;
     void CheckForChanges();
     void ResumeWatching();
-    HANDLE GetFileWatchEvent() const noexcept { return watcher_.GetEventHandle(); }
+    constexpr HANDLE GetFileWatchEvent() const noexcept { return watcher_.GetEventHandle(); }
 
     static bool NeedsAsyncLoad(const std::pmr::wstring& path) noexcept;
     static bool NeedsLoadingAnimation(const std::pmr::wstring& path) noexcept;

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -2,6 +2,7 @@
 #include <string>
 #include <vector>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <memory_resource>
 #include <algorithm>
@@ -87,6 +88,10 @@ struct NodeImageData {
     float height = 0.0f;       // 元画像の高さ（ピクセル）
 };
 
+// Node::source_offset が未設定であることを示すセンチネル値。
+// HorizontalRule のようなテキストを持たないノードはオフセットを記録しない。
+inline constexpr uint32_t kUnsetSourceOffset = std::numeric_limits<uint32_t>::max();
+
 struct Node {
     std::pmr::vector<TextRun> runs;
 
@@ -100,34 +105,36 @@ struct Node {
     using Extra = std::variant<std::monostate, NodeTableData, NodeImageData, NodeHeadingData, NodeCodeData>;
     Extra extra;
 
-    int heading_level = 0;
-    int indent_level = 0;
-    int list_number = 0;      // 0 = 順序なし, >0 = 順序付きリスト番号
-    uint32_t alert_label_length = 0; // ラベル部分の文字数（描画エフェクト適用範囲）
-    uint32_t source_offset = UINT32_MAX; // ソース wide テキスト内の UTF-16 コード単位オフセット（未設定時UINT32_MAX）
-    int blockquote_group = -1;       // 最外側 blockquote 単位のグループID（ネストしてもgroupは共有）
-    int line_count = 0;              // テキスト内の改行数（パース時にカウント済み）
+    // --- 4 バイトアライメント ---
+    int32_t list_number = 0;             // 0 = 順序なし, >0 = 順序付きリスト番号
+    uint32_t alert_label_length = 0;     // ラベル部分の文字数（描画エフェクト適用範囲）
+    uint32_t source_offset = kUnsetSourceOffset; // ソース wide テキスト内の UTF-16 コード単位オフセット
+    int32_t blockquote_group = -1;       // 最外側 blockquote 単位のグループID（ネストしてもgroupは共有）
+    int32_t line_count = 0;              // テキスト内の改行数（パース時にカウント済み）
 
+    // --- 1 バイトアライメント（8 個ぴったり = 末尾パディング 0、text_ の 8B 境界に乗る）---
     NodeType type = NodeType::Paragraph;
     bool task_checked = false;
     AlertType alert_type = AlertType::None;
     SyntaxLanguage code_language = SyntaxLanguage::None;
     int8_t quote_depth = 0;          // 現在の blockquote ネスト深さ（0 = 引用外, 1.. = ネストレベル）
     int8_t quote_outer_indent = 0;   // 最外側 blockquote が居る indent_level（バー位置の起点）
+    int8_t heading_level = 0;        // 1〜6（0 = 見出しでない）
+    int8_t indent_level = 0;         // リスト/引用のネスト深さ（int8_t の最大値で飽和）
 
-    bool HasText() const noexcept { return !text_.empty(); }
+    constexpr bool HasText() const noexcept { return !text_.empty(); }
 
-    const std::pmr::wstring& GetText() const noexcept { return text_; }
+    constexpr const std::pmr::wstring& GetText() const noexcept { return text_; }
 
-    void SetText(const wchar_t* s) { SetText(std::wstring_view{ s }); }
+    constexpr void SetText(const wchar_t* s) { SetText(std::wstring_view{ s }); }
 
-    void SetText(std::wstring_view s)
+    constexpr void SetText(std::wstring_view s)
     {
         text_.assign(s);
         FinalizeSetText();
     }
 
-    void SetText(std::pmr::wstring&& s) noexcept
+    constexpr void SetText(std::pmr::wstring&& s) noexcept
     {
         text_ = std::move(s);
         FinalizeSetText();
@@ -135,13 +142,13 @@ struct Node {
 
     // text_ と line_count を一括更新する（呼び出し側が積算済みの line_count を渡す）。
     // 改行を逐次カウントしておけるパーサ向けの最適化バリアント。
-    void SetTextWithLineCount(std::wstring_view s, int line_count_value) noexcept
+    constexpr void SetTextWithLineCount(std::wstring_view s, int line_count_value) noexcept
     {
         text_.assign(s);
         line_count = line_count_value;
     }
 
-    void SetTextWithLineCount(std::pmr::wstring&& s, int line_count_value) noexcept
+    constexpr void SetTextWithLineCount(std::pmr::wstring&& s, int line_count_value) noexcept
     {
         text_ = std::move(s);
         line_count = line_count_value;
@@ -149,43 +156,43 @@ struct Node {
 
     // ---- 拡張データへのアクセサ ----
     // get_if 風に *_data() でポインタを返す。所持していなければ nullptr。
-    NodeTableData* table_data() noexcept { return std::get_if<NodeTableData>(&extra); }
-    const NodeTableData* table_data() const noexcept { return std::get_if<NodeTableData>(&extra); }
-    NodeImageData* image_data() noexcept { return std::get_if<NodeImageData>(&extra); }
-    const NodeImageData* image_data() const noexcept { return std::get_if<NodeImageData>(&extra); }
-    NodeHeadingData* heading_data() noexcept { return std::get_if<NodeHeadingData>(&extra); }
-    const NodeHeadingData* heading_data() const noexcept { return std::get_if<NodeHeadingData>(&extra); }
-    NodeCodeData* code_data() noexcept { return std::get_if<NodeCodeData>(&extra); }
-    const NodeCodeData* code_data() const noexcept { return std::get_if<NodeCodeData>(&extra); }
+    constexpr NodeTableData* table_data() noexcept { return std::get_if<NodeTableData>(&extra); }
+    constexpr const NodeTableData* table_data() const noexcept { return std::get_if<NodeTableData>(&extra); }
+    constexpr NodeImageData* image_data() noexcept { return std::get_if<NodeImageData>(&extra); }
+    constexpr const NodeImageData* image_data() const noexcept { return std::get_if<NodeImageData>(&extra); }
+    constexpr NodeHeadingData* heading_data() noexcept { return std::get_if<NodeHeadingData>(&extra); }
+    constexpr const NodeHeadingData* heading_data() const noexcept { return std::get_if<NodeHeadingData>(&extra); }
+    constexpr NodeCodeData* code_data() noexcept { return std::get_if<NodeCodeData>(&extra); }
+    constexpr const NodeCodeData* code_data() const noexcept { return std::get_if<NodeCodeData>(&extra); }
 
-    bool has_table() const noexcept { return std::holds_alternative<NodeTableData>(extra); }
-    bool has_image() const noexcept { return std::holds_alternative<NodeImageData>(extra); }
-    bool has_heading() const noexcept { return std::holds_alternative<NodeHeadingData>(extra); }
-    bool has_code() const noexcept { return std::holds_alternative<NodeCodeData>(extra); }
+    constexpr bool has_table() const noexcept { return std::holds_alternative<NodeTableData>(extra); }
+    constexpr bool has_image() const noexcept { return std::holds_alternative<NodeImageData>(extra); }
+    constexpr bool has_heading() const noexcept { return std::holds_alternative<NodeHeadingData>(extra); }
+    constexpr bool has_code() const noexcept { return std::holds_alternative<NodeCodeData>(extra); }
 
     // ensure_*: 既に同じ型を持っていれば内部参照を、違う型を持っていれば差し替えて新規確保した参照を返す。
-    NodeTableData* ensure_table()
+    constexpr NodeTableData* ensure_table()
     {
         if (!has_table()) {
             return &extra.emplace<NodeTableData>();
         }
         return std::get_if<NodeTableData>(&extra);
     }
-    NodeImageData* ensure_image()
+    constexpr NodeImageData* ensure_image()
     {
         if (!has_image()) {
             return &extra.emplace<NodeImageData>();
         }
         return std::get_if<NodeImageData>(&extra);
     }
-    NodeHeadingData* ensure_heading()
+    constexpr NodeHeadingData* ensure_heading()
     {
         if (!has_heading()) {
             return &extra.emplace<NodeHeadingData>();
         }
         return std::get_if<NodeHeadingData>(&extra);
     }
-    NodeCodeData* ensure_code()
+    constexpr NodeCodeData* ensure_code()
     {
         if (!has_code()) {
             return &extra.emplace<NodeCodeData>();
@@ -193,10 +200,10 @@ struct Node {
         return std::get_if<NodeCodeData>(&extra);
     }
 
-    std::pmr::vector<TableRow>& table_rows() noexcept { return table_data()->rows; }
-    const std::pmr::vector<TableRow>& table_rows() const noexcept { return table_data()->rows; }
+    constexpr std::pmr::vector<TableRow>& table_rows() noexcept { return table_data()->rows; }
+    constexpr const std::pmr::vector<TableRow>& table_rows() const noexcept { return table_data()->rows; }
 
-    std::wstring_view anchor_id() const noexcept
+    constexpr std::wstring_view anchor_id() const noexcept
     {
         const auto* hd = heading_data();
         return hd ? std::wstring_view{ hd->anchor_id } : std::wstring_view{};
@@ -210,15 +217,15 @@ struct Node {
         static const std::pmr::vector<SyntaxToken> empty;
         return empty;
     }
-    std::pmr::vector<SyntaxToken>& syntax_tokens_mut()
+    constexpr std::pmr::vector<SyntaxToken>& syntax_tokens_mut()
     {
         return ensure_code()->syntax_tokens;
     }
 
 private:
-    void FinalizeSetText() noexcept
+    constexpr void FinalizeSetText() noexcept
     {
-        line_count = static_cast<int>(std::ranges::count(text_, L'\n'));
+        line_count = static_cast<int32_t>(std::ranges::count(text_, L'\n'));
     }
 
     std::pmr::wstring text_;    // Wide テキスト

--- a/src/core/document_utils.h
+++ b/src/core/document_utils.h
@@ -32,7 +32,7 @@ bool IsMarkdownFile(std::wstring_view path);
 
 // ヘルプ用仮想パス
 inline constexpr std::wstring_view HELP_PATH = L"mendo://help";
-inline bool IsHelpPath(std::wstring_view path) noexcept { return path == HELP_PATH; }
+inline constexpr bool IsHelpPath(std::wstring_view path) noexcept { return path == HELP_PATH; }
 
 // フルファイルパスからファイル名部分を抽出する。
 // 例: "C:\\dir\\file.md" -> "file.md"

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -22,7 +22,7 @@ namespace {
 
 struct ParseContext {
     // パース用 monotonic リソース（一括確保→一括解放）
-    MonotonicResource parse_resource{ 64 * 1024 };
+    MonotonicResource parse_resource{ 128 * 1024 };
 
     std::pmr::vector<Node> nodes;
 
@@ -30,7 +30,8 @@ struct ParseContext {
     std::pmr::vector<size_t> heading_indices;
     std::pmr::vector<size_t> image_indices;
     std::pmr::vector<size_t> diagram_indices;
-    std::pmr::vector<size_t> blockquote_indices;
+    // DetectAlerts 後に破棄するため parse_resource に載せられる（他 indices は ParseResult 経由で持ち出すので不可）。
+    std::pmr::vector<size_t> blockquote_indices{ parse_resource.resource() };
     size_t current_node_index = 0;
 
     // span ネスト追跡は md4c 推奨のカウンタ方式。enter で +1, leave で -1。
@@ -111,11 +112,12 @@ struct ParseContext {
         current_node = &nodes.back();
         current_node->type = type;
         current_node_index = nodes.size() - 1;
-        current_node->indent_level = indent_level;
+        constexpr int kInt8Max = std::numeric_limits<int8_t>::max();
+        current_node->indent_level = static_cast<int8_t>(std::min(indent_level, kInt8Max));
         if (blockquote_depth > 0) {
             current_node->blockquote_group = current_blockquote_group;
-            current_node->quote_depth = static_cast<int8_t>(std::min(blockquote_depth, static_cast<int>(INT8_MAX)));
-            current_node->quote_outer_indent = static_cast<int8_t>(std::min(outermost_quote_indent, static_cast<int>(INT8_MAX)));
+            current_node->quote_depth = static_cast<int8_t>(std::min(blockquote_depth, kInt8Max));
+            current_node->quote_outer_indent = static_cast<int8_t>(std::min(outermost_quote_indent, kInt8Max));
         }
         current_node_url_map.clear();
     }
@@ -236,7 +238,7 @@ int OnEnterBlock(MD_BLOCKTYPE type, void* detail, void* userdata)
     case MD_BLOCK_H: {
         auto* const h = static_cast<MD_BLOCK_H_DETAIL*>(detail);
         ctx->BeginNode(NodeType::Heading);
-        ctx->current_node->heading_level = static_cast<int>(h->level);
+        ctx->current_node->heading_level = static_cast<int8_t>(h->level);
         break;
     }
 
@@ -567,7 +569,7 @@ int OnText(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, void* userdata)
     }
 
     // 各ノードの最初のテキストコールバックでソースオフセットを記録（UTF-16 コード単位）
-    if (ctx->current_node->source_offset == UINT32_MAX && ctx->markdown_base) {
+    if (ctx->current_node->source_offset == kUnsetSourceOffset && ctx->markdown_base) {
         ctx->current_node->source_offset = static_cast<uint32_t>(text - ctx->markdown_base);
     }
 

--- a/src/core/reload.cpp
+++ b/src/core/reload.cpp
@@ -31,15 +31,15 @@ ReloadDecision AnalyzeReloadDiff(std::wstring_view old_wide, std::wstring_view n
 int FindNodeBySourceOffset(const std::pmr::vector<Node>& nodes, uint32_t diff_offset) noexcept
 {
     // source_offset はパース順で基本的に単調増加するため二分探索を使用。
-    // UINT32_MAX（未設定）ノードに当たった場合は左に有効ノードを探してから判定する。
+    // 未設定ノードに当たった場合は左に有効ノードを探してから判定する。
     int lo = 0, hi = static_cast<int>(nodes.size()) - 1;
     int result = -1;
     while (lo <= hi) {
         const int mid = lo + (hi - lo) / 2;
         const uint32_t offset = nodes[mid].source_offset;
-        if (offset == UINT32_MAX) {
+        if (offset == kUnsetSourceOffset) {
             int probe = mid - 1;
-            while (probe >= lo && nodes[probe].source_offset == UINT32_MAX) {
+            while (probe >= lo && nodes[probe].source_offset == kUnsetSourceOffset) {
                 probe--;
             }
             if (probe < lo) {
@@ -82,11 +82,11 @@ float CalcScrollYForDiff(
     const float node_h = cache[changed_node].height;
 
     const uint32_t node_start = nodes[changed_node].source_offset;
-    if (node_start != UINT32_MAX) {
+    if (node_start != kUnsetSourceOffset) {
         uint32_t next_start = static_cast<uint32_t>(content.size());
         const auto node_count = static_cast<int>(nodes.size());
         for (int i = changed_node + 1; i < node_count; ++i) {
-            if (nodes[i].source_offset != UINT32_MAX && nodes[i].source_offset > node_start) {
+            if (nodes[i].source_offset != kUnsetSourceOffset && nodes[i].source_offset > node_start) {
                 next_start = nodes[i].source_offset;
                 break;
             }

--- a/src/core/reload.h
+++ b/src/core/reload.h
@@ -19,7 +19,7 @@ size_t FindFirstDifference(std::wstring_view old_text, std::wstring_view new_tex
 
 // diff_pos が短い方の末尾と一致するかを判定する。
 // 片方がもう片方の prefix であり、ファイルの伸縮（エディタの中間書き込み状態）を示す。
-inline bool IsPrefixOnlyDiff(size_t diff_pos, size_t old_size, size_t new_size) noexcept
+inline constexpr bool IsPrefixOnlyDiff(size_t diff_pos, size_t old_size, size_t new_size) noexcept
 {
     return diff_pos == std::min(old_size, new_size);
 }

--- a/src/core/selection_html.cpp
+++ b/src/core/selection_html.cpp
@@ -545,7 +545,7 @@ std::pmr::wstring ExtractSelectedTextAsHtml(const std::pmr::vector<Node>& nodes,
 
         switch (node.type) {
         case NodeType::Heading: {
-            const int level = std::clamp(node.heading_level, 1, 6);
+            const int level = std::clamp(static_cast<int>(node.heading_level), 1, 6);
             AppendHeadingOpenTag(out, level);
             AppendNodeInlineHtml(out, node, start, end);
             AppendHeadingCloseTag(out, level);

--- a/src/core/toc.h
+++ b/src/core/toc.h
@@ -13,16 +13,17 @@ struct TocEntry {
 
 class TableOfContents {
 public:
-    const std::pmr::vector<TocEntry>& GetEntries() const noexcept { return entries_; }
     int HitTest(float local_y, float item_height) const noexcept;
 
     // ビューポート先頭のスクロール位置から、現在表示中の見出しに対応するTOCエントリのインデックスを返す。
     // 見つからない場合は -1 を返す。
     int FindActiveIndex(const LayoutCache& cache, float scroll_y, float margin = 0.0f) const noexcept;
 
-    void Clear() noexcept { entries_.clear(); }
-    void Reserve(size_t n) { entries_.reserve(n); }
     void AddEntry(const Node& node, int node_index);
+
+    constexpr const std::pmr::vector<TocEntry>& GetEntries() const noexcept { return entries_; }
+    constexpr void Clear() noexcept { entries_.clear(); }
+    constexpr void Reserve(size_t n) { entries_.reserve(n); }
 
 private:
     std::pmr::vector<TocEntry> entries_;

--- a/src/input/hit_test_service.h
+++ b/src/input/hit_test_service.h
@@ -4,8 +4,8 @@
 #include "ui_types.h"
 #include "theme.h"
 #include "ui_constants.h"
-#include <climits>
 #include <concepts>
+#include <limits>
 #include <memory_resource>
 
 // ボタン矩形の純粋表現。テスト側が実装の式を再構築せずに済むよう、
@@ -19,7 +19,7 @@ struct ButtonRect {
 };
 
 // 戻るボタンの矩形。実装側の NavButtonHitTest と同一の式を使う。
-inline ButtonRect NavBackButtonRect(const PaneRect& md_rect) noexcept
+inline constexpr ButtonRect NavBackButtonRect(const PaneRect& md_rect) noexcept
 {
     const float x = md_rect.x + md_rect.width
         - NAV_BTN_MARGIN - NAV_BTN_SIZE * 2.0f - NAV_BTN_GAP - NAV_BTN_SCROLLBAR_OFFSET;
@@ -28,7 +28,7 @@ inline ButtonRect NavBackButtonRect(const PaneRect& md_rect) noexcept
 }
 
 // 進むボタンの矩形。Back の右に NAV_BTN_GAP の隙間を空けて並ぶ。
-inline ButtonRect NavForwardButtonRect(const PaneRect& md_rect) noexcept
+inline constexpr ButtonRect NavForwardButtonRect(const PaneRect& md_rect) noexcept
 {
     const ButtonRect back = NavBackButtonRect(md_rect);
     return { back.x + NAV_BTN_SIZE + NAV_BTN_GAP, back.y, NAV_BTN_SIZE, NAV_BTN_SIZE };
@@ -52,7 +52,7 @@ struct MdPaneHitContext {
 
 // 物理ピクセルをMDペインローカルのDIP座標に変換する。
 struct PaneDip { float x, y; };
-inline PaneDip ScreenToPaneDip(const MdPaneHitContext& ctx) noexcept
+inline constexpr PaneDip ScreenToPaneDip(const MdPaneHitContext& ctx) noexcept
 {
     return {
         ctx.screen_x / ctx.dpi_scale - ctx.md_pane_left,
@@ -100,17 +100,17 @@ private:
     // effects_generation が変わると自動で無効化される。
     template <typename T>
     struct HitCache {
-        int screen_x = INT_MIN, screen_y = INT_MIN;
+        int screen_x = std::numeric_limits<int>::min(), screen_y = std::numeric_limits<int>::min();
         float scroll_y = 0.0f;
-        uint32_t effects_gen = UINT32_MAX;
+        uint32_t effects_gen = std::numeric_limits<uint32_t>::max();
         T result{};
 
-        bool Matches(const MdPaneHitContext& ctx, uint32_t gen) const noexcept
+        constexpr bool Matches(const MdPaneHitContext& ctx, uint32_t gen) const noexcept
         {
             return ctx.screen_x == screen_x && ctx.screen_y == screen_y
                 && ctx.scroll_y == scroll_y && gen == effects_gen;
         }
-        void Store(const MdPaneHitContext& ctx, uint32_t gen, const T& r) noexcept
+        constexpr void Store(const MdPaneHitContext& ctx, uint32_t gen, const T& r) noexcept
         {
             screen_x = ctx.screen_x;
             screen_y = ctx.screen_y;

--- a/src/input/mouse_gesture.h
+++ b/src/input/mouse_gesture.h
@@ -4,9 +4,9 @@
 #include <cmath>
 #include <memory_resource>
 
-enum class GesturePhase { Idle, Pressed, Tracking };
-enum class GestureDirection { None, Left, Right };
-enum class GestureResult { None, ShowContextMenu, Back, Forward };
+enum class GesturePhase : uint8_t { Idle, Pressed, Tracking };
+enum class GestureDirection : uint8_t { None, Left, Right };
+enum class GestureResult : uint8_t { None, ShowContextMenu, Back, Forward };
 
 struct GesturePoint {
     float x = 0.0f;

--- a/src/input/swipe_detector.h
+++ b/src/input/swipe_detector.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <cstdint>
 
-enum class SwipeResult { None, Back, Forward };
+enum class SwipeResult : uint8_t { None, Back, Forward };
 
 // タッチパッド水平スクロール（WM_MOUSEHWHEEL）を蓄積し、
 // 閾値を超えたら戻る/進むナビゲーションを発火するジェスチャー検出器。
@@ -10,7 +10,7 @@ enum class SwipeResult { None, Back, Forward };
 // タイムアウト: 一定時間水平入力がなければ蓄積をリセットする。
 class SwipeDetector {
 public:
-    void OnHWheel(int delta, uint64_t now_ms) noexcept
+    constexpr void OnHWheel(int delta, uint64_t now_ms) noexcept
     {
         // 直近の縦スクロールから一定時間内なら無視（軸ロック）
         if (now_ms - last_vscroll_time_ < AXIS_LOCK_MS) {
@@ -26,7 +26,7 @@ public:
         accumulated_delta_ += delta;
     }
 
-    SwipeResult Commit() noexcept
+    constexpr SwipeResult Commit() noexcept
     {
         SwipeResult result = SwipeResult::None;
         if (accumulated_delta_ >= TRIGGER_THRESHOLD) {
@@ -40,13 +40,13 @@ public:
         return result;
     }
 
-    void NotifyVScroll(uint64_t now_ms) noexcept
+    constexpr void NotifyVScroll(uint64_t now_ms) noexcept
     {
         last_vscroll_time_ = now_ms;
         accumulated_delta_ = 0;
     }
 
-    void Reset() noexcept
+    constexpr void Reset() noexcept
     {
         accumulated_delta_ = 0;
         last_hscroll_time_ = 0;

--- a/src/io/file_explorer.cpp
+++ b/src/io/file_explorer.cpp
@@ -34,8 +34,8 @@ void FileExplorer::Refresh()
         if (parent != dir_path) {
             FileEntry pe;
             pe.full_path.assign(parent.native());
-            pe.is_directory = true;
-            pe.is_parent = true;
+            pe.set_directory(true);
+            pe.set_parent(true);
             entries_.emplace_back(std::move(pe));
         }
     }
@@ -74,7 +74,7 @@ void FileExplorer::Refresh()
 
         FileEntry entry;
         entry.full_path.assign((dir_base / fd.cFileName).native());
-        entry.is_directory = is_dir;
+        entry.set_directory(is_dir);
         entries_.emplace_back(std::move(entry));
     } while (FindNextFileW(hFind.get(), &fd));
 
@@ -82,8 +82,8 @@ void FileExplorer::Refresh()
     // 比較対象は full_path 全体ではなく末尾ファイル名のみ（GetDisplayName）。
     std::ranges::sort(entries_.begin() + static_cast<ptrdiff_t>(sort_begin), entries_.end(),
         [](const FileEntry& a, const FileEntry& b) noexcept {
-            if (a.is_directory != b.is_directory) {
-                return a.is_directory > b.is_directory;
+            if (a.is_directory() != b.is_directory()) {
+                return a.is_directory() > b.is_directory();
             }
             return path_util::iless(a.GetDisplayName(), b.GetDisplayName());
         });
@@ -104,6 +104,6 @@ int FileExplorer::HitTest(float local_y, float item_height) const noexcept
 void FileExplorer::SetCurrentFile(std::wstring_view path)
 {
     for (auto& entry : entries_) {
-        entry.is_current = (!entry.is_directory && path_util::iequal(entry.full_path, path));
+        entry.set_current(!entry.is_directory() && path_util::iequal(entry.full_path, path));
     }
 }

--- a/src/io/file_explorer.h
+++ b/src/io/file_explorer.h
@@ -6,20 +6,37 @@
 
 struct FileEntry {
     std::pmr::wstring full_path;
-    bool is_current = false;
-    bool is_directory = false;
-    bool is_parent = false;  // ".." エントリ
+
+    constexpr bool is_current() const noexcept { return flags_ & CURRENT; }
+    constexpr bool is_directory() const noexcept { return flags_ & DIRECTORY; }
+    constexpr bool is_parent() const noexcept { return flags_ & PARENT; }
+
+    constexpr void set_current(bool v) noexcept { set_flag(CURRENT, v); }
+    constexpr void set_directory(bool v) noexcept { set_flag(DIRECTORY, v); }
+    constexpr void set_parent(bool v) noexcept { set_flag(PARENT, v); }
 
     // 表示名を返す（full_pathの末尾ファイル名、".."エントリは"..") 。
     // 戻り値はfull_pathの内部バッファまたはリテラルを指すためnull終端。
-    const wchar_t* GetDisplayName() const noexcept
+    constexpr const wchar_t* GetDisplayName() const noexcept
     {
-        if (is_parent) {
+        if (is_parent()) {
             return L"..";
         }
         const auto pos = full_path.find_last_of(L"\\/");
         return (pos != full_path.npos) ? full_path.c_str() + pos + 1 : full_path.c_str();
     }
+
+private:
+    static constexpr uint8_t CURRENT = 0x01;
+    static constexpr uint8_t DIRECTORY = 0x02;
+    static constexpr uint8_t PARENT = 0x04;
+
+    constexpr void set_flag(uint8_t mask, bool v) noexcept
+    {
+        flags_ = v ? (flags_ | mask) : static_cast<uint8_t>(flags_ & ~mask);
+    }
+
+    uint8_t flags_ = 0;
 };
 
 class FileExplorer {

--- a/src/io/file_loader.h
+++ b/src/io/file_loader.h
@@ -9,7 +9,7 @@
 inline constexpr LONGLONG MAX_FILE_SIZE = 256LL * 1024 * 1024;
 
 // FileLoader::LoadFile のエラー型
-enum class FileLoadError {
+enum class FileLoadError : uint8_t {
     NotFound,    // ファイルが見つからない、またはアクセス拒否
     TooLarge,    // ファイルサイズが MAX_FILE_SIZE を超過
     ReadFailed,  // 読み込み中のI/Oエラー

--- a/src/io/file_watcher.cpp
+++ b/src/io/file_watcher.cpp
@@ -137,11 +137,6 @@ void FileWatcher::CheckForChanges()
     BeginRead();
 }
 
-HANDLE FileWatcher::GetEventHandle() const noexcept
-{
-    return (watching_ && read_pending_) ? overlapped_.hEvent : nullptr;
-}
-
 void FileWatcher::ResumeWatching()
 {
     if (!watching_) {

--- a/src/io/file_watcher.h
+++ b/src/io/file_watcher.h
@@ -20,7 +20,10 @@ public:
     void CheckForChanges();
 
     void ResumeWatching();
-    HANDLE GetEventHandle() const noexcept;
+    constexpr HANDLE GetEventHandle() const noexcept
+    {
+        return (watching_ && read_pending_) ? overlapped_.hEvent : nullptr;
+    }
 
 private:
     void BeginRead();

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -98,7 +98,7 @@ float EstimateNodeHeight(const Node& node, const Theme& theme) noexcept
     const float line_height = theme.font_size_body * 1.5f;
     switch (node.type) {
     case NodeType::Heading: {
-        const int level = std::clamp(node.heading_level, 1, 6) - 1;
+        const int level = std::clamp(static_cast<int>(node.heading_level), 1, 6) - 1;
         return theme.font_size_h[level] * 1.5f;
     }
     case NodeType::CodeBlock: {

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -31,7 +31,8 @@ struct YPositionResult {
 };
 
 YPositionResult RecomputeYPositions(std::pmr::vector<Node>& nodes, LayoutCache& cache, const Theme& theme,
-    size_t from_index = 0, bool has_earlier_dirty = false, size_t safe_exit_after = SIZE_MAX) noexcept;
+    size_t from_index = 0, bool has_earlier_dirty = false,
+    size_t safe_exit_after = std::numeric_limits<size_t>::max()) noexcept;
 
 float EstimateNodeHeight(const Node& node, const Theme& theme) noexcept;
 

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -5,6 +5,7 @@
 #include "text_measurer.h"
 #include "viewport_manager.h"
 #include <dwrite.h>
+#include <limits>
 #include <memory_resource>
 
 class Document;

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -110,7 +110,7 @@ struct NodeLayoutEntry {
         }
         return *table_layout;
     }
-    bool has_table_layout() const noexcept { return table_layout != nullptr; }
+    constexpr bool has_table_layout() const noexcept { return table_layout != nullptr; }
 
     // マッチの絶対 Y とその行の高さを返す。text_layout（テーブルはセル layout）が
     // あれば text_offset に対応する行 Y を精密に計算し、無ければ
@@ -168,7 +168,7 @@ public:
 
     // prefix 部分のキャッシュを保持したままリサイズする。
     // 追加エントリの y_position を旧末尾に配置し、二分探索の単調性を維持する。
-    void ResizePreservingPrefix(size_t new_node_count)
+    constexpr void ResizePreservingPrefix(size_t new_node_count)
     {
         const size_t old_count = entries_.size();
         Resize(new_node_count);
@@ -181,7 +181,7 @@ public:
         }
     }
 
-    void Reset(size_t node_count, bool shrink = true)
+    constexpr void Reset(size_t node_count, bool shrink = true)
     {
         entries_.clear();
         if (shrink) {
@@ -327,7 +327,7 @@ public:
     // エフェクト世代カウンタ。レイアウト変更時にインクリメントされる。
     // Renderer が ApplyVisibleEffects のスキップ判定に使用する。
     constexpr uint32_t GetEffectsGeneration() const noexcept { return effects_generation_; }
-    void IncrementEffectsGeneration() noexcept { effects_generation_++; }
+    constexpr void IncrementEffectsGeneration() noexcept { effects_generation_++; }
 
 private:
     static void EvictEntryLayout(NodeLayoutEntry& e) noexcept

--- a/src/mermaid/mermaid_file_cache.h
+++ b/src/mermaid/mermaid_file_cache.h
@@ -54,7 +54,7 @@ public:
 #ifdef MENDO_TESTING
     // テスト用: 外部キーから実ファイル名（PNG）を導く。
     // 内部で DPR を mix した内部キーを使うため。
-    uint64_t InternalKeyForTest(uint64_t external_key) const noexcept
+    constexpr uint64_t InternalKeyForTest(uint64_t external_key) const noexcept
     {
         return InternalKey(external_key);
     }
@@ -87,7 +87,7 @@ private:
 
     // current_dpr_ を mix した内部キーを返す。DPR ごとにエントリを分離して
     // DPI 変更/モニタ切替時の全消去を避ける。
-    uint64_t InternalKey(uint64_t external_key) const noexcept
+    constexpr uint64_t InternalKey(uint64_t external_key) const noexcept
     {
         // DPR を 1/100 単位で量子化（典型値 100/125/150/175/200）。
         const uint32_t dpr_q = static_cast<uint32_t>(current_dpr_ * 100.0f + 0.5f);

--- a/src/nav/nav.cpp
+++ b/src/nav/nav.cpp
@@ -3,7 +3,7 @@
 
 uint32_t NavHistory::InternPath(std::wstring_view path)
 {
-    if (last_interned_index_ != UINT32_MAX && last_interned_view_ == path) {
+    if (last_interned_index_ != std::numeric_limits<uint32_t>::max() && last_interned_view_ == path) {
         return last_interned_index_;
     }
     if (const auto it = path_index_.find(path); it != path_index_.end()) {
@@ -53,7 +53,7 @@ void NavHistory::ReleasePath(uint32_t idx) noexcept
         path_index_.erase(std::wstring_view(slot.text));
         if (last_interned_index_ == idx) {
             last_interned_view_ = {};
-            last_interned_index_ = UINT32_MAX;
+            last_interned_index_ = std::numeric_limits<uint32_t>::max();
         }
         // text の capacity はあえて保持する。次に free_slots_ から
         // 取り出された際、同程度の長さのパスで assign が再割り当てせずに済む。
@@ -130,7 +130,7 @@ void NavHistory::Clear() noexcept
     path_index_.clear();
     free_slots_.clear();
     last_interned_view_ = {};
-    last_interned_index_ = UINT32_MAX;
+    last_interned_index_ = std::numeric_limits<uint32_t>::max();
 }
 
 // ShellExecuteWに渡しても安全なURLスキームかどうかを判定する。

--- a/src/nav/nav.h
+++ b/src/nav/nav.h
@@ -2,6 +2,7 @@
 #include <string>
 #include <string_view>
 #include <deque>
+#include <limits>
 #include <vector>
 #include <memory_resource>
 #include <map>

--- a/src/nav/nav.h
+++ b/src/nav/nav.h
@@ -75,11 +75,11 @@ private:
 
     // Back→Forward→Back の連続操作で path_index_::find を回避する直前値キャッシュ
     std::wstring_view last_interned_view_;
-    uint32_t last_interned_index_ = UINT32_MAX;
+    uint32_t last_interned_index_ = std::numeric_limits<uint32_t>::max();
 };
 
 struct LinkClickResult {
-    enum class Type { None, Anchor, ExternalUrl };
+    enum class Type : uint8_t { None, Anchor, ExternalUrl };
     Type type = Type::None;
     std::pmr::wstring target;
 };

--- a/src/pch.h
+++ b/src/pch.h
@@ -15,6 +15,7 @@
 #include <filesystem>
 #include <functional>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <memory_resource>
 #include <mutex>

--- a/src/render/command_executor.h
+++ b/src/render/command_executor.h
@@ -34,7 +34,7 @@ public:
 
 #ifdef MENDO_TESTING
     size_t PoolSizeForTest() const noexcept { return brush_pool_.size(); }
-    const ID2D1RenderTarget* BoundRtForTest() const noexcept { return bound_rt_; }
+    constexpr const ID2D1RenderTarget* BoundRtForTest() const noexcept { return bound_rt_; }
 #endif
 
 private:

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -151,7 +151,7 @@ private:
 
     std::pmr::vector<DWRITE_HIT_TEST_METRICS>* shared_hit_test_buffer_ = nullptr;
     std::pmr::vector<DWRITE_HIT_TEST_METRICS> hit_test_buffer_;
-    std::pmr::vector<DWRITE_HIT_TEST_METRICS>& GetHitTestBuffer() noexcept
+    constexpr std::pmr::vector<DWRITE_HIT_TEST_METRICS>& GetHitTestBuffer() noexcept
     {
         return shared_hit_test_buffer_ ? *shared_hit_test_buffer_ : hit_test_buffer_;
     }

--- a/src/render/render_params.h
+++ b/src/render/render_params.h
@@ -48,6 +48,8 @@ struct TitleBarRenderState {
     float height = 0.0f;
     float window_width = 0.0f;
     // --- 1バイトアライメント ---
+    // ホバー中のボタン。各 TitleBarButton に bool を持たせず一元管理する。
+    TitleBarHitZone hovered_zone = TitleBarHitZone::None;
     bool is_dark_mode = false;
     bool search_active = false;
     bool file_pane_visible = false;

--- a/src/render/renderer.h
+++ b/src/render/renderer.h
@@ -11,6 +11,7 @@
 #include <dwrite.h>
 #include <wrl/client.h>
 #include <functional>
+#include <limits>
 #include <vector>
 #include <array>
 #include <memory>

--- a/src/render/renderer.h
+++ b/src/render/renderer.h
@@ -177,7 +177,7 @@ private:
     PaneCache toc_pane_cache_;
 
     // ApplyVisibleEffects スキップ判定用キャッシュ
-    uint32_t last_effects_gen_ = UINT32_MAX;
+    uint32_t last_effects_gen_ = std::numeric_limits<uint32_t>::max();
     int last_effects_first_ = -1;
     float last_effects_bottom_ = -1.0f;
 

--- a/src/render/renderer_pane.cpp
+++ b/src/render/renderer_pane.cpp
@@ -177,7 +177,7 @@ void Renderer::DrawFileExplorer(const std::pmr::vector<FileEntry>& entries, cons
         const auto& entry = entries[i];
 
         const D2D1_RECT_F item_rect = D2D1::RectF(0, item_y, width, item_y + theme_.pane_item_height);
-        if (entry.is_current) {
+        if (entry.is_current()) {
             rt->FillRectangle(item_rect, Brush(BrushId::PaneItemActive));
         }
         else if (i == hovered_index) {
@@ -186,10 +186,10 @@ void Renderer::DrawFileExplorer(const std::pmr::vector<FileEntry>& entries, cons
 
         if (fmt_.pane_icon) {
             const wchar_t* icon;
-            if (entry.is_parent) {
+            if (entry.is_parent()) {
                 icon = L"\uE74A";
             }
-            else if (entry.is_directory) {
+            else if (entry.is_directory()) {
                 icon = L"\uE8B7";
             }
             else {

--- a/src/render/renderer_titlebar.cpp
+++ b/src/render/renderer_titlebar.cpp
@@ -11,6 +11,7 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
     rt()->FillRectangle(bg_rect, Brush(BrushId::TitleBarBg));
 
     const float text_alpha = tb.window_active ? 1.0f : 0.5f;
+    const auto is_hovered = [&](TitleBarHitZone z) noexcept { return tb.hovered_zone == z; };
 
     // アイコンボタン描画ヘルパー
     auto drawButton = [&](const DipRect& dip_rect, const wchar_t* icon, bool show_bg, BrushId bg_id, BrushId text_id, float alpha) {
@@ -32,7 +33,7 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
     drawButton(
         tb.open_file.rect,
         L"\uE838",
-        tb.open_file.hovered,
+        is_hovered(TitleBarHitZone::OpenFile),
         BrushId::TitleBarButtonHover,
         BrushId::TitleBarText,
         text_alpha
@@ -41,7 +42,7 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
     drawButton(
         tb.help.rect,
         L"\uE897",
-        tb.help.hovered,
+        is_hovered(TitleBarHitZone::Help),
         BrushId::TitleBarButtonHover,
         BrushId::TitleBarText,
         text_alpha
@@ -50,7 +51,7 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
     drawButton(
         tb.theme_toggle.rect,
         tb.is_dark_mode ? L"\uE706" : L"\uE708",
-        tb.theme_toggle.hovered,
+        is_hovered(TitleBarHitZone::ThemeToggle),
         BrushId::TitleBarButtonHover,
         BrushId::TitleBarText,
         text_alpha
@@ -59,7 +60,7 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
     drawButton(
         tb.search.rect,
         L"\uE721",
-        tb.search_active || tb.search.hovered,
+        tb.search_active || is_hovered(TitleBarHitZone::Search),
         tb.search_active ? BrushId::TitleBarButtonActive : BrushId::TitleBarButtonHover,
         BrushId::TitleBarText,
         text_alpha
@@ -68,7 +69,7 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
     drawButton(
         tb.file_toggle.rect,
         L"\uE8B7",
-        tb.file_pane_visible || tb.file_toggle.hovered,
+        tb.file_pane_visible || is_hovered(TitleBarHitZone::FileToggle),
         tb.file_pane_visible ? BrushId::TitleBarButtonActive : BrushId::TitleBarButtonHover,
         BrushId::TitleBarText,
         text_alpha
@@ -76,7 +77,7 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
     drawButton(
         tb.toc_toggle.rect,
         L"\uE8FD",
-        tb.toc_pane_visible || tb.toc_toggle.hovered,
+        tb.toc_pane_visible || is_hovered(TitleBarHitZone::TocToggle),
         tb.toc_pane_visible ? BrushId::TitleBarButtonActive : BrushId::TitleBarButtonHover,
         BrushId::TitleBarText,
         text_alpha
@@ -85,7 +86,7 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
     drawButton(
         tb.minimize.rect,
         L"\uE921",
-        tb.minimize.hovered,
+        is_hovered(TitleBarHitZone::Minimize),
         BrushId::TitleBarButtonHover,
         BrushId::TitleBarText,
         text_alpha
@@ -95,13 +96,13 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
     drawButton(
         tb.maximize.rect,
         max_icon,
-        tb.maximize.hovered,
+        is_hovered(TitleBarHitZone::Maximize),
         BrushId::TitleBarButtonHover,
         BrushId::TitleBarText,
         text_alpha
     );
     // 閉じるボタン（ホバー時は赤背景＋白アイコン）
-    if (tb.close.hovered) {
+    if (is_hovered(TitleBarHitZone::Close)) {
         drawButton(
             tb.close.rect, L"\uE8BB",
             true,

--- a/src/ui/context_menu.h
+++ b/src/ui/context_menu.h
@@ -34,7 +34,7 @@ struct ContextMenuParams {
 class ContextMenu {
 public:
     // メニュー項目の種類
-    enum class ItemType { NavRow, Separator, Text };
+    enum class ItemType : uint8_t { NavRow, Separator, Text };
 
     struct Item {
         ItemType type = ItemType::Text;

--- a/src/ui/cursor_manager.h
+++ b/src/ui/cursor_manager.h
@@ -13,10 +13,10 @@ public:
         sizewe_ = LoadCursorW(nullptr, IDC_SIZEWE);
     }
 
-    HCURSOR Arrow() const noexcept { return arrow_; }
-    HCURSOR Hand() const noexcept { return hand_; }
-    HCURSOR IBeam() const noexcept { return ibeam_; }
-    HCURSOR SizeWE() const noexcept { return sizewe_; }
+    constexpr HCURSOR Arrow() const noexcept { return arrow_; }
+    constexpr HCURSOR Hand() const noexcept { return hand_; }
+    constexpr HCURSOR IBeam() const noexcept { return ibeam_; }
+    constexpr HCURSOR SizeWE() const noexcept { return sizewe_; }
 
 private:
     HCURSOR arrow_ = nullptr;

--- a/src/ui/hover_throttle.h
+++ b/src/ui/hover_throttle.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <windows.h>
-#include <climits>
+#include <limits>
 
 // ホバー時のヒットテスト省略判定用の距離の二乗（ピクセル²）
 inline constexpr int HOVER_THROTTLE_DISTANCE_SQ = 16;
@@ -8,11 +8,15 @@ inline constexpr int HOVER_THROTTLE_DISTANCE_SQ = 16;
 inline constexpr DWORD HOVER_THROTTLE_MIN_INTERVAL_MS = 8;
 
 // last_pos の "未設定" sentinel。
-// (px - LONG_MIN) は signed int オーバーフロー (UB) になるため、
+// (px - LONG の最小値) は signed int オーバーフロー (UB) になるため、
 // この値の間は距離計算を行わず即座に "移動した" として扱う。
-inline constexpr POINT kUnsetHoverPos{ LONG_MIN, LONG_MIN };
+inline constexpr POINT kUnsetHoverPos{
+    std::numeric_limits<LONG>::min(), std::numeric_limits<LONG>::min() };
 
-inline constexpr bool IsUnset(POINT p) noexcept { return p.x == LONG_MIN; }
+inline constexpr bool IsUnset(POINT p) noexcept
+{
+    return p.x == std::numeric_limits<LONG>::min();
+}
 
 // ヒットテストのスロットリング状態。
 // マウス位置が一定距離以上動いた場合のみヒットテストを再実行する。
@@ -26,7 +30,7 @@ struct HoverThrottle {
     DWORD last_md_hit_tick = 0;
     DWORD last_copy_hit_tick = 0;
 
-    void Reset() noexcept
+    constexpr void Reset() noexcept
     {
         last_md_hit_pos = kUnsetHoverPos;
         last_copy_hit_pos = kUnsetHoverPos;
@@ -39,7 +43,7 @@ struct HoverThrottle {
     // 完全同一座標の連続ディスパッチを抑止する。
     // 最低限の前段フィルタであり、通常のスロットリングは
     // last_md_hit_pos 等の距離比較で行う。
-    bool ShouldSkipSameDispatch(int px, int py) noexcept
+    constexpr bool ShouldSkipSameDispatch(int px, int py) noexcept
     {
         if (last_hover_dispatch_pos.x == px && last_hover_dispatch_pos.y == py) {
             return true;
@@ -71,7 +75,7 @@ struct HoverThrottle {
     }
 
     // 距離のみ判定。時間ガードが不要な経路（タイマー駆動など）向け。
-    [[nodiscard]] bool TryMarkMoved(POINT& last_pos, int px, int py) noexcept
+    [[nodiscard]] constexpr bool TryMarkMoved(POINT& last_pos, int px, int py) noexcept
     {
         if (IsUnset(last_pos)) {
             last_pos = { px, py };

--- a/src/ui/i18n.h
+++ b/src/ui/i18n.h
@@ -203,10 +203,10 @@ inline void Init(std::wstring_view config_lang) noexcept
     }
 }
 
-inline const Strings& S() noexcept { return *g_strings; }
+constexpr const Strings& S() noexcept { return *g_strings; }
 
 // 現在の言語を設定ファイル用のキー文字列で返す。
-inline std::wstring_view GetLangKey() noexcept
+constexpr std::wstring_view GetLangKey() noexcept
 {
     return (g_strings == &kEn) ? L"en" : L"ja";
 }

--- a/src/ui/pane_controller.h
+++ b/src/ui/pane_controller.h
@@ -8,7 +8,7 @@
 class PaneController {
 public:
     // ---- ドラッグ対象 ----
-    enum class DragTarget { None, Splitter1, Splitter2, FileScrollbar, TocScrollbar, MdScrollbar };
+    enum class DragTarget : uint8_t { None, Splitter1, Splitter2, FileScrollbar, TocScrollbar, MdScrollbar };
 
     // ---- 表示/非表示 ----
     constexpr bool IsFilePaneVisible() const noexcept { return show_file_; }

--- a/src/ui/pane_layout.h
+++ b/src/ui/pane_layout.h
@@ -2,7 +2,7 @@
 #include "ui_types.h"
 
 // ペイン領域識別子（ある座標がどのペインに属するか）
-enum class PaneZone : int {
+enum class PaneZone : uint8_t {
     None,
     FilePane,
     Splitter1,

--- a/src/ui/search_state.h
+++ b/src/ui/search_state.h
@@ -18,8 +18,8 @@ struct SearchMatch {
 // 検索状態の管理（Win32非依存）
 class SearchState {
 public:
-    bool IsVisible() const noexcept { return visible_; }
-    void Show() noexcept { visible_ = true; }
+    constexpr bool IsVisible() const noexcept { return visible_; }
+    constexpr void Show() noexcept { visible_ = true; }
     void Hide() noexcept
     {
         visible_ = false;
@@ -36,7 +36,7 @@ public:
     // ExecuteSearch / Hide / Reset のたびにインクリメントされる世代カウンタ。
     // 描画側が検索ハイライト矩形のキャッシュ有効性判定に使う。0 は未初期化を意味するため
     // 1 からカウントし始める（search_hl_gen=0 と常に不一致になる）。
-    uint32_t GetGeneration() const noexcept { return generation_; }
+    constexpr uint32_t GetGeneration() const noexcept { return generation_; }
 
     // ドキュメントが切り替わった/構造が変わったときに呼ぶ。
     // 次回 ExecuteSearch 時に lowercase キャッシュが再生成される。
@@ -49,18 +49,18 @@ public:
         cached_node_count_ = 0;
     }
 
-    const std::pmr::wstring& GetQuery() const noexcept { return query_; }
-    const std::pmr::vector<SearchMatch>& GetMatches() const noexcept { return matches_; }
-    int GetCurrentMatchIndex() const noexcept { return current_match_; }
-    int GetMatchCount() const noexcept { return static_cast<int>(matches_.size()); }
+    constexpr const std::pmr::wstring& GetQuery() const noexcept { return query_; }
+    constexpr const std::pmr::vector<SearchMatch>& GetMatches() const noexcept { return matches_; }
+    constexpr int GetCurrentMatchIndex() const noexcept { return current_match_; }
+    constexpr int GetMatchCount() const noexcept { return static_cast<int>(matches_.size()); }
     // 大文字小文字の区別
-    bool IsCaseSensitive() const noexcept { return case_sensitive_; }
-    void SetCaseSensitive(bool v) noexcept { case_sensitive_ = v; }
-    void ToggleCaseSensitive() noexcept { case_sensitive_ = !case_sensitive_; }
+    constexpr bool IsCaseSensitive() const noexcept { return case_sensitive_; }
+    constexpr void SetCaseSensitive(bool v) noexcept { case_sensitive_ = v; }
+    constexpr void ToggleCaseSensitive() noexcept { case_sensitive_ = !case_sensitive_; }
 
     // ハイライト表示のON/OFF
-    bool IsHighlightEnabled() const noexcept { return highlight_enabled_; }
-    void ToggleHighlightEnabled() noexcept { highlight_enabled_ = !highlight_enabled_; }
+    constexpr bool IsHighlightEnabled() const noexcept { return highlight_enabled_; }
+    constexpr void ToggleHighlightEnabled() noexcept { highlight_enabled_ = !highlight_enabled_; }
 
     void SetQuery(std::wstring_view query);
     void ExecuteSearch(const std::pmr::vector<Node>& nodes);

--- a/src/ui/titlebar.cpp
+++ b/src/ui/titlebar.cpp
@@ -84,14 +84,5 @@ bool TitleBar::SetHovered(TitleBarHitZone zone) noexcept
         return false;
     }
     hovered_ = zone;
-    open_file_.hovered = (zone == TitleBarHitZone::OpenFile);
-    help_.hovered = (zone == TitleBarHitZone::Help);
-    theme_toggle_.hovered = (zone == TitleBarHitZone::ThemeToggle);
-    search_.hovered = (zone == TitleBarHitZone::Search);
-    file_toggle_.hovered = (zone == TitleBarHitZone::FileToggle);
-    toc_toggle_.hovered = (zone == TitleBarHitZone::TocToggle);
-    minimize_.hovered = (zone == TitleBarHitZone::Minimize);
-    maximize_.hovered = (zone == TitleBarHitZone::Maximize);
-    close_.hovered = (zone == TitleBarHitZone::Close);
     return true;
 }

--- a/src/ui/titlebar.h
+++ b/src/ui/titlebar.h
@@ -2,7 +2,7 @@
 #include "ui_types.h"
 
 // タイトルバー上のヒット領域
-enum class TitleBarHitZone {
+enum class TitleBarHitZone : uint8_t {
     None,        // タイトルバー外
     Caption,     // ドラッグ可能領域
     Icon,        // アプリアイコン（システムメニュー）
@@ -17,10 +17,9 @@ enum class TitleBarHitZone {
     Close,       // 閉じるボタン
 };
 
-// タイトルバーボタンの状態
+// タイトルバーボタンの位置情報。ホバー状態は TitleBarHitZone で集約管理する。
 struct TitleBarButton {
     DipRect rect{};
-    bool hovered = false;
 };
 
 // カスタムタイトルバーの状態管理。

--- a/src/ui/toast_notifier.h
+++ b/src/ui/toast_notifier.h
@@ -11,14 +11,14 @@ public:
     static constexpr float INITIAL_ALPHA = 2.5f;   // 約0.8秒ホールド + 約0.5秒フェードアウト（合計~1.3秒）
     static constexpr float FADE_SPEED = 0.03f;      // 16ms/tickで約83tick
 
-    void Show(std::wstring_view message)
+    constexpr void Show(std::wstring_view message)
     {
         message_ = message;
         alpha_ = INITIAL_ALPHA;
     }
 
     // タイマーティックごとに呼び出す。まだ表示中なら true を返す。
-    bool Tick() noexcept
+    constexpr bool Tick() noexcept
     {
         if (alpha_ <= 0.0f) {
             return false;
@@ -32,7 +32,7 @@ public:
         return true;
     }
 
-    void Reset() noexcept
+    constexpr void Reset() noexcept
     {
         alpha_ = 0.0f;
         message_.clear();

--- a/src/ui/tooltip.h
+++ b/src/ui/tooltip.h
@@ -28,11 +28,11 @@ struct TooltipTarget {
     Zone zone = Zone::None;
     std::pmr::wstring text;
 
-    TooltipTarget() = default;
-    TooltipTarget(Zone z, std::wstring_view t) : zone(z), text(t) {}
+    constexpr TooltipTarget() = default;
+    constexpr TooltipTarget(Zone z, std::wstring_view t) : zone(z), text(t) {}
 
-    bool operator==(const TooltipTarget&) const = default;
-    bool IsEmpty() const noexcept { return zone == Zone::None; }
+    constexpr bool operator==(const TooltipTarget&) const = default;
+    constexpr bool IsEmpty() const noexcept { return zone == Zone::None; }
 };
 
 // <windows.h> を巻き込まずに HWND を扱うための前方宣言（Windows SDK の

--- a/src/ui/ui_constants.h
+++ b/src/ui/ui_constants.h
@@ -181,7 +181,7 @@ enum class SearchBarHitZone : uint8_t {
     Input,
 };
 
-inline SearchBarHitZone HitTestSearchBar(const SearchBarLayout& sbl, float x, float y) noexcept
+inline constexpr SearchBarHitZone HitTestSearchBar(const SearchBarLayout& sbl, float x, float y) noexcept
 {
     if (y < sbl.bar_top) {
         return SearchBarHitZone::None;
@@ -231,7 +231,7 @@ inline constexpr float GESTURE_TRAIL_STROKE_WIDTH = 4.0f;
 
 // ダイアグラム（Mermaid 等）右上に並ぶオーバーレイボタンのスロット。
 // 値は OverlayButtonRect の button_index に対応し、0 が最も右、左隣に並ぶごとに +1。
-enum class DiagramButtonSlot : int {
+enum class DiagramButtonSlot : uint8_t {
     Save = 0,
     SvgCopy = 1,
 };

--- a/src/ui/ui_types.h
+++ b/src/ui/ui_types.h
@@ -43,15 +43,15 @@ struct ScrollRestoration {
     int pending_restore_node = -1;
     int pending_restore_offset = 0;
 
-    bool HasNodeRestore() const noexcept { return pending_restore_node >= 0; }
+    constexpr bool HasNodeRestore() const noexcept { return pending_restore_node >= 0; }
 
-    void SetNodeRestore(int node, int offset) noexcept
+    constexpr void SetNodeRestore(int node, int offset) noexcept
     {
         pending_restore_node = node;
         pending_restore_offset = offset;
     }
 
-    void ClearNodeRestore() noexcept
+    constexpr void ClearNodeRestore() noexcept
     {
         pending_restore_node = -1;
         pending_restore_offset = 0;
@@ -69,7 +69,7 @@ struct HoveredButtons {
 };
 
 // ナビゲーションボタン（戻る/進む）のホバー状態。
-enum class NavButtonHover {
+enum class NavButtonHover : uint8_t {
     None,
     Back,
     Forward

--- a/src/ui/viewport_manager.h
+++ b/src/ui/viewport_manager.h
@@ -156,51 +156,56 @@ public:
     // 設定ファイル等の外部入力経路から不正値が来ても out-of-bounds にならない契約を setter 側で保証する。
     constexpr void SetZoomIndex(int idx) noexcept
     {
-        zoom_index_ = std::clamp(idx, 0, ZOOM_STEP_COUNT - 1);
+        zoom_index_ = static_cast<uint8_t>(std::clamp(idx, 0, ZOOM_STEP_COUNT - 1));
     }
     constexpr float GetCurrentZoom() const noexcept { return ZOOM_STEPS[zoom_index_]; }
 
-    // 新しいズーム値を返す。既に上限/下限の場合は0を返す。
-    constexpr float ZoomIn() noexcept
+    // zoom_index が変化したら true を返す。新しい値は GetZoomIndex() / GetCurrentZoom() で取得する。
+    // Why: float の戻り値で「0.0 == 変化なし」を表現すると ZOOM_STEPS に 0.0 が含まれた瞬間に
+    // 破綻するし、SSOT を zoom_index に寄せる方針と相性が悪い。
+    constexpr bool ZoomIn() noexcept
     {
         if (zoom_index_ < ZOOM_STEP_COUNT - 1) {
-            return ZOOM_STEPS[++zoom_index_];
+            ++zoom_index_;
+            return true;
         }
-        return 0.0f;
+        return false;
     }
 
-    constexpr float ZoomOut() noexcept
+    constexpr bool ZoomOut() noexcept
     {
         if (zoom_index_ > 0) {
-            return ZOOM_STEPS[--zoom_index_];
+            --zoom_index_;
+            return true;
         }
-        return 0.0f;
+        return false;
     }
 
-    constexpr float ZoomReset() noexcept
+    constexpr bool ZoomReset() noexcept
     {
         if (zoom_index_ != ZOOM_DEFAULT_INDEX) {
-            zoom_index_ = ZOOM_DEFAULT_INDEX;
-            return ZOOM_STEPS[zoom_index_];
+            zoom_index_ = static_cast<uint8_t>(ZOOM_DEFAULT_INDEX);
+            return true;
         }
-        return 0.0f;
+        return false;
     }
 
 private:
+    // --- 4 バイトアライメント ---
     // スクロール状態
     float scroll_y_ = 0.0f;
     float max_scroll_ = 0.0f;
-    bool is_scrollbar_tracking_ = false;
-    ScrollTarget scroll_target_{};
+    ScrollTarget scroll_target_{};        // int(4) + float(4)
 
     // 選択状態
-    TextSelection selection_;
-    int anchor_node_ = -1;
+    TextSelection selection_;             // 20B
+    int32_t anchor_node_ = -1;
     uint32_t anchor_pos_ = 0;
-    bool is_dragging_ = false;
-    int click_start_x_ = 0;
-    int click_start_y_ = 0;
+    int32_t click_start_x_ = 0;
+    int32_t click_start_y_ = 0;
 
-    // ズーム状態
-    int zoom_index_ = ZOOM_DEFAULT_INDEX;
+    // --- 1 バイトアライメント ---
+    uint8_t zoom_index_ = static_cast<uint8_t>(ZOOM_DEFAULT_INDEX);
+    bool is_scrollbar_tracking_ = false;
+    bool is_dragging_ = false;
 };

--- a/src/util/file_io.h
+++ b/src/util/file_io.h
@@ -67,7 +67,7 @@ struct OpenedFile {
 [[nodiscard]] inline std::pair<std::unique_ptr<uint8_t[]>, size_t> ReadAllBytes(
     const std::filesystem::path& path, DWORD* out_error = nullptr)
 {
-    auto r = OpenFileForReadShared(path, FILE_SHARE_READ, UINT32_MAX, out_error);
+    auto r = OpenFileForReadShared(path, FILE_SHARE_READ, std::numeric_limits<uint32_t>::max(), out_error);
     if (r.error != OpenFileError::None || r.size == 0) {
         return {};
     }
@@ -98,7 +98,7 @@ inline bool IsFileLargerThan(const std::filesystem::path& path,
 // ファイルに全て書き込む。成功時はtrueを返す。
 [[nodiscard]] inline bool WriteAllBytes(const std::filesystem::path& path, const void* data, size_t size)
 {
-    if (size > UINT32_MAX) {
+    if (size > std::numeric_limits<uint32_t>::max()) {
         return false;
     }
     UniqueHandle hFile(CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr,

--- a/src/util/file_io.h
+++ b/src/util/file_io.h
@@ -3,6 +3,7 @@
 #include <windows.h>
 #include <cstdint>
 #include <filesystem>
+#include <limits>
 #include <memory>
 #include <string_view>
 #include <utility>

--- a/src/util/lru_cache.h
+++ b/src/util/lru_cache.h
@@ -16,14 +16,14 @@
 template <typename Key, typename Value>
 class LruCache {
 public:
-    explicit LruCache(size_t max_entries) : max_entries_(max_entries)
+    constexpr explicit LruCache(size_t max_entries) : max_entries_(max_entries)
     {
         keys_.reserve(max_entries);
         values_.reserve(max_entries);
         generations_.reserve(max_entries);
     }
 
-    auto* Find(this auto& self, const Key& key)
+    constexpr auto* Find(this auto& self, const Key& key)
     {
         for (size_t i = 0; i < self.size_; i++) {
             if (self.keys_[i] == key) {
@@ -34,12 +34,12 @@ public:
         return decltype(&self.values_[0]){ nullptr };
     }
 
-    bool Contains(const Key& key) const
+    constexpr bool Contains(const Key& key) const
     {
         return std::ranges::contains(keys_ | std::views::take(size_), key);
     }
 
-    void Insert(const Key& key, Value value)
+    constexpr void Insert(const Key& key, Value value)
     {
         if (max_entries_ == 0) {
             return;
@@ -70,7 +70,7 @@ public:
         ++size_;
     }
 
-    void Clear()
+    constexpr void Clear()
     {
         keys_.clear();
         values_.clear();
@@ -79,12 +79,12 @@ public:
         generation_counter_ = 0;
     }
 
-    size_t Size() const noexcept { return size_; }
-    bool Empty() const noexcept { return size_ == 0; }
-    size_t MaxSize() const noexcept { return max_entries_; }
+    constexpr size_t Size() const noexcept { return size_; }
+    constexpr bool Empty() const noexcept { return size_ == 0; }
+    constexpr size_t MaxSize() const noexcept { return max_entries_; }
 
 private:
-    size_t FindOldestIndex() const noexcept
+    constexpr size_t FindOldestIndex() const noexcept
     {
         size_t oldest = 0;
         uint64_t min_gen = generations_[0];

--- a/src/util/stream_util.h
+++ b/src/util/stream_util.h
@@ -2,8 +2,8 @@
 #include "win_handle.h"
 #include <wrl/client.h>
 #include <objidl.h>
-#include <climits>
 #include <cstdint>
+#include <limits>
 #include <memory_resource>
 #include <vector>
 
@@ -25,7 +25,7 @@ inline std::pmr::vector<uint8_t> ReadAllBytes(IStream* stream)
     }
 
     const auto size64 = stat.cbSize.QuadPart;
-    if (size64 <= 0 || static_cast<uint64_t>(size64) > ULONG_MAX) {
+    if (size64 <= 0 || static_cast<uint64_t>(size64) > std::numeric_limits<ULONG>::max()) {
         return {};
     }
     const auto size = static_cast<size_t>(size64);
@@ -53,7 +53,7 @@ inline Microsoft::WRL::ComPtr<IStream> CreateMemoryStream(const void* data, size
     if (size > 0 && !data) {
         return nullptr;
     }
-    if (size > ULONG_MAX) {
+    if (size > std::numeric_limits<ULONG>::max()) {
         return nullptr;
     }
 
@@ -78,7 +78,7 @@ inline Microsoft::WRL::ComPtr<IStream> CreateMemoryStream(const void* data, size
 // 大きな画像ファイルで一時バッファへのコピーを避けるため、ReadFile を HGLOBAL にロックしたまま呼ぶ。
 inline Microsoft::WRL::ComPtr<IStream> CreateMemoryStreamFromFile(HANDLE file, size_t size)
 {
-    if (!file || file == INVALID_HANDLE_VALUE || size == 0 || size > ULONG_MAX) {
+    if (!file || file == INVALID_HANDLE_VALUE || size == 0 || size > std::numeric_limits<ULONG>::max()) {
         return nullptr;
     }
 

--- a/src/util/string_convert.h
+++ b/src/util/string_convert.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <climits>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <memory_resource>
@@ -13,8 +13,8 @@ inline void Utf8ToWide(std::string_view utf8, std::pmr::wstring& out)
         out.clear();
         return;
     }
-    // Windows API の cb*Char は int なので INT_MAX を超える入力は拒否する
-    if (utf8.size() > static_cast<size_t>(INT_MAX)) {
+    // Windows API の cb*Char は int なので int の最大値を超える入力は拒否する
+    if (utf8.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
         out.clear();
         return;
     }
@@ -39,7 +39,7 @@ inline void WideToUtf8(std::wstring_view wide, std::string& out)
         return;
     }
     // wide.size() * 3 のオーバーフローと cb*Char の int 制限を同時にガード
-    if (wide.size() > static_cast<size_t>(INT_MAX) / 3) {
+    if (wide.size() > static_cast<size_t>(std::numeric_limits<int>::max()) / 3) {
         out.clear();
         return;
     }

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -162,7 +162,7 @@ TEST(DocumentTest, RawTextSourceOffsetConsistency)
 
     // source_offset 位置の文字がノードのテキスト先頭と対応する
     for (const auto& n : nodes) {
-        if (n.source_offset != UINT32_MAX && n.source_offset < raw.size()) {
+        if (n.source_offset != kUnsetSourceOffset && n.source_offset < raw.size()) {
             EXPECT_LT(n.source_offset, static_cast<uint32_t>(raw.size()));
         }
     }

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -1217,9 +1217,9 @@ TEST(FindNodeBySourceOffset, SkipsUnsetOffsets)
 {
     std::pmr::vector<Node> nodes(3);
     nodes[0].source_offset = 0;
-    nodes[1].source_offset = UINT32_MAX; // 未設定（HorizontalRule等）
+    nodes[1].source_offset = kUnsetSourceOffset; // 未設定（HorizontalRule等）
     nodes[2].source_offset = 20;
-    // UINT32_MAX は常に diff_offset 以上にならない（UINT32_MAX <= diff_offset は通常 false）
+    // 未設定値は常に diff_offset 以上にならない（kUnsetSourceOffset <= diff_offset は通常 false）
     // → ノード0を返す
     EXPECT_EQ(FindNodeBySourceOffset(nodes, 10), 0);
     EXPECT_EQ(FindNodeBySourceOffset(nodes, 20), 2);
@@ -1231,7 +1231,7 @@ TEST(FindNodeBySourceOffset, ParsedMarkdown)
     ASSERT_GE(nodes.size(), 3u);
     // 各ノードが有効な source_offset を持つ
     for (const auto& n : nodes) {
-        EXPECT_NE(n.source_offset, UINT32_MAX);
+        EXPECT_NE(n.source_offset, kUnsetSourceOffset);
     }
     // 最初のノードの offset は "# " の後 = 2
     EXPECT_EQ(nodes[0].source_offset, 2u);
@@ -1251,11 +1251,11 @@ TEST(FindNodeBySourceOffset, LastNodeForLargeOffset)
 
 TEST(FindNodeBySourceOffset, AllUnsetOffsets)
 {
-    // 全ノードが UINT32_MAX（テキストなし）→ 該当なし
+    // 全ノードが未設定（テキストなし）→ 該当なし
     std::pmr::vector<Node> nodes(3);
-    nodes[0].source_offset = UINT32_MAX;
-    nodes[1].source_offset = UINT32_MAX;
-    nodes[2].source_offset = UINT32_MAX;
+    nodes[0].source_offset = kUnsetSourceOffset;
+    nodes[1].source_offset = kUnsetSourceOffset;
+    nodes[2].source_offset = kUnsetSourceOffset;
     EXPECT_EQ(FindNodeBySourceOffset(nodes, 50), -1);
 }
 
@@ -1264,9 +1264,9 @@ TEST(FindNodeBySourceOffset, MixedWithHorizontalRules)
     // パース結果で HorizontalRule が混在するケース
     auto nodes = ParseMarkdown("AAA\n\n---\n\nBBB").nodes;
     ASSERT_GE(nodes.size(), 3u);
-    // "AAA" offset=0, "---" offset=UINT32_MAX, "BBB" offset=10
+    // "AAA" offset=0, "---" は未設定, "BBB" offset=10
     EXPECT_EQ(nodes[0].source_offset, 0u);
-    EXPECT_EQ(nodes[1].source_offset, UINT32_MAX);
+    EXPECT_EQ(nodes[1].source_offset, kUnsetSourceOffset);
 
     // offset=5（"---"のソース位置付近）→ AAA(offset=0)を返す（HRはスキップ）
     EXPECT_EQ(FindNodeBySourceOffset(nodes, 5), 0);
@@ -1596,10 +1596,10 @@ TEST(CalcScrollYForDiff, FractionClampsToOne)
 
 TEST(CalcScrollYForDiff, SkipsUnsetSourceOffsets)
 {
-    // ノード1の source_offset が UINT32_MAX の場合、ノード2を next_start として使う
+    // ノード1の source_offset が未設定の場合、ノード2を next_start として使う
     std::pmr::vector<Node> nodes(3);
     nodes[0].source_offset = 0;
-    nodes[1].source_offset = UINT32_MAX; // 未設定（HorizontalRule等）
+    nodes[1].source_offset = kUnsetSourceOffset; // 未設定（HorizontalRule等）
     nodes[2].source_offset = 200;
     auto cache = MakeUniformCache(3, 100.0f);
     std::wstring content(300, L'x');

--- a/tests/test_file_explorer.cpp
+++ b/tests/test_file_explorer.cpp
@@ -54,7 +54,7 @@ TEST_F(FileExplorerTest, EmptyDirectoryHasParentOnly)
     // ".." 親エントリのみ
     auto& entries = explorer.GetEntries();
     ASSERT_EQ(entries.size(), 1u);
-    EXPECT_TRUE(entries[0].is_parent);
+    EXPECT_TRUE(entries[0].is_parent());
     EXPECT_EQ(std::wstring_view(entries[0].GetDisplayName()), L"..");
 }
 
@@ -178,9 +178,9 @@ TEST_F(FileExplorerTest, DirectoriesBeforeFiles)
 
     ASSERT_GE(entries.size(), 3u);
     // エントリ0: "..", エントリ1: ディレクトリ, エントリ2: ファイル
-    EXPECT_TRUE(entries[0].is_parent);
-    EXPECT_TRUE(entries[1].is_directory);
-    EXPECT_FALSE(entries[2].is_directory);
+    EXPECT_TRUE(entries[0].is_parent());
+    EXPECT_TRUE(entries[1].is_directory());
+    EXPECT_FALSE(entries[2].is_directory());
 }
 
 TEST_F(FileExplorerTest, EntriesSortedCaseInsensitive)
@@ -227,11 +227,11 @@ TEST_F(FileExplorerTest, SetCurrentFileMarksEntry)
     bool found = false;
     for (const auto& e : entries) {
         if (std::wstring_view(e.GetDisplayName()) == L"b.md") {
-            EXPECT_TRUE(e.is_current);
+            EXPECT_TRUE(e.is_current());
             found = true;
         }
         else {
-            EXPECT_FALSE(e.is_current);
+            EXPECT_FALSE(e.is_current());
         }
     }
     EXPECT_TRUE(found);
@@ -248,7 +248,7 @@ TEST_F(FileExplorerTest, SetCurrentFileDoesNotMarkDirectories)
     explorer.SetCurrentFile(dir_path);
 
     for (const auto& e : explorer.GetEntries()) {
-        EXPECT_FALSE(e.is_current);
+        EXPECT_FALSE(e.is_current());
     }
 }
 
@@ -298,7 +298,7 @@ TEST_F(FileExplorerTest, SetDirectoryWithoutCurrentFileHasNoCurrent)
 
     // SetCurrentFileを呼ばない場合、どのエントリもcurrentでないこと
     for (const auto& e : explorer.GetEntries()) {
-        EXPECT_FALSE(e.is_current);
+        EXPECT_FALSE(e.is_current());
     }
 }
 
@@ -315,7 +315,7 @@ TEST_F(FileExplorerTest, SetDirectoryWithCurrentWorkingDirectory)
     EXPECT_FALSE(explorer.GetDirectory().empty());
     // 少なくとも ".." エントリがあること
     EXPECT_GE(explorer.GetEntries().size(), 1u);
-    EXPECT_TRUE(explorer.GetEntries()[0].is_parent);
+    EXPECT_TRUE(explorer.GetEntries()[0].is_parent());
 }
 
 TEST_F(FileExplorerTest, SetDirectoryThenSetDirectoryAgainSwitches)

--- a/tests/test_hover_throttle.cpp
+++ b/tests/test_hover_throttle.cpp
@@ -4,11 +4,11 @@
 TEST(HoverThrottle, InitialState)
 {
     HoverThrottle ht;
-    EXPECT_EQ(ht.last_md_hit_pos.x, LONG_MIN);
-    EXPECT_EQ(ht.last_md_hit_pos.y, LONG_MIN);
+    EXPECT_EQ(ht.last_md_hit_pos.x, std::numeric_limits<LONG>::min());
+    EXPECT_EQ(ht.last_md_hit_pos.y, std::numeric_limits<LONG>::min());
     EXPECT_FALSE(ht.last_md_cursor_hand);
-    EXPECT_EQ(ht.last_copy_hit_pos.x, LONG_MIN);
-    EXPECT_EQ(ht.last_copy_hit_pos.y, LONG_MIN);
+    EXPECT_EQ(ht.last_copy_hit_pos.x, std::numeric_limits<LONG>::min());
+    EXPECT_EQ(ht.last_copy_hit_pos.y, std::numeric_limits<LONG>::min());
 }
 
 TEST(HoverThrottle, Reset)
@@ -18,10 +18,10 @@ TEST(HoverThrottle, Reset)
     ht.last_copy_hit_pos = { 300, 400 };
 
     ht.Reset();
-    EXPECT_EQ(ht.last_md_hit_pos.x, LONG_MIN);
-    EXPECT_EQ(ht.last_md_hit_pos.y, LONG_MIN);
-    EXPECT_EQ(ht.last_copy_hit_pos.x, LONG_MIN);
-    EXPECT_EQ(ht.last_copy_hit_pos.y, LONG_MIN);
+    EXPECT_EQ(ht.last_md_hit_pos.x, std::numeric_limits<LONG>::min());
+    EXPECT_EQ(ht.last_md_hit_pos.y, std::numeric_limits<LONG>::min());
+    EXPECT_EQ(ht.last_copy_hit_pos.x, std::numeric_limits<LONG>::min());
+    EXPECT_EQ(ht.last_copy_hit_pos.y, std::numeric_limits<LONG>::min());
 }
 
 TEST(HoverThrottle, ResetDoesNotAffectCursorFlag)

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1331,7 +1331,7 @@ TEST(Parser, SourceOffsetIncreasing)
     ASSERT_GE(nodes.size(), 3u);
     uint32_t prev = 0;
     for (size_t i = 0; i < nodes.size(); ++i) {
-        if (nodes[i].source_offset != UINT32_MAX) {
+        if (nodes[i].source_offset != kUnsetSourceOffset) {
             EXPECT_GE(nodes[i].source_offset, prev)
                 << "ノード " << i << " の source_offset が前のノードより小さい";
             prev = nodes[i].source_offset;
@@ -1357,11 +1357,11 @@ TEST(Parser, SourceOffsetEmptyInput)
 
 TEST(Parser, SourceOffsetHorizontalRule)
 {
-    // "---" はテキストを持たないのでsource_offsetは未設定(UINT32_MAX)のまま
+    // "---" はテキストを持たないのでsource_offsetは未設定のまま
     auto nodes = ParseMarkdown("---").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::HorizontalRule);
-    EXPECT_EQ(nodes[0].source_offset, UINT32_MAX);
+    EXPECT_EQ(nodes[0].source_offset, kUnsetSourceOffset);
 }
 
 TEST(Parser, SourceOffsetCjkMultiCodeUnit)
@@ -1410,7 +1410,7 @@ TEST(Parser, SourceOffsetNestedList)
     ASSERT_GE(nodes.size(), 3u);
     uint32_t prev = 0;
     for (size_t i = 0; i < nodes.size(); ++i) {
-        if (nodes[i].source_offset != UINT32_MAX) {
+        if (nodes[i].source_offset != kUnsetSourceOffset) {
             EXPECT_GE(nodes[i].source_offset, prev)
                 << "ノード " << i << " の offset が前のノードより小さい";
             prev = nodes[i].source_offset;
@@ -1448,14 +1448,14 @@ TEST(Parser, SourceOffsetMixedDocument)
         "- item\n\n"             // list
         "> quote\n\n"            // blockquote
         "```\ncode\n```\n\n"     // code
-        "---\n\n"                // hr (UINT32_MAX)
+        "---\n\n"                // hr (offset 未設定)
         "End";                   // paragraph
     auto nodes = ParseMarkdown(md).nodes;
     ASSERT_GE(nodes.size(), 6u);
 
     uint32_t prev = 0;
     for (size_t i = 0; i < nodes.size(); ++i) {
-        if (nodes[i].source_offset != UINT32_MAX) {
+        if (nodes[i].source_offset != kUnsetSourceOffset) {
             EXPECT_GE(nodes[i].source_offset, prev)
                 << "ノード " << i << " (type="
                 << static_cast<int>(nodes[i].type) << ") の offset が不正";

--- a/tests/test_render_composer.cpp
+++ b/tests/test_render_composer.cpp
@@ -135,9 +135,7 @@ TEST(RenderComposer, TitleBarState_ButtonsComeFromTitleBar)
     state.window.titlebar.SetHovered(TitleBarHitZone::Close);
 
     auto tb = render_composer::BuildTitleBarState(state, 1024.0f, false, false);
-    EXPECT_TRUE(tb.close.hovered);
-    EXPECT_FALSE(tb.minimize.hovered);
-    EXPECT_FALSE(tb.maximize.hovered);
+    EXPECT_EQ(tb.hovered_zone, TitleBarHitZone::Close);
 }
 
 TEST(RenderComposer, TitleBarState_PaneVisibilityMirrorsState)

--- a/tests/test_side_effect_executor.cpp
+++ b/tests/test_side_effect_executor.cpp
@@ -232,12 +232,10 @@ TEST_F(SideEffectExecutorTest, ApplyThemeChangeForwardsStruct)
 {
     effect::ApplyThemeChange in{};
     in.type = effect::ApplyThemeChange::Type::Zoom;
-    in.new_zoom = 1.25f;
     in.zoom_index = 4;
     exec_.ExecuteOne(in);
     EXPECT_EQ(apply_theme_change_count_, 1);
     EXPECT_EQ(last_theme_change_.type, effect::ApplyThemeChange::Type::Zoom);
-    EXPECT_FLOAT_EQ(last_theme_change_.new_zoom, 1.25f);
     EXPECT_EQ(last_theme_change_.zoom_index, 4);
 }
 

--- a/tests/test_titlebar.cpp
+++ b/tests/test_titlebar.cpp
@@ -281,15 +281,12 @@ TEST_F(TitleBarTest, HitTestButtonBoundaryRight)
 TEST_F(TitleBarTest, InitialHoverIsNone)
 {
     EXPECT_EQ(tb_.GetHovered(), TitleBarHitZone::None);
-    EXPECT_FALSE(tb_.GetFileToggleButton().hovered);
-    EXPECT_FALSE(tb_.GetCloseButton().hovered);
 }
 
 TEST_F(TitleBarTest, SetHoveredReturnsTrueOnChange)
 {
     EXPECT_TRUE(tb_.SetHovered(TitleBarHitZone::Close));
     EXPECT_EQ(tb_.GetHovered(), TitleBarHitZone::Close);
-    EXPECT_TRUE(tb_.GetCloseButton().hovered);
 }
 
 TEST_F(TitleBarTest, SetHoveredReturnsFalseOnSame)
@@ -302,8 +299,6 @@ TEST_F(TitleBarTest, SetHoveredClearsPrevious)
 {
     tb_.SetHovered(TitleBarHitZone::Close);
     tb_.SetHovered(TitleBarHitZone::Minimize);
-    EXPECT_FALSE(tb_.GetCloseButton().hovered);
-    EXPECT_TRUE(tb_.GetMinimizeButton().hovered);
     EXPECT_EQ(tb_.GetHovered(), TitleBarHitZone::Minimize);
 }
 
@@ -311,45 +306,7 @@ TEST_F(TitleBarTest, SetHoveredNoneClearsAll)
 {
     tb_.SetHovered(TitleBarHitZone::FileToggle);
     tb_.SetHovered(TitleBarHitZone::None);
-    EXPECT_FALSE(tb_.GetOpenFileButton().hovered);
-    EXPECT_FALSE(tb_.GetHelpButton().hovered);
-    EXPECT_FALSE(tb_.GetThemeToggleButton().hovered);
-    EXPECT_FALSE(tb_.GetSearchButton().hovered);
-    EXPECT_FALSE(tb_.GetFileToggleButton().hovered);
-    EXPECT_FALSE(tb_.GetTocToggleButton().hovered);
-    EXPECT_FALSE(tb_.GetMinimizeButton().hovered);
-    EXPECT_FALSE(tb_.GetMaximizeButton().hovered);
-    EXPECT_FALSE(tb_.GetCloseButton().hovered);
-}
-
-TEST_F(TitleBarTest, SetHoveredSetsExactlyOneButton)
-{
-    auto countHovered = [&]() {
-        int count = 0;
-        if (tb_.GetOpenFileButton().hovered) { ++count; }
-        if (tb_.GetHelpButton().hovered) { ++count; }
-        if (tb_.GetThemeToggleButton().hovered) { ++count; }
-        if (tb_.GetSearchButton().hovered) { ++count; }
-        if (tb_.GetFileToggleButton().hovered) { ++count; }
-        if (tb_.GetTocToggleButton().hovered) { ++count; }
-        if (tb_.GetMinimizeButton().hovered) { ++count; }
-        if (tb_.GetMaximizeButton().hovered) { ++count; }
-        if (tb_.GetCloseButton().hovered) { ++count; }
-        return count;
-    };
-
-    TitleBarHitZone zones[] = {
-        TitleBarHitZone::OpenFile,
-        TitleBarHitZone::Help, TitleBarHitZone::ThemeToggle,
-        TitleBarHitZone::Search,
-        TitleBarHitZone::FileToggle, TitleBarHitZone::TocToggle,
-        TitleBarHitZone::Minimize, TitleBarHitZone::Maximize,
-        TitleBarHitZone::Close,
-    };
-    for (auto zone : zones) {
-        tb_.SetHovered(zone);
-        EXPECT_EQ(countHovered(), 1) << "zone=" << std::to_underlying(zone);
-    }
+    EXPECT_EQ(tb_.GetHovered(), TitleBarHitZone::None);
 }
 
 // ═══════════════════════════════════════════════

--- a/tests/test_viewport_manager.cpp
+++ b/tests/test_viewport_manager.cpp
@@ -243,39 +243,39 @@ TEST(ViewportManagerTest, SelectAllEmpty)
 
 // ---- ズームテスト ----
 
-TEST(ViewportManagerTest, ZoomInReturnsNewZoom)
+TEST(ViewportManagerTest, ZoomInAdvancesIndex)
 {
     ViewportManager vm; // starts at ZOOM_DEFAULT_INDEX (1.0)
-    float z = vm.ZoomIn();
-    EXPECT_GT(z, 1.0f);
+    EXPECT_TRUE(vm.ZoomIn());
     EXPECT_EQ(vm.GetZoomIndex(), ZOOM_DEFAULT_INDEX + 1);
+    EXPECT_GT(vm.GetCurrentZoom(), 1.0f);
 }
 
-TEST(ViewportManagerTest, ZoomOutReturnsNewZoom)
+TEST(ViewportManagerTest, ZoomOutDecrementsIndex)
 {
     ViewportManager vm;
-    float z = vm.ZoomOut();
-    EXPECT_LT(z, 1.0f);
-    EXPECT_GT(z, 0.0f);
+    EXPECT_TRUE(vm.ZoomOut());
     EXPECT_EQ(vm.GetZoomIndex(), ZOOM_DEFAULT_INDEX - 1);
+    EXPECT_LT(vm.GetCurrentZoom(), 1.0f);
+    EXPECT_GT(vm.GetCurrentZoom(), 0.0f);
 }
 
-TEST(ViewportManagerTest, ZoomInAtMaxReturnsZero)
+TEST(ViewportManagerTest, ZoomInAtMaxReturnsFalse)
 {
     ViewportManager vm;
     // 最大までズーム
     for (int i = 0; i < 50; ++i) vm.ZoomIn();
-    float z = vm.ZoomIn();
-    EXPECT_FLOAT_EQ(z, 0.0f);
+    EXPECT_FALSE(vm.ZoomIn());
+    EXPECT_EQ(vm.GetZoomIndex(), ZOOM_STEP_COUNT - 1);
 }
 
-TEST(ViewportManagerTest, ZoomOutAtMinReturnsZero)
+TEST(ViewportManagerTest, ZoomOutAtMinReturnsFalse)
 {
     ViewportManager vm;
     // 最小までズーム
     for (int i = 0; i < 50; ++i) vm.ZoomOut();
-    float z = vm.ZoomOut();
-    EXPECT_FLOAT_EQ(z, 0.0f);
+    EXPECT_FALSE(vm.ZoomOut());
+    EXPECT_EQ(vm.GetZoomIndex(), 0);
 }
 
 TEST(ViewportManagerTest, ZoomResetFromNonDefault)
@@ -283,16 +283,16 @@ TEST(ViewportManagerTest, ZoomResetFromNonDefault)
     ViewportManager vm;
     vm.ZoomIn();
     vm.ZoomIn();
-    float z = vm.ZoomReset();
-    EXPECT_FLOAT_EQ(z, 1.0f);
+    EXPECT_TRUE(vm.ZoomReset());
     EXPECT_EQ(vm.GetZoomIndex(), ZOOM_DEFAULT_INDEX);
+    EXPECT_FLOAT_EQ(vm.GetCurrentZoom(), 1.0f);
 }
 
 TEST(ViewportManagerTest, ZoomResetAlreadyDefault)
 {
     ViewportManager vm;
-    float z = vm.ZoomReset();
-    EXPECT_FLOAT_EQ(z, 0.0f); // 変更不要
+    EXPECT_FALSE(vm.ZoomReset()); // 変更不要
+    EXPECT_EQ(vm.GetZoomIndex(), ZOOM_DEFAULT_INDEX);
 }
 
 TEST(ViewportManagerTest, SetZoomIndexClampsBelowZero)


### PR DESCRIPTION
## Summary

- 各 `enum class` に明示的な `uint8_t` 基底型を付与し、`Node` フィールドを 4B/1B アライメント別に並べ替え。`heading_level`/`indent_level` 等を `int8_t` に縮小。`TitleBarRenderState` の per-button `bool hovered` を `TitleBarHitZone hovered_zone` 1 個に統合。`FileEntry` の 3 つの bool を `uint8_t flags_` に統合。
- `ViewportManager::ZoomIn/Out/Reset` の戻り値を `float` センチネル(0.0=変化なし)から `bool changed` に変更。`effect::ApplyThemeChange::new_zoom` を撤去し `zoom_index` を SSOT 化（消費側で `ZOOM_STEPS[zoom_index]` 復元）。
- `*_MAX/*_MIN` マクロを `std::numeric_limits<T>::max()/min()` に統一。`Node::source_offset` の "未設定" センチネルを `kUnsetSourceOffset` として `document_types.h` に集約し、`reload.cpp` の重複 `kUnset` を削除。
- ヘッダ定義のメンバ関数群に `constexpr` を波及（インライン化補助）。
- `parser.cpp`: `blockquote_indices` を `parse_resource` に載せて per-parse ヒープ確保を削減。monotonic 初期チャンクを 64KB→128KB に拡大。

## /simplify レビュー指摘対応
- 自明に成り立つ `SetHoveredSetsExactlyOneButton` テストを削除（`hovered_` 単一値を 9 ゾーンに対し `==` 比較すると常に 1 になる）。
- `app_mouse_helpers.h` の clang-format に潰された `requires` 節（`concept&&` 連結）を 1 制約 1 行に整形。
- 差分を narrate するだけのコメント（"9 個並ぶ末尾パディング 27B を節約" 等）を削除。

## Test plan

- [x] `cmake --build build --config Release` が成功
- [x] `mendo_tests.exe --gtest_brief=1` が 2042 件すべて PASS
- [x] 起動して MD ファイルを開く・ズーム・タイトルバーホバー・検索の golden path を手動確認
- [x] ファイルペインのアイコン/カレント行ハイライトの回帰確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)