### PR TITLE
refactor: UTF-8 BOM 除去の集約と file_io.h の inline 解消

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ add_library(mendo_core STATIC
     src/app/app_controller.cpp
     src/app/reducer.cpp
     # util - ユーティリティ
+    src/util/file_io.cpp
     src/util/task_scheduler.cpp
 )
 target_include_directories(mendo_core PUBLIC ${MENDO_SRC_DIRS} third_party/md4c)

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -365,7 +365,7 @@ void App::DoReloadCurrentFile()
     std::pmr::wstring new_wide;
     {
         MENDO_PROFILE("Reload::Utf8ToWide");
-        string_convert::Utf8ToWide(new_utf8, new_wide);
+        string_convert::Utf8ToWideStripBom(new_utf8, new_wide);
     }
 
     const std::wstring_view old_view(state_.document.doc.GetRawText());

--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -29,7 +29,7 @@ Document Document::FromMarkdown(std::pmr::string utf8, std::wstring_view path)
     std::pmr::wstring wide;
     {
         MENDO_PROFILE("Utf8ToWide");
-        string_convert::Utf8ToWide(utf8, wide);
+        string_convert::Utf8ToWideStripBom(utf8, wide);
     }
     return FromMarkdown(std::move(wide), byte_size, path);
 }
@@ -65,7 +65,7 @@ void Document::ReplaceFromMarkdown(std::pmr::string utf8)
     std::pmr::wstring wide;
     {
         MENDO_PROFILE("Utf8ToWide");
-        string_convert::Utf8ToWide(utf8, wide);
+        string_convert::Utf8ToWideStripBom(utf8, wide);
     }
     ReplaceFromMarkdown(std::move(wide), byte_size);
 }

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -2,7 +2,6 @@
 #include "ascii_util.h"
 #include "document_utils.h"
 #include "syntax.h"
-#include "string_convert.h"
 #include "memory_resource.h"
 #include "md4c.h"
 #include <stack>
@@ -683,13 +682,6 @@ ParseResult ParseMarkdown(std::wstring_view markdown_text)
     result.image_indices = std::move(ctx.image_indices);
     result.diagram_indices = std::move(ctx.diagram_indices);
     return result;
-}
-
-ParseResult ParseMarkdown(std::string_view utf8_markdown_text)
-{
-    std::pmr::wstring wide;
-    string_convert::Utf8ToWide(utf8_markdown_text, wide);
-    return ParseMarkdown(std::wstring_view{ wide });
 }
 
 std::wstring_view GetAlertLabel(AlertType type) noexcept

