### PR TITLE
refactor: switch を unreachable で網羅化し、文字列比較を lookup table 化

### DIFF
--- a/src/core/document_utils.cpp
+++ b/src/core/document_utils.cpp
@@ -1,9 +1,11 @@
 #include "document_utils.h"
 #include "ascii_util.h"
+#include <algorithm>
 #include <cstdint>
 #include <filesystem>
 #include <format>
 #include <iterator>
+#include <ranges>
 
 std::pmr::wstring ToLowerAscii(std::wstring_view text)
 {
@@ -56,10 +58,15 @@ WordBoundary FindWordBoundaries(std::wstring_view text, uint32_t pos) noexcept
 
 bool IsMarkdownFile(std::wstring_view path)
 {
+    static constexpr ascii_util::LowercaseAsciiLiteral kMarkdownExts[]{
+        L".md",
+        L".markdown",
+        L".mkd",
+    };
     const auto ext = std::filesystem::path(path).extension().wstring();
-    return ascii_util::iequal(ext, L".md")
-        || ascii_util::iequal(ext, L".markdown")
-        || ascii_util::iequal(ext, L".mkd");
+    return std::ranges::any_of(kMarkdownExts, [&](const auto& e) {
+        return ascii_util::iequal(ext, e);
+    });
 }
 
 std::pmr::wstring ExtractFilename(std::wstring_view path)

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <utility>
 
 namespace {
 
@@ -345,6 +346,8 @@ int OnEnterBlock(MD_BLOCKTYPE type, void* detail, void* userdata)
     }
     case MD_BLOCK_HTML:
         break;
+    default:
+        std::unreachable();
     }
 
     return 0;
@@ -444,8 +447,12 @@ int OnLeaveBlock(MD_BLOCKTYPE type, void* /*detail*/, void* userdata)
         ctx->current_node = nullptr;
         break;
 
-    default:
+    case MD_BLOCK_DOC:
+    case MD_BLOCK_HTML:
         break;
+
+    default:
+        std::unreachable();
     }
 
     return 0;
@@ -508,9 +515,14 @@ int OnEnterSpan(MD_SPANTYPE type, void* detail, void* userdata)
         ctx->AppendWide(L"$");
         ctx->paragraph_has_other_content = true;
         break;
-    default:
+        // WIKILINK / U は現フラグ (MD_FLAG_WIKILINKS / MD_FLAG_UNDERLINE 未指定) では未到達。
+        // 将来フラグ追加時に default の std::unreachable() を踏まないよう明示している。
+    case MD_SPAN_WIKILINK:
+    case MD_SPAN_U:
         ctx->paragraph_has_other_content = true;
         break;
+    default:
+        std::unreachable();
     }
 
     return 0;
@@ -553,8 +565,11 @@ int OnLeaveSpan(MD_SPANTYPE type, void* /*detail*/, void* userdata)
     case MD_SPAN_LATEXMATH:
         ctx->AppendWide(L"$");
         break;
-    default:
+    case MD_SPAN_WIKILINK:
+    case MD_SPAN_U:
         break;
+    default:
+        std::unreachable();
     }
 
     return 0;
@@ -620,8 +635,12 @@ int OnText(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, void* userdata)
         ctx->AppendWide(L" ");
         break;
 
-    default:
+    case MD_TEXT_NULLCHAR:
+    case MD_TEXT_HTML:
         break;
+
+    default:
+        std::unreachable();
     }
 
     return 0;
@@ -676,24 +695,26 @@ ParseResult ParseMarkdown(std::string_view utf8_markdown_text)
 std::wstring_view GetAlertLabel(AlertType type) noexcept
 {
     switch (type) {
+    case AlertType::None:      return L"";
     case AlertType::Note:      return L"Note";
     case AlertType::Tip:       return L"Tip";
     case AlertType::Important: return L"Important";
     case AlertType::Warning:   return L"Warning";
     case AlertType::Caution:   return L"Caution";
-    default:                   return L"";
+    default:                   std::unreachable();
     }
 }
 
 std::wstring_view GetAlertIcon(AlertType type) noexcept
 {
     switch (type) {
+    case AlertType::None:      return L" ";
     case AlertType::Note:      return L"ℹ";         // ℹ Information Source
     case AlertType::Tip:       return L"\xD83D\xDCA1";   // 💡 Light Bulb (surrogate pair)
     case AlertType::Important: return L"❗";         // ❗ Heavy Exclamation Mark
     case AlertType::Warning:   return L"⚠";         // ⚠ Warning Sign
     case AlertType::Caution:   return L"⛔";         // ⛔ No Entry
-    default:                   return L" ";
+    default:                   std::unreachable();
     }
 }
 
