### PR TITLE
fix: issue #158 縦に長いテーブル直後の描画が重なる + ライブリロード UX 改善

### DIFF
--- a/src/app/app.h
+++ b/src/app/app.h
@@ -181,7 +181,7 @@ private:
     void ReloadCurrentFile();
     void DoReloadCurrentFile();
     void DoLoadMarkdownFile();
-    void BeginAsyncLoad(std::pmr::wstring path);
+    void BeginAsyncLoad(std::pmr::wstring path, bool suppress_animation = false);
     void FinishLoadMarkdownFile(bool heights_estimated = false);
     void HandleLoadFailureFallback();
     float CalcScrollForDiff(size_t diff_pos, float viewport_height) const;

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -315,8 +315,10 @@ void App::ReloadCurrentFile()
     if (path.empty() || IsHelpPath(path)) {
         return;
     }
-    // ローディングアニメーション表示中は重複リロードを抑制
-    if (file_load_service_.IsLoading()) {
+    // ローディング表示中・非同期パース進行中は重複リロードを抑制。
+    // suppress_animation 経路では IsLoading() が立たないため IsAsyncLoading() も
+    // 併せて見ないと FileWatcher のバーストで重複スケジュールされる。
+    if (file_load_service_.IsLoading() || file_load_service_.IsAsyncLoading()) {
         return;
     }
 

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -315,9 +315,9 @@ void App::ReloadCurrentFile()
     if (path.empty() || IsHelpPath(path)) {
         return;
     }
-    // ローディング表示中・非同期パース進行中は重複リロードを抑制。
-    // suppress_animation 経路では IsLoading() が立たないため IsAsyncLoading() も
-    // 併せて見ないと FileWatcher のバーストで重複スケジュールされる。
+    // FileWatcher のバーストで重複スケジュールされないよう、進行中のロードが
+    // あれば即 return する。suppress_animation 経路では IsLoading() が立たない
+    // ため IsAsyncLoading() も併せて見る。
     if (file_load_service_.IsLoading() || file_load_service_.IsAsyncLoading()) {
         return;
     }

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -55,9 +55,14 @@ void App::LoadHelpDocument()
     UpdateTitleBar();
 }
 
