### PR TITLE
style: switch 網羅性の徹底と case ラベルのブレース整形

### DIFF
--- a/src/app/app_controller.cpp
+++ b/src/app/app_controller.cpp
@@ -7,8 +7,10 @@ AppAction AppController::HandleKeyDown(const KeyDownEvent& event) const
     // Alt+矢印キー: 戻る/進むナビゲーション
     if (event.alt && !event.ctrl) {
         switch (event.key) {
-        case VK_LEFT:  return NavigateBackAction{};
-        case VK_RIGHT: return NavigateForwardAction{};
+        case VK_LEFT:
+            return NavigateBackAction{};
+        case VK_RIGHT:
+            return NavigateForwardAction{};
         }
         return NoOpAction{};
     }
@@ -20,9 +22,12 @@ AppAction AppController::HandleKeyDown(const KeyDownEvent& event) const
                 return CopyFormattedClipboardAction{};
             }
             return CopyClipboardAction{};
-        case 'A': return SelectAllAction{};
-        case 'O': return OpenFileAction{};
-        case 'F': return OpenSearchBarAction{};
+        case 'A':
+            return SelectAllAction{};
+        case 'O':
+            return OpenFileAction{};
+        case 'F':
+            return OpenSearchBarAction{};
         case 'G':
             if (event.shift) {
                 return SearchPrevAction{};
@@ -30,8 +35,10 @@ AppAction AppController::HandleKeyDown(const KeyDownEvent& event) const
             else {
                 return SearchNextAction{};
             }
-        case '1': return TogglePaneAction{ PaneTarget::File };
-        case '2': return TogglePaneAction{ PaneTarget::Toc };
+        case '1':
+            return TogglePaneAction{ PaneTarget::File };
+        case '2':
+            return TogglePaneAction{ PaneTarget::Toc };
         case VK_OEM_PLUS:
         case VK_ADD:
             return ZoomAction{ ZoomDirection::In };
@@ -46,13 +53,20 @@ AppAction AppController::HandleKeyDown(const KeyDownEvent& event) const
     }
 
     switch (event.key) {
-    case VK_UP:    return KeyScrollAction{ ScrollType::LineUp };
-    case VK_DOWN:  return KeyScrollAction{ ScrollType::LineDown };
-    case VK_PRIOR: return KeyScrollAction{ ScrollType::PageUp };
-    case VK_NEXT:  return KeyScrollAction{ ScrollType::PageDown };
-    case VK_HOME:  return KeyScrollAction{ ScrollType::Home };
-    case VK_END:   return KeyScrollAction{ ScrollType::End };
-    case VK_F1:    return ShowHelpAction{};
+    case VK_UP:
+        return KeyScrollAction{ ScrollType::LineUp };
+    case VK_DOWN:
+        return KeyScrollAction{ ScrollType::LineDown };
+    case VK_PRIOR:
+        return KeyScrollAction{ ScrollType::PageUp };
+    case VK_NEXT:
+        return KeyScrollAction{ ScrollType::PageDown };
+    case VK_HOME:
+        return KeyScrollAction{ ScrollType::Home };
+    case VK_END:
+        return KeyScrollAction{ ScrollType::End };
+    case VK_F1:
+        return ShowHelpAction{};
     case VK_F3:
         if (event.shift) {
             return SearchPrevAction{};
@@ -60,8 +74,10 @@ AppAction AppController::HandleKeyDown(const KeyDownEvent& event) const
         else {
             return SearchNextAction{};
         }
-    case VK_F5:    return ReloadFileAction{};
-    case VK_ESCAPE: return ClearSelectionAction{};
+    case VK_F5:
+        return ReloadFileAction{};
+    case VK_ESCAPE:
+        return ClearSelectionAction{};
     }
 
     return NoOpAction{};

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -38,8 +38,12 @@ bool App::Init(HWND hwnd)
     win32_host_.Init(hwnd_, cursors_);
     effect_executor_.Init(win32_host_, resource_manager_, doc_service_,
         state_, *layout_service_, {
-            .load_file = [this](std::wstring_view path) { LoadMarkdownFile(path); },
-            .reload_file = [this]() { ReloadCurrentFile(); },
+            .load_file = [this](std::wstring_view path) {
+                LoadMarkdownFile(path);
+            },
+            .reload_file = [this]() {
+                ReloadCurrentFile();
+            },
             .open_file_dialog = [this]() {
                 const auto path = FileLoader::OpenFileDialog(hwnd_);
                 if (!path.empty()) {
@@ -112,7 +116,7 @@ bool App::Init(HWND hwnd)
 
     const auto webview2_data = config_dir.empty()
         ? std::filesystem::path{}
-        : config_dir / L"WebView2Data";
+    : config_dir / L"WebView2Data";
     mermaid_renderer_.Init(hwnd_, renderer_.GetRenderTarget(), renderer_.GetWICFactory(),
         webview2_data, [this]() {
             resource_manager_.ScheduleMermaidBatch();
@@ -128,7 +132,7 @@ bool App::Init(HWND hwnd)
         image_loader_.SetRenderTarget(new_rt);
         image_loader_.ClearCache();
         resource_manager_.LoadImages();
-    });
+        });
 
     theme_service_.LoadDarkMode();
     state_.view.viewport.SetZoomIndex(theme_service_.LoadZoomIndex());
@@ -173,9 +177,15 @@ bool App::Init(HWND hwnd)
 ResourceManager::Callbacks App::BuildResourceManagerCallbacks()
 {
     return {
-        .invalidate = [this]() { Invalidate(); },
-        .set_timer = [this](UINT_PTR id, UINT ms) { SetTimer(hwnd_, id, ms, nullptr); },
-        .kill_timer = [this](UINT_PTR id) { KillTimer(hwnd_, id); },
+        .invalidate = [this]() {
+            Invalidate();
+        },
+        .set_timer = [this](UINT_PTR id, UINT ms) {
+            SetTimer(hwnd_, id, ms, nullptr);
+        },
+        .kill_timer = [this](UINT_PTR id) {
+            KillTimer(hwnd_, id);
+        },
         .get_content_width = [this]() -> float {
             return renderer_.GetTheme().ContentWidth(GetMarkdownPaneWidth());
         },
@@ -201,15 +211,21 @@ ResourceManager::Callbacks App::BuildResourceManagerCallbacks()
 SearchBarController::Callbacks App::BuildSearchBarCallbacks()
 {
     return {
-        .invalidate = [this]() { Invalidate(); },
+        .invalidate = [this]() {
+            Invalidate();
+        },
         .invalidate_search_bar = [this]() {
             const auto& layout = GetPaneLayout();
             const auto& r = layout.md_rect;
             const PaneRect search_area{ r.x, r.y + r.height - SEARCH_BAR_HEIGHT, r.width, SEARCH_BAR_HEIGHT };
             InvalidatePane(search_area);
         },
-        .set_timer = [this](UINT_PTR id, UINT ms) { SetTimer(hwnd_, id, ms, nullptr); },
-        .kill_timer = [this](UINT_PTR id) { KillTimer(hwnd_, id); },
+        .set_timer = [this](UINT_PTR id, UINT ms) {
+            SetTimer(hwnd_, id, ms, nullptr);
+        },
+        .kill_timer = [this](UINT_PTR id) {
+            KillTimer(hwnd_, id);
+        },
         .focus_select_all = [this]() {
             PostMessage(hwnd_, app_msg::SEARCH_FOCUS, app_param::SEARCH_FOCUS_SELECT_ALL, 0);
         },

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -114,9 +114,7 @@ bool App::Init(HWND hwnd)
         }
     );
 
-    const auto webview2_data = config_dir.empty()
-        ? std::filesystem::path{}
-    : config_dir / L"WebView2Data";
+    const auto webview2_data = config_dir.empty() ? std::filesystem::path{} : config_dir / L"WebView2Data";
     mermaid_renderer_.Init(hwnd_, renderer_.GetRenderTarget(), renderer_.GetWICFactory(),
         webview2_data, [this]() {
             resource_manager_.ScheduleMermaidBatch();

--- a/src/app/app_mouse_click.cpp
+++ b/src/app/app_mouse_click.cpp
@@ -115,9 +115,19 @@ void App::HandleFilePaneClick(float dip_x, float dip_y, const PaneLayout& layout
 
     const auto& theme = renderer_.GetTheme();
 
-    if (ProcessSidePaneHeaderClick(dip_x, dip_y, layout.file_rect, theme.pane_header_height, true,
-        [this]() { state_.view.panes.ToggleFilePane(); RefreshPaneLayout(); },
-        [this]() { RefreshFilePane(); })) {
+    if (ProcessSidePaneHeaderClick(
+        dip_x,
+        dip_y,
+        layout.file_rect,
+        theme.pane_header_height,
+        true,
+        [this]() {
+            state_.view.panes.ToggleFilePane();
+            RefreshPaneLayout();
+        },
+        [this]() {
+            RefreshFilePane();
+        })) {
         return;
     }
 
@@ -156,8 +166,16 @@ void App::HandleTocPaneClick(float dip_x, float dip_y, const PaneLayout& layout)
 
     const auto& theme = renderer_.GetTheme();
 
-    if (ProcessSidePaneHeaderClick(dip_x, dip_y, layout.toc_rect, theme.pane_header_height, false,
-        [this]() { state_.view.panes.ToggleTocPane(); RefreshPaneLayout(); },
+    if (ProcessSidePaneHeaderClick(
+        dip_x,
+        dip_y,
+        layout.toc_rect,
+        theme.pane_header_height,
+        false,
+        [this]() {
+            state_.view.panes.ToggleTocPane();
+            RefreshPaneLayout();
+        },
         []() {})) {
         return;
     }

--- a/src/app/side_effect_executor.cpp
+++ b/src/app/side_effect_executor.cpp
@@ -23,13 +23,27 @@ void SideEffectExecutor::Init(IWin32Host& host, ResourceManager& resource_manage
 void SideEffectExecutor::ExecuteOne(const SideEffect& e)
 {
     std::visit(overloaded{
-        [this](const UiEffect& sub) { ExecuteUi(sub); },
-        [this](const WindowEffect& sub) { ExecuteWindow(sub); },
-        [this](const NavigationEffect& sub) { ExecuteNavigation(sub); },
-        [this](const LayoutEffect& sub) { ExecuteLayout(sub); },
-        [this](const ResourceEffect& sub) { ExecuteResource(sub); },
-        [this](const TimerEffect& sub) { ExecuteTimer(sub); },
-        [this](const LifecycleEffect& sub) { ExecuteLifecycle(sub); },
+        [this](const UiEffect& sub) {
+            ExecuteUi(sub);
+        },
+        [this](const WindowEffect& sub) {
+            ExecuteWindow(sub);
+        },
+        [this](const NavigationEffect& sub) {
+            ExecuteNavigation(sub);
+        },
+        [this](const LayoutEffect& sub) {
+            ExecuteLayout(sub);
+        },
+        [this](const ResourceEffect& sub) {
+            ExecuteResource(sub);
+        },
+        [this](const TimerEffect& sub) {
+            ExecuteTimer(sub);
+        },
+        [this](const LifecycleEffect& sub) {
+            ExecuteLifecycle(sub);
+        },
         }, e);
 }
 
@@ -168,8 +182,11 @@ void SideEffectExecutor::ExecuteLayout(const LayoutEffect& e)
         },
         [this](const effect::ViewportLayout& ev) {
             layout_service_->ViewportLayout(
-                state_->document.doc, state_->document.layout_cache,
-                ev.md_width, ev.md_height);
+                state_->document.doc,
+                state_->document.layout_cache,
+                ev.md_width,
+                ev.md_height
+            );
         },
         [this](const effect::SyncMaxScroll& ev) {
             const float total = layout_service_->GetTotalHeight();

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -693,8 +693,8 @@ std::wstring_view GetAlertLabel(AlertType type) noexcept
     case AlertType::Important: return L"Important";
     case AlertType::Warning:   return L"Warning";
     case AlertType::Caution:   return L"Caution";
-    default:                   std::unreachable();
     }
+    std::unreachable();
 }
 
 std::wstring_view GetAlertIcon(AlertType type) noexcept
@@ -706,8 +706,8 @@ std::wstring_view GetAlertIcon(AlertType type) noexcept
     case AlertType::Important: return L"❗";         // ❗ Heavy Exclamation Mark
     case AlertType::Warning:   return L"⚠";         // ⚠ Warning Sign
     case AlertType::Caution:   return L"⛔";         // ⛔ No Entry
-    default:                   std::unreachable();
     }
+    std::unreachable();
 }
 
 namespace {

--- a/src/core/selection_html.cpp
+++ b/src/core/selection_html.cpp
@@ -262,9 +262,8 @@ constexpr std::optional<uint32_t> SyntaxTokenColor(SyntaxTokenType type, const t
         return palette.syntax_preprocessor;
     case SyntaxTokenType::Function:
         return palette.syntax_function;
-    default:
-        std::unreachable();
     }
+    std::unreachable();
 }
 
 constexpr void AppendSyntaxHighlightedSpan(std::pmr::wstring& out, std::wstring_view chunk,

--- a/src/core/selection_html.cpp
+++ b/src/core/selection_html.cpp
@@ -52,12 +52,24 @@ constexpr void AppendHtmlEscaped(std::pmr::wstring& out, std::wstring_view text)
 {
     for (const wchar_t c : text) {
         switch (c) {
-        case L'&': out.append(L"&amp;"); break;
-        case L'<': out.append(L"&lt;"); break;
-        case L'>': out.append(L"&gt;"); break;
-        case L'"': out.append(L"&quot;"); break;
-        case L'\'': out.append(L"&#39;"); break;
-        default: out.push_back(c); break;
+        case L'&':
+            out.append(L"&amp;");
+            break;
+        case L'<':
+            out.append(L"&lt;");
+            break;
+        case L'>':
+            out.append(L"&gt;");
+            break;
+        case L'"':
+            out.append(L"&quot;");
+            break;
+        case L'\'':
+            out.append(L"&#39;");
+            break;
+        default:
+            out.push_back(c);
+            break;
         }
     }
 }
@@ -81,7 +93,8 @@ public:
     // CloseAll() は out_.append() 経由で bad_alloc を投げ得るが、デストラクタからは例外を出さない。
     ~InlineTagScope() noexcept
     {
-        try { CloseAll(); } catch (...) {}
+        try { CloseAll(); }
+        catch (...) {}
     }
 
     // 開く順: <a> → <strong> → <em> → <s> → <code>（code は最内側）。
@@ -230,18 +243,27 @@ constexpr void AppendHexColor(std::pmr::wstring& out, uint32_t rgb)
     out.push_back(kDigits[rgb & 0xF]);
 }
 
-constexpr std::optional<uint32_t> SyntaxTokenColor(SyntaxTokenType type,
-    const theme_palette::SharedColors& palette) noexcept
+constexpr std::optional<uint32_t> SyntaxTokenColor(SyntaxTokenType type, const theme_palette::SharedColors& palette) noexcept
 {
     switch (type) {
-    case SyntaxTokenType::Keyword:      return palette.syntax_keyword;
-    case SyntaxTokenType::Type:         return palette.syntax_type;
-    case SyntaxTokenType::String:       return palette.syntax_string;
-    case SyntaxTokenType::Number:       return palette.syntax_number;
-    case SyntaxTokenType::Comment:      return palette.syntax_comment;
-    case SyntaxTokenType::Preprocessor: return palette.syntax_preprocessor;
-    case SyntaxTokenType::Function:     return palette.syntax_function;
-    default:                            return std::nullopt;
+    case SyntaxTokenType::Plain:
+        return std::nullopt;
+    case SyntaxTokenType::Keyword:
+        return palette.syntax_keyword;
+    case SyntaxTokenType::Type:
+        return palette.syntax_type;
+    case SyntaxTokenType::String:
+        return palette.syntax_string;
+    case SyntaxTokenType::Number:
+        return palette.syntax_number;
+    case SyntaxTokenType::Comment:
+        return palette.syntax_comment;
+    case SyntaxTokenType::Preprocessor:
+        return palette.syntax_preprocessor;
+    case SyntaxTokenType::Function:
+        return palette.syntax_function;
+    default:
+        std::unreachable();
     }
 }
 
@@ -336,7 +358,8 @@ public:
     // Close() は out_.append() 経由で bad_alloc を投げ得るが、デストラクタからは例外を出さない。
     ~TableSectionScope() noexcept
     {
-        try { Close(); } catch (...) {}
+        try { Close(); }
+        catch (...) {}
     }
     TableSectionScope(const TableSectionScope&) = delete;
     TableSectionScope& operator=(const TableSectionScope&) = delete;
@@ -375,9 +398,14 @@ constexpr void AppendTableCellStyle(std::pmr::wstring& out, const TableCell& cel
     AppendHexColor(out, palette.table_border);
     out.append(L";padding:6px 13px");
     switch (cell.align) {
-    case TableAlign::Center: out.append(L";text-align:center"); break;
-    case TableAlign::Right:  out.append(L";text-align:right"); break;
-    default: break;
+    case TableAlign::Center:
+        out.append(L";text-align:center");
+        break;
+    case TableAlign::Right:
+        out.append(L";text-align:right");
+        break;
+    default:
+        break;
     }
     out.append(L";\"");
 }
@@ -452,7 +480,7 @@ std::optional<std::pmr::wstring> FindLinkInRuns(const std::pmr::vector<TextRun>&
 {
     const auto it = std::ranges::find_if(runs, [pos](const TextRun& run) noexcept {
         return run.has_link() && (pos >= run.start) && (pos < run.start + run.length);
-    });
+        });
     if (it == runs.end()) {
         return std::nullopt;
     }
@@ -510,7 +538,7 @@ std::pmr::wstring ExtractSelectedTextAsHtml(const std::pmr::vector<Node>& nodes,
             out.append(list_close_tag);
             list_close_tag = nullptr;
         }
-    };
+        };
 
     for (int i = selection.start_node; i <= selection.end_node; ++i) {
         if (i < 0 || i >= static_cast<int>(nodes.size())) {

--- a/src/core/syntax.cpp
+++ b/src/core/syntax.cpp
@@ -49,7 +49,9 @@ bool IsIdentChar(wchar_t c)
 
 bool IsAtLineStart(std::wstring_view text, size_t pos)
 {
-    if (pos == 0) { return true; }
+    if (pos == 0) {
+        return true;
+    }
     for (size_t i = pos - 1; ; i--) {
         if (text[i] == L'\n') {
             return true;
@@ -252,14 +254,14 @@ std::pmr::vector<SyntaxToken> TokenizeGeneric(
             EmitToken(tokens, plain_start, static_cast<uint32_t>(i) - plain_start, SyntaxTokenType::Plain);
             in_plain = false;
         }
-    };
+        };
 
     const auto start_plain = [&]() {
         if (!in_plain) {
             plain_start = static_cast<uint32_t>(i);
             in_plain = true;
         }
-    };
+        };
 
     while (i < text.size()) {
         const wchar_t c = text[i];

--- a/src/io/file_load_service.h
+++ b/src/io/file_load_service.h
@@ -50,8 +50,8 @@ public:
 
     // ---- パスアクセス ----
 
-    std::wstring_view GetLoadingPath() const noexcept { return loading_path_; }
-    void SetLoadingPath(std::pmr::wstring path) { loading_path_ = std::move(path); }
+    constexpr std::wstring_view GetLoadingPath() const noexcept { return loading_path_; }
+    constexpr void SetLoadingPath(std::pmr::wstring path) noexcept { loading_path_ = std::move(path); }
 
 private:
     // 不変条件: loading_ が true なら async_in_flight_ も true。

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -19,8 +19,15 @@ static float GetSpacingAbove(const Node& node, const Theme& theme) noexcept
     case NodeType::CodeBlock:
     case NodeType::BlockQuote:
         return theme.code_block_spacing_above;
-    default:
+    case NodeType::Paragraph:
+    case NodeType::HorizontalRule:
+    case NodeType::ListItem:
+    case NodeType::Table:
+    case NodeType::TaskListItem:
+    case NodeType::Image:
         return 0.0f;
+    default:
+        std::unreachable();
     }
 }
 
@@ -40,8 +47,12 @@ static float GetSpacingBelow(const Node& node, const Theme& theme) noexcept
         return theme.list_item_spacing;
     case NodeType::HorizontalRule:
         return 0.0f;
-    default:
+    case NodeType::Table:
+    case NodeType::Paragraph:
+    case NodeType::BlockQuote:
         return theme.paragraph_spacing;
+    default:
+        std::unreachable();
     }
 }
 
@@ -106,23 +117,25 @@ float EstimateNodeHeight(const Node& node, const Theme& theme) noexcept
         const float h = theme.font_size_code * 1.3f * static_cast<float>(lines);
         return std::max(h, line_height);
     }
+    case NodeType::HorizontalRule:
+        return theme.paragraph_spacing + theme.hr_thickness;
     case NodeType::Table: {
-        const size_t row_count = node.has_table()
-            ? std::max(static_cast<size_t>(1), node.table_rows().size())
-            : static_cast<size_t>(1);
+        const size_t row_count = node.has_table() ? std::max(1uz, node.table_rows().size()) : 1uz;
         return line_height * static_cast<float>(row_count);
     }
     case NodeType::Image:
         return std::max(60.0f, theme.font_size_body * 3.0f);
-    case NodeType::HorizontalRule:
-        return theme.paragraph_spacing + theme.hr_thickness;
-    default:
+    case NodeType::Paragraph:
+    case NodeType::ListItem:
+    case NodeType::BlockQuote:
+    case NodeType::TaskListItem:
         // テキストの行数からおおよその高さを推定
         if (!node.HasText()) {
             return theme.paragraph_spacing;
         }
-        const int lines = 1 + node.line_count;
-        return line_height * static_cast<float>(lines);
+        return line_height * static_cast<float>(1 + node.line_count);
+    default:
+        std::unreachable();
     }
 }
 

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -26,9 +26,8 @@ static float GetSpacingAbove(const Node& node, const Theme& theme) noexcept
     case NodeType::TaskListItem:
     case NodeType::Image:
         return 0.0f;
-    default:
-        std::unreachable();
     }