@@ -713,23 +734,25 @@ AlertType DetectAlertMarker(std::wstring_view text, size_t& marker_end)
 
     const auto type_str = text.substr(2, close - 2);
 
-    AlertType type = AlertType::None;
-    if (ascii_util::iequal(type_str, L"NOTE")) {
-        type = AlertType::Note;
-    }
-    else if (ascii_util::iequal(type_str, L"TIP")) {
-        type = AlertType::Tip;
-    }
-    else if (ascii_util::iequal(type_str, L"IMPORTANT")) {
-        type = AlertType::Important;
-    }
-    else if (ascii_util::iequal(type_str, L"WARNING")) {
-        type = AlertType::Warning;
-    }
-    else if (ascii_util::iequal(type_str, L"CAUTION")) {
-        type = AlertType::Caution;
-    }
+    struct AlertEntry {
+        ascii_util::LowercaseAsciiLiteral name;
+        AlertType type;
+    };
+    static constexpr AlertEntry kAlerts[]{
+        { L"note",      AlertType::Note      },
+        { L"tip",       AlertType::Tip       },
+        { L"important", AlertType::Important },
+        { L"warning",   AlertType::Warning   },
+        { L"caution",   AlertType::Caution   },
+    };
 
+    AlertType type = AlertType::None;
+    for (const auto& [name, t] : kAlerts) {
+        if (ascii_util::iequal(type_str, name)) {
+            type = t;
+            break;
+        }
+    }
     if (type == AlertType::None) {
         return AlertType::None;
     }