-void App::BeginAsyncLoad(std::pmr::wstring path)
+void App::BeginAsyncLoad(std::pmr::wstring path, bool suppress_animation)
 {
-    const bool show_anim = DocumentService::NeedsLoadingAnimation(path) && !state_.pending_reload_retry;
+    // ライブリロード時はアニメーションを表示しない。
+    // 大きいファイルを編集中の差分リロードでスピナーが点滅すると視認性が下がるため、
+    // 旧コンテンツを表示したまま静かにバックグラウンドでパースし差し替える。
+    const bool show_anim = !suppress_animation
+        && DocumentService::NeedsLoadingAnimation(path)
+        && !state_.pending_reload_retry;
     if (show_anim) {
         file_load_service_.StartLoading(std::move(path));
         EmitEffect(effect::SetTimer{ app_timer::LOADING_ANIM, app_timer::FRAME_INTERVAL_MS });
@@ -317,7 +322,7 @@ void App::ReloadCurrentFile()
 
     if (DocumentService::NeedsAsyncLoad(path)) {
         MENDO_TRACE("ReloadCurrentFile: async path");
-        BeginAsyncLoad(path);
+        BeginAsyncLoad(path, /* suppress_animation = */ true);
     }
     else {
         MENDO_TRACE("ReloadCurrentFile: sync path (DoReloadCurrentFile)");

--- a/src/io/file_load_service.cpp
+++ b/src/io/file_load_service.cpp
@@ -14,6 +14,7 @@ void FileLoadService::StartLoading(std::pmr::wstring path)
 void FileLoadService::StopLoading() noexcept
 {
     loading_ = false;
+    async_in_flight_ = false;
 }
 
 void FileLoadService::TickLoadingAnimation() noexcept
@@ -43,6 +44,7 @@ void FileLoadService::StartAsyncLoad(TaskScheduler& scheduler, HWND hwnd, UINT m
         const std::lock_guard lock(async_mutex_);
         async_result_.reset();
     }
+    async_in_flight_ = true;
     const uint32_t gen = async_gen_.fetch_add(1, std::memory_order_relaxed) + 1;
 
     // ワーカースレッドは loading_path_ に触らないため、capture コピーで安全。

--- a/src/io/file_load_service.cpp
+++ b/src/io/file_load_service.cpp
@@ -8,6 +8,7 @@ void FileLoadService::StartLoading(std::pmr::wstring path)
 {
     loading_path_ = std::move(path);
     loading_ = true;
+    async_in_flight_ = true;
     loading_angle_ = 0.0f;
 }
 

--- a/src/io/file_load_service.h
+++ b/src/io/file_load_service.h
@@ -25,6 +25,9 @@ public:
     // ---- ローディングアニメーション状態 ----
 
     constexpr bool IsLoading() const noexcept { return loading_; }
+    // スピナー非表示でも非同期パースが進行中なら true。ライブリロードのバースト時に
+    // 重複スケジューリングを抑制するためのフラグ。
+    constexpr bool IsAsyncLoading() const noexcept { return async_in_flight_; }
     constexpr float GetLoadingAngle() const noexcept { return loading_angle_; }
 
     void StartLoading(std::pmr::wstring path);
@@ -39,7 +42,11 @@ public:
 
     void StartAsyncLoad(TaskScheduler& scheduler, HWND hwnd, UINT msg_id, const Theme& theme);
     std::optional<AsyncLoadResult> TakeAsyncResult();
-    void CancelAsyncLoad() noexcept { async_gen_.fetch_add(1, std::memory_order_relaxed); }
+    void CancelAsyncLoad() noexcept
+    {
+        async_gen_.fetch_add(1, std::memory_order_relaxed);
+        async_in_flight_ = false;
+    }
 
     // ---- パスアクセス ----
 
@@ -49,6 +56,7 @@ public:
 private:
     DocumentService& doc_service_;
     bool loading_ = false;
+    bool async_in_flight_ = false;
     float loading_angle_ = 0.0f;
     std::pmr::wstring loading_path_;
 

--- a/src/io/file_load_service.h
+++ b/src/io/file_load_service.h
@@ -54,6 +54,8 @@ public:
     void SetLoadingPath(std::pmr::wstring path) { loading_path_ = std::move(path); }
 
 private:
+    // 不変条件: loading_ が true なら async_in_flight_ も true。
+    // worker thread は async_gen_ (atomic) と async_result_ (mutex 保護) のみ触る。
     DocumentService& doc_service_;
     bool loading_ = false;
     bool async_in_flight_ = false;

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -266,13 +266,23 @@ void LayoutEngine::ComputeLayout(std::pmr::vector<Node>& nodes, LayoutCache& cac
                     // ただしダイアグラム系コードブロックの高さは描画完了時にビットマップ
                     // 実寸で確定する。テキスト基準の EstimateNodeHeight で上書きすると
                     // 描画時に bitmap が後続ノードへはみ出すため既存値を維持する。
+                    // また、テーブル/画像/折り返しが多い段落では推定値が実測値を
+                    // 大きく下回るため、シュリンク方向の更新も後続ノードと重なる
+                    // 原因になる。よって既存値より小さくはしない。
                     const bool is_diagram = (node.type == NodeType::CodeBlock
                         && IsDiagramLanguage(node.code_language));
                     if (!is_diagram) {
                         const float estimated = EstimateNodeHeight(node, *theme_);
-                        if (entry.height != estimated) {
+                        if (entry.height < estimated) {
                             entry.height = estimated;
                             any_height_changed = true;
+                            // entry.height は推定値に成長したが、テーブルの row_heights
+                            // 合計や col_widths は旧値のまま乖離する。次の MeasureNode が
+                            // 走るまで描画を抑制し、描画範囲(row_heights 合計)が
+                            // 後続ノード位置(entry.height ベース)を越えて重なるのを防ぐ。
+                            if (node.type == NodeType::Table && entry.has_table_layout()) {
+                                entry.table_layout->col_widths.clear();
+                            }
                         }
                     }
                     entry.layout_dirty = true;

--- a/tests/test_text_measurer.cpp
+++ b/tests/test_text_measurer.cpp
@@ -328,6 +328,104 @@ TEST_F(MockLayoutTest, MermaidHeightPreservedAtZeroWidth)
     }
 }
 
+// ---- issue #158 リグレッション: 縦に長いテーブルの直後の描画がテーブルに重なる ----
+
+// 長いテーブルが viewport 外にあって partial モードで再レイアウトされたときに、
+// 既存の実測高さが推定値で縮められないことを確認する。
+// 縮められると以降のノードの y_position が上に詰まり、テーブル直後のノードが
+// テーブルに重なって描画される。
+TEST_F(MockLayoutTest, LongTableHeightNotShrunkByEstimateInPartialMode)
+{
+    // 100 行のテーブル + その後の段落
+    std::string md = "| col1 | col2 |\n|------|------|\n";
+    for (int i = 0; i < 100; i++) {
+        md += "| row" + std::to_string(i) + " | val" + std::to_string(i) + " |\n";
+    }
+    md += "\nFollow-up paragraph";
+
+    auto nodes = ParseMarkdown(md).nodes;
+    ASSERT_GE(nodes.size(), 2u);
+    LayoutCache cache;
+    cache.Resize(nodes.size());
+
+    // 1) フルレイアウトでテーブルの実測高さを取得
+    engine_.LayoutNodes(nodes, cache, 800.0f);
+    size_t table_idx = 0;
+    for (size_t i = 0; i < nodes.size(); i++) {
+        if (nodes[i].type == NodeType::Table) { table_idx = i; break; }
+    }
+    ASSERT_EQ(nodes[table_idx].type, NodeType::Table);
+    const float measured_table_h = cache[table_idx].height;
+    EXPECT_GT(measured_table_h, 0.0f);
+
+    // テーブル直後の段落
+    ASSERT_LT(table_idx + 1, nodes.size());
+    const size_t para_idx = table_idx + 1;
+
+    // 2) 幅変更 + partial モード（viewport は冒頭の小さい領域のみ）
+    //    テーブルは viewport 外なので不可視扱いになり、現行バグでは推定値で
+    //    上書きされて高さが縮む。
+    engine_.ComputeLayout(nodes, cache, 600.0f, 0.0f, 10.0f);
+
+    // テーブルの高さが実測値から縮んでいないこと。
+    // 修正後の partial モードは shrink を起こさないため厳密一致を期待する。
+    EXPECT_GE(cache[table_idx].height, measured_table_h)
+        << "partial モードで実測済みテーブルの高さが推定値で縮められた";
+
+    // テーブル直後の段落の y_position もテーブル下端より下にあること
+    const float table_bottom = cache[table_idx].y_position + cache[table_idx].height;
+    EXPECT_GE(cache[para_idx].y_position, table_bottom)
+        << "テーブル直後ノードの y_position がテーブル下端より上に詰まっている (issue #158)";
+}
+
+// 推定値より小さい既存高さは、推定値まで成長させてよい（max_scroll の精度のため）
+TEST_F(MockLayoutTest, PartialModeGrowsHeightWhenEstimateLarger)
+{
+    auto nodes = ParseMarkdown("First\n\nSecond\n\nThird").nodes;
+    LayoutCache cache;
+    cache.Resize(nodes.size());
+
+    // 高さ 0 で partial モード（width_changed=true）。
+    // 不可視ノードでも entry.height が 0 なら推定値まで成長すべき。
+    engine_.ComputeLayout(nodes, cache, 800.0f, 0.0f, 1.0f);
+    for (size_t i = 0; i < nodes.size(); i++) {
+        EXPECT_GT(cache[i].height, 0.0f)
+            << "ノード " << i << " の高さが推定値まで成長していない";
+    }
+}
+
+// partial + invisible で entry.height が推定値に成長した場合、Table の col_widths を
+// クリアし、row_heights 合計と乖離した entry.height のまま描画されないようにする。
+// (issue #158: col_widths を残すと描画範囲が後続ノード位置を越えて重なる)
+TEST_F(MockLayoutTest, PartialModeClearsTableColWidthsWhenHeightGrows)
+{
+    std::string md = "| a | b |\n|---|---|\n";
+    for (int i = 0; i < 50; i++) {
+        md += "| r" + std::to_string(i) + " | v" + std::to_string(i) + " |\n";
+    }
+    auto nodes = ParseMarkdown(md).nodes;
+    LayoutCache cache;
+    cache.Resize(nodes.size());
+
+    engine_.LayoutNodes(nodes, cache, 800.0f);
+    size_t table_idx = 0;
+    for (size_t i = 0; i < nodes.size(); i++) {
+        if (nodes[i].type == NodeType::Table) { table_idx = i; break; }
+    }
+    ASSERT_EQ(nodes[table_idx].type, NodeType::Table);
+    ASSERT_TRUE(cache[table_idx].has_table_layout());
+    ASSERT_FALSE(cache[table_idx].table_layout->col_widths.empty());
+
+    // 成長分岐を強制発動させるため、現在の entry.height を意図的に小さくする
+    cache[table_idx].height = 1.0f;
+
+    // partial + invisible (テーブルは viewport より下) で再レイアウト
+    engine_.ComputeLayout(nodes, cache, 600.0f, 0.0f, 10.0f);
+
+    EXPECT_TRUE(cache[table_idx].table_layout->col_widths.empty())
+        << "成長時に col_widths がクリアされず、描画範囲と entry.height が乖離する";
+}
+
 // ---- RecreateFormats ----
 
 TEST_F(MockLayoutTest, RecreateFormatsSucceeds)

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -23,7 +23,7 @@
 		"C_Cpp.formatting": "vcFormat",
 		"C_Cpp.doxygen.generatedStyle": "//!",
 		"C_Cpp.vcFormat.indent.namespaceContents": false,
-		"C_Cpp.vcFormat.indent.lambdaBracesWhenParameter": false,
+		"C_Cpp.vcFormat.indent.lambdaBracesWhenParameter": true,
 		"C_Cpp.vcFormat.newLine.beforeOpenBrace.function": "newLine",
 		"C_Cpp.vcFormat.newLine.beforeOpenBrace.lambda": "sameLine",
 		"C_Cpp.vcFormat.space.withinExpressionParentheses": false


### PR DESCRIPTION
## Summary

- **issue #158 修正**: partial レイアウトの不可視分岐で `entry.height` が推定値で縮められる経路を `<` 判定に変更し、さらに成長経路で `row_heights` / `col_widths` と乖離して描画範囲が後続ノード位置を越える問題を、Table ノードの `col_widths` クリアによる描画一時抑制で防止。
- **ライブリロード UX**: `ReloadCurrentFile` からの非同期ロードでスピナー点滅を抑制（`suppress_animation` 引数を追加）。短絡評価の最左に配置して `NeedsLoadingAnimation` の stat もスキップ。
- **設定**: `lambdaBracesWhenParameter` を true に変更（パラメータ位置の多行ラムダがインデントされる）。

## issue #158 の根本原因

レイアウトと描画で別々のサイズ情報を使っていた:
- レイアウト: 後続ノードの y_position は `entry.height` を加算
- 描画 (`GenTable`): `tl.row_heights` の合計分描画

`MeasureNode` 直後だけ両者が一致し、その後 `entry.height` だけが推定値で更新されると乖離する。とくに不可視分岐で旧 `entry.height` が小さい場合、推定値に成長させると `row_heights` 合計（古い値、より大きい場合がある）との乖離で重なりが発生する。

修正後は成長させたタイミングで `col_widths.clear()` し、`GenTable` の早期 return 条件 (`col_widths.empty()`) に該当させて、再測定されるまでテーブル描画を抑制する。`ProcessDirtyBatch` / `EnsureVisibleLayout` で `MeasureNode` が走ると同期されてテーブル描画が復活する。

## 追加したリグレッションテスト

- \`LongTableHeightNotShrunkByEstimateInPartialMode\`
- \`PartialModeGrowsHeightWhenEstimateLarger\`
- \`PartialModeClearsTableColWidthsWhenHeightGrows\`

## Test plan

- [x] \`cmake --build build --config Release\` が通る
- [x] \`build/tests/Release/mendo_tests.exe\` が全 2057 件パス
- [x] 実機で長いテーブルを跨いでウィンドウサイズ変更しても重ならないこと（ユーザ確認済み）
- [x] 実機でライブリロード中にスピナーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)