--- a/src/core/parser.h
+++ b/src/core/parser.h
@@ -18,10 +18,6 @@ struct ParseResult {
 // 本物の Markdown パーサ。md4c を MD4C_USE_UTF16 モードで起動するため入力は wide。
 ParseResult ParseMarkdown(std::wstring_view markdown_text);
 
-// テスト・便宜用の UTF-8 入力シム。内部で wide 化してから wstring_view 版へ委譲する。
-// 本番コードでは使わない（FileLoader 経由で wide が直接渡る）。
-ParseResult ParseMarkdown(std::string_view utf8_markdown_text);
-
 // BlockQuoteノードからGitHub Alertsを検出し、マーカー除去・ラベル挿入・グルーピングを行う（テスト用に公開）。
 // blockquote_indices は ParseMarkdown が収集した BlockQuote ノードのインデックス。
 void DetectAlerts(std::pmr::vector<Node>& nodes, std::span<const size_t> blockquote_indices);

--- a/src/io/file_loader.cpp
+++ b/src/io/file_loader.cpp
@@ -28,26 +28,11 @@ std::expected<std::pmr::string, FileLoadError> FileLoader::LoadFile(const std::p
         return std::pmr::string{};
     }
 
-    // UTF-8 BOMを先に検出し、全内容の memmove を回避する
-    const size_t file_size = r.size;
-    size_t bom_skip = 0;
-    if (file_size >= 3) {
-        unsigned char bom[3]{};
-        DWORD bom_read = 0;
-        if (ReadFile(r.handle.get(), bom, 3, &bom_read, nullptr) && bom_read == 3 &&
-            bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF) {
-            bom_skip = 3;
-        }
-        else {
-            // BOMなし: ファイル先頭に巻き戻す
-            SetFilePointer(r.handle.get(), 0, nullptr, FILE_BEGIN);
-        }
-    }
-
+    // BOM の除去は呼び出し側 (Utf8ToWideStripBom) が担うため、ここではバイト列をそのまま返す。
     std::pmr::string content;
     DWORD bytesRead = 0;
     BOOL ok = FALSE;
-    content.resize_and_overwrite(file_size - bom_skip, [&](char* buf, size_t count) -> size_t {
+    content.resize_and_overwrite(r.size, [&](char* buf, size_t count) -> size_t {
         ok = ReadFile(r.handle.get(), buf, static_cast<DWORD>(count), &bytesRead, nullptr);
         return ok ? bytesRead : 0;
     });

--- a/src/util/file_io.cpp
+++ b/src/util/file_io.cpp
@@ -1,0 +1,79 @@
+#include "file_io.h"
+#include <limits>
+#include <utility>
+
+OpenedFile OpenFileForReadShared(const std::filesystem::path& path,
+    DWORD share_mode, LONGLONG max_size, DWORD* out_error) noexcept
+{
+    if (out_error) {
+        *out_error = 0;
+    }
+    OpenedFile r;
+    UniqueHandle hFile(CreateFileW(path.c_str(), GENERIC_READ, share_mode, nullptr,
+        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+    if (!hFile) {
+        if (out_error) {
+            *out_error = GetLastError();
+        }
+        r.error = OpenFileError::NotFound;
+        return r;
+    }
+    LARGE_INTEGER file_size;
+    if (!GetFileSizeEx(hFile.get(), &file_size) || file_size.QuadPart < 0) {
+        r.error = OpenFileError::SizeQueryFailed;
+        return r;
+    }
+    if (file_size.QuadPart > max_size) {
+        r.error = OpenFileError::TooLarge;
+        return r;
+    }
+    r.handle = std::move(hFile);
+    r.size = static_cast<size_t>(file_size.QuadPart);
+    return r;
+}
+
+std::pair<std::unique_ptr<uint8_t[]>, size_t> ReadAllBytes(
+    const std::filesystem::path& path, DWORD* out_error)
+{
+    auto r = OpenFileForReadShared(path, FILE_SHARE_READ, std::numeric_limits<uint32_t>::max(), out_error);
+    if (r.error != OpenFileError::None || r.size == 0) {
+        return {};
+    }
+    auto buf = std::make_unique_for_overwrite<uint8_t[]>(r.size);
+    DWORD bytes_read = 0;
+    if (!ReadFile(r.handle.get(), buf.get(), static_cast<DWORD>(r.size), &bytes_read, nullptr) ||
+        bytes_read != static_cast<DWORD>(r.size)) {
+        return {};
+    }
+    return { std::move(buf), r.size };
+}
+
+bool IsFileLargerThan(const std::filesystem::path& path,
+    size_t reference_size, size_t tolerance) noexcept
+{
+    WIN32_FILE_ATTRIBUTE_DATA attr{};
+    if (!GetFileAttributesExW(path.c_str(), GetFileExInfoStandard, &attr)) {
+        return false;
+    }
+    const uint64_t current_size = (static_cast<uint64_t>(attr.nFileSizeHigh) << 32)
+        | static_cast<uint64_t>(attr.nFileSizeLow);
+    return current_size > static_cast<uint64_t>(reference_size) + tolerance;
+}
+
+bool WriteAllBytes(const std::filesystem::path& path, const void* data, size_t size)
+{
+    if (size > std::numeric_limits<uint32_t>::max()) {
+        return false;
+    }
+    UniqueHandle hFile(CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr,
+        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
+    if (!hFile) {
+        return false;
+    }
+    DWORD bytes_written = 0;
+    if (!WriteFile(hFile.get(), data, static_cast<DWORD>(size), &bytes_written, nullptr) ||
+        bytes_written != static_cast<DWORD>(size)) {
+        return false;
+    }
+    return true;
+}

--- a/src/util/file_io.h
+++ b/src/util/file_io.h
@@ -3,7 +3,6 @@
 #include <windows.h>
 #include <cstdint>
 #include <filesystem>
-#include <limits>
 #include <memory>
 #include <string_view>
 #include <utility>
@@ -22,98 +21,31 @@ enum class OpenFileError : uint8_t {
     TooLarge,         // max_size を超過
 };
 
-// CreateFileW + GetFileSizeEx + サイズ上限チェックを束ねた共通ヘルパー。
-// 共有モードと最大サイズは呼び出し側で指定する。
+// CreateFileW + GetFileSizeEx + サイズ上限チェックを束ねた共通ヘルパーの結果。
 // 失敗時は handle が空で、error に区分が入る。
-// out_error は CreateFileW 失敗時のみ GetLastError() を格納する
-// （SizeQueryFailed / TooLarge では更新しない）。
 struct OpenedFile {
     UniqueHandle handle;
     size_t size = 0;
     OpenFileError error = OpenFileError::None;
 };
 
-[[nodiscard]] inline OpenedFile OpenFileForReadShared(const std::filesystem::path& path,
-    DWORD share_mode, LONGLONG max_size, DWORD* out_error = nullptr) noexcept
-{
-    if (out_error) {
-        *out_error = 0;
-    }
-    OpenedFile r;
-    UniqueHandle hFile(CreateFileW(path.c_str(), GENERIC_READ, share_mode, nullptr,
-        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
-    if (!hFile) {
-        if (out_error) {
-            *out_error = GetLastError();
-        }
-        r.error = OpenFileError::NotFound;
-        return r;
-    }
-    LARGE_INTEGER file_size;
-    if (!GetFileSizeEx(hFile.get(), &file_size) || file_size.QuadPart < 0) {
-        r.error = OpenFileError::SizeQueryFailed;
-        return r;
-    }
-    if (file_size.QuadPart > max_size) {
-        r.error = OpenFileError::TooLarge;
-        return r;
-    }
-    r.handle = std::move(hFile);
-    r.size = static_cast<size_t>(file_size.QuadPart);
-    return r;
-}
+// 共有モードと最大サイズは呼び出し側で指定する。
+// out_error は CreateFileW 失敗時のみ GetLastError() を格納する
+// （SizeQueryFailed / TooLarge では更新しない）。
+[[nodiscard]] OpenedFile OpenFileForReadShared(const std::filesystem::path& path,
+    DWORD share_mode, LONGLONG max_size, DWORD* out_error = nullptr) noexcept;
 
-// ファイルを全て読み込む。失敗時は{nullptr, 0}を返す。
-// out_errorが非nullの場合、CreateFileW失敗時のGetLastError()を格納する。
-[[nodiscard]] inline std::pair<std::unique_ptr<uint8_t[]>, size_t> ReadAllBytes(
-    const std::filesystem::path& path, DWORD* out_error = nullptr)
-{
-    auto r = OpenFileForReadShared(path, FILE_SHARE_READ, std::numeric_limits<uint32_t>::max(), out_error);
-    if (r.error != OpenFileError::None || r.size == 0) {
-        return {};
-    }
-    auto buf = std::make_unique_for_overwrite<uint8_t[]>(r.size);
-    DWORD bytes_read = 0;
-    if (!ReadFile(r.handle.get(), buf.get(), static_cast<DWORD>(r.size), &bytes_read, nullptr) ||
-        bytes_read != static_cast<DWORD>(r.size)) {
-        return {};
-    }
-    return { std::move(buf), r.size };
-}
+// out_error が非 null の場合、CreateFileW 失敗時の GetLastError() を格納する。
+[[nodiscard]] std::pair<std::unique_ptr<uint8_t[]>, size_t> ReadAllBytes(
+    const std::filesystem::path& path, DWORD* out_error = nullptr);
 
 // 読み込み済みコンテンツの後にファイルがさらに伸びていれば、エディタ側が
 // 書き込み途中である可能性が高い。BOM の 3 バイトずれ等を吸収するため
 // 16 バイトの許容範囲を持たせる。
-inline bool IsFileLargerThan(const std::filesystem::path& path,
-    size_t reference_size, size_t tolerance = 16) noexcept
-{
-    WIN32_FILE_ATTRIBUTE_DATA attr{};
-    if (!GetFileAttributesExW(path.c_str(), GetFileExInfoStandard, &attr)) {
-        return false;
-    }
-    const uint64_t current_size = (static_cast<uint64_t>(attr.nFileSizeHigh) << 32)
-        | static_cast<uint64_t>(attr.nFileSizeLow);
-    return current_size > static_cast<uint64_t>(reference_size) + tolerance;
-}
+bool IsFileLargerThan(const std::filesystem::path& path,
+    size_t reference_size, size_t tolerance = 16) noexcept;
 
-// ファイルに全て書き込む。成功時はtrueを返す。
-[[nodiscard]] inline bool WriteAllBytes(const std::filesystem::path& path, const void* data, size_t size)
-{
-    if (size > std::numeric_limits<uint32_t>::max()) {
-        return false;
-    }
-    UniqueHandle hFile(CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr,
-        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
-    if (!hFile) {
-        return false;
-    }
-    DWORD bytes_written = 0;
-    if (!WriteFile(hFile.get(), data, static_cast<DWORD>(size), &bytes_written, nullptr) ||
-        bytes_written != static_cast<DWORD>(size)) {
-        return false;
-    }
-    return true;
-}
+[[nodiscard]] bool WriteAllBytes(const std::filesystem::path& path, const void* data, size_t size);
 
 // ファイル名・フルパス比較ユーティリティ。
 // `CompareStringOrdinal(..., TRUE)` ベースで NTFS と挙動が一致する

--- a/src/util/string_convert.h
+++ b/src/util/string_convert.h
@@ -32,6 +32,17 @@ inline std::pmr::wstring Utf8ToWide(std::string_view utf8)
     return result;
 }
 
+// 先頭の UTF-8 BOM (EF BB BF) を取り除いてから Utf8ToWide を呼ぶ。
+// FileLoader が返す UTF-8 のように BOM 付きの可能性がある経路で使う。
+inline void Utf8ToWideStripBom(std::string_view utf8, std::pmr::wstring& out)
+{
+    constexpr std::string_view kUtf8Bom = "\xEF\xBB\xBF";
+    if (utf8.starts_with(kUtf8Bom)) {
+        utf8.remove_prefix(kUtf8Bom.size());
+    }
+    Utf8ToWide(utf8, out);
+}
+
 inline void WideToUtf8(std::wstring_view wide, std::string& out)
 {
     if (wide.empty()) {

--- a/tests/cmd_gen_mock_test_base.h
+++ b/tests/cmd_gen_mock_test_base.h
@@ -29,7 +29,7 @@ protected:
         gen_.SetFormats({ nullptr, nullptr, nullptr, nullptr });
     }
 
-    void Parse(const std::string& md, float viewport_w = 800.0f)
+    void Parse(std::wstring_view md, float viewport_w = 800.0f)
     {
         nodes_ = ParseMarkdown(md).nodes;
         cache_.Resize(nodes_.size());

--- a/tests/dwrite_test_base.h
+++ b/tests/dwrite_test_base.h
@@ -44,7 +44,7 @@ protected:
     };
 
     // パース → レイアウト計測まで一括実施。多くのテストで定型的に使う。
-    ParsedLayout ParseAndLayout(const std::string& md, float viewport_w = 800.0f)
+    ParsedLayout ParseAndLayout(std::wstring_view md, float viewport_w = 800.0f)
     {
         ParsedLayout r;
         r.nodes = ParseMarkdown(md).nodes;

--- a/tests/test_command_generator_content.cpp
+++ b/tests/test_command_generator_content.cpp
@@ -22,7 +22,7 @@ class CmdGenContentTest : public CmdGenMockTestBase {};
 
 TEST_F(CmdGenContentTest, HeadingH1_EmitsUnderlineWithHrColor)
 {
-    Parse("# Title");
+    Parse(L"# Title");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
     auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
 
@@ -37,7 +37,7 @@ TEST_F(CmdGenContentTest, HeadingH1_EmitsUnderlineWithHrColor)
 
 TEST_F(CmdGenContentTest, HeadingH2_EmitsUnderlineWithCorrectThickness)
 {
-    Parse("## Subtitle");
+    Parse(L"## Subtitle");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
     auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
 
@@ -56,7 +56,7 @@ TEST_F(CmdGenContentTest, HeadingH2_EmitsUnderlineWithCorrectThickness)
 
 TEST_F(CmdGenContentTest, HeadingH3_DoesNotEmitUnderline)
 {
-    Parse("### Sub");
+    Parse(L"### Sub");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
     auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
 
@@ -70,7 +70,7 @@ TEST_F(CmdGenContentTest, HeadingH3_DoesNotEmitUnderline)
 
 TEST_F(CmdGenContentTest, BlockQuote_EmitsBarLine)
 {
-    Parse("> Quoted");
+    Parse(L"> Quoted");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
     auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
 
@@ -86,7 +86,7 @@ TEST_F(CmdGenContentTest, BlockQuote_EmitsBarLine)
 
 TEST_F(CmdGenContentTest, BlockQuote_FullyAboveViewport_NoBar)
 {
-    Parse("> Quoted");
+    Parse(L"> Quoted");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 50.0f };
     // viewport_top を blockquote の下端より十分大きくする
     auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 100000.0f, TextSelection{});
@@ -100,7 +100,7 @@ TEST_F(CmdGenContentTest, BlockQuote_FullyAboveViewport_NoBar)
 // ネスト blockquote の各レベルを別 x 座標のバーで描画する (PR #156)
 TEST_F(CmdGenContentTest, NestedBlockQuote_EmitsBarPerLevel)
 {
-    Parse("> outer\n> > inner");
+    Parse(L"> outer\n> > inner");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
     auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
 
@@ -120,7 +120,7 @@ TEST_F(CmdGenContentTest, NestedBlockQuote_EmitsBarPerLevel)
 // 外→内→外の連続描画: 外側 (level=1) はネストを貫通して 1 本のバーになる
 TEST_F(CmdGenContentTest, NestedBlockQuote_OuterBarSpansAcrossInnerNesting)
 {
-    Parse("> outer\n> > inner\n>\n> back to outer");
+    Parse(L"> outer\n> > inner\n>\n> back to outer");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
     auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
 
@@ -142,7 +142,7 @@ TEST_F(CmdGenContentTest, NestedBlockQuote_OuterBarSpansAcrossInnerNesting)
 // Alert ネスト + 後段: 最外側バーは Alert 色で描画される
 TEST_F(CmdGenContentTest, AlertWithNested_OuterBarUsesAlertColor)
 {
-    Parse("> [!NOTE]\n> Alert head\n> > inner\n>\n> Alert continues");
+    Parse(L"> [!NOTE]\n> Alert head\n> > inner\n>\n> Alert continues");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
     auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
 
@@ -163,7 +163,7 @@ TEST_F(CmdGenContentTest, AlertWithNested_OuterBarUsesAlertColor)
 
 TEST_F(CmdGenContentTest, HorizontalRule_AllAboveViewport_NoLines)
 {
-    Parse("---\n\n---\n\n---");
+    Parse(L"---\n\n---\n\n---");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 100.0f };
     // 全 hr ノードより十分下にスクロール → 上方向カリングを踏む
     auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 100000.0f, TextSelection{});
@@ -179,7 +179,7 @@ TEST_F(CmdGenContentTest, HorizontalRule_AllAboveViewport_NoLines)
 
 TEST_F(CmdGenContentTest, HorizontalRule_PartialViewportLimitsToVisible)
 {
-    Parse("---\n\n---\n\n---\n\n---\n\n---");
+    Parse(L"---\n\n---\n\n---\n\n---\n\n---");
     ASSERT_FALSE(nodes_.empty());
 
     // 1 本目の hr の下端より少し大きい viewport を用意する。

--- a/tests/test_command_generator_frame.cpp
+++ b/tests/test_command_generator_frame.cpp
@@ -17,7 +17,7 @@ class CmdGenFrameTest : public CmdGenMockTestBase {};
 
 TEST_F(CmdGenFrameTest, PushClipMatchesPaneRect)
 {
-    Parse("Hello");
+    Parse(L"Hello");
     const PaneRect pane{ 100.0f, 50.0f, 600.0f, 400.0f };
     auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
 
@@ -31,7 +31,7 @@ TEST_F(CmdGenFrameTest, PushClipMatchesPaneRect)
 
 TEST_F(CmdGenFrameTest, TransformTranslatesByPaneOriginAndScroll)
 {
-    Parse("Hello");
+    Parse(L"Hello");
     constexpr float origin_x = 120.0f;
     constexpr float scroll_y = 40.0f;
     const PaneRect pane{ origin_x, 0.0f, 600.0f, 400.0f };
@@ -46,7 +46,7 @@ TEST_F(CmdGenFrameTest, TransformTranslatesByPaneOriginAndScroll)
 TEST_F(CmdGenFrameTest, TransformSnapsScrollToPixelWithDpi)
 {
     // DPI=2.0 → round(scroll_y * 2) / 2 で 0.5px 境界にスナップ
-    Parse("Hello");
+    Parse(L"Hello");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 400.0f };
     const float scroll_y = 0.3f;
     const float dpi = 2.0f;
@@ -64,7 +64,7 @@ TEST_F(CmdGenFrameTest, TransformSnapsScrollToPixelWithDpi)
 TEST_F(CmdGenFrameTest, ScrolledBeyondBottomProducesOnlyFrameCommands)
 {
     // 数個の水平線を生成し、ビューポートより大きく下にスクロールする
-    Parse("---\n\n---\n\n---");
+    Parse(L"---\n\n---\n\n---");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 100.0f };
     // 全ノードより下にスクロール → DrawLineCmd なし
     auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 10000.0f, TextSelection{});
@@ -97,7 +97,7 @@ TEST_F(CmdGenFrameTest, EmptyNodesListEmitsOnlyFrameScaffolding)
 
 TEST_F(CmdGenFrameTest, ExplicitFirstVisibleMatchesAutoDiscovery)
 {
-    Parse("---\n\n---\n\n---\n\n---\n\n---");
+    Parse(L"---\n\n---\n\n---\n\n---\n\n---");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 500.0f };
 
     // first_visible=-1 (自動) と first_visible=0 (明示) は 0 からスクロール時に同じ結果
@@ -108,7 +108,7 @@ TEST_F(CmdGenFrameTest, ExplicitFirstVisibleMatchesAutoDiscovery)
 
 TEST_F(CmdGenFrameTest, FirstVisibleBeyondEndProducesNoContent)
 {
-    Parse("---\n\n---\n\n---");
+    Parse(L"---\n\n---\n\n---");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 500.0f };
 
     // first_visible がノード数以上 → 本体ループに入らない
@@ -125,7 +125,7 @@ TEST_F(CmdGenFrameTest, FirstVisibleBeyondEndProducesNoContent)
 
 TEST_F(CmdGenFrameTest, ShrinkBuffersIsSafeWithoutSharedBuffer)
 {
-    Parse("Hello");
+    Parse(L"Hello");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 400.0f };
     const auto baseline_size = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{}).size();
     gen_.ShrinkBuffers();
@@ -136,7 +136,7 @@ TEST_F(CmdGenFrameTest, ShrinkBuffersIsSafeWithoutSharedBuffer)
 
 TEST_F(CmdGenFrameTest, SetSharedHitTestBufferPreventsShrink)
 {
-    Parse("Hello");
+    Parse(L"Hello");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 400.0f };
     std::pmr::vector<DWRITE_HIT_TEST_METRICS> shared;
     shared.reserve(32);
@@ -150,7 +150,7 @@ TEST_F(CmdGenFrameTest, SetSharedHitTestBufferPreventsShrink)
 
 TEST_F(CmdGenFrameTest, SetSearchMatchesWithNullIsSafe)
 {
-    Parse("Hello world");
+    Parse(L"Hello world");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 400.0f };
     gen_.SetSearchMatches(nullptr, -1, 0);
     auto& cmds = gen_.GenerateMdPane(nodes_, cache_, pane, 0.0f, TextSelection{});
@@ -159,7 +159,7 @@ TEST_F(CmdGenFrameTest, SetSearchMatchesWithNullIsSafe)
 
 TEST_F(CmdGenFrameTest, SetSearchMatchesWithEmptyProducesNoHighlight)
 {
-    Parse("Hello world");
+    Parse(L"Hello world");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 400.0f };
     std::pmr::vector<SearchMatch> matches;
     gen_.SetSearchMatches(&matches, -1, 1);
@@ -180,7 +180,7 @@ TEST_F(CmdGenFrameTest, DarkThemeSelectionUsesDifferentStripeCache)
 {
     auto light = GetLightTheme();
     auto dark = GetDarkTheme();
-    Parse("| A | B |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |");
+    Parse(L"| A | B |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 400.0f };
 
     auto find_stripe = [](const DrawCommandList& cmds) -> std::optional<D2D1_COLOR_F> {

--- a/tests/test_command_generator_highlight.cpp
+++ b/tests/test_command_generator_highlight.cpp
@@ -44,7 +44,7 @@ protected:
 // 本文が両ハイライトの下に隠れる、という視覚的不具合が発生する。
 TEST_F(HighlightOrderTest, SearchThenSelectionThenText)
 {
-    auto pl = ParseAndLayout("Hello World");
+    auto pl = ParseAndLayout(L"Hello World");
     ASSERT_FALSE(pl.nodes.empty());
 
     // node 0 の "Hello" を検索マッチに、"World" を選択範囲に設定する。
@@ -93,7 +93,7 @@ TEST_F(HighlightOrderTest, SearchThenSelectionThenText)
 // 失敗時に「ノイズ FillRect が出ている」=どの装飾が漏れているかが分かる。
 TEST_F(HighlightOrderTest, NoHighlightsWhenNeitherActive)
 {
-    auto pl = ParseAndLayout("Hello World");
+    auto pl = ParseAndLayout(L"Hello World");
     gen_.SetSearchMatches(nullptr, -1, 0);
     const TextSelection sel{};
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
@@ -113,7 +113,7 @@ TEST_F(HighlightOrderTest, NoHighlightsWhenNeitherActive)
 // 失敗するとユーザー視点で「現在マッチがどこにあるか分からない」状態になる。
 TEST_F(HighlightOrderTest, CurrentMatchUsesCurrentColor)
 {
-    auto pl = ParseAndLayout("Hello Hello");
+    auto pl = ParseAndLayout(L"Hello Hello");
     std::pmr::vector<SearchMatch> matches;
     matches.push_back({ 0, 0, 5, -1, -1 });
     matches.push_back({ 0, 6, 5, -1, -1 });
@@ -142,7 +142,7 @@ TEST_F(HighlightOrderTest, CurrentMatchUsesCurrentColor)
 // SetScrollSelectionMoved 等で起きうる空選択で余計な FillRectCmd が出ないことの確認。
 TEST_F(HighlightOrderTest, EmptySelectionProducesNoSelectionRect)
 {
-    auto pl = ParseAndLayout("Hello World");
+    auto pl = ParseAndLayout(L"Hello World");
     gen_.SetSearchMatches(nullptr, -1, 0);
     TextSelection sel = TextSelection::MakeOrdered(0, 5, 0, 5);
     sel.active = true;
@@ -161,7 +161,7 @@ TEST_F(HighlightOrderTest, EmptySelectionProducesNoSelectionRect)
 // kinds 抽出ヘルパーが順序を正しく取り出すこと（ヘルパー自身のスモーク）。
 TEST_F(HighlightOrderTest, ExtractCmdKindsIsOrdered)
 {
-    auto pl = ParseAndLayout("Hello");
+    auto pl = ParseAndLayout(L"Hello");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
     const auto& cmds = gen_.GenerateMdPane(pl.nodes, pl.cache, pane, 0.0f, TextSelection{});
     const auto kinds = ExtractCmdKinds(cmds);

--- a/tests/test_copy_button.cpp
+++ b/tests/test_copy_button.cpp
@@ -27,7 +27,7 @@ protected:
     };
 
     // Markdown をパースしてレイアウトを計算するヘルパー
-    ParsedLayout Parse(const std::string& md, float viewport_w = 800.0f)
+    ParsedLayout Parse(std::wstring_view md, float viewport_w = 800.0f)
     {
         ParsedLayout r;
         r.nodes = ParseMarkdown(md).nodes;
@@ -84,7 +84,7 @@ TEST_F(CopyButtonTest, CopyButtonRectIsInsideBlockTopRight)
 
 TEST_F(CopyButtonTest, HitOnCopyButtonReturnsNodeIndex)
 {
-    auto pr = Parse("```\nsome code\n```");
+    auto pr = Parse(L"```\nsome code\n```");
     // コードブロックのノードインデックスを特定
     int code_idx = -1;
     for (size_t i = 0; i < pr.nodes.size(); i++) {
@@ -101,7 +101,7 @@ TEST_F(CopyButtonTest, HitOnCopyButtonReturnsNodeIndex)
 
 TEST_F(CopyButtonTest, HitOutsideCopyButtonReturnsNegative)
 {
-    auto pr = Parse("```\nsome code\n```");
+    auto pr = Parse(L"```\nsome code\n```");
     float content_width = 800.0f - theme_.margin_left - theme_.margin_right;
     // 明らかにボタン外の座標（左上端）
     int result = hit_test_.CopyButtonHitTest(
@@ -111,7 +111,7 @@ TEST_F(CopyButtonTest, HitOutsideCopyButtonReturnsNegative)
 
 TEST_F(CopyButtonTest, NonCodeBlockReturnsNegative)
 {
-    auto pr = Parse("Just a paragraph");
+    auto pr = Parse(L"Just a paragraph");
     float content_width = 800.0f - theme_.margin_left - theme_.margin_right;
     // ドキュメント中央をクリック
     int result = hit_test_.CopyButtonHitTest(
@@ -121,7 +121,7 @@ TEST_F(CopyButtonTest, NonCodeBlockReturnsNegative)
 
 TEST_F(CopyButtonTest, MermaidBlockReturnsNegative)
 {
-    auto pr = Parse("```mermaid\ngraph TD\n```");
+    auto pr = Parse(L"```mermaid\ngraph TD\n```");
     float content_width = 800.0f - theme_.margin_left - theme_.margin_right;
     // Mermaidブロックがある場合でもコピーボタンは無効
     int mermaid_idx = -1;
@@ -139,7 +139,7 @@ TEST_F(CopyButtonTest, MermaidBlockReturnsNegative)
 TEST_F(CopyButtonTest, LatexMathBlockReturnsNegative)
 {
     // LatexMath ブロックも Mermaid 同様コピーボタン非対応
-    auto pr = Parse("$$E = mc^2$$");
+    auto pr = Parse(L"$$E = mc^2$$");
     float content_width = 800.0f - theme_.margin_left - theme_.margin_right;
     int latex_idx = -1;
     for (size_t i = 0; i < pr.nodes.size(); i++) {
@@ -158,7 +158,7 @@ TEST_F(CopyButtonTest, LatexMathBlockReturnsNegative)
 
 TEST_F(CopyButtonTest, MultipleCodeBlocksHitCorrectOne)
 {
-    auto pr = Parse("```\nfirst\n```\n\n```\nsecond\n```");
+    auto pr = Parse(L"```\nfirst\n```\n\n```\nsecond\n```");
     float content_width = 800.0f - theme_.margin_left - theme_.margin_right;
 
     // すべてのコードブロックインデックスを収集
@@ -185,7 +185,7 @@ TEST_F(CopyButtonTest, MultipleCodeBlocksHitCorrectOne)
 
 TEST_F(CopyButtonTest, EmptyDocumentReturnsNegative)
 {
-    auto pr = Parse("");
+    auto pr = Parse(L"");
     float content_width = 800.0f - theme_.margin_left - theme_.margin_right;
     int result = hit_test_.CopyButtonHitTest(
         { pr.nodes, pr.cache, theme_, 0.0f, 0.0f, 1.0f, 400, 400, content_width, 2000.0f });
@@ -195,9 +195,9 @@ TEST_F(CopyButtonTest, EmptyDocumentReturnsNegative)
 TEST_F(CopyButtonTest, ScrolledViewportHitTest)
 {
     // 多くの段落の後にコードブロックを配置
-    std::string md;
-    for (int i = 0; i < 30; i++) md += "Paragraph " + std::to_string(i) + "\n\n";
-    md += "```\nscrolled code\n```";
+    std::wstring md;
+    for (int i = 0; i < 30; i++) md += L"Paragraph " + std::to_wstring(i) + L"\n\n";
+    md += L"```\nscrolled code\n```";
     auto pr = Parse(md);
 
     int code_idx = -1;

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -68,7 +68,7 @@ TEST(DocumentTest, ReplaceContent)
     EXPECT_EQ(doc.GetNodes()[doc.GetToc().GetEntries()[0].node_index].GetText(), L"First");
 
     // 新しいコンテンツで置き換え
-    doc.ReplaceContent(ParseMarkdown("# Second\n## Sub"));
+    doc.ReplaceContent(ParseMarkdown(L"# Second\n## Sub"));
 
     // TOCが再構築されるべき
     EXPECT_GE(doc.GetToc().GetEntries().size(), 2u);
@@ -214,7 +214,7 @@ TEST(DocumentTest, BuildIndicesAfterReplaceContent)
     EXPECT_EQ(doc.GetToc().GetEntries().size(), 1u);
     EXPECT_EQ(doc.FindAnchorIndex(L"old"), 0);
 
-    doc.ReplaceContent(ParseMarkdown("# New\n\n## Sub"));
+    doc.ReplaceContent(ParseMarkdown(L"# New\n\n## Sub"));
     EXPECT_EQ(doc.GetToc().GetEntries().size(), 2u);
     EXPECT_EQ(doc.FindAnchorIndex(L"old"), -1);
     EXPECT_EQ(doc.FindAnchorIndex(L"new"), 0);

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -5,7 +5,6 @@
 #include "document_test_helpers.h"
 #include "test_helpers.h"
 #include "parser.h"
-#include "string_convert.h"
 #include "syntax.h"
 
 // ============================================================
@@ -14,7 +13,7 @@
 
 TEST(ExtractSelectedText, InactiveSelectionReturnsEmpty)
 {
-    auto nodes = ParseMarkdown("Hello world").nodes;
+    auto nodes = ParseMarkdown(L"Hello world").nodes;
     TextSelection sel;
     sel.active = false;
     EXPECT_TRUE(ExtractSelectedText(nodes, sel).empty());
@@ -22,28 +21,28 @@ TEST(ExtractSelectedText, InactiveSelectionReturnsEmpty)
 
 TEST(ExtractSelectedText, SingleNodeFullSelection)
 {
-    auto nodes = ParseMarkdown("Hello world").nodes;
+    auto nodes = ParseMarkdown(L"Hello world").nodes;
     auto sel = TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(nodes[0].GetText().size()));
     EXPECT_EQ(ExtractSelectedText(nodes, sel), L"Hello world");
 }
 
 TEST(ExtractSelectedText, SingleNodePartialSelection)
 {
-    auto nodes = ParseMarkdown("Hello world").nodes;
+    auto nodes = ParseMarkdown(L"Hello world").nodes;
     auto sel = TextSelection::MakeOrdered(0, 0, 0, 5);
     EXPECT_EQ(ExtractSelectedText(nodes, sel), L"Hello");
 }
 
 TEST(ExtractSelectedText, SingleNodeMiddleSelection)
 {
-    auto nodes = ParseMarkdown("Hello world").nodes;
+    auto nodes = ParseMarkdown(L"Hello world").nodes;
     auto sel = TextSelection::MakeOrdered(0, 6, 0, 11);
     EXPECT_EQ(ExtractSelectedText(nodes, sel), L"world");
 }
 
 TEST(ExtractSelectedText, MultipleNodesFullSelection)
 {
-    auto nodes = ParseMarkdown("First\n\nSecond\n\nThird").nodes;
+    auto nodes = ParseMarkdown(L"First\n\nSecond\n\nThird").nodes;
     ASSERT_EQ(nodes.size(), 3u);
     auto sel = TextSelection::MakeOrdered(
         0, 0, 2, static_cast<uint32_t>(nodes[2].GetText().size()));
@@ -55,7 +54,7 @@ TEST(ExtractSelectedText, MultipleNodesFullSelection)
 
 TEST(ExtractSelectedText, MultipleNodesPartialSelection)
 {
-    auto nodes = ParseMarkdown("First\n\nSecond\n\nThird").nodes;
+    auto nodes = ParseMarkdown(L"First\n\nSecond\n\nThird").nodes;
     ASSERT_EQ(nodes.size(), 3u);
     // "First"の途中から"Third"の途中まで選択
     auto sel = TextSelection::MakeOrdered(0, 2, 2, 3);
@@ -67,7 +66,7 @@ TEST(ExtractSelectedText, MultipleNodesPartialSelection)
 
 TEST(ExtractSelectedText, NewlineBetweenNodes)
 {
-    auto nodes = ParseMarkdown("A\n\nB").nodes;
+    auto nodes = ParseMarkdown(L"A\n\nB").nodes;
     ASSERT_EQ(nodes.size(), 2u);
     auto sel = TextSelection::MakeOrdered(
         0, 0, 1, static_cast<uint32_t>(nodes[1].GetText().size()));
@@ -86,7 +85,7 @@ TEST(ExtractSelectedText, EmptyNodes)
 
 TEST(ExtractSelectedText, EndBeyondTextSize)
 {
-    auto nodes = ParseMarkdown("Short").nodes;
+    auto nodes = ParseMarkdown(L"Short").nodes;
     auto sel = TextSelection::MakeOrdered(0, 0, 0, 1000);
     // end_posがテキストサイズを超える場合はクランプされるべき
     EXPECT_EQ(ExtractSelectedText(nodes, sel), L"Short");
@@ -94,7 +93,7 @@ TEST(ExtractSelectedText, EndBeyondTextSize)
 
 TEST(ExtractSelectedText, JapaneseText)
 {
-    auto nodes = ParseMarkdown("日本語テスト").nodes;
+    auto nodes = ParseMarkdown(L"日本語テスト").nodes;
     auto sel = TextSelection::MakeOrdered(
         0, 0, 0, static_cast<uint32_t>(nodes[0].GetText().size()));
     EXPECT_EQ(ExtractSelectedText(nodes, sel), L"日本語テスト");
@@ -106,7 +105,7 @@ TEST(ExtractSelectedText, JapaneseText)
 
 TEST(ExtractSelectedTextAsHtml, InactiveSelectionReturnsEmpty)
 {
-    auto nodes = ParseMarkdown("Hello").nodes;
+    auto nodes = ParseMarkdown(L"Hello").nodes;
     TextSelection sel;
     sel.active = false;
     EXPECT_TRUE(ExtractSelectedTextAsHtml(nodes, sel).empty());
@@ -114,21 +113,21 @@ TEST(ExtractSelectedTextAsHtml, InactiveSelectionReturnsEmpty)
 
 TEST(ExtractSelectedTextAsHtml, ParagraphWrapsInPTag)
 {
-    auto nodes = ParseMarkdown("Hello world").nodes;
+    auto nodes = ParseMarkdown(L"Hello world").nodes;
     auto sel = TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(nodes[0].GetText().size()));
     EXPECT_EQ(ExtractSelectedTextAsHtml(nodes, sel), L"<p>Hello world</p>");
 }
 
 TEST(ExtractSelectedTextAsHtml, HeadingLevels)
 {
-    auto nodes = ParseMarkdown("## Section").nodes;
+    auto nodes = ParseMarkdown(L"## Section").nodes;
     auto sel = TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(nodes[0].GetText().size()));
     EXPECT_EQ(ExtractSelectedTextAsHtml(nodes, sel), L"<h2>Section</h2>");
 }
 
 TEST(ExtractSelectedTextAsHtml, BoldAndItalic)
 {
-    auto nodes = ParseMarkdown("**bold** and *italic*").nodes;
+    auto nodes = ParseMarkdown(L"**bold** and *italic*").nodes;
     auto sel = TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(nodes[0].GetText().size()));
     auto html = ExtractSelectedTextAsHtml(nodes, sel);
     EXPECT_NE(html.find(L"<strong>bold</strong>"), std::wstring::npos);
@@ -137,7 +136,7 @@ TEST(ExtractSelectedTextAsHtml, BoldAndItalic)
 
 TEST(ExtractSelectedTextAsHtml, InlineCode)
 {
-    auto nodes = ParseMarkdown("text `code` more").nodes;
+    auto nodes = ParseMarkdown(L"text `code` more").nodes;
     auto sel = TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(nodes[0].GetText().size()));
     auto html = ExtractSelectedTextAsHtml(nodes, sel);
     EXPECT_NE(html.find(L"<code>code</code>"), std::wstring::npos);
@@ -145,7 +144,7 @@ TEST(ExtractSelectedTextAsHtml, InlineCode)
 
 TEST(ExtractSelectedTextAsHtml, LinkProducesAnchor)
 {
-    auto nodes = ParseMarkdown("[click](https://example.com)").nodes;
+    auto nodes = ParseMarkdown(L"[click](https://example.com)").nodes;
     auto sel = TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(nodes[0].GetText().size()));
     auto html = ExtractSelectedTextAsHtml(nodes, sel);
     EXPECT_NE(html.find(L"<a href=\"https://example.com\">click</a>"), std::wstring::npos);
@@ -165,7 +164,7 @@ TEST(ExtractSelectedTextAsHtml, EscapesSpecialChars)
 
 TEST(ExtractSelectedTextAsHtml, CodeBlockIsEscapedInPreCode)
 {
-    auto nodes = ParseMarkdown("```\nint x = 1 < 2;\n```").nodes;
+    auto nodes = ParseMarkdown(L"```\nint x = 1 < 2;\n```").nodes;
     ASSERT_EQ(nodes[0].type, NodeType::CodeBlock);
     auto sel = TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(nodes[0].GetText().size()));
     auto html = ExtractSelectedTextAsHtml(nodes, sel);
@@ -181,7 +180,7 @@ TEST(ExtractSelectedTextAsHtml, CodeBlockIsEscapedInPreCode)
 TEST(ExtractSelectedTextAsHtml, CodeBlockWithoutTokensHasNoSyntaxSpans)
 {
     // 言語指定なし -> syntax_tokens が空 -> span タグは付かない
-    auto nodes = ParseMarkdown("```\nplain text\n```").nodes;
+    auto nodes = ParseMarkdown(L"```\nplain text\n```").nodes;
     ASSERT_EQ(nodes[0].type, NodeType::CodeBlock);
     auto sel = TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(nodes[0].GetText().size()));
     auto html = ExtractSelectedTextAsHtml(nodes, sel);
@@ -192,7 +191,7 @@ TEST(ExtractSelectedTextAsHtml, CodeBlockWithoutTokensHasNoSyntaxSpans)
 TEST(ExtractSelectedTextAsHtml, CodeBlockWithSyntaxTokensWrapsInSpans)
 {
     // syntax_tokens を手動でセットし、span による色付けが行われることを確認
-    auto nodes = ParseMarkdown("```cpp\nint x = 42;\n```").nodes;
+    auto nodes = ParseMarkdown(L"```cpp\nint x = 42;\n```").nodes;
     ASSERT_EQ(nodes[0].type, NodeType::CodeBlock);
     auto& n = nodes[0];
     const std::wstring_view text = n.GetText();
@@ -217,7 +216,7 @@ TEST(ExtractSelectedTextAsHtml, CodeBlockWithSyntaxTokensWrapsInSpans)
 
 TEST(ExtractSelectedTextAsHtml, CodeBlockSpanEscapesSpecialChars)
 {
-    auto nodes = ParseMarkdown("```cpp\na<b\n```").nodes;
+    auto nodes = ParseMarkdown(L"```cpp\na<b\n```").nodes;
     auto& n = nodes[0];
     const std::wstring_view text = n.GetText();
     auto& tokens = n.syntax_tokens_mut();
@@ -235,7 +234,7 @@ TEST(ExtractSelectedTextAsHtml, CodeBlockSpanEscapesSpecialChars)
 
 TEST(ExtractSelectedTextAsHtml, CodeBlockDarkModeUsesDarkColors)
 {
-    auto nodes = ParseMarkdown("```cpp\nint x = 42;\n```").nodes;
+    auto nodes = ParseMarkdown(L"```cpp\nint x = 42;\n```").nodes;
     auto& n = nodes[0];
     const std::wstring_view text = n.GetText();
     auto& tokens = n.syntax_tokens_mut();
@@ -271,7 +270,7 @@ static TextSelection MakeTableFullSelection(Node& table)
 TEST(ExtractSelectedTextAsHtml, TableRendersAsTableStructure)
 {
     auto nodes = ParseMarkdown(
-        "| A | B |\n"
+        L"| A | B |\n"
         "|---|---|\n"
         "| 1 | 2 |"
     ).nodes;
@@ -298,7 +297,7 @@ TEST(ExtractSelectedTextAsHtml, TableRendersAsTableStructure)
 TEST(ExtractSelectedTextAsHtml, TableAlignmentAppliedAsTextAlign)
 {
     auto nodes = ParseMarkdown(
-        "| L | C | R |\n"
+        L"| L | C | R |\n"
         "|:--|:--:|--:|\n"
         "| a | b | c |"
     ).nodes;
@@ -313,7 +312,7 @@ TEST(ExtractSelectedTextAsHtml, TableAlignmentAppliedAsTextAlign)
 TEST(ExtractSelectedTextAsHtml, TablePreservesInlineFormatting)
 {
     auto nodes = ParseMarkdown(
-        "| A | B |\n"
+        L"| A | B |\n"
         "|---|---|\n"
         "| **bold** | [link](https://example.com) |"
     ).nodes;
@@ -328,7 +327,7 @@ TEST(ExtractSelectedTextAsHtml, TablePreservesInlineFormatting)
 TEST(ExtractSelectedTextAsHtml, TableDarkModeUsesDarkBorder)
 {
     auto nodes = ParseMarkdown(
-        "| A | B |\n"
+        L"| A | B |\n"
         "|---|---|\n"
         "| 1 | 2 |"
     ).nodes;
@@ -355,7 +354,7 @@ TEST(ExtractSelectedTextAsHtml, TableWithoutDataFallsBackToPre)
 
 TEST(ExtractSelectedTextAsHtml, UnorderedListWrapsInUl)
 {
-    auto nodes = ParseMarkdown("- one\n- two").nodes;
+    auto nodes = ParseMarkdown(L"- one\n- two").nodes;
     ASSERT_GE(nodes.size(), 2u);
     auto sel = TextSelection::MakeOrdered(0, 0, 1, static_cast<uint32_t>(nodes[1].GetText().size()));
     auto html = ExtractSelectedTextAsHtml(nodes, sel);
@@ -367,7 +366,7 @@ TEST(ExtractSelectedTextAsHtml, UnorderedListWrapsInUl)
 
 TEST(ExtractSelectedTextAsHtml, OrderedListWrapsInOl)
 {
-    auto nodes = ParseMarkdown("1. first\n2. second").nodes;
+    auto nodes = ParseMarkdown(L"1. first\n2. second").nodes;
     ASSERT_GE(nodes.size(), 2u);
     auto sel = TextSelection::MakeOrdered(0, 0, 1, static_cast<uint32_t>(nodes[1].GetText().size()));
     auto html = ExtractSelectedTextAsHtml(nodes, sel);
@@ -379,7 +378,7 @@ TEST(ExtractSelectedTextAsHtml, OrderedListWrapsInOl)
 
 TEST(ExtractSelectedTextAsHtml, BlockQuote)
 {
-    auto nodes = ParseMarkdown("> quoted text").nodes;
+    auto nodes = ParseMarkdown(L"> quoted text").nodes;
     ASSERT_EQ(nodes[0].type, NodeType::BlockQuote);
     auto sel = TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(nodes[0].GetText().size()));
     auto html = ExtractSelectedTextAsHtml(nodes, sel);
@@ -390,7 +389,7 @@ TEST(ExtractSelectedTextAsHtml, BlockQuote)
 
 TEST(ExtractSelectedTextAsHtml, HorizontalRule)
 {
-    auto nodes = ParseMarkdown("before\n\n---\n\nafter").nodes;
+    auto nodes = ParseMarkdown(L"before\n\n---\n\nafter").nodes;
     ASSERT_GE(nodes.size(), 3u);
     ASSERT_EQ(nodes[1].type, NodeType::HorizontalRule);
     auto sel = TextSelection::MakeOrdered(0, 0, 2, static_cast<uint32_t>(nodes[2].GetText().size()));
@@ -400,7 +399,7 @@ TEST(ExtractSelectedTextAsHtml, HorizontalRule)
 
 TEST(ExtractSelectedTextAsHtml, MultiParagraph)
 {
-    auto nodes = ParseMarkdown("First\n\nSecond").nodes;
+    auto nodes = ParseMarkdown(L"First\n\nSecond").nodes;
     ASSERT_EQ(nodes.size(), 2u);
     auto sel = TextSelection::MakeOrdered(0, 0, 1, static_cast<uint32_t>(nodes[1].GetText().size()));
     EXPECT_EQ(ExtractSelectedTextAsHtml(nodes, sel),
@@ -409,14 +408,14 @@ TEST(ExtractSelectedTextAsHtml, MultiParagraph)
 
 TEST(ExtractSelectedTextAsHtml, PartialSelectionInParagraph)
 {
-    auto nodes = ParseMarkdown("Hello world").nodes;
+    auto nodes = ParseMarkdown(L"Hello world").nodes;
     auto sel = TextSelection::MakeOrdered(0, 6, 0, 11);
     EXPECT_EQ(ExtractSelectedTextAsHtml(nodes, sel), L"<p>world</p>");
 }
 
 TEST(ExtractSelectedTextAsHtml, OrderedTaskListWrapsInOl)
 {
-    auto nodes = ParseMarkdown("1. [ ] first\n2. [x] second").nodes;
+    auto nodes = ParseMarkdown(L"1. [ ] first\n2. [x] second").nodes;
     ASSERT_GE(nodes.size(), 2u);
     ASSERT_EQ(nodes[0].type, NodeType::TaskListItem);
     ASSERT_EQ(nodes[1].type, NodeType::TaskListItem);
@@ -429,7 +428,7 @@ TEST(ExtractSelectedTextAsHtml, OrderedTaskListWrapsInOl)
 
 TEST(ExtractSelectedTextAsHtml, UnsafeSchemeLinkIsStripped)
 {
-    auto nodes = ParseMarkdown("[click](javascript:alert(1))").nodes;
+    auto nodes = ParseMarkdown(L"[click](javascript:alert(1))").nodes;
     auto sel = TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(nodes[0].GetText().size()));
     auto html = ExtractSelectedTextAsHtml(nodes, sel);
     EXPECT_EQ(html.find(L"<a href="), std::wstring::npos);
@@ -439,7 +438,7 @@ TEST(ExtractSelectedTextAsHtml, UnsafeSchemeLinkIsStripped)
 
 TEST(ExtractSelectedTextAsHtml, FileSchemeLinkIsStripped)
 {
-    auto nodes = ParseMarkdown("[open](file:///C:/secret.txt)").nodes;
+    auto nodes = ParseMarkdown(L"[open](file:///C:/secret.txt)").nodes;
     auto sel = TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(nodes[0].GetText().size()));
     auto html = ExtractSelectedTextAsHtml(nodes, sel);
     EXPECT_EQ(html.find(L"<a href="), std::wstring::npos);
@@ -448,7 +447,7 @@ TEST(ExtractSelectedTextAsHtml, FileSchemeLinkIsStripped)
 
 TEST(ExtractSelectedTextAsHtml, MailtoLinkIsKept)
 {
-    auto nodes = ParseMarkdown("[mail](mailto:user@example.com)").nodes;
+    auto nodes = ParseMarkdown(L"[mail](mailto:user@example.com)").nodes;
     auto sel = TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(nodes[0].GetText().size()));
     auto html = ExtractSelectedTextAsHtml(nodes, sel);
     EXPECT_NE(html.find(L"<a href=\"mailto:user@example.com\">mail</a>"), std::wstring::npos);
@@ -456,7 +455,7 @@ TEST(ExtractSelectedTextAsHtml, MailtoLinkIsKept)
 
 TEST(ExtractSelectedTextAsHtml, InternalAnchorLinkIsStripped)
 {
-    auto nodes = ParseMarkdown("[sec](#section)").nodes;
+    auto nodes = ParseMarkdown(L"[sec](#section)").nodes;
     auto sel = TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(nodes[0].GetText().size()));
     auto html = ExtractSelectedTextAsHtml(nodes, sel);
     EXPECT_EQ(html.find(L"<a href="), std::wstring::npos);
@@ -469,7 +468,7 @@ TEST(ExtractSelectedTextAsHtml, InternalAnchorLinkIsStripped)
 
 TEST(FindLinkAtPosition, NoLinks)
 {
-    auto nodes = ParseMarkdown("plain text").nodes;
+    auto nodes = ParseMarkdown(L"plain text").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     auto result = FindLinkAtPosition(nodes[0], 0);
     EXPECT_FALSE(result.has_value());
@@ -477,7 +476,7 @@ TEST(FindLinkAtPosition, NoLinks)
 
 TEST(FindLinkAtPosition, LinkFound)
 {
-    auto nodes = ParseMarkdown("[click](https://example.com)").nodes;
+    auto nodes = ParseMarkdown(L"[click](https://example.com)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     // リンクテキスト内の位置
     auto result = FindLinkAtPosition(nodes[0], 0);
@@ -487,7 +486,7 @@ TEST(FindLinkAtPosition, LinkFound)
 
 TEST(FindLinkAtPosition, PositionOutsideLink)
 {
-    auto nodes = ParseMarkdown("before [link](https://example.com) after").nodes;
+    auto nodes = ParseMarkdown(L"before [link](https://example.com) after").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     // "before"テキスト内の位置（リンクではないはず）
     auto result = FindLinkAtPosition(nodes[0], 0);
@@ -496,7 +495,7 @@ TEST(FindLinkAtPosition, PositionOutsideLink)
 
 TEST(FindLinkAtPosition, InternalLink)
 {
-    auto nodes = ParseMarkdown("[section](#my-section)").nodes;
+    auto nodes = ParseMarkdown(L"[section](#my-section)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     auto result = FindLinkAtPosition(nodes[0], 0);
     ASSERT_TRUE(result.has_value());
@@ -505,7 +504,7 @@ TEST(FindLinkAtPosition, InternalLink)
 
 TEST(FindLinkAtPosition, PositionAtLinkBoundary)
 {
-    auto nodes = ParseMarkdown("[link](https://example.com)").nodes;
+    auto nodes = ParseMarkdown(L"[link](https://example.com)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     // リンクの最後の文字の位置
     uint32_t last_pos = static_cast<uint32_t>(nodes[0].GetText().size()) - 1;
@@ -515,7 +514,7 @@ TEST(FindLinkAtPosition, PositionAtLinkBoundary)
 
 TEST(FindLinkAtPosition, PositionBeyondText)
 {
-    auto nodes = ParseMarkdown("[link](https://example.com)").nodes;
+    auto nodes = ParseMarkdown(L"[link](https://example.com)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     auto result = FindLinkAtPosition(nodes[0], 9999);
     EXPECT_FALSE(result.has_value());
@@ -540,13 +539,13 @@ TEST(FindAnchorNodeIndex, EmptyNodes)
 
 TEST(FindAnchorNodeIndex, EmptyAnchor)
 {
-    auto nodes = ParseMarkdown("# Title").nodes;
+    auto nodes = ParseMarkdown(L"# Title").nodes;
     EXPECT_EQ(FindAnchorNodeIndexLinear(nodes, L""), -1);
 }
 
 TEST(FindAnchorNodeIndex, FindExistingAnchor)
 {
-    auto nodes = ParseMarkdown("# Title\n\nParagraph\n\n## Section").nodes;
+    auto nodes = ParseMarkdown(L"# Title\n\nParagraph\n\n## Section").nodes;
     ASSERT_GE(nodes.size(), 3u);
     int idx = FindAnchorNodeIndexLinear(nodes, L"title");
     EXPECT_EQ(idx, 0);
@@ -554,7 +553,7 @@ TEST(FindAnchorNodeIndex, FindExistingAnchor)
 
 TEST(FindAnchorNodeIndex, FindSecondHeading)
 {
-    auto nodes = ParseMarkdown("# First\n\nParagraph\n\n## Second").nodes;
+    auto nodes = ParseMarkdown(L"# First\n\nParagraph\n\n## Second").nodes;
     int idx = FindAnchorNodeIndexLinear(nodes, L"second");
     EXPECT_GE(idx, 0);
     EXPECT_EQ(nodes[idx].GetText(), L"Second");
@@ -562,7 +561,7 @@ TEST(FindAnchorNodeIndex, FindSecondHeading)
 
 TEST(FindAnchorNodeIndex, CaseInsensitiveSearch)
 {
-    auto nodes = ParseMarkdown("# Hello World").nodes;
+    auto nodes = ParseMarkdown(L"# Hello World").nodes;
     // アンカーは"hello-world"、大文字で検索
     int idx = FindAnchorNodeIndexLinear(nodes, L"Hello-World");
     EXPECT_EQ(idx, 0);
@@ -570,20 +569,20 @@ TEST(FindAnchorNodeIndex, CaseInsensitiveSearch)
 
 TEST(FindAnchorNodeIndex, NotFound)
 {
-    auto nodes = ParseMarkdown("# Title").nodes;
+    auto nodes = ParseMarkdown(L"# Title").nodes;
     EXPECT_EQ(FindAnchorNodeIndexLinear(nodes, L"nonexistent"), -1);
 }
 
 TEST(FindAnchorNodeIndex, CjkAnchor)
 {
-    auto nodes = ParseMarkdown("## コードブロック").nodes;
+    auto nodes = ParseMarkdown(L"## コードブロック").nodes;
     int idx = FindAnchorNodeIndexLinear(nodes, L"コードブロック");
     EXPECT_EQ(idx, 0);
 }
 
 TEST(FindAnchorNodeIndex, SkipsNonHeadings)
 {
-    auto nodes = ParseMarkdown("Paragraph\n\n# Heading").nodes;
+    auto nodes = ParseMarkdown(L"Paragraph\n\n# Heading").nodes;
     int idx = FindAnchorNodeIndexLinear(nodes, L"heading");
     EXPECT_GE(idx, 0);
     EXPECT_EQ(nodes[idx].type, NodeType::Heading);
@@ -888,7 +887,7 @@ TEST(FindLinkAtPosition, TableCellLinkFound)
 TEST(FindLinkAtPosition, TableCellLinkFromParsedMarkdown)
 {
     auto nodes = ParseMarkdown(
-        "| Text | Link |\n"
+        L"| Text | Link |\n"
         "|------|------|\n"
         "| hello | [click](https://example.com) |"
     ).nodes;
@@ -1227,7 +1226,7 @@ TEST(FindNodeBySourceOffset, SkipsUnsetOffsets)
 
 TEST(FindNodeBySourceOffset, ParsedMarkdown)
 {
-    auto nodes = ParseMarkdown("# Title\n\nParagraph\n\n## Section").nodes;
+    auto nodes = ParseMarkdown(L"# Title\n\nParagraph\n\n## Section").nodes;
     ASSERT_GE(nodes.size(), 3u);
     // 各ノードが有効な source_offset を持つ
     for (const auto& n : nodes) {
@@ -1262,7 +1261,7 @@ TEST(FindNodeBySourceOffset, AllUnsetOffsets)
 TEST(FindNodeBySourceOffset, MixedWithHorizontalRules)
 {
     // パース結果で HorizontalRule が混在するケース
-    auto nodes = ParseMarkdown("AAA\n\n---\n\nBBB").nodes;
+    auto nodes = ParseMarkdown(L"AAA\n\n---\n\nBBB").nodes;
     ASSERT_GE(nodes.size(), 3u);
     // "AAA" offset=0, "---" は未設定, "BBB" offset=10
     EXPECT_EQ(nodes[0].source_offset, 0u);
@@ -1280,13 +1279,10 @@ TEST(FindNodeBySourceOffset, MixedWithHorizontalRules)
 // ============================================================
 
 // ヘルパー: old→new の編集をシミュレートし、変更箇所のノードを特定する。
-// 入力 UTF-8 を wide 化して FindFirstDifference を呼ぶ（source_offset は wide 単位）。
-static int SimulateEditAndFindNode(std::string_view old_md, std::string_view new_md)
+// source_offset は wide 単位なので、wide のまま FindFirstDifference / ParseMarkdown を呼ぶ。
+static int SimulateEditAndFindNode(std::wstring_view old_md, std::wstring_view new_md)
 {
-    std::pmr::wstring old_w, new_w;
-    string_convert::Utf8ToWide(old_md, old_w);
-    string_convert::Utf8ToWide(new_md, new_w);
-    size_t diff_pos = FindFirstDifference(old_w, new_w);
+    size_t diff_pos = FindFirstDifference(old_md, new_md);
     if (diff_pos == std::wstring_view::npos) {
         return -1;
     }
@@ -1300,8 +1296,8 @@ static int SimulateEditAndFindNode(std::string_view old_md, std::string_view new
 TEST(DiffToNode, EditMiddleParagraph)
 {
     // 2番目の段落を編集
-    std::string old_md = "First\n\nSecond\n\nThird";
-    std::string new_md = "First\n\nModified\n\nThird";
+    std::wstring old_md = L"First\n\nSecond\n\nThird";
+    std::wstring new_md = L"First\n\nModified\n\nThird";
     int node = SimulateEditAndFindNode(old_md, new_md);
     auto nodes = ParseMarkdown(new_md).nodes;
     EXPECT_EQ(node, 1); // 2番目の段落
@@ -1310,16 +1306,16 @@ TEST(DiffToNode, EditMiddleParagraph)
 
 TEST(DiffToNode, EditFirstParagraph)
 {
-    std::string old_md = "Hello\n\nWorld";
-    std::string new_md = "Changed\n\nWorld";
+    std::wstring old_md = L"Hello\n\nWorld";
+    std::wstring new_md = L"Changed\n\nWorld";
     int node = SimulateEditAndFindNode(old_md, new_md);
     EXPECT_EQ(node, 0);
 }
 
 TEST(DiffToNode, EditLastParagraph)
 {
-    std::string old_md = "First\n\nSecond\n\nThird";
-    std::string new_md = "First\n\nSecond\n\nChanged";
+    std::wstring old_md = L"First\n\nSecond\n\nThird";
+    std::wstring new_md = L"First\n\nSecond\n\nChanged";
     int node = SimulateEditAndFindNode(old_md, new_md);
     EXPECT_EQ(node, 2); // 最後の段落
 }
@@ -1327,8 +1323,8 @@ TEST(DiffToNode, EditLastParagraph)
 TEST(DiffToNode, InsertNewParagraph)
 {
     // 段落を挿入
-    std::string old_md = "Before\n\nAfter";
-    std::string new_md = "Before\n\nInserted\n\nAfter";
+    std::wstring old_md = L"Before\n\nAfter";
+    std::wstring new_md = L"Before\n\nInserted\n\nAfter";
     int node = SimulateEditAndFindNode(old_md, new_md);
     auto nodes = ParseMarkdown(new_md).nodes;
     ASSERT_GE(node, 0);
@@ -1339,8 +1335,8 @@ TEST(DiffToNode, InsertNewParagraph)
 TEST(DiffToNode, DeleteParagraph)
 {
     // 段落を削除
-    std::string old_md = "First\n\nRemoveMe\n\nLast";
-    std::string new_md = "First\n\nLast";
+    std::wstring old_md = L"First\n\nRemoveMe\n\nLast";
+    std::wstring new_md = L"First\n\nLast";
     int node = SimulateEditAndFindNode(old_md, new_md);
     ASSERT_GE(node, 0);
     // diff_pos=7（"RemoveMe" vs "Last"の開始位置）→ "Last"(offset=7)か"First"
@@ -1350,8 +1346,8 @@ TEST(DiffToNode, DeleteParagraph)
 
 TEST(DiffToNode, AppendToEnd)
 {
-    std::string old_md = "Existing";
-    std::string new_md = "Existing\n\nAppended";
+    std::wstring old_md = L"Existing";
+    std::wstring new_md = L"Existing\n\nAppended";
     int node = SimulateEditAndFindNode(old_md, new_md);
     auto nodes = ParseMarkdown(new_md).nodes;
     ASSERT_GE(node, 0);
@@ -1363,8 +1359,8 @@ TEST(DiffToNode, AppendToEnd)
 TEST(DiffToNode, EditInCodeBlock)
 {
     // コードブロック内の編集
-    std::string old_md = "text\n\n```\nold code\n```\n\nend";
-    std::string new_md = "text\n\n```\nnew code\n```\n\nend";
+    std::wstring old_md = L"text\n\n```\nold code\n```\n\nend";
+    std::wstring new_md = L"text\n\n```\nnew code\n```\n\nend";
     int node = SimulateEditAndFindNode(old_md, new_md);
     auto nodes = ParseMarkdown(new_md).nodes;
     ASSERT_GE(node, 0);
@@ -1374,8 +1370,8 @@ TEST(DiffToNode, EditInCodeBlock)
 TEST(DiffToNode, EditInListItem)
 {
     // リストアイテムの編集
-    std::string old_md = "- first\n- second\n- third";
-    std::string new_md = "- first\n- changed\n- third";
+    std::wstring old_md = L"- first\n- second\n- third";
+    std::wstring new_md = L"- first\n- changed\n- third";
     int node = SimulateEditAndFindNode(old_md, new_md);
     auto nodes = ParseMarkdown(new_md).nodes;
     ASSERT_GE(node, 0);
@@ -1385,22 +1381,22 @@ TEST(DiffToNode, EditInListItem)
 TEST(DiffToNode, EditHeading)
 {
     // 見出しテキストの編集
-    std::string old_md = "# Old Title\n\nBody";
-    std::string new_md = "# New Title\n\nBody";
+    std::wstring old_md = L"# Old Title\n\nBody";
+    std::wstring new_md = L"# New Title\n\nBody";
     int node = SimulateEditAndFindNode(old_md, new_md);
     EXPECT_EQ(node, 0); // 見出しノード
 }
 
 TEST(DiffToNode, NoChange)
 {
-    std::string md = "Same content";
+    std::wstring md = L"Same content";
     EXPECT_EQ(SimulateEditAndFindNode(md, md), -1);
 }
 
 TEST(DiffToNode, EditInBlockQuote)
 {
-    std::string old_md = "normal\n\n> old quote\n\nafter";
-    std::string new_md = "normal\n\n> new quote\n\nafter";
+    std::wstring old_md = L"normal\n\n> old quote\n\nafter";
+    std::wstring new_md = L"normal\n\n> new quote\n\nafter";
     int node = SimulateEditAndFindNode(old_md, new_md);
     auto nodes = ParseMarkdown(new_md).nodes;
     ASSERT_GE(node, 0);
@@ -1410,8 +1406,8 @@ TEST(DiffToNode, EditInBlockQuote)
 TEST(DiffToNode, EditWithJapanese)
 {
     // 日本語テキストの編集
-    std::string old_md = "# はじめに\n\n旧テキスト\n\nおわり";
-    std::string new_md = "# はじめに\n\n新テキスト\n\nおわり";
+    std::wstring old_md = L"# はじめに\n\n旧テキスト\n\nおわり";
+    std::wstring new_md = L"# はじめに\n\n新テキスト\n\nおわり";
     int node = SimulateEditAndFindNode(old_md, new_md);
     auto nodes = ParseMarkdown(new_md).nodes;
     ASSERT_GE(node, 0);
@@ -1422,14 +1418,14 @@ TEST(DiffToNode, EditWithJapanese)
 
 TEST(DiffToNode, EditInTable)
 {
-    std::string old_md =
-        "| A | B |\n"
-        "|---|---|\n"
-        "| 1 | 2 |";
-    std::string new_md =
-        "| A | B |\n"
-        "|---|---|\n"
-        "| X | 2 |";
+    std::wstring old_md =
+        L"| A | B |\n"
+        L"|---|---|\n"
+        L"| 1 | 2 |";
+    std::wstring new_md =
+        L"| A | B |\n"
+        L"|---|---|\n"
+        L"| X | 2 |";
     int node = SimulateEditAndFindNode(old_md, new_md);
     auto nodes = ParseMarkdown(new_md).nodes;
     ASSERT_GE(node, 0);
@@ -1439,14 +1435,14 @@ TEST(DiffToNode, EditInTable)
 TEST(DiffToNode, LargeDocumentMiddleEdit)
 {
     // 多数のノードを持つ文書の中間を編集
-    std::string old_md, new_md;
+    std::wstring old_md, new_md;
     for (int i = 0; i < 100; ++i) {
-        old_md += "Paragraph " + std::to_string(i) + "\n\n";
+        old_md += L"Paragraph " + std::to_wstring(i) + L"\n\n";
         if (i == 50) {
-            new_md += "CHANGED paragraph 50\n\n";
+            new_md += L"CHANGED paragraph 50\n\n";
         }
         else {
-            new_md += "Paragraph " + std::to_string(i) + "\n\n";
+            new_md += L"Paragraph " + std::to_wstring(i) + L"\n\n";
         }
     }
     int node = SimulateEditAndFindNode(old_md, new_md);

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -271,8 +271,8 @@ TEST(ExtractSelectedTextAsHtml, TableRendersAsTableStructure)
 {
     auto nodes = ParseMarkdown(
         L"| A | B |\n"
-        "|---|---|\n"
-        "| 1 | 2 |"
+        L"|---|---|\n"
+        L"| 1 | 2 |"
     ).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_EQ(nodes[0].type, NodeType::Table);
@@ -298,8 +298,8 @@ TEST(ExtractSelectedTextAsHtml, TableAlignmentAppliedAsTextAlign)
 {
     auto nodes = ParseMarkdown(
         L"| L | C | R |\n"
-        "|:--|:--:|--:|\n"
-        "| a | b | c |"
+        L"|:--|:--:|--:|\n"
+        L"| a | b | c |"
     ).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_EQ(nodes[0].type, NodeType::Table);
@@ -313,8 +313,8 @@ TEST(ExtractSelectedTextAsHtml, TablePreservesInlineFormatting)
 {
     auto nodes = ParseMarkdown(
         L"| A | B |\n"
-        "|---|---|\n"
-        "| **bold** | [link](https://example.com) |"
+        L"|---|---|\n"
+        L"| **bold** | [link](https://example.com) |"
     ).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_EQ(nodes[0].type, NodeType::Table);
@@ -328,8 +328,8 @@ TEST(ExtractSelectedTextAsHtml, TableDarkModeUsesDarkBorder)
 {
     auto nodes = ParseMarkdown(
         L"| A | B |\n"
-        "|---|---|\n"
-        "| 1 | 2 |"
+        L"|---|---|\n"
+        L"| 1 | 2 |"
     ).nodes;
     ASSERT_EQ(nodes[0].type, NodeType::Table);
     auto sel = MakeTableFullSelection(nodes[0]);
@@ -888,8 +888,8 @@ TEST(FindLinkAtPosition, TableCellLinkFromParsedMarkdown)
 {
     auto nodes = ParseMarkdown(
         L"| Text | Link |\n"
-        "|------|------|\n"
-        "| hello | [click](https://example.com) |"
+        L"|------|------|\n"
+        L"| hello | [click](https://example.com) |"
     ).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Table);

--- a/tests/test_draw_command.cpp
+++ b/tests/test_draw_command.cpp
@@ -23,7 +23,7 @@ protected:
     }
 
     // ヘルパー: Markdownをパースし、レイアウトを計算し、MDペイン用のコマンドを生成する。
-    DrawCommandList Generate(const std::string& md, float viewport_w = 800.0f)
+    DrawCommandList Generate(std::wstring_view md, float viewport_w = 800.0f)
     {
         auto nodes = ParseMarkdown(md).nodes;
         LayoutCache cache;
@@ -38,7 +38,7 @@ protected:
 
 TEST_F(CmdGenTest, EmptyDocumentProducesClipAndTransformOnly)
 {
-    auto cmds = Generate("");
+    auto cmds = Generate(L"");
     // 期待値: PushClip, SetTransform, SetTransform(単位行列), PopClip
     ASSERT_GE(cmds.size(), 4u);
     EXPECT_TRUE(std::holds_alternative<PushClipCmd>(cmds.front()));
@@ -47,7 +47,7 @@ TEST_F(CmdGenTest, EmptyDocumentProducesClipAndTransformOnly)
 
 TEST_F(CmdGenTest, PushClipAndPopClipArePaired)
 {
-    auto cmds = Generate("Hello\n\n---\n\nWorld");
+    auto cmds = Generate(L"Hello\n\n---\n\nWorld");
     int push = 0, pop = 0;
     for (const auto& cmd : cmds) {
         if (std::holds_alternative<PushClipCmd>(cmd)) push++;
@@ -59,7 +59,7 @@ TEST_F(CmdGenTest, PushClipAndPopClipArePaired)
 
 TEST_F(CmdGenTest, TransformsArePaired)
 {
-    auto cmds = Generate("Hello");
+    auto cmds = Generate(L"Hello");
     int transforms = 0;
     for (const auto& cmd : cmds) {
         if (std::holds_alternative<SetTransformCmd>(cmd)) transforms++;
@@ -71,7 +71,7 @@ TEST_F(CmdGenTest, TransformsArePaired)
 
 TEST_F(CmdGenTest, HorizontalRuleGeneratesDrawLine)
 {
-    auto cmds = Generate("---");
+    auto cmds = Generate(L"---");
     int line_count = 0;
     for (const auto& cmd : cmds) {
         if (std::holds_alternative<DrawLineCmd>(cmd)) line_count++;
@@ -83,7 +83,7 @@ TEST_F(CmdGenTest, HorizontalRuleGeneratesDrawLine)
 
 TEST_F(CmdGenTest, CodeBlockGeneratesRoundedRectBackground)
 {
-    auto cmds = Generate("```\ncode\n```");
+    auto cmds = Generate(L"```\ncode\n```");
     int rounded_count = 0;
     for (const auto& cmd : cmds) {
         if (std::holds_alternative<FillRoundedRectCmd>(cmd)) rounded_count++;
@@ -95,7 +95,7 @@ TEST_F(CmdGenTest, CodeBlockGeneratesRoundedRectBackground)
 
 TEST_F(CmdGenTest, TableGeneratesLinesAndRects)
 {
-    auto cmds = Generate("| A | B |\n|---|---|\n| 1 | 2 |");
+    auto cmds = Generate(L"| A | B |\n|---|---|\n| 1 | 2 |");
     int lines = 0, rects = 0;
     for (const auto& cmd : cmds) {
         if (std::holds_alternative<DrawLineCmd>(cmd)) lines++;
@@ -110,7 +110,7 @@ TEST_F(CmdGenTest, TableGeneratesLinesAndRects)
 
 TEST_F(CmdGenTest, UnorderedListGeneratesFillEllipse)
 {
-    auto cmds = Generate("- Item");
+    auto cmds = Generate(L"- Item");
     int ellipses = 0;
     for (const auto& cmd : cmds) {
         if (std::holds_alternative<FillEllipseCmd>(cmd)) ellipses++;
@@ -120,7 +120,7 @@ TEST_F(CmdGenTest, UnorderedListGeneratesFillEllipse)
 
 TEST_F(CmdGenTest, NestedListGeneratesDrawEllipse)
 {
-    auto cmds = Generate("- Item\n  - Sub");
+    auto cmds = Generate(L"- Item\n  - Sub");
     int outline_ellipses = 0;
     for (const auto& cmd : cmds) {
         if (std::holds_alternative<DrawEllipseCmd>(cmd)) outline_ellipses++;
@@ -132,7 +132,7 @@ TEST_F(CmdGenTest, NestedListGeneratesDrawEllipse)
 
 TEST_F(CmdGenTest, BlockQuoteGeneratesBarLine)
 {
-    auto cmds = Generate("> Quote");
+    auto cmds = Generate(L"> Quote");
     int lines = 0;
     for (const auto& cmd : cmds) {
         if (auto* line = std::get_if<DrawLineCmd>(&cmd)) {
@@ -146,7 +146,7 @@ TEST_F(CmdGenTest, BlockQuoteGeneratesBarLine)
 
 TEST_F(CmdGenTest, MultiLineBlockQuoteGeneratesSingleBar)
 {
-    auto cmds = Generate("> Line 1\n>\n> Line 2");
+    auto cmds = Generate(L"> Line 1\n>\n> Line 2");
     int vertical_lines = 0;
     for (const auto& cmd : cmds) {
         if (auto* line = std::get_if<DrawLineCmd>(&cmd)) {
@@ -160,7 +160,7 @@ TEST_F(CmdGenTest, MultiLineBlockQuoteGeneratesSingleBar)
 
 TEST_F(CmdGenTest, MultiLineAlertGeneratesSingleBarAndBackground)
 {
-    auto cmds = Generate("> [!NOTE]\n> Line 1\n>\n> Line 2");
+    auto cmds = Generate(L"> [!NOTE]\n> Line 1\n>\n> Line 2");
     int vertical_lines = 0;
     int rounded_rects = 0;
     for (const auto& cmd : cmds) {
@@ -182,8 +182,8 @@ TEST_F(CmdGenTest, MultiLineAlertGeneratesSingleBarAndBackground)
 TEST_F(CmdGenTest, ViewportCullingExcludesOffscreenNodes)
 {
     // 多数の水平線を作成。text_layoutがなくてもDrawLineCmdを生成する。
-    std::string md;
-    for (int i = 0; i < 50; i++) md += "---\n\n";
+    std::wstring md;
+    for (int i = 0; i < 50; i++) md += L"---\n\n";
     auto nodes = ParseMarkdown(md).nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
@@ -204,7 +204,7 @@ TEST_F(CmdGenTest, ViewportCullingExcludesOffscreenNodes)
 
 TEST_F(CmdGenTest, HorizontalRuleColorMatchesTheme)
 {
-    auto cmds = Generate("---");
+    auto cmds = Generate(L"---");
     for (const auto& cmd : cmds) {
         if (auto* line = std::get_if<DrawLineCmd>(&cmd)) {
             EXPECT_FLOAT_EQ(line->color.r, theme_.hr_color.r);
@@ -219,7 +219,7 @@ TEST_F(CmdGenTest, HorizontalRuleColorMatchesTheme)
 
 TEST_F(CmdGenTest, MixedContentGeneratesVariousCommands)
 {
-    auto cmds = Generate("# Heading\n\nParagraph\n\n---\n\n- List\n\n> Quote\n\n```\ncode\n```");
+    auto cmds = Generate(L"# Heading\n\nParagraph\n\n---\n\n- List\n\n> Quote\n\n```\ncode\n```");
     // すべてのノード種別からのコマンドがあるべき
     bool has_line = false, has_ellipse = false, has_rounded = false;
     for (const auto& cmd : cmds) {
@@ -236,7 +236,7 @@ TEST_F(CmdGenTest, MixedContentGeneratesVariousCommands)
 
 TEST_F(CmdGenTest, OrderedListGeneratesDrawText)
 {
-    auto cmds = Generate("1. First\n2. Second\n3. Third");
+    auto cmds = Generate(L"1. First\n2. Second\n3. Third");
     // 番号付きリストは箇条書きの楕円を生成しないべき
     int fill_ellipses = 0;
     for (const auto& cmd : cmds) {
@@ -249,7 +249,7 @@ TEST_F(CmdGenTest, OrderedListGeneratesDrawText)
 
 TEST_F(CmdGenTest, TaskListItemGeneratesNoEllipse)
 {
-    auto cmds = Generate("- [x] Done\n- [ ] Not done");
+    auto cmds = Generate(L"- [x] Done\n- [ ] Not done");
     // タスクリスト項目は箇条書きの楕円を生成しないべき
     int fill_ellipses = 0;
     for (const auto& cmd : cmds) {
@@ -262,7 +262,7 @@ TEST_F(CmdGenTest, TaskListItemGeneratesNoEllipse)
 
 TEST_F(CmdGenTest, SelectionGeneratesFillRects)
 {
-    auto nodes = ParseMarkdown("Hello world paragraph").nodes;
+    auto nodes = ParseMarkdown(L"Hello world paragraph").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -289,8 +289,8 @@ TEST_F(CmdGenTest, SelectionGeneratesFillRects)
 TEST_F(CmdGenTest, ScrolledViewportCullsTopNodes)
 {
     // 複数の段落を作成
-    std::string md;
-    for (int i = 0; i < 20; i++) md += "Paragraph " + std::to_string(i) + "\n\n";
+    std::wstring md;
+    for (int i = 0; i < 20; i++) md += L"Paragraph " + std::to_wstring(i) + L"\n\n";
 
     auto nodes = ParseMarkdown(md).nodes;
     LayoutCache cache;
@@ -313,7 +313,7 @@ TEST_F(CmdGenTest, ScrolledViewportCullsTopNodes)
 
 TEST_F(CmdGenTest, CodeBlockWithLanguageGeneratesBackground)
 {
-    auto cmds = Generate("```cpp\nint x = 42;\n```");
+    auto cmds = Generate(L"```cpp\nint x = 42;\n```");
     int rounded_count = 0;
     for (const auto& cmd : cmds) {
         if (std::holds_alternative<FillRoundedRectCmd>(cmd)) rounded_count++;
@@ -325,7 +325,7 @@ TEST_F(CmdGenTest, CodeBlockWithLanguageGeneratesBackground)
 
 TEST_F(CmdGenTest, MultipleHorizontalRulesGenerateMultipleLines)
 {
-    auto cmds = Generate("---\n\n---\n\n---");
+    auto cmds = Generate(L"---\n\n---\n\n---");
     int line_count = 0;
     for (const auto& cmd : cmds) {
         if (std::holds_alternative<DrawLineCmd>(cmd)) line_count++;
@@ -337,7 +337,7 @@ TEST_F(CmdGenTest, MultipleHorizontalRulesGenerateMultipleLines)
 
 TEST_F(CmdGenTest, BlockQuoteBarColorMatchesTheme)
 {
-    auto cmds = Generate("> Quote text");
+    auto cmds = Generate(L"> Quote text");
     for (const auto& cmd : cmds) {
         if (auto* line = std::get_if<DrawLineCmd>(&cmd)) {
             // 引用ブロックのバー: 垂直線（xが同じ）
@@ -359,7 +359,7 @@ TEST_F(CmdGenTest, DarkThemeTableGeneratesCommands)
     gen_.SetTheme(&theme_);
     ASSERT_TRUE(engine_.Init(&mock_, theme_));
 
-    auto cmds = Generate("| A | B |\n|---|---|\n| 1 | 2 |");
+    auto cmds = Generate(L"| A | B |\n|---|---|\n| 1 | 2 |");
     int lines = 0;
     for (const auto& cmd : cmds) {
         if (std::holds_alternative<DrawLineCmd>(cmd)) lines++;
@@ -371,7 +371,7 @@ TEST_F(CmdGenTest, DarkThemeTableGeneratesCommands)
 
 TEST_F(CmdGenTest, EmptyDocumentNoExtraCommands)
 {
-    auto cmds = Generate("");
+    auto cmds = Generate(L"");
     // clip/transformコマンドのみで、描画コマンドはない
     for (size_t i = 1; i < cmds.size() - 1; i++) {
         // 中間のコマンドはSetTransformCmd（単位行列リセット）のみであるべき
@@ -386,7 +386,7 @@ TEST_F(CmdGenTest, EmptyDocumentNoExtraCommands)
 
 TEST_F(CmdGenTest, AlertGeneratesColoredBar)
 {
-    auto cmds = Generate("> [!NOTE]\n> Alert content");
+    auto cmds = Generate(L"> [!NOTE]\n> Alert content");
     // Alertのバーは垂直線で、通常のblockquoteとは異なる色を持つべき
     bool found_alert_bar = false;
     for (const auto& cmd : cmds) {
@@ -408,7 +408,7 @@ TEST_F(CmdGenTest, AlertGeneratesColoredBar)
 
 TEST_F(CmdGenTest, AlertGeneratesBackground)
 {
-    auto cmds = Generate("> [!WARNING]\n> Be careful");
+    auto cmds = Generate(L"> [!WARNING]\n> Be careful");
     // Alertは角丸四角形の背景を生成するべき
     int rounded_count = 0;
     for (const auto& cmd : cmds) {
@@ -419,7 +419,7 @@ TEST_F(CmdGenTest, AlertGeneratesBackground)
 
 TEST_F(CmdGenTest, AlertBarColorMatchesTheme)
 {
-    auto cmds = Generate("> [!NOTE]\n> text");
+    auto cmds = Generate(L"> [!NOTE]\n> text");
     // Note の色は theme_.alert_color[0]
     for (const auto& cmd : cmds) {
         if (auto* line = std::get_if<DrawLineCmd>(&cmd)) {
@@ -439,7 +439,7 @@ TEST_F(CmdGenTest, AlertBarColorMatchesTheme)
 
 TEST_F(CmdGenTest, RegularBlockquoteStillUsesOriginalColor)
 {
-    auto cmds = Generate("> Normal quote");
+    auto cmds = Generate(L"> Normal quote");
     for (const auto& cmd : cmds) {
         if (auto* line = std::get_if<DrawLineCmd>(&cmd)) {
             if (std::abs(line->p0.x - line->p1.x) < 0.01f) {
@@ -455,20 +455,21 @@ TEST_F(CmdGenTest, RegularBlockquoteStillUsesOriginalColor)
 
 TEST_F(CmdGenTest, AllAlertTypesGenerateCommands)
 {
-    const char* alerts[] = {
-        "> [!NOTE]\n> n",
-        "> [!TIP]\n> t",
-        "> [!IMPORTANT]\n> i",
-        "> [!WARNING]\n> w",
-        "> [!CAUTION]\n> c"
+    struct AlertCase { const char* name; const wchar_t* md; };
+    constexpr AlertCase alerts[] = {
+        { "NOTE",      L"> [!NOTE]\n> n" },
+        { "TIP",       L"> [!TIP]\n> t" },
+        { "IMPORTANT", L"> [!IMPORTANT]\n> i" },
+        { "WARNING",   L"> [!WARNING]\n> w" },
+        { "CAUTION",   L"> [!CAUTION]\n> c" },
     };
-    for (const char* md : alerts) {
-        auto cmds = Generate(md);
+    for (const auto& a : alerts) {
+        auto cmds = Generate(a.md);
         int lines = 0;
         for (const auto& cmd : cmds) {
             if (std::holds_alternative<DrawLineCmd>(cmd)) lines++;
         }
-        EXPECT_GE(lines, 1) << "Alert '" << md << "' はバー線を生成するべき";
+        EXPECT_GE(lines, 1) << "Alert '" << a.name << "' はバー線を生成するべき";
     }
 }
 
@@ -476,7 +477,7 @@ TEST_F(CmdGenTest, AllAlertTypesGenerateCommands)
 
 TEST_F(CmdGenTest, H1GeneratesUnderline)
 {
-    auto cmds = Generate("# Heading 1");
+    auto cmds = Generate(L"# Heading 1");
     int hlines = 0;
     for (const auto& cmd : cmds) {
         if (auto* line = std::get_if<DrawLineCmd>(&cmd)) {
@@ -491,7 +492,7 @@ TEST_F(CmdGenTest, H1GeneratesUnderline)
 
 TEST_F(CmdGenTest, H2GeneratesUnderline)
 {
-    auto cmds = Generate("## Heading 2");
+    auto cmds = Generate(L"## Heading 2");
     int hlines = 0;
     for (const auto& cmd : cmds) {
         if (auto* line = std::get_if<DrawLineCmd>(&cmd)) {
@@ -505,7 +506,7 @@ TEST_F(CmdGenTest, H2GeneratesUnderline)
 
 TEST_F(CmdGenTest, H3DoesNotGenerateUnderline)
 {
-    auto cmds = Generate("### Heading 3");
+    auto cmds = Generate(L"### Heading 3");
     int hlines = 0;
     for (const auto& cmd : cmds) {
         if (auto* line = std::get_if<DrawLineCmd>(&cmd)) {
@@ -519,7 +520,7 @@ TEST_F(CmdGenTest, H3DoesNotGenerateUnderline)
 
 TEST_F(CmdGenTest, HeadingUnderlineColorMatchesTheme)
 {
-    auto cmds = Generate("# Title");
+    auto cmds = Generate(L"# Title");
     for (const auto& cmd : cmds) {
         if (auto* line = std::get_if<DrawLineCmd>(&cmd)) {
             if (std::abs(line->p0.y - line->p1.y) < 0.01f) {
@@ -536,7 +537,7 @@ TEST_F(CmdGenTest, HeadingUnderlineColorMatchesTheme)
 
 TEST_F(CmdGenTest, H2UnderlineThicknessMatchesTheme)
 {
-    auto cmds = Generate("## Heading 2");
+    auto cmds = Generate(L"## Heading 2");
     for (const auto& cmd : cmds) {
         if (auto* line = std::get_if<DrawLineCmd>(&cmd)) {
             if (std::abs(line->p0.y - line->p1.y) < 0.01f) {
@@ -554,7 +555,7 @@ TEST_F(CmdGenTest, H2UnderlineThicknessMatchesTheme)
 // formats_.copy_btn_icon が null の場合、コピーボタン用の DrawTextCmd は生成されない
 TEST_F(CmdGenTest, CodeBlockNoCopyButtonWithoutIconFont)
 {
-    auto cmds = Generate("```\ncode\n```");
+    auto cmds = Generate(L"```\ncode\n```");
     int text_cmd_count = 0;
     for (const auto& cmd : cmds) {
         if (std::holds_alternative<DrawTextCmd>(cmd)) text_cmd_count++;
@@ -565,7 +566,7 @@ TEST_F(CmdGenTest, CodeBlockNoCopyButtonWithoutIconFont)
 // 非コードブロックノードはコピーボタンのコマンドを生成しない
 TEST_F(CmdGenTest, NonCodeBlockNoCopyButton)
 {
-    auto cmds = Generate("Hello world");
+    auto cmds = Generate(L"Hello world");
     int text_cmd_count = 0;
     for (const auto& cmd : cmds) {
         if (std::holds_alternative<DrawTextCmd>(cmd)) text_cmd_count++;
@@ -577,7 +578,7 @@ TEST_F(CmdGenTest, NonCodeBlockNoCopyButton)
 
 TEST_F(CmdGenTest, UnorderedListBulletCenteredOnFirstLine)
 {
-    auto nodes = ParseMarkdown("- Item").nodes;
+    auto nodes = ParseMarkdown(L"- Item").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -598,7 +599,7 @@ TEST_F(CmdGenTest, UnorderedListBulletCenteredOnFirstLine)
 
 TEST_F(CmdGenTest, NestedListBulletCenteredOnFirstLine)
 {
-    auto nodes = ParseMarkdown("- A\n  - B").nodes;
+    auto nodes = ParseMarkdown(L"- A\n  - B").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -625,7 +626,7 @@ TEST_F(CmdGenTest, NestedListBulletCenteredOnFirstLine)
 // HoveredButtons パラメータが GenerateMdPane に渡せることの検証
 TEST_F(CmdGenTest, CodeBlockWithHoveredCopyNodeAccepted)
 {
-    auto nodes = ParseMarkdown("```\ncode\n```").nodes;
+    auto nodes = ParseMarkdown(L"```\ncode\n```").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -640,7 +641,7 @@ TEST_F(CmdGenTest, CodeBlockWithHoveredCopyNodeAccepted)
 
 TEST_F(CmdGenTest, ImageWithoutBitmapGeneratesPlaceholder)
 {
-    auto nodes = ParseMarkdown("![alt](image.png)").nodes;
+    auto nodes = ParseMarkdown(L"![alt](image.png)").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -659,7 +660,7 @@ TEST_F(CmdGenTest, ImageWithoutBitmapGeneratesPlaceholder)
 
 TEST_F(CmdGenTest, MermaidWithoutBitmapGeneratesPlaceholder)
 {
-    auto nodes = ParseMarkdown("```mermaid\ngraph TD\n  A-->B\n```").nodes;
+    auto nodes = ParseMarkdown(L"```mermaid\ngraph TD\n  A-->B\n```").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -678,7 +679,7 @@ TEST_F(CmdGenTest, MermaidWithoutBitmapGeneratesPlaceholder)
 
 TEST_F(CmdGenTest, PlaceholderBgUsesCodeBgColor)
 {
-    auto nodes = ParseMarkdown("![alt](image.png)").nodes;
+    auto nodes = ParseMarkdown(L"![alt](image.png)").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);

--- a/tests/test_file_loader.cpp
+++ b/tests/test_file_loader.cpp
@@ -40,13 +40,13 @@ TEST_F(FileLoaderTest, LoadsMultilineFile)
     EXPECT_EQ(*result, "line1\nline2\nline3");
 }
 
-TEST_F(FileLoaderTest, StripsUtf8Bom)
+// FileLoader はバイト列をそのまま返す。BOM 除去は Utf8ToWideStripBom 側の責務。
+TEST_F(FileLoaderTest, KeepsUtf8Bom)
 {
-    std::string bom = "\xEF\xBB\xBF" "Hello";
-    auto path = WriteFile(L"bom.md", bom);
+    auto path = WriteFile(L"bom.md", "\xEF\xBB\xBF" "Hello");
     auto result = FileLoader::LoadFile(path.native().c_str());
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, "Hello");
+    EXPECT_EQ(*result, "\xEF\xBB\xBF" "Hello");
 }
 
 TEST_F(FileLoaderTest, NonExistentFileReturnsError)
@@ -72,13 +72,12 @@ TEST_F(FileLoaderTest, LoadsJapaneseUtf8)
     EXPECT_EQ(*result, "日本語テスト");
 }
 
-TEST_F(FileLoaderTest, BomOnlyFileReturnsEmpty)
+TEST_F(FileLoaderTest, BomOnlyFileReturnsBomBytes)
 {
-    std::string bom_only = "\xEF\xBB\xBF";
-    auto path = WriteFile(L"bomonly.md", bom_only);
+    auto path = WriteFile(L"bomonly.md", "\xEF\xBB\xBF");
     auto result = FileLoader::LoadFile(path.native().c_str());
     ASSERT_TRUE(result.has_value());
-    EXPECT_TRUE(result->empty());
+    EXPECT_EQ(*result, "\xEF\xBB\xBF");
 }
 
 // ---- ファイル監視テスト ----
@@ -136,15 +135,6 @@ TEST_F(FileLoaderTest, LargeFile)
     auto result = FileLoader::LoadFile(path.native().c_str());
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result->size(), large_content.size());
-}
-
-TEST_F(FileLoaderTest, FileWithOnlyBomAndContent)
-{
-    std::string bom_content = "\xEF\xBB\xBF# Title\n\nContent";
-    auto path = WriteFile(L"bomcontent.md", bom_content);
-    auto result = FileLoader::LoadFile(path.native().c_str());
-    ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, "# Title\n\nContent");
 }
 
 TEST_F(FileLoaderTest, WatcherRestartOnNewFile)

--- a/tests/test_hit_test_service.cpp
+++ b/tests/test_hit_test_service.cpp
@@ -29,7 +29,7 @@ protected:
         LayoutCache cache;
     };
 
-    ParsedLayout Parse(const std::string& md, float viewport_w = 800.0f)
+    ParsedLayout Parse(std::wstring_view md, float viewport_w = 800.0f)
     {
         ParsedLayout r;
         r.nodes = ParseMarkdown(md).nodes;
@@ -138,7 +138,7 @@ TEST_F(HitTestServiceTest, NavButton_PositionsWithNonZeroPaneOrigin)
 
 TEST_F(HitTestServiceTest, HitTest_EmptyDocumentReturnsSentinel)
 {
-    auto pr = Parse("");
+    auto pr = Parse(L"");
     if (!pr.nodes.empty()) {
         // 空入力でも他のノード（例: 空段落）が生成される実装の場合は以下を適用。
         // このテストは ctx.nodes.empty() 分岐の検証なので、nodes が空の場合のみ
@@ -156,7 +156,7 @@ TEST_F(HitTestServiceTest, HitTest_EmptyDocumentReturnsSentinel)
 
 TEST_F(HitTestServiceTest, HitTest_BelowAllNodesReturnsLastNonEmpty)
 {
-    auto pr = Parse("First paragraph\n\nSecond paragraph");
+    auto pr = Parse(L"First paragraph\n\nSecond paragraph");
     ASSERT_FALSE(pr.nodes.empty());
 
     // 全ノードの下端より十分下（dpi=1, scroll=0 なので dip_y = screen_y）
@@ -189,7 +189,7 @@ TEST_F(HitTestServiceTest, HitTest_TextLayoutNullFallsBackToLastNode)
     // MockTextMeasurer は text_layout=nullptr を設定する。
     // ノード範囲内をクリックしても entry.text_layout 経由の分岐に入らず、
     // 末尾フォールバック（最後の非空ノード末尾）が返る。
-    auto pr = Parse("Hello\n\nWorld");
+    auto pr = Parse(L"Hello\n\nWorld");
     ASSERT_GE(pr.nodes.size(), 1u);
 
     MdPaneHitContext ctx{
@@ -210,7 +210,7 @@ TEST_F(HitTestServiceTest, HitTest_TextLayoutNullFallsBackToLastNode)
 
 TEST_F(HitTestServiceTest, HitTestTable_NoLayoutDataReturnsTextEnd)
 {
-    auto pr = Parse("| A | B |\n|---|---|\n| 1 | 2 |");
+    auto pr = Parse(L"| A | B |\n|---|---|\n| 1 | 2 |");
     int table_idx = -1;
     for (size_t i = 0; i < pr.nodes.size(); ++i) {
         if (pr.nodes[i].type == NodeType::Table) {
@@ -234,7 +234,7 @@ TEST_F(HitTestServiceTest, HitTestTable_NoLayoutDataReturnsTextEnd)
 
 TEST_F(HitTestServiceTest, HitTestTable_ClickAboveAllRowsReturnsTextEnd)
 {
-    auto pr = Parse("| A | B |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |");
+    auto pr = Parse(L"| A | B |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |");
     int table_idx = -1;
     for (size_t i = 0; i < pr.nodes.size(); ++i) {
         if (pr.nodes[i].type == NodeType::Table) {
@@ -262,7 +262,7 @@ TEST_F(HitTestServiceTest, HitTestTable_LinearScanHitsFirstRow)
     // MockTextMeasurer は row_cum_y / col_cum_x / cell_layouts を設定しないので
     // 線形フォールバックに落ちる。cell_layout=null のため text_pos は flat_offset。
     // 先頭行・先頭列の flat_offset は 0。
-    auto pr = Parse("| A | B |\n|---|---|\n| 1 | 2 |");
+    auto pr = Parse(L"| A | B |\n|---|---|\n| 1 | 2 |");
     int table_idx = -1;
     for (size_t i = 0; i < pr.nodes.size(); ++i) {
         if (pr.nodes[i].type == NodeType::Table) {
@@ -291,7 +291,7 @@ TEST_F(HitTestServiceTest, HitTestTable_LinearScanHitsFirstRow)
 
 TEST_F(HitTestServiceTest, SaveButton_NoDiagramReturnsNegative)
 {
-    auto pr = Parse("Just text.");
+    auto pr = Parse(L"Just text.");
     const float content_width = 800.0f - theme_.margin_left - theme_.margin_right;
     MdPaneHitContext ctx{
         pr.nodes, pr.cache, theme_,
@@ -303,7 +303,7 @@ TEST_F(HitTestServiceTest, SaveButton_NoDiagramReturnsNegative)
 
 TEST_F(HitTestServiceTest, SaveButton_NonDiagramCodeBlockReturnsNegative)
 {
-    auto pr = Parse("```\nplain code\n```");
+    auto pr = Parse(L"```\nplain code\n```");
     const float content_width = 800.0f - theme_.margin_left - theme_.margin_right;
     MdPaneHitContext ctx{
         pr.nodes, pr.cache, theme_,
@@ -316,7 +316,7 @@ TEST_F(HitTestServiceTest, SaveButton_NonDiagramCodeBlockReturnsNegative)
 TEST_F(HitTestServiceTest, SaveButton_DiagramWithoutBitmapReturnsNegative)
 {
     // Mermaid ブロックはあるが diagram.bitmap が空（未ロード）→ -1
-    auto pr = Parse("```mermaid\ngraph TD\n```");
+    auto pr = Parse(L"```mermaid\ngraph TD\n```");
     int mermaid_idx = -1;
     for (size_t i = 0; i < pr.nodes.size(); ++i) {
         if (pr.nodes[i].type == NodeType::CodeBlock &&
@@ -342,7 +342,7 @@ TEST_F(HitTestServiceTest, SaveButton_DiagramWithoutBitmapReturnsNegative)
 
 TEST_F(HitTestServiceTest, SaveButton_EmptyDocumentReturnsNegative)
 {
-    auto pr = Parse("");
+    auto pr = Parse(L"");
     const float content_width = 800.0f - theme_.margin_left - theme_.margin_right;
     MdPaneHitContext ctx{
         pr.nodes, pr.cache, theme_,

--- a/tests/test_hit_test_service_dwrite.cpp
+++ b/tests/test_hit_test_service_dwrite.cpp
@@ -28,7 +28,7 @@ protected:
 // 返されてしまうため、DirectWrite を通したことの直接的な検証になる。
 TEST_F(HitTestDWriteTest, ParagraphHitReturnsTextPositionFromTextLayout)
 {
-    auto pl = ParseAndLayout("Hello, this is a long paragraph for hit testing.");
+    auto pl = ParseAndLayout(L"Hello, this is a long paragraph for hit testing.");
     ASSERT_FALSE(pl.nodes.empty());
 
     // 段落の中央付近 (margin_left + 数文字分) をクリックする想定。
@@ -53,7 +53,7 @@ TEST_F(HitTestDWriteTest, ParagraphHitReturnsTextPositionFromTextLayout)
 // row_cum_y / col_cum_x が積まれる。HitTestTable はそれを upper_bound で参照する。
 TEST_F(HitTestDWriteTest, TableHitDetectsRowAndColumn)
 {
-    auto pl = ParseAndLayout("| H1 | H2 |\n|---|---|\n| 11 | 12 |\n| 21 | 22 |");
+    auto pl = ParseAndLayout(L"| H1 | H2 |\n|---|---|\n| 11 | 12 |\n| 21 | 22 |");
 
     int table_idx = -1;
     for (size_t i = 0; i < pl.nodes.size(); ++i) {
@@ -85,7 +85,7 @@ TEST_F(HitTestDWriteTest, TableHitDetectsRowAndColumn)
 // インデックスが入ること。共有 cache の matches も正しく動くかを軽く確認する。
 TEST_F(HitTestDWriteTest, CodeBlockButtonsHitTest_CopyHitReturnsNode)
 {
-    auto pl = ParseAndLayout("```\nint main() { return 0; }\n```");
+    auto pl = ParseAndLayout(L"```\nint main() { return 0; }\n```");
 
     int code_idx = -1;
     for (size_t i = 0; i < pl.nodes.size(); ++i) {
@@ -118,7 +118,7 @@ TEST_F(HitTestDWriteTest, CodeBlockButtonsHitTest_CopyHitReturnsNode)
 // の繰り返し呼び出しでは結果が再利用される。書き換えしないことを 2 回呼んで確認する。
 TEST_F(HitTestDWriteTest, CodeBlockButtonsHitTest_RepeatCallReturnsSameResult)
 {
-    auto pl = ParseAndLayout("```\nfoo\n```");
+    auto pl = ParseAndLayout(L"```\nfoo\n```");
     const float content_width = ContentWidth(800.0f);
     const MdPaneHitContext ctx{
         pl.nodes, pl.cache, theme_, 0.0f, 0.0f, 1.0f,

--- a/tests/test_image.cpp
+++ b/tests/test_image.cpp
@@ -23,7 +23,7 @@ using Microsoft::WRL::ComPtr;
 
 TEST(ParserImage, ImageOnlyParagraphBecomesImageNode)
 {
-    auto nodes = ParseMarkdown("![alt text](image.png)").nodes;
+    auto nodes = ParseMarkdown(L"![alt text](image.png)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Image);
     EXPECT_EQ(nodes[0].image_data()->src, L"image.png");
@@ -32,7 +32,7 @@ TEST(ParserImage, ImageOnlyParagraphBecomesImageNode)
 
 TEST(ParserImage, ImageWithRelativePath)
 {
-    auto nodes = ParseMarkdown("![photo](./images/photo.jpg)").nodes;
+    auto nodes = ParseMarkdown(L"![photo](./images/photo.jpg)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Image);
     EXPECT_EQ(nodes[0].image_data()->src, L"./images/photo.jpg");
@@ -40,7 +40,7 @@ TEST(ParserImage, ImageWithRelativePath)
 
 TEST(ParserImage, ImageWithAbsolutePath)
 {
-    auto nodes = ParseMarkdown("![img](C:/Users/test/pic.png)").nodes;
+    auto nodes = ParseMarkdown(L"![img](C:/Users/test/pic.png)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Image);
     EXPECT_EQ(nodes[0].image_data()->src, L"C:/Users/test/pic.png");
@@ -48,7 +48,7 @@ TEST(ParserImage, ImageWithAbsolutePath)
 
 TEST(ParserImage, ImageWithHttpUrl)
 {
-    auto nodes = ParseMarkdown("![logo](https://example.com/logo.png)").nodes;
+    auto nodes = ParseMarkdown(L"![logo](https://example.com/logo.png)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Image);
     EXPECT_EQ(nodes[0].image_data()->src, L"https://example.com/logo.png");
@@ -56,7 +56,7 @@ TEST(ParserImage, ImageWithHttpUrl)
 
 TEST(ParserImage, ImageWithEmptyAlt)
 {
-    auto nodes = ParseMarkdown("![](image.png)").nodes;
+    auto nodes = ParseMarkdown(L"![](image.png)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Image);
     EXPECT_EQ(nodes[0].image_data()->src, L"image.png");
@@ -65,7 +65,7 @@ TEST(ParserImage, ImageWithEmptyAlt)
 
 TEST(ParserImage, ImageWithTitle)
 {
-    auto nodes = ParseMarkdown("![alt](image.png \"My Title\")").nodes;
+    auto nodes = ParseMarkdown(L"![alt](image.png \"My Title\")").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Image);
     EXPECT_EQ(nodes[0].image_data()->src, L"image.png");
@@ -73,14 +73,14 @@ TEST(ParserImage, ImageWithTitle)
 
 TEST(ParserImage, ImageAltTextPreserved)
 {
-    auto nodes = ParseMarkdown("![Hello World](pic.png)").nodes;
+    auto nodes = ParseMarkdown(L"![Hello World](pic.png)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"Hello World");
 }
 
 TEST(ParserImage, ImageDefaultDimensionsZero)
 {
-    auto nodes = ParseMarkdown("![alt](img.png)").nodes;
+    auto nodes = ParseMarkdown(L"![alt](img.png)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_FLOAT_EQ(nodes[0].image_data()->width, 0.0f);
     EXPECT_FLOAT_EQ(nodes[0].image_data()->height, 0.0f);
@@ -91,7 +91,7 @@ TEST(ParserImage, ImageDefaultDimensionsZero)
 TEST(ParserImage, ImageWithSurroundingTextStillConverts)
 {
     // 現在の実装では、画像を含む段落は全体がImageノードに変換される
-    auto nodes = ParseMarkdown("before ![alt](img.png) after").nodes;
+    auto nodes = ParseMarkdown(L"before ![alt](img.png) after").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Image);
     EXPECT_EQ(nodes[0].image_data()->src, L"img.png");
@@ -99,7 +99,7 @@ TEST(ParserImage, ImageWithSurroundingTextStillConverts)
 
 TEST(ParserImage, MultipleImagesLastOneWins)
 {
-    auto nodes = ParseMarkdown("![a](first.png) ![b](second.png)").nodes;
+    auto nodes = ParseMarkdown(L"![a](first.png) ![b](second.png)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Image);
     // OnLeaveSpanで最後のimage_srcがノードに設定される
@@ -110,7 +110,7 @@ TEST(ParserImage, MultipleImagesLastOneWins)
 
 TEST(ParserImage, ImageInBlockquoteBecomesImageNode)
 {
-    auto nodes = ParseMarkdown("> ![alt](img.png)").nodes;
+    auto nodes = ParseMarkdown(L"> ![alt](img.png)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Image);
     EXPECT_EQ(nodes[0].image_data()->src, L"img.png");
@@ -119,7 +119,7 @@ TEST(ParserImage, ImageInBlockquoteBecomesImageNode)
 TEST(ParserImage, ImageInTightListStaysListItem)
 {
     // タイトリスト内の画像はP生成されないため、ListItem のまま
-    auto nodes = ParseMarkdown("- ![alt](img.png)").nodes;
+    auto nodes = ParseMarkdown(L"- ![alt](img.png)").nodes;
     ASSERT_GE(nodes.size(), 1u);
     // ListItemノードの型が保持されること
     EXPECT_EQ(nodes[0].type, NodeType::ListItem);
@@ -130,7 +130,7 @@ TEST(ParserImage, ImageInTightListStaysListItem)
 TEST(ParserImage, ImageInTightListDoesNotLeakToNextParagraph)
 {
     // 画像を含むリスト項目の後の段落が Image に変換されないこと
-    auto nodes = ParseMarkdown("- ![alt](img.png)\n\nNormal paragraph").nodes;
+    auto nodes = ParseMarkdown(L"- ![alt](img.png)\n\nNormal paragraph").nodes;
     bool found_para = false;
     for (const auto& node : nodes) {
         if (node.type == NodeType::Paragraph) {
@@ -144,7 +144,7 @@ TEST(ParserImage, ImageInTightListDoesNotLeakToNextParagraph)
 
 TEST(ParserImage, ImageInTaskListStaysTaskListItem)
 {
-    auto nodes = ParseMarkdown("- [x] ![alt](img.png)").nodes;
+    auto nodes = ParseMarkdown(L"- [x] ![alt](img.png)").nodes;
     ASSERT_GE(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::TaskListItem);
 }
@@ -153,7 +153,7 @@ TEST(ParserImage, ImageInTaskListStaysTaskListItem)
 
 TEST(ParserImage, ParagraphWithoutImageStaysParagraph)
 {
-    auto nodes = ParseMarkdown("Just text").nodes;
+    auto nodes = ParseMarkdown(L"Just text").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Paragraph);
     EXPECT_FALSE(nodes[0].has_image());
@@ -161,7 +161,7 @@ TEST(ParserImage, ParagraphWithoutImageStaysParagraph)
 
 TEST(ParserImage, LinkDoesNotTriggerImage)
 {
-    auto nodes = ParseMarkdown("[link text](https://example.com)").nodes;
+    auto nodes = ParseMarkdown(L"[link text](https://example.com)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Paragraph);
     EXPECT_FALSE(nodes[0].has_image());
@@ -171,7 +171,7 @@ TEST(ParserImage, LinkDoesNotTriggerImage)
 
 TEST(ParserImage, ImageBetweenParagraphs)
 {
-    auto nodes = ParseMarkdown("Before\n\n![alt](img.png)\n\nAfter").nodes;
+    auto nodes = ParseMarkdown(L"Before\n\n![alt](img.png)\n\nAfter").nodes;
     ASSERT_EQ(nodes.size(), 3u);
     EXPECT_EQ(nodes[0].type, NodeType::Paragraph);
     EXPECT_EQ(nodes[1].type, NodeType::Image);
@@ -180,7 +180,7 @@ TEST(ParserImage, ImageBetweenParagraphs)
 
 TEST(ParserImage, MultipleImageParagraphs)
 {
-    auto nodes = ParseMarkdown("![a](a.png)\n\n![b](b.png)\n\n![c](c.png)").nodes;
+    auto nodes = ParseMarkdown(L"![a](a.png)\n\n![b](b.png)\n\n![c](c.png)").nodes;
     ASSERT_EQ(nodes.size(), 3u);
     for (size_t i = 0; i < 3; i++) {
         EXPECT_EQ(nodes[i].type, NodeType::Image) << "ノード " << i;
@@ -194,7 +194,7 @@ TEST(ParserImage, MultipleImageParagraphs)
 
 TEST(ParserImage, ImageWithSpecialCharsInPath)
 {
-    auto nodes = ParseMarkdown("![alt](path%20with%20spaces/img.png)").nodes;
+    auto nodes = ParseMarkdown(L"![alt](path%20with%20spaces/img.png)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Image);
     EXPECT_EQ(nodes[0].image_data()->src, L"path%20with%20spaces/img.png");
@@ -202,7 +202,7 @@ TEST(ParserImage, ImageWithSpecialCharsInPath)
 
 TEST(ParserImage, ImageWithJapaneseAltText)
 {
-    auto nodes = ParseMarkdown("![日本語のaltテキスト](img.png)").nodes;
+    auto nodes = ParseMarkdown(L"![日本語のaltテキスト](img.png)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Image);
     EXPECT_EQ(nodes[0].GetText(), L"日本語のaltテキスト");
@@ -210,7 +210,7 @@ TEST(ParserImage, ImageWithJapaneseAltText)
 
 TEST(ParserImage, ImageWithJapanesePath)
 {
-    auto nodes = ParseMarkdown("![alt](画像/テスト.png)").nodes;
+    auto nodes = ParseMarkdown(L"![alt](画像/テスト.png)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].image_data()->src, L"画像/テスト.png");
 }
@@ -234,7 +234,7 @@ protected:
 
 TEST_F(ImageLayoutTest, ImagePlaceholderHeight)
 {
-    auto nodes = ParseMarkdown("![alt](img.png)").nodes;
+    auto nodes = ParseMarkdown(L"![alt](img.png)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_EQ(nodes[0].type, NodeType::Image);
 
@@ -248,7 +248,7 @@ TEST_F(ImageLayoutTest, ImagePlaceholderHeight)
 
 TEST_F(ImageLayoutTest, ImageWithDimensionsUsesScaledHeight)
 {
-    auto nodes = ParseMarkdown("![alt](img.png)").nodes;
+    auto nodes = ParseMarkdown(L"![alt](img.png)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     // 画像読み込み後のサイズをシミュレート
     nodes[0].image_data()->width = 400.0f;
@@ -264,7 +264,7 @@ TEST_F(ImageLayoutTest, ImageWithDimensionsUsesScaledHeight)
 
 TEST_F(ImageLayoutTest, WideImageScaledDown)
 {
-    auto nodes = ParseMarkdown("![alt](img.png)").nodes;
+    auto nodes = ParseMarkdown(L"![alt](img.png)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     // コンテンツ幅より大きい画像
     nodes[0].image_data()->width = 1600.0f;
@@ -281,7 +281,7 @@ TEST_F(ImageLayoutTest, WideImageScaledDown)
 
 TEST_F(ImageLayoutTest, SmallImageNotScaledUp)
 {
-    auto nodes = ParseMarkdown("![alt](img.png)").nodes;
+    auto nodes = ParseMarkdown(L"![alt](img.png)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     nodes[0].image_data()->width = 100.0f;
     nodes[0].image_data()->height = 80.0f;
@@ -296,7 +296,7 @@ TEST_F(ImageLayoutTest, SmallImageNotScaledUp)
 
 TEST_F(ImageLayoutTest, ImageHeightRecalculatedOnWidthChange)
 {
-    auto nodes = ParseMarkdown("![alt](img.png)").nodes;
+    auto nodes = ParseMarkdown(L"![alt](img.png)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     nodes[0].image_data()->width = 1600.0f;
     nodes[0].image_data()->height = 900.0f;
@@ -317,7 +317,7 @@ TEST_F(ImageLayoutTest, ImageHeightRecalculatedOnWidthChange)
 
 TEST_F(ImageLayoutTest, ImageNodesDoNotOverlap)
 {
-    auto nodes = ParseMarkdown("![a](a.png)\n\n![b](b.png)\n\n![c](c.png)").nodes;
+    auto nodes = ParseMarkdown(L"![a](a.png)\n\n![b](b.png)\n\n![c](c.png)").nodes;
     for (auto& n : nodes) {
         n.image_data()->width = 200.0f;
         n.image_data()->height = 150.0f;
@@ -335,7 +335,7 @@ TEST_F(ImageLayoutTest, ImageNodesDoNotOverlap)
 
 TEST_F(ImageLayoutTest, ImageBetweenTextNodesDoNotOverlap)
 {
-    auto nodes = ParseMarkdown("Text before\n\n![alt](img.png)\n\nText after").nodes;
+    auto nodes = ParseMarkdown(L"Text before\n\n![alt](img.png)\n\nText after").nodes;
     ASSERT_EQ(nodes.size(), 3u);
     nodes[1].image_data()->width = 400.0f;
     nodes[1].image_data()->height = 300.0f;
@@ -352,7 +352,7 @@ TEST_F(ImageLayoutTest, ImageBetweenTextNodesDoNotOverlap)
 
 TEST_F(ImageLayoutTest, ImageWithZeroDimensionsGetsPlaceholder)
 {
-    auto nodes = ParseMarkdown("![alt](img.png)").nodes;
+    auto nodes = ParseMarkdown(L"![alt](img.png)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     // image_width/heightはデフォルトの0.0f
     ASSERT_FLOAT_EQ(nodes[0].image_data()->width, 0.0f);
@@ -366,7 +366,7 @@ TEST_F(ImageLayoutTest, ImageWithZeroDimensionsGetsPlaceholder)
 
 TEST_F(ImageLayoutTest, ImageAspectRatioPreserved)
 {
-    auto nodes = ParseMarkdown("![alt](img.png)").nodes;
+    auto nodes = ParseMarkdown(L"![alt](img.png)").nodes;
     nodes[0].image_data()->width = 1000.0f;
     nodes[0].image_data()->height = 500.0f;
 

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -17,7 +17,7 @@ TEST_F(LayoutTest, EmptyNodesProduceZeroHeight)
 
 TEST_F(LayoutTest, SingleParagraphHasPositiveHeight)
 {
-    auto nodes = ParseMarkdown("Hello world").nodes;
+    auto nodes = ParseMarkdown(L"Hello world").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -27,11 +27,11 @@ TEST_F(LayoutTest, SingleParagraphHasPositiveHeight)
 
 TEST_F(LayoutTest, HeadingIsTallerThanParagraph)
 {
-    auto heading_nodes = ParseMarkdown("# Big Title").nodes;
+    auto heading_nodes = ParseMarkdown(L"# Big Title").nodes;
     LayoutCache heading_cache;
     heading_cache.Resize(heading_nodes.size());
 
-    auto para_nodes = ParseMarkdown("Small text").nodes;
+    auto para_nodes = ParseMarkdown(L"Small text").nodes;
     LayoutCache para_cache;
     para_cache.Resize(para_nodes.size());
 
@@ -46,7 +46,7 @@ TEST_F(LayoutTest, HeadingIsTallerThanParagraph)
 
 TEST_F(LayoutTest, YPositionsIncreaseMonotonically)
 {
-    auto nodes = ParseMarkdown("# A\n\nB\n\nC\n\nD").nodes;
+    auto nodes = ParseMarkdown(L"# A\n\nB\n\nC\n\nD").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -59,7 +59,7 @@ TEST_F(LayoutTest, YPositionsIncreaseMonotonically)
 
 TEST_F(LayoutTest, NodesDoNotOverlap)
 {
-    auto nodes = ParseMarkdown("# Heading\n\nParagraph\n\n---\n\n- List").nodes;
+    auto nodes = ParseMarkdown(L"# Heading\n\nParagraph\n\n---\n\n- List").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -73,11 +73,11 @@ TEST_F(LayoutTest, NodesDoNotOverlap)
 
 TEST_F(LayoutTest, NarrowViewportWrapsText)
 {
-    auto nodes_wide = ParseMarkdown("This is a somewhat long paragraph that should wrap.").nodes;
+    auto nodes_wide = ParseMarkdown(L"This is a somewhat long paragraph that should wrap.").nodes;
     LayoutCache cache_wide;
     cache_wide.Resize(nodes_wide.size());
 
-    auto nodes_narrow = ParseMarkdown("This is a somewhat long paragraph that should wrap.").nodes;
+    auto nodes_narrow = ParseMarkdown(L"This is a somewhat long paragraph that should wrap.").nodes;
     LayoutCache cache_narrow;
     cache_narrow.Resize(nodes_narrow.size());
 
@@ -93,7 +93,7 @@ TEST_F(LayoutTest, NarrowViewportWrapsText)
 
 TEST_F(LayoutTest, LayoutDirtyFlagCleared)
 {
-    auto nodes = ParseMarkdown("Test").nodes;
+    auto nodes = ParseMarkdown(L"Test").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     EXPECT_TRUE(cache[0].layout_dirty);
@@ -103,7 +103,7 @@ TEST_F(LayoutTest, LayoutDirtyFlagCleared)
 
 TEST_F(LayoutTest, TextLayoutCreated)
 {
-    auto nodes = ParseMarkdown("Test paragraph").nodes;
+    auto nodes = ParseMarkdown(L"Test paragraph").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -112,7 +112,7 @@ TEST_F(LayoutTest, TextLayoutCreated)
 
 TEST_F(LayoutTest, HorizontalRuleHasNoTextLayout)
 {
-    auto nodes = ParseMarkdown("---").nodes;
+    auto nodes = ParseMarkdown(L"---").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -122,7 +122,7 @@ TEST_F(LayoutTest, HorizontalRuleHasNoTextLayout)
 
 TEST_F(LayoutTest, CodeBlockTextLayout)
 {
-    auto nodes = ParseMarkdown("```\ncode\n```").nodes;
+    auto nodes = ParseMarkdown(L"```\ncode\n```").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -132,7 +132,7 @@ TEST_F(LayoutTest, CodeBlockTextLayout)
 TEST_F(LayoutTest, TableLayout)
 {
     auto nodes = ParseMarkdown(
-        "| A | B |\n"
+        L"| A | B |\n"
         "|---|---|\n"
         "| 1 | 2 |"
     ).nodes;
@@ -149,7 +149,7 @@ TEST_F(LayoutTest, TableLayout)
 TEST_F(LayoutTest, TableCellLayoutsCreated)
 {
     auto nodes = ParseMarkdown(
-        "| A | B |\n"
+        L"| A | B |\n"
         "|---|---|\n"
         "| 1 | 2 |"
     ).nodes;
@@ -171,7 +171,7 @@ TEST_F(LayoutTest, TableCellLayoutsCreated)
 TEST_F(LayoutTest, TableCellLinkHasUnderline)
 {
     auto nodes = ParseMarkdown(
-        "| Text | Link |\n"
+        L"| Text | Link |\n"
         "|------|------|\n"
         "| hello | [click](https://example.com) |"
     ).nodes;
@@ -204,7 +204,7 @@ TEST_F(LayoutTest, TableCellLinkHasUnderline)
 
 TEST_F(LayoutTest, MultipleHeadingLevelsDecreasingSize)
 {
-    auto nodes = ParseMarkdown("# H1\n\n## H2\n\n### H3").nodes;
+    auto nodes = ParseMarkdown(L"# H1\n\n## H2\n\n### H3").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -216,9 +216,9 @@ TEST_F(LayoutTest, MultipleHeadingLevelsDecreasingSize)
 
 TEST_F(LayoutTest, TotalHeightWithManyNodes)
 {
-    std::string md;
+    std::wstring md;
     for (int i = 0; i < 100; i++) {
-        md += "Paragraph " + std::to_string(i) + "\n\n";
+        md += L"Paragraph " + std::to_wstring(i) + L"\n\n";
     }
     auto nodes = ParseMarkdown(md).nodes;
     LayoutCache cache;
@@ -237,7 +237,7 @@ TEST_F(LayoutTest, TotalHeightWithManyNodes)
 
 TEST_F(LayoutTest, ProcessDirtyBatchCleansNodes)
 {
-    auto nodes = ParseMarkdown("# A\n\nB\n\nC\n\nD\n\nE").nodes;
+    auto nodes = ParseMarkdown(L"# A\n\nB\n\nC\n\nD\n\nE").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     // まず部分的なレイアウトを実行
@@ -259,9 +259,9 @@ TEST_F(LayoutTest, ProcessDirtyBatchCleansNodes)
 TEST_F(LayoutTest, ProcessDirtyBatchSmallBatch)
 {
     // 多数の段落を作成
-    std::string md;
+    std::wstring md;
     for (int i = 0; i < 50; i++) {
-        md += "Paragraph " + std::to_string(i) + "\n\n";
+        md += L"Paragraph " + std::to_wstring(i) + L"\n\n";
     }
     auto nodes = ParseMarkdown(md).nodes;
     LayoutCache cache;
@@ -282,7 +282,7 @@ TEST_F(LayoutTest, ProcessDirtyBatchSmallBatch)
 
 TEST_F(LayoutTest, WidthChangeRecomputesLayouts)
 {
-    auto nodes = ParseMarkdown("This is a paragraph with some text that might wrap differently.").nodes;
+    auto nodes = ParseMarkdown(L"This is a paragraph with some text that might wrap differently.").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -317,11 +317,11 @@ TEST_F(LayoutTest, EmptyTableMinimalHeight)
 
 TEST_F(LayoutTest, IndentedNodesHaveNarrowerWidth)
 {
-    auto nodes_plain = ParseMarkdown("This is a somewhat long paragraph that wraps.").nodes;
+    auto nodes_plain = ParseMarkdown(L"This is a somewhat long paragraph that wraps.").nodes;
     LayoutCache cache_plain;
     cache_plain.Resize(nodes_plain.size());
 
-    auto nodes_list = ParseMarkdown("- This is a somewhat long paragraph that wraps.").nodes;
+    auto nodes_list = ParseMarkdown(L"- This is a somewhat long paragraph that wraps.").nodes;
     LayoutCache cache_list;
     cache_list.Resize(nodes_list.size());
 
@@ -339,7 +339,7 @@ TEST_F(LayoutTest, IndentedNodesHaveNarrowerWidth)
 
 TEST_F(LayoutTest, BlockQuoteLayout)
 {
-    auto nodes = ParseMarkdown("> Quoted text here").nodes;
+    auto nodes = ParseMarkdown(L"> Quoted text here").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -352,9 +352,9 @@ TEST_F(LayoutTest, BlockQuoteLayout)
 
 TEST_F(LayoutTest, CodeBlockDoesNotWrap)
 {
-    std::string long_line = "```\n";
-    for (int i = 0; i < 50; i++) long_line += "long_word ";
-    long_line += "\n```";
+    std::wstring long_line = L"```\n";
+    for (int i = 0; i < 50; i++) long_line += L"long_word ";
+    long_line += L"\n```";
 
     auto nodes = ParseMarkdown(long_line).nodes;
     LayoutCache cache;
@@ -372,7 +372,7 @@ TEST_F(LayoutTest, CodeBlockDoesNotWrap)
 
 TEST_F(LayoutTest, HeadingHasSpacingAboveAndBelow)
 {
-    auto nodes = ParseMarkdown("Paragraph\n\n# Heading\n\nAnother paragraph").nodes;
+    auto nodes = ParseMarkdown(L"Paragraph\n\n# Heading\n\nAnother paragraph").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -723,9 +723,9 @@ TEST(RecomputeYPositionsTest, MonotonicallyIncreasingY)
 TEST_F(LayoutTest, EnsureVisibleLayoutFixesDirtyVisibleNodes)
 {
     // 複数の段落を作成し、ある幅でフルレイアウトを実行
-    std::string md;
+    std::wstring md;
     for (int i = 0; i < 20; i++) {
-        md += "Paragraph " + std::to_string(i) + "\n\n";
+        md += L"Paragraph " + std::to_wstring(i) + L"\n\n";
     }
     auto nodes = ParseMarkdown(md).nodes;
     LayoutCache cache;
@@ -760,7 +760,7 @@ TEST_F(LayoutTest, EnsureVisibleLayoutFixesDirtyVisibleNodes)
 
 TEST_F(LayoutTest, EnsureVisibleLayoutReturnsFalseWhenClean)
 {
-    auto nodes = ParseMarkdown("Hello world").nodes;
+    auto nodes = ParseMarkdown(L"Hello world").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -772,9 +772,9 @@ TEST_F(LayoutTest, EnsureVisibleLayoutReturnsFalseWhenClean)
 
 TEST_F(LayoutTest, EnsureVisibleLayoutSkipsOffscreenDirtyNodes)
 {
-    std::string md;
+    std::wstring md;
     for (int i = 0; i < 30; i++) {
-        md += "Paragraph " + std::to_string(i) + "\n\n";
+        md += L"Paragraph " + std::to_wstring(i) + L"\n\n";
     }
     auto nodes = ParseMarkdown(md).nodes;
     LayoutCache cache;
@@ -802,9 +802,9 @@ TEST_F(LayoutTest, EnsureVisibleLayoutSkipsOffscreenDirtyNodes)
 
 TEST_F(LayoutTest, EnsureVisibleLayoutRecomputesYPositions)
 {
-    std::string md;
+    std::wstring md;
     for (int i = 0; i < 10; i++) {
-        md += "Paragraph " + std::to_string(i) + "\n\n";
+        md += L"Paragraph " + std::to_wstring(i) + L"\n\n";
     }
     auto nodes = ParseMarkdown(md).nodes;
     LayoutCache cache;
@@ -827,9 +827,9 @@ TEST_F(LayoutTest, EnsureVisibleLayoutRecomputesYPositions)
 
 TEST_F(LayoutTest, EnsureVisibleLayoutUpdatesTotalHeight)
 {
-    std::string md;
+    std::wstring md;
     for (int i = 0; i < 10; i++) {
-        md += "Paragraph " + std::to_string(i) + "\n\n";
+        md += L"Paragraph " + std::to_wstring(i) + L"\n\n";
     }
     auto nodes = ParseMarkdown(md).nodes;
     LayoutCache cache;
@@ -850,9 +850,9 @@ TEST_F(LayoutTest, EnsureVisibleLayoutUpdatesTotalHeight)
 // ズーム/テーマ変更直後の SyncMaxScroll が stale な total_height_ を読まないことを保証する。
 TEST_F(LayoutTest, PartialLayoutRefreshesStaleInvisibleHeights)
 {
-    std::string md;
+    std::wstring md;
     for (int i = 0; i < 30; i++) {
-        md += "Paragraph " + std::to_string(i) + "\n\n";
+        md += L"Paragraph " + std::to_wstring(i) + L"\n\n";
     }
     auto nodes = ParseMarkdown(md).nodes;
     LayoutCache cache;
@@ -1200,8 +1200,8 @@ TEST(RecomputeYPositionsTest, FromIndexListItem)
 TEST_F(LayoutTest, InlineCodeInHeadingAllLevels)
 {
     for (int level = 1; level <= 6; ++level) {
-        std::string md(level, '#');
-        md += " Test `code`";
+        std::wstring md(level, L'#');
+        md += L" Test `code`";
 
         auto nodes = ParseMarkdown(md).nodes;
         LayoutCache cache;
@@ -1231,7 +1231,7 @@ TEST_F(LayoutTest, InlineCodeInHeadingAllLevels)
 TEST_F(LayoutTest, InlineCodeInParagraphUsesCodeFontSize)
 {
     // 段落内のインラインコードは従来通り font_size_code を使うこと
-    auto nodes = ParseMarkdown("Hello `code` world").nodes;
+    auto nodes = ParseMarkdown(L"Hello `code` world").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -1254,7 +1254,7 @@ TEST_F(LayoutTest, InlineCodeInParagraphUsesCodeFontSize)
 TEST_F(LayoutTest, InlineCodeInHeadingUsesMonospaceFont)
 {
     // 見出し内のインラインコードはフォントサイズは見出しと同じだが、フォントファミリーはモノスペースであること
-    auto nodes = ParseMarkdown("# Hello `code`").nodes;
+    auto nodes = ParseMarkdown(L"# Hello `code`").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -1307,7 +1307,7 @@ TEST(EstimateNodeHeightsTest, SingleParagraph)
 
 TEST(EstimateNodeHeightsTest, YPositionsIncreaseMonotonically)
 {
-    auto nodes = ParseMarkdown("# A\n\nB\n\nC\n\nD").nodes;
+    auto nodes = ParseMarkdown(L"# A\n\nB\n\nC\n\nD").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     Theme theme = GetLightTheme();
@@ -1322,7 +1322,7 @@ TEST(EstimateNodeHeightsTest, YPositionsIncreaseMonotonically)
 
 TEST(EstimateNodeHeightsTest, NodesDoNotOverlap)
 {
-    auto nodes = ParseMarkdown("# Heading\n\nParagraph\n\n---\n\n- List").nodes;
+    auto nodes = ParseMarkdown(L"# Heading\n\nParagraph\n\n---\n\n- List").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     Theme theme = GetLightTheme();
@@ -1552,7 +1552,7 @@ TEST(EstimateNodeHeightsTest, AllNodeTypesProducePositiveHeight)
 TEST_F(LayoutTest, EstimateVsActualHeightReasonableRange)
 {
     // 推定値がDirectWrite実測値と比べて極端に乖離しないことを確認する
-    auto nodes = ParseMarkdown("# Heading\n\nParagraph text\n\n```\ncode\n```\n\n---").nodes;
+    auto nodes = ParseMarkdown(L"# Heading\n\nParagraph text\n\n```\ncode\n```\n\n---").nodes;
     LayoutCache est_cache;
     est_cache.Resize(nodes.size());
 
@@ -1574,7 +1574,7 @@ TEST_F(LayoutTest, EstimateVsActualHeightReasonableRange)
 
 TEST_F(LayoutTest, UnorderedListBulletCenteredWithRealLayout)
 {
-    auto nodes = ParseMarkdown("- Item text here").nodes;
+    auto nodes = ParseMarkdown(L"- Item text here").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -133,8 +133,8 @@ TEST_F(LayoutTest, TableLayout)
 {
     auto nodes = ParseMarkdown(
         L"| A | B |\n"
-        "|---|---|\n"
-        "| 1 | 2 |"
+        L"|---|---|\n"
+        L"| 1 | 2 |"
     ).nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
@@ -150,8 +150,8 @@ TEST_F(LayoutTest, TableCellLayoutsCreated)
 {
     auto nodes = ParseMarkdown(
         L"| A | B |\n"
-        "|---|---|\n"
-        "| 1 | 2 |"
+        L"|---|---|\n"
+        L"| 1 | 2 |"
     ).nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
@@ -172,8 +172,8 @@ TEST_F(LayoutTest, TableCellLinkHasUnderline)
 {
     auto nodes = ParseMarkdown(
         L"| Text | Link |\n"
-        "|------|------|\n"
-        "| hello | [click](https://example.com) |"
+        L"|------|------|\n"
+        L"| hello | [click](https://example.com) |"
     ).nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());

--- a/tests/test_memory_eviction.cpp
+++ b/tests/test_memory_eviction.cpp
@@ -160,9 +160,9 @@ protected:
 TEST_F(ProcessDirtyBatchViewportTest, SkipsFarOffscreenNodes)
 {
     // 100 ノードのドキュメントを作成
-    std::string md;
+    std::wstring md;
     for (int i = 0; i < 100; i++) {
-        md += "paragraph " + std::to_string(i) + "\n\n";
+        md += L"paragraph " + std::to_wstring(i) + L"\n\n";
     }
     auto nodes = ParseMarkdown(md).nodes;
     ASSERT_GT(nodes.size(), 50u);
@@ -204,9 +204,9 @@ TEST_F(ProcessDirtyBatchViewportTest, SkipsFarOffscreenNodes)
 
 TEST_F(ProcessDirtyBatchViewportTest, WithoutViewportLimitProcessesAll)
 {
-    std::string md;
+    std::wstring md;
     for (int i = 0; i < 50; i++) {
-        md += "paragraph " + std::to_string(i) + "\n\n";
+        md += L"paragraph " + std::to_wstring(i) + L"\n\n";
     }
     auto nodes = ParseMarkdown(md).nodes;
 
@@ -230,9 +230,9 @@ TEST_F(ProcessDirtyBatchViewportTest, WithoutViewportLimitProcessesAll)
 
 TEST_F(ProcessDirtyBatchViewportTest, HasDirtyNodesFalseAfterNearbyProcessed)
 {
-    std::string md;
+    std::wstring md;
     for (int i = 0; i < 100; i++) {
-        md += "paragraph " + std::to_string(i) + "\n\n";
+        md += L"paragraph " + std::to_wstring(i) + L"\n\n";
     }
     auto nodes = ParseMarkdown(md).nodes;
 

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -5,19 +5,19 @@
 
 TEST(Parser, EmptyInputReturnsNoNodes)
 {
-    auto nodes = ParseMarkdown("").nodes;
+    auto nodes = ParseMarkdown(L"").nodes;
     EXPECT_TRUE(nodes.empty());
 }
 
 TEST(Parser, WhitespaceOnlyReturnsNoNodes)
 {
-    auto nodes = ParseMarkdown("   \n\n  ").nodes;
+    auto nodes = ParseMarkdown(L"   \n\n  ").nodes;
     EXPECT_TRUE(nodes.empty());
 }
 
 TEST(Parser, SingleParagraph)
 {
-    auto nodes = ParseMarkdown("Hello world").nodes;
+    auto nodes = ParseMarkdown(L"Hello world").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Paragraph);
     EXPECT_EQ(nodes[0].GetText(), L"Hello world");
@@ -25,7 +25,7 @@ TEST(Parser, SingleParagraph)
 
 TEST(Parser, MultipleParagraphs)
 {
-    auto nodes = ParseMarkdown("First\n\nSecond\n\nThird").nodes;
+    auto nodes = ParseMarkdown(L"First\n\nSecond\n\nThird").nodes;
     ASSERT_EQ(nodes.size(), 3u);
     EXPECT_EQ(nodes[0].type, NodeType::Paragraph);
     EXPECT_EQ(nodes[1].type, NodeType::Paragraph);
@@ -39,7 +39,7 @@ TEST(Parser, MultipleParagraphs)
 
 TEST(Parser, HeadingH1)
 {
-    auto nodes = ParseMarkdown("# Title").nodes;
+    auto nodes = ParseMarkdown(L"# Title").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Heading);
     EXPECT_EQ(nodes[0].heading_level, 1);
@@ -48,7 +48,7 @@ TEST(Parser, HeadingH1)
 
 TEST(Parser, HeadingH2)
 {
-    auto nodes = ParseMarkdown("## Subtitle").nodes;
+    auto nodes = ParseMarkdown(L"## Subtitle").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].heading_level, 2);
 }
@@ -56,8 +56,8 @@ TEST(Parser, HeadingH2)
 TEST(Parser, HeadingH3ToH6)
 {
     for (int level = 3; level <= 6; level++) {
-        std::string md(level, '#');
-        md += " Test";
+        std::wstring md(level, L'#');
+        md += L" Test";
         auto nodes = ParseMarkdown(md).nodes;
         ASSERT_EQ(nodes.size(), 1u) << "level=" << level;
         EXPECT_EQ(nodes[0].heading_level, level) << "level=" << level;
@@ -66,14 +66,14 @@ TEST(Parser, HeadingH3ToH6)
 
 TEST(Parser, HeadingAnchorId)
 {
-    auto nodes = ParseMarkdown("# Hello World").nodes;
+    auto nodes = ParseMarkdown(L"# Hello World").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].anchor_id(), L"hello-world");
 }
 
 TEST(Parser, HeadingAnchorIdCjk)
 {
-    auto nodes = ParseMarkdown("## コードブロック").nodes;
+    auto nodes = ParseMarkdown(L"## コードブロック").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].anchor_id(), L"コードブロック");
 }
@@ -82,7 +82,7 @@ TEST(Parser, HeadingAnchorIdCjk)
 
 TEST(Parser, BoldText)
 {
-    auto nodes = ParseMarkdown("**bold**").nodes;
+    auto nodes = ParseMarkdown(L"**bold**").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"bold");
     ASSERT_GE(nodes[0].runs.size(), 1u);
@@ -92,7 +92,7 @@ TEST(Parser, BoldText)
 
 TEST(Parser, ItalicText)
 {
-    auto nodes = ParseMarkdown("*italic*").nodes;
+    auto nodes = ParseMarkdown(L"*italic*").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"italic");
     ASSERT_GE(nodes[0].runs.size(), 1u);
@@ -102,7 +102,7 @@ TEST(Parser, ItalicText)
 
 TEST(Parser, BoldItalicText)
 {
-    auto nodes = ParseMarkdown("***bolditalic***").nodes;
+    auto nodes = ParseMarkdown(L"***bolditalic***").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_GE(nodes[0].runs.size(), 1u);
     EXPECT_TRUE(nodes[0].runs[0].bold());
@@ -111,7 +111,7 @@ TEST(Parser, BoldItalicText)
 
 TEST(Parser, InlineCode)
 {
-    auto nodes = ParseMarkdown("`code`").nodes;
+    auto nodes = ParseMarkdown(L"`code`").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"code");
     ASSERT_GE(nodes[0].runs.size(), 1u);
@@ -120,7 +120,7 @@ TEST(Parser, InlineCode)
 
 TEST(Parser, StrikethroughText)
 {
-    auto nodes = ParseMarkdown("~~deleted~~").nodes;
+    auto nodes = ParseMarkdown(L"~~deleted~~").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_GE(nodes[0].runs.size(), 1u);
     EXPECT_TRUE(nodes[0].runs[0].strikethrough());
@@ -128,7 +128,7 @@ TEST(Parser, StrikethroughText)
 
 TEST(Parser, MixedFormattingPreservesOrder)
 {
-    auto nodes = ParseMarkdown("normal **bold** normal").nodes;
+    auto nodes = ParseMarkdown(L"normal **bold** normal").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     // 少なくとも3つのランを持つべき: "normal ", "bold", " normal"
     ASSERT_GE(nodes[0].runs.size(), 3u);
@@ -141,7 +141,7 @@ TEST(Parser, MixedFormattingPreservesOrder)
 
 TEST(Parser, ExternalLink)
 {
-    auto nodes = ParseMarkdown("[text](https://example.com)").nodes;
+    auto nodes = ParseMarkdown(L"[text](https://example.com)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_GE(nodes[0].runs.size(), 1u);
     ASSERT_TRUE(nodes[0].runs[0].has_link());
@@ -151,7 +151,7 @@ TEST(Parser, ExternalLink)
 
 TEST(Parser, InternalLink)
 {
-    auto nodes = ParseMarkdown("[section](#my-section)").nodes;
+    auto nodes = ParseMarkdown(L"[section](#my-section)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_GE(nodes[0].runs.size(), 1u);
     ASSERT_TRUE(nodes[0].runs[0].has_link());
@@ -160,7 +160,7 @@ TEST(Parser, InternalLink)
 
 TEST(Parser, ParagraphWithNoLink)
 {
-    auto nodes = ParseMarkdown("plain text").nodes;
+    auto nodes = ParseMarkdown(L"plain text").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     for (const auto& run : nodes[0].runs) {
         EXPECT_FALSE(run.has_link());
@@ -171,7 +171,7 @@ TEST(Parser, ParagraphWithNoLink)
 
 TEST(Parser, FencedCodeBlock)
 {
-    auto nodes = ParseMarkdown("```\ncode line 1\ncode line 2\n```").nodes;
+    auto nodes = ParseMarkdown(L"```\ncode line 1\ncode line 2\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::CodeBlock);
     EXPECT_NE(nodes[0].GetText().find(L"code line 1"), std::wstring::npos);
@@ -180,7 +180,7 @@ TEST(Parser, FencedCodeBlock)
 
 TEST(Parser, CodeBlockPreservesNewlines)
 {
-    auto nodes = ParseMarkdown("```\na\nb\nc\n```").nodes;
+    auto nodes = ParseMarkdown(L"```\na\nb\nc\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::CodeBlock);
     // 行間に改行を含むべき
@@ -194,14 +194,14 @@ TEST(Parser, CodeBlockPreservesNewlines)
 
 TEST(Parser, HorizontalRule)
 {
-    auto nodes = ParseMarkdown("---").nodes;
+    auto nodes = ParseMarkdown(L"---").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::HorizontalRule);
 }
 
 TEST(Parser, HorizontalRuleWithAsterisks)
 {
-    auto nodes = ParseMarkdown("***").nodes;
+    auto nodes = ParseMarkdown(L"***").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::HorizontalRule);
 }
@@ -210,7 +210,7 @@ TEST(Parser, HorizontalRuleWithAsterisks)
 
 TEST(Parser, UnorderedList)
 {
-    auto nodes = ParseMarkdown("- item1\n- item2\n- item3").nodes;
+    auto nodes = ParseMarkdown(L"- item1\n- item2\n- item3").nodes;
     ASSERT_EQ(nodes.size(), 3u);
     for (const auto& node : nodes) {
         EXPECT_EQ(node.type, NodeType::ListItem);
@@ -225,7 +225,7 @@ TEST(Parser, UnorderedList)
 
 TEST(Parser, NestedBlockquotePreservesOuterStyle)
 {
-    auto nodes = ParseMarkdown("> outer\n>\n> > inner\n>\n> still outer").nodes;
+    auto nodes = ParseMarkdown(L"> outer\n>\n> > inner\n>\n> still outer").nodes;
     // 内側の引用ブロックが終了した後、"still outer"はまだBlockQuoteであるべき
     bool found_still_outer = false;
     for (const auto& node : nodes) {
@@ -240,7 +240,7 @@ TEST(Parser, NestedBlockquotePreservesOuterStyle)
 
 TEST(Parser, SingleBlockquoteIsBlockQuoteType)
 {
-    auto nodes = ParseMarkdown("> quoted text").nodes;
+    auto nodes = ParseMarkdown(L"> quoted text").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::BlockQuote);
     EXPECT_EQ(nodes[0].GetText(), L"quoted text");
@@ -251,7 +251,7 @@ TEST(Parser, SingleBlockquoteIsBlockQuoteType)
 
 TEST(Parser, NestedBlockquote_SharesSameGroup)
 {
-    auto nodes = ParseMarkdown("> outer\n>\n> > inner\n>\n> still outer").nodes;
+    auto nodes = ParseMarkdown(L"> outer\n>\n> > inner\n>\n> still outer").nodes;
     ASSERT_GE(nodes.size(), 3u);
     const int group = nodes[0].blockquote_group;
     EXPECT_GE(group, 0);
@@ -265,7 +265,7 @@ TEST(Parser, NestedBlockquote_SharesSameGroup)
 
 TEST(Parser, NestedBlockquote_QuoteDepthReflectsNesting)
 {
-    auto nodes = ParseMarkdown("> outer\n> > inner\n> > > deep").nodes;
+    auto nodes = ParseMarkdown(L"> outer\n> > inner\n> > > deep").nodes;
     int max_depth = 0;
     for (const auto& n : nodes) {
         if (n.type == NodeType::BlockQuote && n.quote_depth > max_depth) {
@@ -278,7 +278,7 @@ TEST(Parser, NestedBlockquote_QuoteDepthReflectsNesting)
 TEST(Parser, NestedBlockquote_OuterReturnAfterInnerKeepsDepthOne)
 {
     // 内側 quote の終了は空行 `>` が必要 (md4c の lazy continuation 挙動)
-    auto nodes = ParseMarkdown("> outer\n> > inner\n>\n> back to outer").nodes;
+    auto nodes = ParseMarkdown(L"> outer\n> > inner\n>\n> back to outer").nodes;
     bool checked = false;
     for (const auto& n : nodes) {
         if (n.GetText().find(L"back to outer") != std::wstring::npos) {
@@ -295,7 +295,7 @@ TEST(Parser, NestedBlockquote_OuterReturnAfterInnerKeepsDepthOne)
 TEST(Parser, HtmlEntitySupplementaryPlane)
 {
     // U+1F600 = ニコニコ顔の絵文字（追加面）
-    auto nodes = ParseMarkdown("&#x1F600;").nodes;
+    auto nodes = ParseMarkdown(L"&#x1F600;").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     // U+1F600のUTF-16サロゲートペア: D83D DE00
     ASSERT_GE(nodes[0].GetText().size(), 2u);
@@ -306,7 +306,7 @@ TEST(Parser, HtmlEntitySupplementaryPlane)
 TEST(Parser, HtmlEntityDecimalSupplementaryPlane)
 {
     // U+1F4A9 = 128169 decimal
-    auto nodes = ParseMarkdown("&#128169;").nodes;
+    auto nodes = ParseMarkdown(L"&#128169;").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_GE(nodes[0].GetText().size(), 2u);
     // U+1F4A9 -> D83D DCA9
@@ -317,7 +317,7 @@ TEST(Parser, HtmlEntityDecimalSupplementaryPlane)
 TEST(Parser, HtmlEntityBmpStillWorks)
 {
     // U+00A9 = 著作権記号（基本多言語面）
-    auto nodes = ParseMarkdown("&#xA9;").nodes;
+    auto nodes = ParseMarkdown(L"&#xA9;").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_EQ(nodes[0].GetText().size(), 1u);
     EXPECT_EQ(nodes[0].GetText()[0], L'\u00A9');
@@ -326,7 +326,7 @@ TEST(Parser, HtmlEntityBmpStillWorks)
 TEST(Parser, HtmlEntityBeyondUnicode)
 {
     // U+110000はUnicodeの最大値を超えている; 無視されるべき
-    auto nodes = ParseMarkdown("&#x110000;").nodes;
+    auto nodes = ParseMarkdown(L"&#x110000;").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     // 生のエンティティテキストとしてそのまま渡されるべき
     EXPECT_NE(nodes[0].GetText().find(L"110000"), std::wstring::npos);
@@ -336,7 +336,7 @@ TEST(Parser, HtmlEntityBeyondUnicode)
 
 TEST(Parser, OrderedList)
 {
-    auto nodes = ParseMarkdown("1. first\n2. second\n3. third").nodes;
+    auto nodes = ParseMarkdown(L"1. first\n2. second\n3. third").nodes;
     ASSERT_EQ(nodes.size(), 3u);
     for (const auto& node : nodes) {
         EXPECT_EQ(node.type, NodeType::ListItem);
@@ -348,7 +348,7 @@ TEST(Parser, OrderedList)
 
 TEST(Parser, OrderedListStartsFromN)
 {
-    auto nodes = ParseMarkdown("5. five\n6. six").nodes;
+    auto nodes = ParseMarkdown(L"5. five\n6. six").nodes;
     ASSERT_EQ(nodes.size(), 2u);
     EXPECT_EQ(nodes[0].list_number, 5);
     EXPECT_EQ(nodes[1].list_number, 6);
@@ -356,7 +356,7 @@ TEST(Parser, OrderedListStartsFromN)
 
 TEST(Parser, ListIndentLevel)
 {
-    auto nodes = ParseMarkdown("- item").nodes;
+    auto nodes = ParseMarkdown(L"- item").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_GT(nodes[0].indent_level, 0);
 }
@@ -365,7 +365,7 @@ TEST(Parser, ListIndentLevel)
 
 TEST(Parser, TaskListChecked)
 {
-    auto nodes = ParseMarkdown("- [x] done").nodes;
+    auto nodes = ParseMarkdown(L"- [x] done").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::TaskListItem);
     EXPECT_TRUE(nodes[0].task_checked);
@@ -374,7 +374,7 @@ TEST(Parser, TaskListChecked)
 
 TEST(Parser, TaskListUnchecked)
 {
-    auto nodes = ParseMarkdown("- [ ] todo").nodes;
+    auto nodes = ParseMarkdown(L"- [ ] todo").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::TaskListItem);
     EXPECT_FALSE(nodes[0].task_checked);
@@ -382,7 +382,7 @@ TEST(Parser, TaskListUnchecked)
 
 TEST(Parser, TaskListUpperX)
 {
-    auto nodes = ParseMarkdown("- [X] also done").nodes;
+    auto nodes = ParseMarkdown(L"- [X] also done").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_TRUE(nodes[0].task_checked);
 }
@@ -391,7 +391,7 @@ TEST(Parser, TaskListUpperX)
 
 TEST(Parser, BlockQuote)
 {
-    auto nodes = ParseMarkdown("> quoted text").nodes;
+    auto nodes = ParseMarkdown(L"> quoted text").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::BlockQuote);
     EXPECT_EQ(nodes[0].GetText(), L"quoted text");
@@ -399,7 +399,7 @@ TEST(Parser, BlockQuote)
 
 TEST(Parser, BlockQuoteIndentLevel)
 {
-    auto nodes = ParseMarkdown("> quoted").nodes;
+    auto nodes = ParseMarkdown(L"> quoted").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_GT(nodes[0].indent_level, 0);
 }
@@ -409,7 +409,7 @@ TEST(Parser, BlockQuoteIndentLevel)
 TEST(Parser, SimpleTable)
 {
     auto nodes = ParseMarkdown(
-        "| A | B |\n"
+        L"| A | B |\n"
         "|---|---|\n"
         "| 1 | 2 |"
     ).nodes;
@@ -421,7 +421,7 @@ TEST(Parser, SimpleTable)
 TEST(Parser, TableHeaderCells)
 {
     auto nodes = ParseMarkdown(
-        "| H1 | H2 |\n"
+        L"| H1 | H2 |\n"
         "|---|---|\n"
         "| D1 | D2 |"
     ).nodes;
@@ -444,7 +444,7 @@ TEST(Parser, TableHeaderCells)
 TEST(Parser, TableAlignment)
 {
     auto nodes = ParseMarkdown(
-        "| L | C | R |\n"
+        L"| L | C | R |\n"
         "|:--|:--:|--:|\n"
         "| a | b | c |"
     ).nodes;
@@ -461,7 +461,7 @@ TEST(Parser, TableAlignment)
 TEST(Parser, TableMultipleRows)
 {
     auto nodes = ParseMarkdown(
-        "| A |\n"
+        L"| A |\n"
         "|---|\n"
         "| 1 |\n"
         "| 2 |\n"
@@ -475,14 +475,14 @@ TEST(Parser, TableMultipleRows)
 
 TEST(Parser, HtmlEntityAmp)
 {
-    auto nodes = ParseMarkdown("A &amp; B").nodes;
+    auto nodes = ParseMarkdown(L"A &amp; B").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_NE(nodes[0].GetText().find(L"&"), std::wstring::npos);
 }
 
 TEST(Parser, HtmlEntityLtGt)
 {
-    auto nodes = ParseMarkdown("&lt;tag&gt;").nodes;
+    auto nodes = ParseMarkdown(L"&lt;tag&gt;").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_NE(nodes[0].GetText().find(L"<"), std::wstring::npos);
     EXPECT_NE(nodes[0].GetText().find(L">"), std::wstring::npos);
@@ -493,7 +493,7 @@ TEST(Parser, HtmlEntityLtGt)
 TEST(Parser, ComplexDocumentNodeCount)
 {
     auto nodes = ParseMarkdown(
-        "# Title\n\n"
+        L"# Title\n\n"
         "Paragraph.\n\n"
         "## Section\n\n"
         "- item1\n"
@@ -509,7 +509,7 @@ TEST(Parser, ComplexDocumentNodeCount)
 TEST(Parser, NodeTypesInComplexDocument)
 {
     auto nodes = ParseMarkdown(
-        "# H\n\nP\n\n- L\n\n---\n\n> Q\n\n```\nC\n```\n"
+        L"# H\n\nP\n\n- L\n\n---\n\n> Q\n\n```\nC\n```\n"
     ).nodes;
     bool has_heading = false, has_para = false, has_list = false;
     bool has_hr = false, has_quote = false, has_code = false;
@@ -533,14 +533,14 @@ TEST(Parser, NodeTypesInComplexDocument)
 
 TEST(Parser, JapaneseText)
 {
-    auto nodes = ParseMarkdown("日本語テスト").nodes;
+    auto nodes = ParseMarkdown(L"日本語テスト").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"日本語テスト");
 }
 
 TEST(Parser, EmojiText)
 {
-    auto nodes = ParseMarkdown("Hello 🎉").nodes;
+    auto nodes = ParseMarkdown(L"Hello 🎉").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     // クラッシュせず出力が生成されることだけを確認
     EXPECT_FALSE(nodes[0].GetText().empty());
@@ -550,7 +550,7 @@ TEST(Parser, EmojiText)
 
 TEST(Parser, SoftBreakBecomesSpace)
 {
-    auto nodes = ParseMarkdown("line1\nline2").nodes;
+    auto nodes = ParseMarkdown(L"line1\nline2").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     // 段落内のソフトブレークはスペースになるべき
     EXPECT_NE(nodes[0].GetText().find(L"line1"), std::wstring::npos);
@@ -561,7 +561,7 @@ TEST(Parser, SoftBreakBecomesSpace)
 
 TEST(Parser, RunPositionsAreValid)
 {
-    auto nodes = ParseMarkdown("normal **bold** `code` *italic*").nodes;
+    auto nodes = ParseMarkdown(L"normal **bold** `code` *italic*").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     const auto& node = nodes[0];
     for (const auto& run : node.runs) {
@@ -572,7 +572,7 @@ TEST(Parser, RunPositionsAreValid)
 
 TEST(Parser, RunsCoverEntireText)
 {
-    auto nodes = ParseMarkdown("aaa **bbb** ccc").nodes;
+    auto nodes = ParseMarkdown(L"aaa **bbb** ccc").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     const auto& node = nodes[0];
     uint32_t total_length = 0;
@@ -584,7 +584,7 @@ TEST(Parser, RunsCoverEntireText)
 
 TEST(Parser, RunsAreContiguous)
 {
-    auto nodes = ParseMarkdown("a **b** c").nodes;
+    auto nodes = ParseMarkdown(L"a **b** c").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     const auto& runs = nodes[0].runs;
     for (size_t i = 1; i < runs.size(); i++) {
@@ -597,7 +597,7 @@ TEST(Parser, RunsAreContiguous)
 
 TEST(Parser, NestedUnorderedList)
 {
-    auto nodes = ParseMarkdown("- a\n  - b\n    - c").nodes;
+    auto nodes = ParseMarkdown(L"- a\n  - b\n    - c").nodes;
     ASSERT_GE(nodes.size(), 3u);
     // より深いアイテムはより高いインデントレベルを持つべき
     EXPECT_LT(nodes[0].indent_level, nodes[1].indent_level);
@@ -606,7 +606,7 @@ TEST(Parser, NestedUnorderedList)
 
 TEST(Parser, NestedOrderedList)
 {
-    auto nodes = ParseMarkdown("1. a\n   1. b\n      1. c").nodes;
+    auto nodes = ParseMarkdown(L"1. a\n   1. b\n      1. c").nodes;
     ASSERT_GE(nodes.size(), 3u);
     EXPECT_EQ(nodes[0].list_number, 1);
     EXPECT_EQ(nodes[1].list_number, 1);
@@ -616,7 +616,7 @@ TEST(Parser, NestedOrderedList)
 
 TEST(Parser, MixedListNesting)
 {
-    auto nodes = ParseMarkdown("1. ordered\n   - unordered\n   - unordered2").nodes;
+    auto nodes = ParseMarkdown(L"1. ordered\n   - unordered\n   - unordered2").nodes;
     ASSERT_GE(nodes.size(), 3u);
     EXPECT_GT(nodes[0].list_number, 0);
     EXPECT_EQ(nodes[1].list_number, 0);
@@ -627,7 +627,7 @@ TEST(Parser, MixedListNesting)
 
 TEST(Parser, CodeBlockWithLanguage)
 {
-    auto nodes = ParseMarkdown("```cpp\nint x = 1;\n```").nodes;
+    auto nodes = ParseMarkdown(L"```cpp\nint x = 1;\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::CodeBlock);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Cpp);
@@ -635,7 +635,7 @@ TEST(Parser, CodeBlockWithLanguage)
 
 TEST(Parser, CodeBlockNoTrailingNewline)
 {
-    auto nodes = ParseMarkdown("```\nhello\n```").nodes;
+    auto nodes = ParseMarkdown(L"```\nhello\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     // 末尾の改行は除去されるべき
     EXPECT_FALSE(nodes[0].GetText().empty());
@@ -647,7 +647,7 @@ TEST(Parser, CodeBlockNoTrailingNewline)
 TEST(Parser, TableCellWithBold)
 {
     auto nodes = ParseMarkdown(
-        "| A | **B** |\n"
+        L"| A | **B** |\n"
         "|---|---|\n"
         "| 1 | 2 |"
     ).nodes;
@@ -666,7 +666,7 @@ TEST(Parser, TableCellWithBold)
 TEST(Parser, TableLinearizedText)
 {
     auto nodes = ParseMarkdown(
-        "| A | B |\n"
+        L"| A | B |\n"
         "|---|---|\n"
         "| 1 | 2 |"
     ).nodes;
@@ -682,7 +682,7 @@ TEST(Parser, TableLinearizedText)
 TEST(Parser, TableCellWithLink)
 {
     auto nodes = ParseMarkdown(
-        "| Name | Link |\n"
+        L"| Name | Link |\n"
         "|------|------|\n"
         "| foo | [bar](https://example.com) |"
     ).nodes;
@@ -710,7 +710,7 @@ TEST(Parser, TableCellWithLink)
 TEST(Parser, TableCellWithInternalLink)
 {
     auto nodes = ParseMarkdown(
-        "| Section |\n"
+        L"| Section |\n"
         "|---------|\n"
         "| [intro](#introduction) |"
     ).nodes;
@@ -731,7 +731,7 @@ TEST(Parser, TableCellWithInternalLink)
 TEST(Parser, TableCellWithBoldLink)
 {
     auto nodes = ParseMarkdown(
-        "| Link |\n"
+        L"| Link |\n"
         "|------|\n"
         "| [**bold**](https://example.com) |"
     ).nodes;
@@ -751,7 +751,7 @@ TEST(Parser, TableCellWithBoldLink)
 TEST(Parser, TableCellMixedTextAndLink)
 {
     auto nodes = ParseMarkdown(
-        "| Content |\n"
+        L"| Content |\n"
         "|---------|\n"
         "| before [link](https://example.com) after |"
     ).nodes;
@@ -774,14 +774,14 @@ TEST(Parser, TableCellMixedTextAndLink)
 
 TEST(Parser, HtmlEntityQuot)
 {
-    auto nodes = ParseMarkdown("&quot;hello&quot;").nodes;
+    auto nodes = ParseMarkdown(L"&quot;hello&quot;").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_NE(nodes[0].GetText().find(L"\""), std::wstring::npos);
 }
 
 TEST(Parser, HtmlEntityNbsp)
 {
-    auto nodes = ParseMarkdown("a&nbsp;b").nodes;
+    auto nodes = ParseMarkdown(L"a&nbsp;b").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_NE(nodes[0].GetText().find(L'\u00A0'), std::wstring::npos);
 }
@@ -790,7 +790,7 @@ TEST(Parser, HtmlEntityNbsp)
 
 TEST(Parser, HardBreakWithTwoSpaces)
 {
-    auto nodes = ParseMarkdown("line1  \nline2").nodes;
+    auto nodes = ParseMarkdown(L"line1  \nline2").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     // ハードブレークはテキスト内に改行を生成するべき
     EXPECT_NE(nodes[0].GetText().find(L'\n'), std::wstring::npos);
@@ -800,7 +800,7 @@ TEST(Parser, HardBreakWithTwoSpaces)
 
 TEST(Parser, MultipleHeadingsHaveAnchors)
 {
-    auto nodes = ParseMarkdown("# A\n\n## B\n\n### C").nodes;
+    auto nodes = ParseMarkdown(L"# A\n\n## B\n\n### C").nodes;
     for (const auto& node : nodes) {
         if (node.type == NodeType::Heading) {
             EXPECT_FALSE(node.anchor_id().empty())
@@ -813,7 +813,7 @@ TEST(Parser, MultipleHeadingsHaveAnchors)
 
 TEST(Parser, BoldLink)
 {
-    auto nodes = ParseMarkdown("[**bold link**](https://example.com)").nodes;
+    auto nodes = ParseMarkdown(L"[**bold link**](https://example.com)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     bool has_bold_link = false;
     for (const auto& run : nodes[0].runs) {
@@ -828,7 +828,7 @@ TEST(Parser, BoldLink)
 
 TEST(Parser, DuplicateHeadingAnchorsAreUnique)
 {
-    auto nodes = ParseMarkdown("# Title\n\n## Title\n\n### Title").nodes;
+    auto nodes = ParseMarkdown(L"# Title\n\n## Title\n\n### Title").nodes;
     ASSERT_EQ(nodes.size(), 3u);
     EXPECT_EQ(nodes[0].anchor_id(), L"title");
     EXPECT_EQ(nodes[1].anchor_id(), L"title-1");
@@ -837,7 +837,7 @@ TEST(Parser, DuplicateHeadingAnchorsAreUnique)
 
 TEST(Parser, DuplicateAnchorsWithDifferentText)
 {
-    auto nodes = ParseMarkdown("# A\n\n## B\n\n### A").nodes;
+    auto nodes = ParseMarkdown(L"# A\n\n## B\n\n### A").nodes;
     ASSERT_EQ(nodes.size(), 3u);
     EXPECT_EQ(nodes[0].anchor_id(), L"a");
     EXPECT_EQ(nodes[1].anchor_id(), L"b");
@@ -848,14 +848,14 @@ TEST(Parser, DuplicateAnchorsWithDifferentText)
 
 TEST(Parser, NumericEntityDecimal)
 {
-    auto nodes = ParseMarkdown("&#65;").nodes;
+    auto nodes = ParseMarkdown(L"&#65;").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"A");
 }
 
 TEST(Parser, NumericEntityHex)
 {
-    auto nodes = ParseMarkdown("&#x41;").nodes;
+    auto nodes = ParseMarkdown(L"&#x41;").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"A");
 }
@@ -863,7 +863,7 @@ TEST(Parser, NumericEntityHex)
 TEST(Parser, NumericEntityJapanese)
 {
     // &#x3042; = あ (Hiragana A)
-    auto nodes = ParseMarkdown("&#x3042;").nodes;
+    auto nodes = ParseMarkdown(L"&#x3042;").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"\u3042");
 }
@@ -872,11 +872,11 @@ TEST(Parser, NumericEntityJapanese)
 
 TEST(Parser, DeeplyNestedList)
 {
-    std::string md;
-    md += "- L1\n";
-    md += "  - L2\n";
-    md += "    - L3\n";
-    md += "      - L4\n";
+    std::wstring md;
+    md += L"- L1\n";
+    md += L"  - L2\n";
+    md += L"    - L3\n";
+    md += L"      - L4\n";
     auto nodes = ParseMarkdown(md).nodes;
     ASSERT_GE(nodes.size(), 4u);
     // より深いレベルはより高いindent_levelを持つべき
@@ -891,7 +891,7 @@ TEST(Parser, TableUnevenColumns)
 {
     // md4cがこれを処理する - 行内のセルが少ない場合
     auto nodes = ParseMarkdown(
-        "| A | B | C |\n"
+        L"| A | B | C |\n"
         "|---|---|---|\n"
         "| 1 | 2 |\n"
     ).nodes;
@@ -904,7 +904,7 @@ TEST(Parser, TableUnevenColumns)
 
 TEST(Parser, MermaidCodeBlock)
 {
-    auto nodes = ParseMarkdown("```mermaid\ngraph TD;\n  A-->B;\n```").nodes;
+    auto nodes = ParseMarkdown(L"```mermaid\ngraph TD;\n  A-->B;\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::CodeBlock);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Mermaid);
@@ -914,7 +914,7 @@ TEST(Parser, MermaidCodeBlock)
 
 TEST(Parser, LatexDisplayMathSingleLinePromotedToCodeBlock)
 {
-    auto result = ParseMarkdown("$$E = mc^2$$");
+    auto result = ParseMarkdown(L"$$E = mc^2$$");
     ASSERT_EQ(result.nodes.size(), 1u);
     EXPECT_EQ(result.nodes[0].type, NodeType::CodeBlock);
     EXPECT_EQ(result.nodes[0].code_language, SyntaxLanguage::LatexMath);
@@ -927,7 +927,7 @@ TEST(Parser, LatexDisplayMathSingleLinePromotedToCodeBlock)
 TEST(Parser, LatexDisplayMathWithOtherContentFallsBackToText)
 {
     // 段落内に数式以外の内容があるときは昇格せず、テキストとして残す
-    auto nodes = ParseMarkdown("before $$x+y$$ after").nodes;
+    auto nodes = ParseMarkdown(L"before $$x+y$$ after").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Paragraph);
     EXPECT_NE(nodes[0].code_language, SyntaxLanguage::LatexMath);
@@ -939,7 +939,7 @@ TEST(Parser, LatexDisplayMathWithOtherContentFallsBackToText)
 TEST(Parser, LatexMultipleDisplayMathInOneParagraphFallsBackToText)
 {
     // 1段落に2つ以上の $$...$$ があるときは昇格しない
-    auto nodes = ParseMarkdown("$$a$$ $$b$$").nodes;
+    auto nodes = ParseMarkdown(L"$$a$$ $$b$$").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Paragraph);
 }
@@ -947,7 +947,7 @@ TEST(Parser, LatexMultipleDisplayMathInOneParagraphFallsBackToText)
 TEST(Parser, LatexInlineMathRemainsAsText)
 {
     // インライン $...$ は昇格対象外。$ 記号を含む元のテキストとして扱う
-    auto nodes = ParseMarkdown("value is $x$ here").nodes;
+    auto nodes = ParseMarkdown(L"value is $x$ here").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Paragraph);
     EXPECT_NE(nodes[0].code_language, SyntaxLanguage::LatexMath);
@@ -958,7 +958,7 @@ TEST(Parser, LatexInlineMathRemainsAsText)
 TEST(Parser, LatexDisplayMathInBlockquoteNotPromoted)
 {
     // blockquote 内の $$...$$ は引用文脈維持のため昇格しない
-    auto nodes = ParseMarkdown("> $$y=x$$").nodes;
+    auto nodes = ParseMarkdown(L"> $$y=x$$").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::BlockQuote);
 }
@@ -968,7 +968,7 @@ TEST(Parser, PlainDollarSignsNotMisdetectedAsMath)
     // "The price is $5 or $10." のような金額表記は LaTeX ではなくテキストとして扱う。
     // md4c は `$` の直後に空白・数字・記号が続く場合などインライン数式として解釈しないため、
     // フラグ有効化で既存のドル記号テキストが壊れないことを確認する。
-    auto nodes = ParseMarkdown("The price is $5 or $10.").nodes;
+    auto nodes = ParseMarkdown(L"The price is $5 or $10.").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Paragraph);
     EXPECT_NE(nodes[0].code_language, SyntaxLanguage::LatexMath);
@@ -980,7 +980,7 @@ TEST(Parser, PlainDollarSignsNotMisdetectedAsMath)
 TEST(Parser, LatexDisplayMathMultiline)
 {
     // 複数行にわたる $$...$$ でも昇格される（中身はパーサがそのまま保持）
-    auto result = ParseMarkdown("$$\nE = mc^2\n$$");
+    auto result = ParseMarkdown(L"$$\nE = mc^2\n$$");
     ASSERT_EQ(result.nodes.size(), 1u);
     EXPECT_EQ(result.nodes[0].type, NodeType::CodeBlock);
     EXPECT_EQ(result.nodes[0].code_language, SyntaxLanguage::LatexMath);
@@ -992,7 +992,7 @@ TEST(Parser, LatexDisplayMathMultiline)
 TEST(Parser, LatexDisplayMathSurroundingParagraphs)
 {
     // 前後に通常段落がある場合も、純粋な $$...$$ 段落のみ昇格される
-    auto result = ParseMarkdown("before\n\n$$E=mc^2$$\n\nafter");
+    auto result = ParseMarkdown(L"before\n\n$$E=mc^2$$\n\nafter");
     ASSERT_EQ(result.nodes.size(), 3u);
     EXPECT_EQ(result.nodes[0].type, NodeType::Paragraph);
     EXPECT_EQ(result.nodes[1].type, NodeType::CodeBlock);
@@ -1007,7 +1007,7 @@ TEST(Parser, LatexDisplayMathSurroundingParagraphs)
 
 TEST(Parser, LinkWithSpecialCharsInUrl)
 {
-    auto nodes = ParseMarkdown("[link](https://example.com/path?q=1&r=2#frag)").nodes;
+    auto nodes = ParseMarkdown(L"[link](https://example.com/path?q=1&r=2#frag)").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     bool found = false;
     for (const auto& run : nodes[0].runs) {
@@ -1023,7 +1023,7 @@ TEST(Parser, LinkWithSpecialCharsInUrl)
 
 TEST(Parser, EmptyHeading)
 {
-    auto nodes = ParseMarkdown("# \n\ntext").nodes;
+    auto nodes = ParseMarkdown(L"# \n\ntext").nodes;
     // md4cは空テキストの見出しノードを生成する場合がある
     bool found_heading = false;
     for (auto& n : nodes) {
@@ -1040,7 +1040,7 @@ TEST(Parser, EmptyHeading)
 
 TEST(Parser, AlertNoteDetected)
 {
-    auto nodes = ParseMarkdown("> [!NOTE]\n> This is a note").nodes;
+    auto nodes = ParseMarkdown(L"> [!NOTE]\n> This is a note").nodes;
     ASSERT_GE(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::BlockQuote);
     EXPECT_EQ(nodes[0].alert_type, AlertType::Note);
@@ -1048,49 +1048,49 @@ TEST(Parser, AlertNoteDetected)
 
 TEST(Parser, AlertTipDetected)
 {
-    auto nodes = ParseMarkdown("> [!TIP]\n> Helpful advice").nodes;
+    auto nodes = ParseMarkdown(L"> [!TIP]\n> Helpful advice").nodes;
     ASSERT_GE(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].alert_type, AlertType::Tip);
 }
 
 TEST(Parser, AlertImportantDetected)
 {
-    auto nodes = ParseMarkdown("> [!IMPORTANT]\n> Key info").nodes;
+    auto nodes = ParseMarkdown(L"> [!IMPORTANT]\n> Key info").nodes;
     ASSERT_GE(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].alert_type, AlertType::Important);
 }
 
 TEST(Parser, AlertWarningDetected)
 {
-    auto nodes = ParseMarkdown("> [!WARNING]\n> Be careful").nodes;
+    auto nodes = ParseMarkdown(L"> [!WARNING]\n> Be careful").nodes;
     ASSERT_GE(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].alert_type, AlertType::Warning);
 }
 
 TEST(Parser, AlertCautionDetected)
 {
-    auto nodes = ParseMarkdown("> [!CAUTION]\n> Dangerous").nodes;
+    auto nodes = ParseMarkdown(L"> [!CAUTION]\n> Dangerous").nodes;
     ASSERT_GE(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].alert_type, AlertType::Caution);
 }
 
 TEST(Parser, AlertCaseInsensitive)
 {
-    auto nodes = ParseMarkdown("> [!note]\n> lower case").nodes;
+    auto nodes = ParseMarkdown(L"> [!note]\n> lower case").nodes;
     ASSERT_GE(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].alert_type, AlertType::Note);
 }
 
 TEST(Parser, AlertCaseMixed)
 {
-    auto nodes = ParseMarkdown("> [!Note]\n> mixed case").nodes;
+    auto nodes = ParseMarkdown(L"> [!Note]\n> mixed case").nodes;
     ASSERT_GE(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].alert_type, AlertType::Note);
 }
 
 TEST(Parser, AlertMarkerStrippedAndLabelInserted)
 {
-    auto nodes = ParseMarkdown("> [!NOTE]\n> Content here").nodes;
+    auto nodes = ParseMarkdown(L"> [!NOTE]\n> Content here").nodes;
     ASSERT_GE(nodes.size(), 1u);
     // マーカー "[!NOTE]" が除去され、アイコン + ラベル "Note" に置換されているべき
     EXPECT_NE(nodes[0].GetText().find(L"Note"), std::wstring::npos);
@@ -1104,7 +1104,7 @@ TEST(Parser, AlertMarkerStrippedAndLabelInserted)
 
 TEST(Parser, AlertLabelIsBold)
 {
-    auto nodes = ParseMarkdown("> [!NOTE]\n> Some text").nodes;
+    auto nodes = ParseMarkdown(L"> [!NOTE]\n> Some text").nodes;
     ASSERT_GE(nodes.size(), 1u);
     ASSERT_GE(nodes[0].runs.size(), 1u);
     // 最初のランはラベル部分で太字であるべき
@@ -1115,18 +1115,18 @@ TEST(Parser, AlertLabelIsBold)
 
 TEST(Parser, AlertLabelLength)
 {
-    auto nodes = ParseMarkdown("> [!NOTE]\n> text").nodes;
+    auto nodes = ParseMarkdown(L"> [!NOTE]\n> text").nodes;
     ASSERT_GE(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].alert_label_length, 6u); // icon + space + "Note" = 2 + 4文字
 
-    auto nodes2 = ParseMarkdown("> [!IMPORTANT]\n> text").nodes;
+    auto nodes2 = ParseMarkdown(L"> [!IMPORTANT]\n> text").nodes;
     ASSERT_GE(nodes2.size(), 1u);
     EXPECT_EQ(nodes2[0].alert_label_length, 11u); // icon + space + "Important" = 2 + 9文字
 }
 
 TEST(Parser, AlertRunPositionsAreValid)
 {
-    auto nodes = ParseMarkdown("> [!WARNING]\n> Some **bold** text").nodes;
+    auto nodes = ParseMarkdown(L"> [!WARNING]\n> Some **bold** text").nodes;
     ASSERT_GE(nodes.size(), 1u);
     const auto& node = nodes[0];
     for (const auto& run : node.runs) {
@@ -1138,7 +1138,7 @@ TEST(Parser, AlertRunPositionsAreValid)
 
 TEST(Parser, AlertMultiParagraphGrouping)
 {
-    auto nodes = ParseMarkdown("> [!NOTE]\n> First para\n>\n> Second para").nodes;
+    auto nodes = ParseMarkdown(L"> [!NOTE]\n> First para\n>\n> Second para").nodes;
     // 複数の BlockQuote ノードが生成され、すべて同じ alert_type を持つべき
     int alert_count = 0;
     for (const auto& node : nodes) {
@@ -1151,7 +1151,7 @@ TEST(Parser, AlertMultiParagraphGrouping)
 
 TEST(Parser, AlertOnlyFirstNodeHasLabel)
 {
-    auto nodes = ParseMarkdown("> [!TIP]\n> First\n>\n> Second").nodes;
+    auto nodes = ParseMarkdown(L"> [!TIP]\n> First\n>\n> Second").nodes;
     // 最初のノードだけ alert_label_length > 0
     int label_count = 0;
     for (const auto& node : nodes) {
@@ -1162,7 +1162,7 @@ TEST(Parser, AlertOnlyFirstNodeHasLabel)
 
 TEST(Parser, RegularBlockquoteUnaffected)
 {
-    auto nodes = ParseMarkdown("> Just a normal quote").nodes;
+    auto nodes = ParseMarkdown(L"> Just a normal quote").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::BlockQuote);
     EXPECT_EQ(nodes[0].alert_type, AlertType::None);
@@ -1172,7 +1172,7 @@ TEST(Parser, RegularBlockquoteUnaffected)
 
 TEST(Parser, AlertMarkerOnlyNoContent)
 {
-    auto nodes = ParseMarkdown("> [!NOTE]").nodes;
+    auto nodes = ParseMarkdown(L"> [!NOTE]").nodes;
     ASSERT_GE(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].alert_type, AlertType::Note);
     // マーカーだけの場合、アイコン + スペース + ラベルのみ残る
@@ -1182,7 +1182,7 @@ TEST(Parser, AlertMarkerOnlyNoContent)
 
 TEST(Parser, AlertFollowedByRegularBlockquote)
 {
-    auto nodes = ParseMarkdown("> [!NOTE]\n> Alert text\n\n> Normal quote").nodes;
+    auto nodes = ParseMarkdown(L"> [!NOTE]\n> Alert text\n\n> Normal quote").nodes;
     // Alert と通常の blockquote が混在
     bool has_alert = false, has_normal = false;
     for (const auto& node : nodes) {
@@ -1201,7 +1201,7 @@ TEST(Parser, Alert_PropagatesAcrossNestedBlockquote)
 {
     // example/nested.md #9 相当: 親 -> ネスト -> 親の続き
     auto nodes = ParseMarkdown(
-        "> [!NOTE]\n"
+        L"> [!NOTE]\n"
         "> Alert head\n"
         "> > nested\n"
         ">\n"
@@ -1222,7 +1222,7 @@ TEST(Parser, Alert_IgnoredWhenStartedInsideNestedBlockquote)
 {
     // GitHub 仕様: ネスト内 (`> > [!NOTE]`) の Alert マーカーは認識しない
     auto nodes = ParseMarkdown(
-        "> outer\n"
+        L"> outer\n"
         "> > [!NOTE]\n"
         "> > inner note text"
     ).nodes;
@@ -1235,7 +1235,7 @@ TEST(Parser, Alert_IgnoredWhenStartedInsideNestedBlockquote)
 
 TEST(Parser, AlertUnknownTypeIgnored)
 {
-    auto nodes = ParseMarkdown("> [!UNKNOWN]\n> text").nodes;
+    auto nodes = ParseMarkdown(L"> [!UNKNOWN]\n> text").nodes;
     ASSERT_GE(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].alert_type, AlertType::None);
     // マーカーがそのまま残っているべき
@@ -1262,7 +1262,7 @@ TEST(Parser, DetectAlertsOnEmptyVector)
 
 TEST(Parser, AlertWithInlineFormatting)
 {
-    auto nodes = ParseMarkdown("> [!TIP]\n> Use **bold** and `code`").nodes;
+    auto nodes = ParseMarkdown(L"> [!TIP]\n> Use **bold** and `code`").nodes;
     ASSERT_GE(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].alert_type, AlertType::Tip);
     // テキストにboldとcodeが含まれるべき
@@ -1280,7 +1280,7 @@ TEST(Parser, AlertWithInlineFormatting)
 
 TEST(Parser, AlertTextStartsWithLabelThenNewline)
 {
-    auto nodes = ParseMarkdown("> [!CAUTION]\n> Don't do this").nodes;
+    auto nodes = ParseMarkdown(L"> [!CAUTION]\n> Don't do this").nodes;
     ASSERT_GE(nodes.size(), 1u);
     // テキストは "[icon] Caution\n..." の形式であるべき
     const auto& text = nodes[0].GetText();
@@ -1294,7 +1294,7 @@ TEST(Parser, AlertTextStartsWithLabelThenNewline)
 
 TEST(Parser, SourceOffsetSingleParagraph)
 {
-    auto nodes = ParseMarkdown("Hello world").nodes;
+    auto nodes = ParseMarkdown(L"Hello world").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].source_offset, 0u);
 }
@@ -1302,7 +1302,7 @@ TEST(Parser, SourceOffsetSingleParagraph)
 TEST(Parser, SourceOffsetHeading)
 {
     // "# Title" → テキスト "Title" はオフセット 2 から
-    auto nodes = ParseMarkdown("# Title").nodes;
+    auto nodes = ParseMarkdown(L"# Title").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].source_offset, 2u);
 }
@@ -1311,7 +1311,7 @@ TEST(Parser, SourceOffsetMultipleParagraphs)
 {
     // "First\n\nSecond\n\nThird"
     // "First" = offset 0, "Second" = offset 7, "Third" = offset 15
-    auto nodes = ParseMarkdown("First\n\nSecond\n\nThird").nodes;
+    auto nodes = ParseMarkdown(L"First\n\nSecond\n\nThird").nodes;
     ASSERT_EQ(nodes.size(), 3u);
     EXPECT_EQ(nodes[0].source_offset, 0u);
     EXPECT_EQ(nodes[1].source_offset, 7u);
@@ -1322,7 +1322,7 @@ TEST(Parser, SourceOffsetIncreasing)
 {
     // ノードの source_offset は単調増加であるべき
     auto nodes = ParseMarkdown(
-        "# Heading\n\n"
+        L"# Heading\n\n"
         "Paragraph\n\n"
         "- item1\n"
         "- item2\n\n"
@@ -1342,7 +1342,7 @@ TEST(Parser, SourceOffsetIncreasing)
 TEST(Parser, SourceOffsetCodeBlock)
 {
     // "```\nhello\n```" → コードブロック内テキストのオフセット
-    auto nodes = ParseMarkdown("```\nhello\n```").nodes;
+    auto nodes = ParseMarkdown(L"```\nhello\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::CodeBlock);
     // コードブロックのテキスト "hello" は "```\n" = 4バイト目から
@@ -1351,14 +1351,14 @@ TEST(Parser, SourceOffsetCodeBlock)
 
 TEST(Parser, SourceOffsetEmptyInput)
 {
-    auto nodes = ParseMarkdown("").nodes;
+    auto nodes = ParseMarkdown(L"").nodes;
     EXPECT_TRUE(nodes.empty());
 }
 
 TEST(Parser, SourceOffsetHorizontalRule)
 {
     // "---" はテキストを持たないのでsource_offsetは未設定のまま
-    auto nodes = ParseMarkdown("---").nodes;
+    auto nodes = ParseMarkdown(L"---").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::HorizontalRule);
     EXPECT_EQ(nodes[0].source_offset, kUnsetSourceOffset);
@@ -1368,7 +1368,7 @@ TEST(Parser, SourceOffsetCjkMultiCodeUnit)
 {
     // "あいう\n\ntest" → wide で "あいう" = 3 wchar_t, "\n\n" = 2 wchar_t
     // source_offset は UTF-16 コード単位
-    auto nodes = ParseMarkdown("あいう\n\ntest").nodes;
+    auto nodes = ParseMarkdown(L"あいう\n\ntest").nodes;
     ASSERT_EQ(nodes.size(), 2u);
     EXPECT_EQ(nodes[0].source_offset, 0u);
     EXPECT_EQ(nodes[1].source_offset, 5u); // 3 + 2
@@ -1379,7 +1379,7 @@ TEST(Parser, SourceOffsetUnorderedList)
     // "- A\n- B\n- C"
     // "- " = 2バイト, "A" offset=2, "\n- " = 3バイト, "B" offset=5+2=7?
     // 実際: "- A\n" = 4, "- B\n" = 4, "- C" = 3
-    auto nodes = ParseMarkdown("- A\n- B\n- C").nodes;
+    auto nodes = ParseMarkdown(L"- A\n- B\n- C").nodes;
     ASSERT_EQ(nodes.size(), 3u);
     EXPECT_EQ(nodes[0].source_offset, 2u);  // "A" = "- " の後
     EXPECT_EQ(nodes[1].source_offset, 6u);  // "B" = "- A\n- " の後
@@ -1389,7 +1389,7 @@ TEST(Parser, SourceOffsetUnorderedList)
 TEST(Parser, SourceOffsetOrderedList)
 {
     // "1. First\n2. Second"
-    auto nodes = ParseMarkdown("1. First\n2. Second").nodes;
+    auto nodes = ParseMarkdown(L"1. First\n2. Second").nodes;
     ASSERT_EQ(nodes.size(), 2u);
     EXPECT_EQ(nodes[0].source_offset, 3u);  // "First" = "1. " の後
     EXPECT_EQ(nodes[1].source_offset, 12u); // "Second" = "1. First\n2. " の後
@@ -1398,7 +1398,7 @@ TEST(Parser, SourceOffsetOrderedList)
 TEST(Parser, SourceOffsetBlockQuote)
 {
     // "> quoted\n\nnormal"
-    auto nodes = ParseMarkdown("> quoted\n\nnormal").nodes;
+    auto nodes = ParseMarkdown(L"> quoted\n\nnormal").nodes;
     ASSERT_GE(nodes.size(), 2u);
     EXPECT_EQ(nodes[0].source_offset, 2u); // "quoted" = "> " の後
 }
@@ -1406,7 +1406,7 @@ TEST(Parser, SourceOffsetBlockQuote)
 TEST(Parser, SourceOffsetNestedList)
 {
     // ネストされたリストでも単調増加
-    auto nodes = ParseMarkdown("- outer\n  - inner\n- next").nodes;
+    auto nodes = ParseMarkdown(L"- outer\n  - inner\n- next").nodes;
     ASSERT_GE(nodes.size(), 3u);
     uint32_t prev = 0;
     for (size_t i = 0; i < nodes.size(); ++i) {
@@ -1422,7 +1422,7 @@ TEST(Parser, SourceOffsetTable)
 {
     // テーブルノードの source_offset はヘッダの最初のセルテキスト
     auto nodes = ParseMarkdown(
-        "| A | B |\n"
+        L"| A | B |\n"
         "|---|---|\n"
         "| 1 | 2 |").nodes;
     ASSERT_EQ(nodes.size(), 1u);
@@ -1434,7 +1434,7 @@ TEST(Parser, SourceOffsetTable)
 TEST(Parser, SourceOffsetCodeBlockWithLanguage)
 {
     // "```cpp\nint x;\n```" → テキストは "```cpp\n" = 7バイト目から
-    auto nodes = ParseMarkdown("```cpp\nint x;\n```").nodes;
+    auto nodes = ParseMarkdown(L"```cpp\nint x;\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].source_offset, 7u);
 }
@@ -1442,14 +1442,14 @@ TEST(Parser, SourceOffsetCodeBlockWithLanguage)
 TEST(Parser, SourceOffsetMixedDocument)
 {
     // 多様なブロック型を含む文書で全ノードの offset が有効かつ単調増加
-    std::string md =
-        "# Title\n\n"            // heading
-        "Paragraph\n\n"          // paragraph
-        "- item\n\n"             // list
-        "> quote\n\n"            // blockquote
-        "```\ncode\n```\n\n"     // code
-        "---\n\n"                // hr (offset 未設定)
-        "End";                   // paragraph
+    std::wstring md =
+        L"# Title\n\n"            // heading
+        L"Paragraph\n\n"          // paragraph
+        L"- item\n\n"             // list
+        L"> quote\n\n"             // blockquote
+        L"```\ncode\n```\n\n"     // code
+        L"---\n\n"                // hr (offset 未設定)
+        L"End";                   // paragraph
     auto nodes = ParseMarkdown(md).nodes;
     ASSERT_GE(nodes.size(), 6u);
 
@@ -1468,7 +1468,7 @@ TEST(Parser, SourceOffsetMixedDocument)
 
 TEST(Parser, SourceOffsetTaskList)
 {
-    auto nodes = ParseMarkdown("- [x] done\n- [ ] todo").nodes;
+    auto nodes = ParseMarkdown(L"- [x] done\n- [ ] todo").nodes;
     ASSERT_EQ(nodes.size(), 2u);
     // "- [x] " = 6バイト, "done" offset=6
     EXPECT_EQ(nodes[0].source_offset, 6u);
@@ -1479,14 +1479,14 @@ TEST(Parser, SourceOffsetTaskList)
 
 TEST(Parser, LineCountSingleLine)
 {
-    auto nodes = ParseMarkdown("Hello world").nodes;
+    auto nodes = ParseMarkdown(L"Hello world").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].line_count, 0);
 }
 
 TEST(Parser, LineCountCodeBlock)
 {
-    auto nodes = ParseMarkdown("```\na\nb\nc\n```").nodes;
+    auto nodes = ParseMarkdown(L"```\na\nb\nc\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::CodeBlock);
     // "a\nb\nc" → 2個の改行（末尾の\nはパーサーが除去する）
@@ -1496,7 +1496,7 @@ TEST(Parser, LineCountCodeBlock)
 TEST(Parser, LineCountMultilineParagraph)
 {
     // softbreakは空白に変換されるため改行にならない
-    auto nodes = ParseMarkdown("line1\nline2\nline3").nodes;
+    auto nodes = ParseMarkdown(L"line1\nline2\nline3").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].line_count, 0);
 }
@@ -1504,14 +1504,14 @@ TEST(Parser, LineCountMultilineParagraph)
 TEST(Parser, LineCountHardBreak)
 {
     // 末尾2スペース+改行 = hard break → \n
-    auto nodes = ParseMarkdown("line1  \nline2  \nline3").nodes;
+    auto nodes = ParseMarkdown(L"line1  \nline2  \nline3").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].line_count, 2);
 }
 
 TEST(Parser, LineCountEmptyCodeBlock)
 {
-    auto nodes = ParseMarkdown("```\n\n```").nodes;
+    auto nodes = ParseMarkdown(L"```\n\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::CodeBlock);
     EXPECT_EQ(nodes[0].line_count, 0);
@@ -1519,11 +1519,11 @@ TEST(Parser, LineCountEmptyCodeBlock)
 
 TEST(Parser, LineCountLargeCodeBlock)
 {
-    std::string md = "```\n";
+    std::wstring md = L"```\n";
     for (int i = 0; i < 100; i++) {
-        md += "line " + std::to_string(i) + "\n";
+        md += L"line " + std::to_wstring(i) + L"\n";
     }
-    md += "```";
+    md += L"```";
     auto nodes = ParseMarkdown(md).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     // 100行 → 99個の改行（末尾の\nが除去される）
@@ -1534,7 +1534,7 @@ TEST(Parser, LineCountLargeCodeBlock)
 
 TEST(Parser, SyntaxTokensEmptyAfterParse)
 {
-    auto nodes = ParseMarkdown("```cpp\nint x = 42;\n```").nodes;
+    auto nodes = ParseMarkdown(L"```cpp\nint x = 42;\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::CodeBlock);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Cpp);
@@ -1544,7 +1544,7 @@ TEST(Parser, SyntaxTokensEmptyAfterParse)
 
 TEST(Parser, SyntaxTokensEmptyForMermaid)
 {
-    auto nodes = ParseMarkdown("```mermaid\ngraph TD\n```").nodes;
+    auto nodes = ParseMarkdown(L"```mermaid\ngraph TD\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Mermaid);
     EXPECT_TRUE(nodes[0].syntax_tokens().empty());
@@ -1554,14 +1554,14 @@ TEST(Parser, SyntaxTokensEmptyForMermaid)
 
 TEST(Parser, Utf8BatchPlainText)
 {
-    auto nodes = ParseMarkdown("Hello world, this is a test.").nodes;
+    auto nodes = ParseMarkdown(L"Hello world, this is a test.").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"Hello world, this is a test.");
 }
 
 TEST(Parser, Utf8BatchWithSpanBoundary)
 {
-    auto nodes = ParseMarkdown("before **bold** after").nodes;
+    auto nodes = ParseMarkdown(L"before **bold** after").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"before bold after");
     ASSERT_GE(nodes[0].runs.size(), 3u);
@@ -1572,14 +1572,14 @@ TEST(Parser, Utf8BatchWithSpanBoundary)
 
 TEST(Parser, Utf8BatchWithEntity)
 {
-    auto nodes = ParseMarkdown("a &amp; b").nodes;
+    auto nodes = ParseMarkdown(L"a &amp; b").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"a & b");
 }
 
 TEST(Parser, Utf8BatchWithSoftBreak)
 {
-    auto nodes = ParseMarkdown("line1\nline2").nodes;
+    auto nodes = ParseMarkdown(L"line1\nline2").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     // softbreak → space
     EXPECT_EQ(nodes[0].GetText(), L"line1 line2");
@@ -1587,21 +1587,21 @@ TEST(Parser, Utf8BatchWithSoftBreak)
 
 TEST(Parser, Utf8BatchWithHardBreak)
 {
-    auto nodes = ParseMarkdown("line1  \nline2").nodes;
+    auto nodes = ParseMarkdown(L"line1  \nline2").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"line1\nline2");
 }
 
 TEST(Parser, Utf8BatchMultibyteUtf8)
 {
-    auto nodes = ParseMarkdown("日本語テスト").nodes;
+    auto nodes = ParseMarkdown(L"日本語テスト").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"日本語テスト");
 }
 
 TEST(Parser, Utf8BatchMixedAsciiAndMultibyte)
 {
-    auto nodes = ParseMarkdown("Hello **世界** test").nodes;
+    auto nodes = ParseMarkdown(L"Hello **世界** test").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"Hello 世界 test");
     ASSERT_GE(nodes[0].runs.size(), 3u);
@@ -1610,7 +1610,7 @@ TEST(Parser, Utf8BatchMixedAsciiAndMultibyte)
 
 TEST(Parser, Utf8BatchCodeBlockContent)
 {
-    auto nodes = ParseMarkdown("```\nint x = 0;\nfloat y = 1.0;\n```").nodes;
+    auto nodes = ParseMarkdown(L"```\nint x = 0;\nfloat y = 1.0;\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::CodeBlock);
     EXPECT_EQ(nodes[0].GetText(), L"int x = 0;\nfloat y = 1.0;");
@@ -1618,14 +1618,14 @@ TEST(Parser, Utf8BatchCodeBlockContent)
 
 TEST(Parser, Utf8BatchEntityBetweenText)
 {
-    auto nodes = ParseMarkdown("a&lt;b&gt;c").nodes;
+    auto nodes = ParseMarkdown(L"a&lt;b&gt;c").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"a<b>c");
 }
 
 TEST(Parser, Utf8BatchNestedFormatting)
 {
-    auto nodes = ParseMarkdown("***bold and italic***").nodes;
+    auto nodes = ParseMarkdown(L"***bold and italic***").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].GetText(), L"bold and italic");
     ASSERT_GE(nodes[0].runs.size(), 1u);
@@ -1635,7 +1635,7 @@ TEST(Parser, Utf8BatchNestedFormatting)
 
 TEST(Parser, Utf8BatchLinkText)
 {
-    auto nodes = ParseMarkdown("before [link text](https://example.com) after").nodes;
+    auto nodes = ParseMarkdown(L"before [link text](https://example.com) after").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_NE(nodes[0].GetText().find(L"before"), std::wstring::npos);
     EXPECT_NE(nodes[0].GetText().find(L"link text"), std::wstring::npos);

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -410,8 +410,8 @@ TEST(Parser, SimpleTable)
 {
     auto nodes = ParseMarkdown(
         L"| A | B |\n"
-        "|---|---|\n"
-        "| 1 | 2 |"
+        L"|---|---|\n"
+        L"| 1 | 2 |"
     ).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Table);
@@ -422,8 +422,8 @@ TEST(Parser, TableHeaderCells)
 {
     auto nodes = ParseMarkdown(
         L"| H1 | H2 |\n"
-        "|---|---|\n"
-        "| D1 | D2 |"
+        L"|---|---|\n"
+        L"| D1 | D2 |"
     ).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_GE(nodes[0].table_rows().size(), 2u);
@@ -445,8 +445,8 @@ TEST(Parser, TableAlignment)
 {
     auto nodes = ParseMarkdown(
         L"| L | C | R |\n"
-        "|:--|:--:|--:|\n"
-        "| a | b | c |"
+        L"|:--|:--:|--:|\n"
+        L"| a | b | c |"
     ).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     // データ行の配置を確認（配置はMD_BLOCK_TD_DETAILから取得）
@@ -462,10 +462,10 @@ TEST(Parser, TableMultipleRows)
 {
     auto nodes = ParseMarkdown(
         L"| A |\n"
-        "|---|\n"
-        "| 1 |\n"
-        "| 2 |\n"
-        "| 3 |"
+        L"|---|\n"
+        L"| 1 |\n"
+        L"| 2 |\n"
+        L"| 3 |"
     ).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].table_rows().size(), 4u); // 1 header + 3 data
@@ -494,13 +494,13 @@ TEST(Parser, ComplexDocumentNodeCount)
 {
     auto nodes = ParseMarkdown(
         L"# Title\n\n"
-        "Paragraph.\n\n"
-        "## Section\n\n"
-        "- item1\n"
-        "- item2\n\n"
-        "---\n\n"
-        "> quote\n\n"
-        "```\ncode\n```\n"
+        L"Paragraph.\n\n"
+        L"## Section\n\n"
+        L"- item1\n"
+        L"- item2\n\n"
+        L"---\n\n"
+        L"> quote\n\n"
+        L"```\ncode\n```\n"
     ).nodes;
     // タイトル、段落、セクション、item1、item2、水平線、引用、コード
     EXPECT_GE(nodes.size(), 7u);
@@ -648,8 +648,8 @@ TEST(Parser, TableCellWithBold)
 {
     auto nodes = ParseMarkdown(
         L"| A | **B** |\n"
-        "|---|---|\n"
-        "| 1 | 2 |"
+        L"|---|---|\n"
+        L"| 1 | 2 |"
     ).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_GE(nodes[0].table_rows().size(), 1u);
@@ -667,8 +667,8 @@ TEST(Parser, TableLinearizedText)
 {
     auto nodes = ParseMarkdown(
         L"| A | B |\n"
-        "|---|---|\n"
-        "| 1 | 2 |"
+        L"|---|---|\n"
+        L"| 1 | 2 |"
     ).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     // パーサーは線形化テキストを構築しない（レイアウトが行う）ので、構造だけ確認
@@ -683,8 +683,8 @@ TEST(Parser, TableCellWithLink)
 {
     auto nodes = ParseMarkdown(
         L"| Name | Link |\n"
-        "|------|------|\n"
-        "| foo | [bar](https://example.com) |"
+        L"|------|------|\n"
+        L"| foo | [bar](https://example.com) |"
     ).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_GE(nodes[0].table_rows().size(), 2u);
@@ -711,8 +711,8 @@ TEST(Parser, TableCellWithInternalLink)
 {
     auto nodes = ParseMarkdown(
         L"| Section |\n"
-        "|---------|\n"
-        "| [intro](#introduction) |"
+        L"|---------|\n"
+        L"| [intro](#introduction) |"
     ).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_GE(nodes[0].table_rows().size(), 2u);
@@ -732,8 +732,8 @@ TEST(Parser, TableCellWithBoldLink)
 {
     auto nodes = ParseMarkdown(
         L"| Link |\n"
-        "|------|\n"
-        "| [**bold**](https://example.com) |"
+        L"|------|\n"
+        L"| [**bold**](https://example.com) |"
     ).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_GE(nodes[0].table_rows().size(), 2u);
@@ -752,8 +752,8 @@ TEST(Parser, TableCellMixedTextAndLink)
 {
     auto nodes = ParseMarkdown(
         L"| Content |\n"
-        "|---------|\n"
-        "| before [link](https://example.com) after |"
+        L"|---------|\n"
+        L"| before [link](https://example.com) after |"
     ).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     ASSERT_GE(nodes[0].table_rows().size(), 2u);
@@ -892,8 +892,8 @@ TEST(Parser, TableUnevenColumns)
     // md4cがこれを処理する - 行内のセルが少ない場合
     auto nodes = ParseMarkdown(
         L"| A | B | C |\n"
-        "|---|---|---|\n"
-        "| 1 | 2 |\n"
+        L"|---|---|---|\n"
+        L"| 1 | 2 |\n"
     ).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Table);
@@ -1202,10 +1202,10 @@ TEST(Parser, Alert_PropagatesAcrossNestedBlockquote)
     // example/nested.md #9 相当: 親 -> ネスト -> 親の続き
     auto nodes = ParseMarkdown(
         L"> [!NOTE]\n"
-        "> Alert head\n"
-        "> > nested\n"
-        ">\n"
-        "> Alert continues"
+        L"> Alert head\n"
+        L"> > nested\n"
+        L">\n"
+        L"> Alert continues"
     ).nodes;
     bool checked_continuation = false;
     for (const auto& n : nodes) {
@@ -1223,8 +1223,8 @@ TEST(Parser, Alert_IgnoredWhenStartedInsideNestedBlockquote)
     // GitHub 仕様: ネスト内 (`> > [!NOTE]`) の Alert マーカーは認識しない
     auto nodes = ParseMarkdown(
         L"> outer\n"
-        "> > [!NOTE]\n"
-        "> > inner note text"
+        L"> > [!NOTE]\n"
+        L"> > inner note text"
     ).nodes;
     for (const auto& n : nodes) {
         EXPECT_EQ(n.alert_type, AlertType::None)
@@ -1323,11 +1323,11 @@ TEST(Parser, SourceOffsetIncreasing)
     // ノードの source_offset は単調増加であるべき
     auto nodes = ParseMarkdown(
         L"# Heading\n\n"
-        "Paragraph\n\n"
-        "- item1\n"
-        "- item2\n\n"
-        "```\ncode\n```\n\n"
-        "End").nodes;
+        L"Paragraph\n\n"
+        L"- item1\n"
+        L"- item2\n\n"
+        L"```\ncode\n```\n\n"
+        L"End").nodes;
     ASSERT_GE(nodes.size(), 3u);
     uint32_t prev = 0;
     for (size_t i = 0; i < nodes.size(); ++i) {
@@ -1423,8 +1423,8 @@ TEST(Parser, SourceOffsetTable)
     // テーブルノードの source_offset はヘッダの最初のセルテキスト
     auto nodes = ParseMarkdown(
         L"| A | B |\n"
-        "|---|---|\n"
-        "| 1 | 2 |").nodes;
+        L"|---|---|\n"
+        L"| 1 | 2 |").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Table);
     // "| " の後の "A" = offset 2

--- a/tests/test_string_convert.cpp
+++ b/tests/test_string_convert.cpp
@@ -53,6 +53,66 @@ TEST(StringConvert, Utf8ToWideRefClearsOnEmpty)
 }
 
 // ═══════════════════════════════════════════════
+// Utf8ToWideStripBom
+// ═══════════════════════════════════════════════
+
+TEST(StringConvert, Utf8ToWideStripBomStripsLeadingBom)
+{
+    std::pmr::wstring out;
+    Utf8ToWideStripBom("\xEF\xBB\xBFHello", out);
+    EXPECT_EQ(out, L"Hello");
+}
+
+TEST(StringConvert, Utf8ToWideStripBomNoBomPassthrough)
+{
+    std::pmr::wstring out;
+    Utf8ToWideStripBom("Hello", out);
+    EXPECT_EQ(out, L"Hello");
+}
+
+TEST(StringConvert, Utf8ToWideStripBomEmptyInput)
+{
+    std::pmr::wstring out = L"old";
+    Utf8ToWideStripBom("", out);
+    EXPECT_TRUE(out.empty());
+}
+
+TEST(StringConvert, Utf8ToWideStripBomBomOnlyResultsEmpty)
+{
+    std::pmr::wstring out = L"old";
+    Utf8ToWideStripBom("\xEF\xBB\xBF", out);
+    EXPECT_TRUE(out.empty());
+}
+
+TEST(StringConvert, Utf8ToWideStripBomOnlyFirstBomStripped)
+{
+    // 2 つ続く BOM は最初の 1 つだけ除去され、残りは U+FEFF として残る。
+    std::pmr::wstring out;
+    Utf8ToWideStripBom("\xEF\xBB\xBF\xEF\xBB\xBF" "A", out);
+    EXPECT_EQ(out.size(), 2u);
+    EXPECT_EQ(out[0], L'\xFEFF');
+    EXPECT_EQ(out[1], L'A');
+}
+
+TEST(StringConvert, Utf8ToWideStripBomBomWithJapanese)
+{
+    std::pmr::wstring out;
+    Utf8ToWideStripBom("\xEF\xBB\xBF日本語", out);
+    EXPECT_EQ(out, L"日本語");
+}
+
+TEST(StringConvert, Utf8ToWideStripBomBomInMiddleNotStripped)
+{
+    // BOM の出現位置が先頭以外なら除去しない（U+FEFF として保持）。
+    std::pmr::wstring out;
+    Utf8ToWideStripBom("A\xEF\xBB\xBF" "B", out);
+    ASSERT_EQ(out.size(), 3u);
+    EXPECT_EQ(out[0], L'A');
+    EXPECT_EQ(out[1], L'\xFEFF');
+    EXPECT_EQ(out[2], L'B');
+}
+
+// ═══════════════════════════════════════════════
 // WideToUtf8
 // ═══════════════════════════════════════════════
 

--- a/tests/test_syntax.cpp
+++ b/tests/test_syntax.cpp
@@ -641,7 +641,7 @@ TEST(Syntax, MultipleLinesOfCode)
 
 TEST(Syntax, ParserExtractsLanguageCpp)
 {
-    auto nodes = ParseMarkdown("```cpp\nint x = 1;\n```").nodes;
+    auto nodes = ParseMarkdown(L"```cpp\nint x = 1;\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::CodeBlock);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Cpp);
@@ -649,42 +649,42 @@ TEST(Syntax, ParserExtractsLanguageCpp)
 
 TEST(Syntax, ParserExtractsLanguagePython)
 {
-    auto nodes = ParseMarkdown("```python\ndef foo(): pass\n```").nodes;
+    auto nodes = ParseMarkdown(L"```python\ndef foo(): pass\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Python);
 }
 
 TEST(Syntax, ParserExtractsLanguageJs)
 {
-    auto nodes = ParseMarkdown("```js\nconst x = 1;\n```").nodes;
+    auto nodes = ParseMarkdown(L"```js\nconst x = 1;\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::JavaScript);
 }
 
 TEST(Syntax, ParserNoLanguage)
 {
-    auto nodes = ParseMarkdown("```\nplain code\n```").nodes;
+    auto nodes = ParseMarkdown(L"```\nplain code\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::None);
 }
 
 TEST(Syntax, ParserExtractsLanguageRust)
 {
-    auto nodes = ParseMarkdown("```rust\nfn main() {}\n```").nodes;
+    auto nodes = ParseMarkdown(L"```rust\nfn main() {}\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Rust);
 }
 
 TEST(Syntax, ParserUnknownLanguage)
 {
-    auto nodes = ParseMarkdown("```java\nclass Main {}\n```").nodes;
+    auto nodes = ParseMarkdown(L"```java\nclass Main {}\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::None);
 }
 
 TEST(Syntax, ParserCaseInsensitiveLanguage)
 {
-    auto nodes = ParseMarkdown("```CPP\nint x;\n```").nodes;
+    auto nodes = ParseMarkdown(L"```CPP\nint x;\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Cpp);
 }
@@ -1745,42 +1745,42 @@ TEST(Syntax, TokensCoverEntireTextJson)
 
 TEST(Syntax, ParserExtractsLanguageGo)
 {
-    auto nodes = ParseMarkdown("```go\nfunc main() {}\n```").nodes;
+    auto nodes = ParseMarkdown(L"```go\nfunc main() {}\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Go);
 }
 
 TEST(Syntax, ParserExtractsLanguageTs)
 {
-    auto nodes = ParseMarkdown("```typescript\nconst x: number = 1;\n```").nodes;
+    auto nodes = ParseMarkdown(L"```typescript\nconst x: number = 1;\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::TypeScript);
 }
 
 TEST(Syntax, ParserExtractsLanguageBash)
 {
-    auto nodes = ParseMarkdown("```bash\necho hello\n```").nodes;
+    auto nodes = ParseMarkdown(L"```bash\necho hello\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Bash);
 }
 
 TEST(Syntax, ParserExtractsLanguagePwsh)
 {
-    auto nodes = ParseMarkdown("```powershell\nWrite-Host hello\n```").nodes;
+    auto nodes = ParseMarkdown(L"```powershell\nWrite-Host hello\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::PowerShell);
 }
 
 TEST(Syntax, ParserExtractsLanguageCmd)
 {
-    auto nodes = ParseMarkdown("```cmd\necho hello\n```").nodes;
+    auto nodes = ParseMarkdown(L"```cmd\necho hello\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Cmd);
 }
 
 TEST(Syntax, ParserExtractsLanguageJson)
 {
-    auto nodes = ParseMarkdown("```json\n{\"k\": 1}\n```").nodes;
+    auto nodes = ParseMarkdown(L"```json\n{\"k\": 1}\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Json);
 }

--- a/tests/test_text_measurer.cpp
+++ b/tests/test_text_measurer.cpp
@@ -31,7 +31,7 @@ TEST_F(MockLayoutTest, EmptyNodesGiveMarginHeight)
 
 TEST_F(MockLayoutTest, SingleParagraphPositiveHeight)
 {
-    auto nodes = ParseMarkdown("Hello world").nodes;
+    auto nodes = ParseMarkdown(L"Hello world").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -41,7 +41,7 @@ TEST_F(MockLayoutTest, SingleParagraphPositiveHeight)
 
 TEST_F(MockLayoutTest, YPositionsAreMonotonicallyIncreasing)
 {
-    auto nodes = ParseMarkdown("A\n\nB\n\nC\n\nD").nodes;
+    auto nodes = ParseMarkdown(L"A\n\nB\n\nC\n\nD").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -52,7 +52,7 @@ TEST_F(MockLayoutTest, YPositionsAreMonotonicallyIncreasing)
 
 TEST_F(MockLayoutTest, NoOverlapBetweenNodes)
 {
-    auto nodes = ParseMarkdown("First\n\nSecond\n\nThird").nodes;
+    auto nodes = ParseMarkdown(L"First\n\nSecond\n\nThird").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -66,7 +66,7 @@ TEST_F(MockLayoutTest, NoOverlapBetweenNodes)
 
 TEST_F(MockLayoutTest, HeadingHasExtraSpacing)
 {
-    auto nodes = ParseMarkdown("Paragraph\n\n# Heading\n\nAnother").nodes;
+    auto nodes = ParseMarkdown(L"Paragraph\n\n# Heading\n\nAnother").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -79,7 +79,7 @@ TEST_F(MockLayoutTest, HeadingHasExtraSpacing)
 
 TEST_F(MockLayoutTest, HeadingTallerThanParagraph)
 {
-    auto nodes = ParseMarkdown("# Heading\n\nParagraph").nodes;
+    auto nodes = ParseMarkdown(L"# Heading\n\nParagraph").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -91,7 +91,7 @@ TEST_F(MockLayoutTest, HeadingTallerThanParagraph)
 
 TEST_F(MockLayoutTest, NoDirtyAfterFullLayout)
 {
-    auto nodes = ParseMarkdown("A\n\nB\n\nC").nodes;
+    auto nodes = ParseMarkdown(L"A\n\nB\n\nC").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -100,7 +100,7 @@ TEST_F(MockLayoutTest, NoDirtyAfterFullLayout)
 
 TEST_F(MockLayoutTest, PartialLayoutLeavesDirtyNodes)
 {
-    auto nodes = ParseMarkdown("A\n\nB\n\nC\n\nD\n\nE").nodes;
+    auto nodes = ParseMarkdown(L"A\n\nB\n\nC\n\nD\n\nE").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     // 部分レイアウト: ビューポート[0, 1)のみ — 非常に小さい
@@ -111,7 +111,7 @@ TEST_F(MockLayoutTest, PartialLayoutLeavesDirtyNodes)
 
 TEST_F(MockLayoutTest, ProcessDirtyBatchResolvesDirty)
 {
-    auto nodes = ParseMarkdown("A\n\nB\n\nC\n\nD\n\nE").nodes;
+    auto nodes = ParseMarkdown(L"A\n\nB\n\nC\n\nD\n\nE").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f, 0.0f, 1.0f);
@@ -128,8 +128,8 @@ TEST_F(MockLayoutTest, ProcessDirtyBatchResolvesDirty)
 
 TEST_F(MockLayoutTest, ProcessDirtyBatchSmallBatch)
 {
-    std::string md;
-    for (int i = 0; i < 50; i++) md += "P" + std::to_string(i) + "\n\n";
+    std::wstring md;
+    for (int i = 0; i < 50; i++) md += L"P" + std::to_wstring(i) + L"\n\n";
     auto nodes = ParseMarkdown(md).nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
@@ -145,7 +145,7 @@ TEST_F(MockLayoutTest, ProcessDirtyBatchSmallBatch)
 
 TEST_F(MockLayoutTest, ProcessDirtyBatchNoDirtyPreservesHeight)
 {
-    auto nodes = ParseMarkdown("A\n\nB\n\nC").nodes;
+    auto nodes = ParseMarkdown(L"A\n\nB\n\nC").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     // フルレイアウト — ダーティノードなし
@@ -165,7 +165,7 @@ TEST_F(MockLayoutTest, ProcessDirtyBatchNoDirtyPreservesHeight)
 
 TEST_F(MockLayoutTest, WidthChangeRecalculates)
 {
-    auto nodes = ParseMarkdown("Some text that could wrap when narrower").nodes;
+    auto nodes = ParseMarkdown(L"Some text that could wrap when narrower").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -179,7 +179,7 @@ TEST_F(MockLayoutTest, WidthChangeRecalculates)
 
 TEST_F(MockLayoutTest, TableHasPositiveHeight)
 {
-    auto nodes = ParseMarkdown("| A | B |\n|---|---|\n| 1 | 2 |").nodes;
+    auto nodes = ParseMarkdown(L"| A | B |\n|---|---|\n| 1 | 2 |").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -197,7 +197,7 @@ TEST_F(MockLayoutTest, TableHasPositiveHeight)
 
 TEST_F(MockLayoutTest, HorizontalRuleHasHeight)
 {
-    auto nodes = ParseMarkdown("Above\n\n---\n\nBelow").nodes;
+    auto nodes = ParseMarkdown(L"Above\n\n---\n\nBelow").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -212,8 +212,8 @@ TEST_F(MockLayoutTest, HorizontalRuleHasHeight)
 
 TEST_F(MockLayoutTest, EnsureVisibleLayoutUpdatesViewport)
 {
-    std::string md;
-    for (int i = 0; i < 20; i++) md += "Paragraph " + std::to_string(i) + "\n\n";
+    std::wstring md;
+    for (int i = 0; i < 20; i++) md += L"Paragraph " + std::to_wstring(i) + L"\n\n";
     auto nodes = ParseMarkdown(md).nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
@@ -231,7 +231,7 @@ TEST_F(MockLayoutTest, EnsureVisibleLayoutUpdatesViewport)
 
 TEST_F(MockLayoutTest, LayoutNodesFullLayout)
 {
-    auto nodes = ParseMarkdown("A\n\nB").nodes;
+    auto nodes = ParseMarkdown(L"A\n\nB").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.LayoutNodes(nodes, cache, 800.0f);
@@ -244,7 +244,7 @@ TEST_F(MockLayoutTest, LayoutNodesFullLayout)
 // Mermaidブロックの初回レイアウトでプレースホルダー高さが設定されること
 TEST_F(MockLayoutTest, MermaidBlockGetsPlaceholderHeight)
 {
-    auto nodes = ParseMarkdown("```mermaid\ngraph TD;\n  A-->B;\n```").nodes;
+    auto nodes = ParseMarkdown(L"```mermaid\ngraph TD;\n  A-->B;\n```").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -260,7 +260,7 @@ TEST_F(MockLayoutTest, MermaidBlockGetsPlaceholderHeight)
 // ビットマップレンダリング後の高さがレイアウト再計算で保持されること（ズーム操作を模擬）
 TEST_F(MockLayoutTest, MermaidHeightPreservedAcrossLayoutCycles)
 {
-    auto nodes = ParseMarkdown("Text\n\n```mermaid\ngraph TD;\n  A-->B;\n```\n\nMore text").nodes;
+    auto nodes = ParseMarkdown(L"Text\n\n```mermaid\ngraph TD;\n  A-->B;\n```\n\nMore text").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.LayoutNodes(nodes, cache, 800.0f);
@@ -293,7 +293,7 @@ TEST_F(MockLayoutTest, MermaidHeightPreservedAcrossLayoutCycles)
 // （500%ズームでMDペインが極小になる場合を模擬）
 TEST_F(MockLayoutTest, MermaidHeightPreservedAtZeroWidth)
 {
-    auto nodes = ParseMarkdown("```mermaid\ngraph TD;\n  A-->B;\n```").nodes;
+    auto nodes = ParseMarkdown(L"```mermaid\ngraph TD;\n  A-->B;\n```").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.LayoutNodes(nodes, cache, 800.0f);
@@ -337,11 +337,11 @@ TEST_F(MockLayoutTest, MermaidHeightPreservedAtZeroWidth)
 TEST_F(MockLayoutTest, LongTableHeightNotShrunkByEstimateInPartialMode)
 {
     // 100 行のテーブル + その後の段落
-    std::string md = "| col1 | col2 |\n|------|------|\n";
+    std::wstring md = L"| col1 | col2 |\n|------|------|\n";
     for (int i = 0; i < 100; i++) {
-        md += "| row" + std::to_string(i) + " | val" + std::to_string(i) + " |\n";
+        md += L"| row" + std::to_wstring(i) + L" | val" + std::to_wstring(i) + L" |\n";
     }
-    md += "\nFollow-up paragraph";
+    md += L"\nFollow-up paragraph";
 
     auto nodes = ParseMarkdown(md).nodes;
     ASSERT_GE(nodes.size(), 2u);
@@ -381,7 +381,7 @@ TEST_F(MockLayoutTest, LongTableHeightNotShrunkByEstimateInPartialMode)
 // 推定値より小さい既存高さは、推定値まで成長させてよい（max_scroll の精度のため）
 TEST_F(MockLayoutTest, PartialModeGrowsHeightWhenEstimateLarger)
 {
-    auto nodes = ParseMarkdown("First\n\nSecond\n\nThird").nodes;
+    auto nodes = ParseMarkdown(L"First\n\nSecond\n\nThird").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
 
@@ -399,9 +399,9 @@ TEST_F(MockLayoutTest, PartialModeGrowsHeightWhenEstimateLarger)
 // (issue #158: col_widths を残すと描画範囲が後続ノード位置を越えて重なる)
 TEST_F(MockLayoutTest, PartialModeClearsTableColWidthsWhenHeightGrows)
 {
-    std::string md = "| a | b |\n|---|---|\n";
+    std::wstring md = L"| a | b |\n|---|---|\n";
     for (int i = 0; i < 50; i++) {
-        md += "| r" + std::to_string(i) + " | v" + std::to_string(i) + " |\n";
+        md += L"| r" + std::to_wstring(i) + L" | v" + std::to_wstring(i) + L" |\n";
     }
     auto nodes = ParseMarkdown(md).nodes;
     LayoutCache cache;
@@ -437,8 +437,8 @@ TEST_F(MockLayoutTest, RecreateFormatsSucceeds)
 
 TEST_F(MockLayoutTest, ManyNodesProduceLargeHeight)
 {
-    std::string md;
-    for (int i = 0; i < 100; i++) md += "Paragraph " + std::to_string(i) + "\n\n";
+    std::wstring md;
+    for (int i = 0; i < 100; i++) md += L"Paragraph " + std::to_wstring(i) + L"\n\n";
     auto nodes = ParseMarkdown(md).nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
@@ -452,7 +452,7 @@ TEST_F(MockLayoutTest, ManyNodesProduceLargeHeight)
 
 TEST_F(MockLayoutTest, ResetClearsAllEntries)
 {
-    auto nodes = ParseMarkdown("Hello\n\nWorld").nodes;
+    auto nodes = ParseMarkdown(L"Hello\n\nWorld").nodes;
     LayoutCache cache;
     cache.Resize(nodes.size());
     engine_.ComputeLayout(nodes, cache, 800.0f);
@@ -476,7 +476,7 @@ TEST_F(MockLayoutTest, ResetClearsAllEntries)
 TEST_F(MockLayoutTest, FileSwitchWithResetProducesCorrectLayout)
 {
     // ファイルAを開くシミュレーション: "# Big Heading\n\nSome paragraph"
-    auto nodes_a = ParseMarkdown("# Big Heading\n\nSome paragraph").nodes;
+    auto nodes_a = ParseMarkdown(L"# Big Heading\n\nSome paragraph").nodes;
     LayoutCache cache;
     cache.Reset(nodes_a.size());
     engine_.LayoutNodes(nodes_a, cache, 800.0f);
@@ -488,7 +488,7 @@ TEST_F(MockLayoutTest, FileSwitchWithResetProducesCorrectLayout)
     EXPECT_GT(para_height_a, 0.0f);
 
     // ファイルBへ切り替えシミュレーション: "Just a paragraph\n\nAnother one\n\nThird"
-    auto nodes_b = ParseMarkdown("Just a paragraph\n\nAnother one\n\nThird").nodes;
+    auto nodes_b = ParseMarkdown(L"Just a paragraph\n\nAnother one\n\nThird").nodes;
     cache.Reset(nodes_b.size());
     engine_.LayoutNodes(nodes_b, cache, 800.0f);
 
@@ -507,7 +507,7 @@ TEST_F(MockLayoutTest, FileSwitchWithResetProducesCorrectLayout)
 TEST_F(MockLayoutTest, FileSwitchSameNodeCountWithResetRecalculates)
 {
     // ファイルA: 見出し2つ
-    auto nodes_a = ParseMarkdown("# H1\n\n## H2").nodes;
+    auto nodes_a = ParseMarkdown(L"# H1\n\n## H2").nodes;
     LayoutCache cache;
     cache.Reset(nodes_a.size());
     engine_.LayoutNodes(nodes_a, cache, 800.0f);
@@ -515,7 +515,7 @@ TEST_F(MockLayoutTest, FileSwitchSameNodeCountWithResetRecalculates)
     float h2_height = cache[1].height;
 
     // ファイルB: 段落2つ（ファイルAと同じノード数）
-    auto nodes_b = ParseMarkdown("alpha\n\nbeta").nodes;
+    auto nodes_b = ParseMarkdown(L"alpha\n\nbeta").nodes;
     cache.Reset(nodes_b.size());
     engine_.LayoutNodes(nodes_b, cache, 800.0f);
 

--- a/tests/test_toc.cpp
+++ b/tests/test_toc.cpp
@@ -14,7 +14,7 @@ TEST(Toc, EmptyDocument)
 
 TEST(Toc, NoHeadings)
 {
-    auto nodes = ParseMarkdown("Just a paragraph.\n\n- List item\n\n> Quote").nodes;
+    auto nodes = ParseMarkdown(L"Just a paragraph.\n\n- List item\n\n> Quote").nodes;
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes);
     EXPECT_TRUE(toc.GetEntries().empty());
@@ -22,7 +22,7 @@ TEST(Toc, NoHeadings)
 
 TEST(Toc, SingleHeading)
 {
-    auto nodes = ParseMarkdown("# Title").nodes;
+    auto nodes = ParseMarkdown(L"# Title").nodes;
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes);
     ASSERT_EQ(toc.GetEntries().size(), 1u);
@@ -34,7 +34,7 @@ TEST(Toc, SingleHeading)
 TEST(Toc, MultipleHeadings)
 {
     auto nodes = ParseMarkdown(
-        "# First\n\n## Second\n\n### Third\n\nParagraph\n\n## Another"
+        L"# First\n\n## Second\n\n### Third\n\nParagraph\n\n## Another"
     ).nodes;
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes);
@@ -47,7 +47,7 @@ TEST(Toc, MultipleHeadings)
 
 TEST(Toc, HeadingTextPreserved)
 {
-    auto nodes = ParseMarkdown("## Hello World").nodes;
+    auto nodes = ParseMarkdown(L"## Hello World").nodes;
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes);
     ASSERT_EQ(toc.GetEntries().size(), 1u);
@@ -56,7 +56,7 @@ TEST(Toc, HeadingTextPreserved)
 
 TEST(Toc, AnchorIdPreserved)
 {
-    auto nodes = ParseMarkdown("## コードブロック").nodes;
+    auto nodes = ParseMarkdown(L"## コードブロック").nodes;
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes);
     ASSERT_EQ(toc.GetEntries().size(), 1u);
@@ -65,8 +65,8 @@ TEST(Toc, AnchorIdPreserved)
 
 TEST(Toc, RebuildClearsPrevious)
 {
-    auto nodes1 = ParseMarkdown("# A\n\n## B").nodes;
-    auto nodes2 = ParseMarkdown("# X").nodes;
+    auto nodes1 = ParseMarkdown(L"# A\n\n## B").nodes;
+    auto nodes2 = ParseMarkdown(L"# X").nodes;
 
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes1);
@@ -81,7 +81,7 @@ TEST(Toc, RebuildClearsPrevious)
 
 TEST(Toc, HitTestValidIndex)
 {
-    auto nodes = ParseMarkdown("# A\n\n## B\n\n### C").nodes;
+    auto nodes = ParseMarkdown(L"# A\n\n## B\n\n### C").nodes;
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes);
 
@@ -92,7 +92,7 @@ TEST(Toc, HitTestValidIndex)
 
 TEST(Toc, HitTestOutOfRange)
 {
-    auto nodes = ParseMarkdown("# A").nodes;
+    auto nodes = ParseMarkdown(L"# A").nodes;
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes);
 
@@ -102,7 +102,7 @@ TEST(Toc, HitTestOutOfRange)
 
 TEST(Toc, HitTestZeroItemHeight)
 {
-    auto nodes = ParseMarkdown("# A").nodes;
+    auto nodes = ParseMarkdown(L"# A").nodes;
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes);
     EXPECT_EQ(toc.HitTest(10.0f, 0.0f), -1);
@@ -118,7 +118,7 @@ TEST(Toc, HitTestEmpty)
 
 TEST(Toc, DuplicateHeadingText)
 {
-    auto nodes = ParseMarkdown("# Title\n\nSome text\n\n# Title\n\nMore text\n\n## Title").nodes;
+    auto nodes = ParseMarkdown(L"# Title\n\nSome text\n\n# Title\n\nMore text\n\n## Title").nodes;
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes);
     ASSERT_EQ(toc.GetEntries().size(), 3u);
@@ -133,9 +133,9 @@ TEST(Toc, DuplicateHeadingText)
 
 TEST(Toc, ManyHeadings)
 {
-    std::string md;
+    std::wstring md;
     for (int i = 0; i < 100; i++) {
-        md += "## Heading " + std::to_string(i) + "\n\ntext\n\n";
+        md += L"## Heading " + std::to_wstring(i) + L"\n\ntext\n\n";
     }
     auto nodes = ParseMarkdown(md).nodes;
     TableOfContents toc;
@@ -146,7 +146,7 @@ TEST(Toc, ManyHeadings)
 TEST(Toc, HeadingLevelsPreserved)
 {
     auto nodes = ParseMarkdown(
-        "# L1\n\n## L2\n\n### L3\n\n#### L4\n\n##### L5\n\n###### L6"
+        L"# L1\n\n## L2\n\n### L3\n\n#### L4\n\n##### L5\n\n###### L6"
     ).nodes;
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes);
@@ -158,7 +158,7 @@ TEST(Toc, HeadingLevelsPreserved)
 
 TEST(Toc, HitTestBoundary)
 {
-    auto nodes = ParseMarkdown("# A\n\n## B").nodes;
+    auto nodes = ParseMarkdown(L"# A\n\n## B").nodes;
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes);
     // アイテム間の境界上ちょうどの位置
@@ -168,7 +168,7 @@ TEST(Toc, HitTestBoundary)
 
 TEST(Toc, HitTestNegativeItemHeight)
 {
-    auto nodes = ParseMarkdown("# A").nodes;
+    auto nodes = ParseMarkdown(L"# A").nodes;
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes);
     EXPECT_EQ(toc.HitTest(10.0f, -1.0f), -1);
@@ -178,7 +178,7 @@ TEST(Toc, HitTestNegativeItemHeight)
 
 TEST(Toc, NodeIndexRecorded)
 {
-    auto nodes = ParseMarkdown("Para\n\n# First\n\nMore text\n\n## Second").nodes;
+    auto nodes = ParseMarkdown(L"Para\n\n# First\n\nMore text\n\n## Second").nodes;
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes);
     ASSERT_EQ(toc.GetEntries().size(), 2u);
@@ -191,7 +191,7 @@ TEST(Toc, NodeIndexRecorded)
 
 TEST(Toc, NodeIndexOrderPreserved)
 {
-    auto nodes = ParseMarkdown("# A\n\n## B\n\n### C").nodes;
+    auto nodes = ParseMarkdown(L"# A\n\n## B\n\n### C").nodes;
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes);
     ASSERT_EQ(toc.GetEntries().size(), 3u);
@@ -211,7 +211,7 @@ TEST(Toc, FindActiveIndexEmpty)
 
 TEST(Toc, FindActiveIndexBeforeFirstHeading)
 {
-    auto nodes = ParseMarkdown("Para\n\n# Title").nodes;
+    auto nodes = ParseMarkdown(L"Para\n\n# Title").nodes;
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes);
 
@@ -228,7 +228,7 @@ TEST(Toc, FindActiveIndexBeforeFirstHeading)
 
 TEST(Toc, FindActiveIndexAtHeading)
 {
-    auto nodes = ParseMarkdown("# First\n\nText\n\n## Second").nodes;
+    auto nodes = ParseMarkdown(L"# First\n\nText\n\n## Second").nodes;
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes);
 
@@ -253,9 +253,9 @@ TEST(Toc, FindActiveIndexAtHeading)
 
 TEST(Toc, FindActiveIndexManyHeadings)
 {
-    std::string md;
+    std::wstring md;
     for (int i = 0; i < 10; ++i) {
-        md += "## H" + std::to_string(i) + "\n\nText\n\n";
+        md += L"## H" + std::to_wstring(i) + L"\n\nText\n\n";
     }
     auto nodes = ParseMarkdown(md).nodes;
     TableOfContents toc;
@@ -279,7 +279,7 @@ TEST(Toc, FindActiveIndexManyHeadings)
 // margin付きのFindActiveIndex: TOCリンククリック時に正しい見出しがアクティブになることを確認
 TEST(Toc, FindActiveIndexWithMargin)
 {
-    auto nodes = ParseMarkdown("# First\n\nText\n\n## Second").nodes;
+    auto nodes = ParseMarkdown(L"# First\n\nText\n\n## Second").nodes;
     TableOfContents toc;
     BuildTocFromNodes(toc, nodes);
 


### PR DESCRIPTION
## Summary

- UTF-8 BOM 除去を `FileLoader::LoadFile` の 2 段読みから `Utf8ToWideStripBom` ラッパーに移し、ファイル読み込みを `ReadFile` 1 回に簡素化
- `ParseMarkdown(std::string_view)` オーバーロード（テスト専用）を削除し、各テストを wide リテラルに移行（テスト毎の UTF-8→UTF-16 変換コストを削減）
- `src/util/file_io.h` の inline 関数 4 つを `file_io.cpp` に分離（Win32 syscall ラッパーで inline の意味なし、include bleed を削減）

それぞれ独立した 3 コミットで分けてあるのでレビュー時はコミット単位で見やすいはずです。

## Test plan

- [x] `cmake --build build --config Release` で `mendo_core` / `mendo_tests` がビルドできる
- [x] `mendo_tests.exe` で全 2063 テスト PASS
- [ ] 実機で BOM 付き / BOM なし Markdown ファイルを開いて見出し位置などにずれがないこと
- [ ] 実機でファイル監視リロード時の動作（`IsFileLargerThan` 経路）に変化がないこと

## Notes

- `Document::FromMarkdown` の `loaded_byte_size_` は今まで BOM 除去後のサイズだったが、今回から BOM を含むファイル全体サイズになる。`IsFileLargerThan` の tolerance は 16 byte あり 3 byte ずれは元から吸収されるため挙動影響なし
- `string_convert.h` の `Utf8ToWide` / `WideToUtf8` も同様に inline 解消余地ありとレビューで指摘されたが今回スコープ外（別 PR で対応予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)