--- a/src/core/syntax.cpp
+++ b/src/core/syntax.cpp
@@ -539,82 +539,62 @@ static_assert(std::size(LANGUAGE_DEFS) == std::to_underlying(SyntaxLanguage::Lat
 
 // ---- 公開API ----
 
-SyntaxLanguage DetectLanguage(std::string_view info_string)
-{
-    if (info_string.empty()) {
-        return SyntaxLanguage::None;
-    }
-
-    // 最初の単語を抽出してASCII小文字に変換（スタックバッファで割り当て回避）
-    char lang_buf[32];
-    size_t lang_len = 0;
-    for (char c : info_string) {
-        if (c == ' ' || c == '\t') {
-            break;
-        }
-        if (lang_len >= sizeof(lang_buf) - 1) {
-            break;
-        }
-        lang_buf[lang_len++] = ascii_util::ToLowerAscii(c);
-    }
-    const std::string_view lang(lang_buf, lang_len);
-
-    if (lang == "c" || lang == "cpp" || lang == "c++" || lang == "cxx" ||
-        lang == "h" || lang == "hpp" || lang == "cc" || lang == "hxx") {
-        return SyntaxLanguage::Cpp;
-    }
-    if (lang == "python" || lang == "py") {
-        return SyntaxLanguage::Python;
-    }
-    if (lang == "javascript" || lang == "js" || lang == "jsx") {
-        return SyntaxLanguage::JavaScript;
-    }
-    if (lang == "typescript" || lang == "ts" || lang == "tsx") {
-        return SyntaxLanguage::TypeScript;
-    }
-    if (lang == "mermaid") {
-        return SyntaxLanguage::Mermaid;
-    }
-    if (lang == "go" || lang == "golang") {
-        return SyntaxLanguage::Go;
-    }
-    if (lang == "rust" || lang == "rs") {
-        return SyntaxLanguage::Rust;
-    }
-    if (lang == "bash" || lang == "sh" || lang == "zsh" || lang == "shell") {
-        return SyntaxLanguage::Bash;
-    }
-    if (lang == "powershell" || lang == "pwsh" || lang == "ps1") {
-        return SyntaxLanguage::PowerShell;
-    }
-    if (lang == "cmd" || lang == "bat" || lang == "batch" || lang == "dosbatch") {
-        return SyntaxLanguage::Cmd;
-    }
-    if (lang == "json" || lang == "jsonc" || lang == "json5") {
-        return SyntaxLanguage::Json;
-    }
-
-    return SyntaxLanguage::None;
-}
-
 SyntaxLanguage DetectLanguage(std::wstring_view info_string)
 {
-    if (info_string.empty()) {
+    // info string の最初の空白/タブまでを言語識別子として抽出。残りは追加情報。
+    const auto lang = info_string.substr(0, info_string.find_first_of(L" \t"));
+    if (lang.empty()) {
         return SyntaxLanguage::None;
     }
-    // 言語名は全てASCIIなのでnarrowに変換してstring_view版に委譲
-    char buf[32];
-    size_t len = 0;
-    for (wchar_t c : info_string) {
-        if (c == L' ' || c == L'\t') {
-            break;
+
+    struct Alias {
+        ascii_util::LowercaseAsciiLiteral name;
+        SyntaxLanguage language;
+    };
+    static constexpr Alias kAliases[]{
+        { L"c",          SyntaxLanguage::Cpp        },
+        { L"cpp",        SyntaxLanguage::Cpp        },
+        { L"c++",        SyntaxLanguage::Cpp        },
+        { L"cxx",        SyntaxLanguage::Cpp        },
+        { L"h",          SyntaxLanguage::Cpp        },
+        { L"hpp",        SyntaxLanguage::Cpp        },
+        { L"cc",         SyntaxLanguage::Cpp        },
+        { L"hxx",        SyntaxLanguage::Cpp        },
+        { L"python",     SyntaxLanguage::Python     },
+        { L"py",         SyntaxLanguage::Python     },
+        { L"javascript", SyntaxLanguage::JavaScript },
+        { L"js",         SyntaxLanguage::JavaScript },
+        { L"jsx",        SyntaxLanguage::JavaScript },
+        { L"typescript", SyntaxLanguage::TypeScript },
+        { L"ts",         SyntaxLanguage::TypeScript },
+        { L"tsx",        SyntaxLanguage::TypeScript },
+        { L"mermaid",    SyntaxLanguage::Mermaid    },
+        { L"go",         SyntaxLanguage::Go         },
+        { L"golang",     SyntaxLanguage::Go         },
+        { L"rust",       SyntaxLanguage::Rust       },
+        { L"rs",         SyntaxLanguage::Rust       },
+        { L"bash",       SyntaxLanguage::Bash       },
+        { L"sh",         SyntaxLanguage::Bash       },
+        { L"zsh",        SyntaxLanguage::Bash       },
+        { L"shell",      SyntaxLanguage::Bash       },
+        { L"powershell", SyntaxLanguage::PowerShell },
+        { L"pwsh",       SyntaxLanguage::PowerShell },
+        { L"ps1",        SyntaxLanguage::PowerShell },
+        { L"cmd",        SyntaxLanguage::Cmd        },
+        { L"bat",        SyntaxLanguage::Cmd        },
+        { L"batch",      SyntaxLanguage::Cmd        },
+        { L"dosbatch",   SyntaxLanguage::Cmd        },
+        { L"json",       SyntaxLanguage::Json       },
+        { L"jsonc",      SyntaxLanguage::Json       },
+        { L"json5",      SyntaxLanguage::Json       },
+    };
+
+    for (const auto& [alias, language] : kAliases) {
+        if (ascii_util::iequal(lang, alias)) {
+            return language;
         }
-        if (len >= sizeof(buf) - 1 || c > 0x7F) {
-            break;
-        }
-        buf[len++] = static_cast<char>(c);
     }
-    return DetectLanguage(std::string_view(buf, len));
+    return SyntaxLanguage::None;
 }
 
 std::pmr::vector<SyntaxToken> Tokenize(std::wstring_view text, SyntaxLanguage language)

--- a/src/core/syntax.h
+++ b/src/core/syntax.h
@@ -50,6 +50,5 @@ struct SyntaxToken {
 };
 
 SyntaxLanguage DetectLanguage(std::wstring_view info_string);
-SyntaxLanguage DetectLanguage(std::string_view info_string);
 
 std::pmr::vector<SyntaxToken> Tokenize(std::wstring_view text, SyntaxLanguage language);

--- a/src/util/ascii_util.h
+++ b/src/util/ascii_util.h
@@ -213,10 +213,18 @@ inline size_t Find(std::wstring_view text, std::wstring_view query, size_t start
     return npos;
 }
 
-// 小文字 ASCII リテラル専用の引数型。コンパイル時に大文字混入を検出する。
+// 小文字 ASCII リテラル専用の引数型。コンパイル時に契約違反を検出する。
 // 配列参照のテンプレートコンストラクタで wchar_t リテラルしか受け付けず、
-// consteval 内で大文字を見つけたら throw により定数評価が ill-formed となり
-// コンパイルエラーになる。実行時オーバーヘッドはゼロ。
+// consteval 内の throw で定数評価を ill-formed にしてコンパイルエラーを発生させる。
+// 実行時オーバーヘッドはゼロ。
+//
+// 検証する契約:
+//  - NUL 終端 (literal[N-1] == L'\0')。文字列リテラルなら自動で満たすが、
+//    手書きの wchar_t[N] 配列で終端を忘れた場合に弾く。
+//  - 全文字が ASCII 範囲 (<= 0x7F)。CJK 等が混じるとサイレントに通って
+//    比較側で常に不一致になるため、明示的に拒否する。
+//  - 大文字 'A'-'Z' を含まない。`iequal` 等は LHS のみ projection で
+//    小文字化する高速版なので、RHS は小文字確定でなければならない。
 struct LowercaseAsciiLiteral {
     std::wstring_view value;
 
@@ -224,7 +232,13 @@ struct LowercaseAsciiLiteral {
     consteval LowercaseAsciiLiteral(const wchar_t (&literal)[N]) noexcept
         : value(literal, N - 1)
     {
+        if (literal[N - 1] != L'\0') {
+            throw "LowercaseAsciiLiteral: literal must be NUL-terminated";
+        }
         for (size_t i = 0; i < N - 1; ++i) {
+            if (literal[i] > 0x7F) {
+                throw "LowercaseAsciiLiteral: literal must contain only ASCII characters";
+            }
             if (literal[i] >= L'A' && literal[i] <= L'Z') {
                 throw "LowercaseAsciiLiteral: literal must be lowercase ASCII";
             }

--- a/src/util/ascii_util.h
+++ b/src/util/ascii_util.h
@@ -213,22 +213,38 @@ inline size_t Find(std::wstring_view text, std::wstring_view query, size_t start
     return npos;
 }
 
-// 大小無視の等価比較。ASCII 'A'-'Z' のみ小文字化、他は素通し。locale 非依存。
-constexpr bool iequal(std::wstring_view a, std::wstring_view b) noexcept
-{
-    return std::ranges::equal(a, b, {}, ToLowerAscii, ToLowerAscii);
-}
+// 小文字 ASCII リテラル専用の引数型。コンパイル時に大文字混入を検出する。
+// 配列参照のテンプレートコンストラクタで wchar_t リテラルしか受け付けず、
+// consteval 内で大文字を見つけたら throw により定数評価が ill-formed となり
+// コンパイルエラーになる。実行時オーバーヘッドはゼロ。
+struct LowercaseAsciiLiteral {
+    std::wstring_view value;
 
-// 大小無視の辞書順比較。a < b なら true。
-constexpr bool iless(std::wstring_view a, std::wstring_view b) noexcept
+    template <size_t N>
+    consteval LowercaseAsciiLiteral(const wchar_t (&literal)[N]) noexcept
+        : value(literal, N - 1)
+    {
+        for (size_t i = 0; i < N - 1; ++i) {
+            if (literal[i] >= L'A' && literal[i] <= L'Z') {
+                throw "LowercaseAsciiLiteral: literal must be lowercase ASCII";
+            }
+        }
+    }
+};
+
+// 大小無視の等価比較。ASCII 'A'-'Z' のみ小文字化、他は素通し。locale 非依存。
+// LHS のみ projection で小文字化する高速版。RHS は LowercaseAsciiLiteral 型で
+// 受けることで、小文字リテラル以外を渡せないことをコンパイル時に保証する。
+constexpr bool iequal(std::wstring_view a, LowercaseAsciiLiteral b) noexcept
 {
-    return std::ranges::lexicographical_compare(a, b, {}, ToLowerAscii, ToLowerAscii);
+    return std::ranges::equal(a, b.value, {}, ToLowerAscii);
 }
 
 // 大小無視のプレフィックスマッチ。s が prefix で始まれば true。
-constexpr bool istarts_with(std::wstring_view s, std::wstring_view prefix) noexcept
+constexpr bool istarts_with(std::wstring_view s, LowercaseAsciiLiteral prefix) noexcept
 {
-    return s.size() >= prefix.size() && iequal(s.substr(0, prefix.size()), prefix);
+    return s.size() >= prefix.value.size() &&
+           std::ranges::equal(s.substr(0, prefix.value.size()), prefix.value, {}, ToLowerAscii);
 }
 
 template <typename T, std::unsigned_integral U>


### PR DESCRIPTION
## Summary

- md4c コールバック 5 関数と Alert ヘルパ 2 関数の switch を完全網羅化。`default: std::unreachable();` でジャンプテーブルの境界チェックを除去できるようにした
- `ascii_util::iequal` / `istarts_with` の RHS を新設の `LowercaseAsciiLiteral` 型に変更。`consteval` コンストラクタで小文字 ASCII リテラル以外を弾くため、暗黙の小文字契約を型システムで強制できる。両辺 projection だった比較を片側 projection に減らせる副次効果あり
- `DetectLanguage` / `IsMarkdownFile` / `DetectAlertMarker` の文字列 if-cascade を `LowercaseAsciiLiteral` を使った `static constexpr` lookup table に統一

## 詳細

### switch 完全網羅 + std::unreachable

`OnEnterBlock` / `OnLeaveBlock` / `OnEnterSpan` / `OnLeaveSpan` / `OnText` の 5 つの md4c コールバック、および `GetAlertLabel` / `GetAlertIcon` で全 enum 値を明示する `case` を並べ、`default:` を `std::unreachable()` に変更した。

`MD_BLOCK_HTML` / `MD_TEXT_HTML` は md4c の現フラグ (`MD_DIALECT_GITHUB | MD_FLAG_LATEXMATHSPANS`) で実際に発行される。`MD_SPAN_WIKILINK` / `MD_SPAN_U` は現フラグでは未到達だが、将来 `MD_FLAG_WIKILINKS` / `MD_FLAG_UNDERLINE` を有効化したときに `std::unreachable()` を踏まないよう明示 case として残してある。`AlertType::None` は `GetAlertLabel(None)` 等のテストから直接呼ばれるため明示 case 必須。

### LowercaseAsciiLiteral

\`\`\`cpp
struct LowercaseAsciiLiteral {
    std::wstring_view value;

    template <size_t N>
    consteval LowercaseAsciiLiteral(const wchar_t (&literal)[N]) noexcept
        : value(literal, N - 1)
    {
        for (size_t i = 0; i < N - 1; ++i) {
            if (literal[i] >= L'A' && literal[i] <= L'Z') {
                throw \"LowercaseAsciiLiteral: literal must be lowercase ASCII\";
            }
        }
    }
};
\`\`\`

`consteval` 内の `throw` は定数評価が ill-formed になるためコンパイルエラー (MSVC C7595) になる。実行時オーバーヘッドはゼロ。

`iequal` / `istarts_with` の RHS をこの型に変更したことで、両辺に `ToLowerAscii` を適用していた projection が片側だけで済む。RHS の小文字保証は型レベルで担保される。

副次変更:
- `DetectAlertMarker` 内の `L\"NOTE\"` 等の大文字リテラルを `L\"note\"` 等に変更
- 未使用の `ascii_util::iless` を削除
- `syntax.cpp` の `DetectLanguage(std::string_view)` オーバーロードを削除し、`DetectLanguage(std::wstring_view)` を `LowercaseAsciiLiteral` ベースに書き換え

### Lookup table 化

`DetectLanguage` (35 エイリアス → SyntaxLanguage)、`IsMarkdownFile` (3 拡張子)、`DetectAlertMarker` (5 種別 → AlertType) の文字列比較を `static constexpr` 配列 + ループに統一。新エイリアス追加が 1 行で済む。

## Test plan

- [x] `cmake --build build --config Release` 成功
- [x] `mendo_tests.exe` 全 2054 テスト pass
- [x] `LowercaseAsciiLiteral` のコンパイル時ガードを `L\".TXT\"` に書き換えて検証 (C7595 エラー発生を確認、その後元に戻し)
- [x] 大規模 Markdown ファイル (README 系、技術文書) で挙動回帰がないことの目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)