+    std::unreachable();
 }
 
 static float GetSpacingBelow(const Node& node, const Theme& theme) noexcept
@@ -36,9 +35,7 @@ static float GetSpacingBelow(const Node& node, const Theme& theme) noexcept
     switch (node.type) {
     case NodeType::Heading:
         // h1/h2 は下線を描くため、下線と次行の余白を確保すべく大きめの値を返す。
-        return (node.heading_level <= 2)
-            ? theme.heading_spacing_below_h1h2
-            : theme.heading_spacing_below;
+        return (node.heading_level <= 2) ? theme.heading_spacing_below_h1h2 : theme.heading_spacing_below;
     case NodeType::CodeBlock:
     case NodeType::Image:
         return theme.paragraph_spacing + theme.code_block_spacing_above;
@@ -51,9 +48,8 @@ static float GetSpacingBelow(const Node& node, const Theme& theme) noexcept
     case NodeType::Paragraph:
     case NodeType::BlockQuote:
         return theme.paragraph_spacing;
-    default:
-        std::unreachable();
     }
+    std::unreachable();
 }
 
 // ---- フリー関数 ----
@@ -134,9 +130,8 @@ float EstimateNodeHeight(const Node& node, const Theme& theme) noexcept
             return theme.paragraph_spacing;
         }
         return line_height * static_cast<float>(1 + node.line_count);
-    default:
-        std::unreachable();
     }
+    std::unreachable();
 }
 
 void EstimateNodeHeights(const std::pmr::vector<Node>& nodes, LayoutCache& cache, const Theme& theme) noexcept


### PR DESCRIPTION
## Summary
- `layout.cpp` の `GetSpacingAbove` / `GetSpacingBelow` / `EstimateNodeHeight` の switch を全 `NodeType` を明示列挙し、`default` を `std::unreachable()` に置換して網羅性を担保
- `selection_html.cpp` の `SyntaxTokenColor` を同様に網羅化（`Plain` を明示し、`default` を `std::unreachable()` 化）
- 各 switch case の `return` / `break` を独立行に整形してスタイルを統一
- パラメータ位置のラムダ本体を複数行整形

## Test plan
- [x] `cmake --build build --config Release` でビルド成功
- [x] `mendo_tests.exe` で全 2063 テストパス