### PR TITLE
chore+perf: コメント整理と描画/レイアウトの最適化

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -33,7 +33,8 @@ static_assert(app_timer::MERMAID_BATCH == ResourceManager::TIMER_MERMAID_BATCH);
 static_assert(app_timer::BITMAP_MANAGE == ResourceManager::TIMER_BITMAP_MANAGE);
 static_assert(app_timer::MERMAID_INIT_RETRY == MermaidRenderer::TIMER_INIT_RETRY);
 
-// DWMWA_USE_IMMERSIVE_DARK_MODE (Windows 10 1809以降 / Windows 11でサポート)
+// DWMWA_USE_IMMERSIVE_DARK_MODE は Windows 10 1809 以降の SDK でしか定義されないため、
+// 古い SDK でビルドできるようフォールバック定義する。
 #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
 #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
 #endif
@@ -43,17 +44,13 @@ static_assert(app_timer::MERMAID_INIT_RETRY == MermaidRenderer::TIMER_INIT_RETRY
 
 void ApplyDarkModeToWindow(HWND hwnd, bool dark)
 {
-    // ダークタイトルバー
     const BOOL value = dark ? TRUE : FALSE;
     DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &value, sizeof(value));
 
-    // エクスプローラーテーマによるダークスクロールバー
+    // エクスプローラーのダークテーマを適用すると非クライアントスクロールバーも
+    // ダーク化される（Windows 標準の挙動を借用）。
     SetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : L"Explorer", nullptr);
 }
-
-// ============================================================
-// ヘルパー
-// ============================================================
 
 App::DipPoint App::PixelToDip(int px, int py) const noexcept
 {
@@ -65,10 +62,6 @@ PaneScrollInfo App::ComputePaneScrollInfo(
 {
     return ComputeScrollInfo(rect, renderer_.GetTheme().pane_header_height, total_content);
 }
-
-// ============================================================
-// ファイル読み込み/リロード共通ヘルパー
-// ============================================================
 
 void App::CancelPendingResources()
 {
@@ -95,10 +88,6 @@ void App::FinalizeLayout(float md_pane_height)
     Invalidate();
     ScheduleDeferredLayoutIfNeeded();
 }
-
-// ============================================================
-// ペインレイアウト
-// ============================================================
 
 const PaneLayout& App::GetPaneLayout()
 {
@@ -159,10 +148,6 @@ float App::GetMarkdownPaneWidth()
     return layout.md_rect.width;
 }
 
-// ============================================================
-// 描画 / リサイズ
-// ============================================================
-
 void App::OnPaint()
 {
     MENDO_PROFILE("OnPaint");
@@ -173,7 +158,6 @@ void App::OnPaint()
     const auto& layout = GetPaneLayout();
     const bool show_loading = file_load_service_.IsLoading() && !state_.pending_reload_retry;
     if (!show_loading) {
-        // 現在表示中のダーティなノードを現在の幅でレイアウトする
         EnsureScrollTarget();
 
         bool updated;
@@ -201,7 +185,6 @@ void App::OnPaint()
         renderer_.DrawLoading(file_load_service_.GetLoadingAngle(), layout.md_rect, sp, tb, gs, ts);
     }
     else {
-        // 検索マッチ情報をコマンドジェネレータに設定
         if (state_.search.search_state.IsVisible() && state_.search.search_state.IsHighlightEnabled() && !state_.search.search_state.GetMatches().empty()) {
             renderer_.SetSearchMatches(&state_.search.search_state.GetMatches(),
                                        state_.search.search_state.GetCurrentMatchIndex(),
@@ -211,7 +194,8 @@ void App::OnPaint()
             renderer_.SetSearchMatches(nullptr, -1, 0);
         }
 
-        // 描画前パス: 可視ノードに描画エフェクトを適用（Render の前に実行）
+        // PrepareVisibleEffects は Render の前に実行する必要がある（描画コマンドが
+        // 各ノードのエフェクト状態を参照するため）。
         renderer_.PrepareVisibleEffects(
             state_.document.doc.GetNodesMut(), state_.document.layout_cache,
             state_.view.viewport.GetScrollY(), layout.md_rect.height);
@@ -237,7 +221,7 @@ void App::OnResize(UINT width, UINT height)
 
 void App::OnDpiChanged(UINT dpi, const RECT* suggested)
 {
-    // Win32 の RECT を platform-agnostic な PixelRect に詰め替える。
+    // reducer をプラットフォーム非依存に保つため、Win32 の RECT を PixelRect に詰め替える。
     const PixelRect rc{
         static_cast<int32_t>(suggested->left),
         static_cast<int32_t>(suggested->top),
@@ -247,15 +231,10 @@ void App::OnDpiChanged(UINT dpi, const RECT* suggested)
     Dispatch(DpiChangedAction{ static_cast<uint32_t>(dpi), rc });
 }
 
-// OnAppImageLoaded / OnAppReloadFile はWM_APPメッセージ経由でresource_manager_に委譲
 void App::OnAppImageLoaded()
 {
     Dispatch(ImageLoadedAction{});
 }
-
-// ============================================================
-// マウスホイール / キーボード
-// ============================================================
 
 void App::OnMouseWheel(int px, int py, short delta, bool ctrl)
 {
@@ -269,7 +248,8 @@ void App::OnMouseWheel(int px, int py, short delta, bool ctrl)
         return;
     }
 
-    // 軸ロック用: 縦スクロール発生をスワイプ検出器に通知
+    // 縦スクロールが発生した時点で SwipeDetector の軸ロックを解除し、
+    // 直後の水平ホイールがスワイプとして誤検出されないようにする。
     const bool had_overlay = state_.interaction.swipe_detector.IsOverlayVisible();
     state_.interaction.swipe_detector.NotifyVScroll(GetTickCount64());
     if (had_overlay) {
@@ -349,7 +329,6 @@ void App::OnCaptureChanged()
 
 void App::ShowToast(std::wstring_view message)
 {
-    // reducer 経由ではなく effect を直接発火する簡易経路。
     effect_executor_.ExecuteOne(effect::ShowToast{ std::pmr::wstring{ message } });
 }
 
@@ -363,7 +342,8 @@ void App::OnDestroy()
     SavePaneState();
     SaveScrollPosition();
     config_.SaveWString("General", "Language", i18n::GetLangKey());
-    // すべての設定値の書き出しを1回にまとめてディスクへ flush する。
+    // 個別 Save 呼び出しでは write が遅延されるため、終了前に明示 flush で
+    // すべての設定値を 1 度のディスク書き込みにまとめる。
     config_.Flush();
     for (UINT_PTR id : {
              app_timer::DEFERRED_LAYOUT,
@@ -399,10 +379,6 @@ RECT App::GetSearchEditRect()
     };
 }
 
-// ============================================================
-// 最後に開いたファイルの永続化
-// ============================================================
-
 void App::SaveLastFilePath()
 {
     if (!IsHelpPath(state_.document.doc.GetFilePath())) {
@@ -421,10 +397,6 @@ void App::ShowDirectory(std::wstring_view dir_path)
     renderer_.InvalidateFilePaneCache();
     Invalidate();
 }
-
-// ============================================================
-// ペイン状態の永続化
-// ============================================================
 
 void App::SavePaneState()
 {

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -40,7 +40,6 @@ public:
     std::pmr::wstring LoadLastFilePath() const;
     void ShowDirectory(std::wstring_view dir_path);
 
-    // Win32Windowから呼び出されるイベントハンドラ
     void OnPaint();
     void OnResize(UINT width, UINT height);
     void OnMouseWheel(int px, int py, short delta, bool ctrl = false);
@@ -58,7 +57,6 @@ public:
     bool OnRButtonUp(int px, int py);
     void OnRButtonMove(int px, int py);
 
-    // ボタン押下なしのマウスホバー処理
     void OnMouseHover(int px, int py);
     void OnMouseLeave()
     {
@@ -66,7 +64,6 @@ public:
     }
     void HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const ::PaneLayout& layout);
 
-    // マウスXボタンによるナビゲーション
     void OnXButtonBack()
     {
         Dispatch(NavigateBackAction{});
@@ -76,14 +73,12 @@ public:
         Dispatch(NavigateForwardAction{});
     }
 
-    // ファイル変更イベント（メッセージループから呼ばれる）
     constexpr HANDLE GetFileWatchEvent() const noexcept
     {
         return doc_service_.GetFileWatchEvent();
     }
     void OnFileWatchEvent();
 
-    // タイマーコールバック
     void HandleTimer(UINT_PTR timer_id);
     void OnAppLoadFile();
     void OnAppReloadFile();
@@ -92,7 +87,6 @@ public:
     void OnCaptureChanged();
     void OnDestroy();
 
-    // 検索（Win32Windowから呼ばれるコールバック）— Reducer経由で状態変更
     void OnSearchTextChanged(std::pmr::wstring text)
     {
         Dispatch(SearchTextChangedAction{ std::move(text) });
@@ -136,7 +130,6 @@ public:
         state_.view.scroll_restore.SetNodeRestore(node, offset);
     }
 
-    // サイズ変更状態 — Reducer経由で状態変更
     void OnEnterSizeMove()
     {
         Dispatch(EnterSizeMoveAction{});
@@ -161,7 +154,6 @@ public:
         return state_.window.cached_dpi_scale;
     }
 
-    // カスタムタイトルバー
     constexpr float GetTitleBarHeightDip() const noexcept
     {
         return state_.window.titlebar.GetHeight();
@@ -178,11 +170,9 @@ public:
     }
 
 private:
-    // AppControllerが返すアクションを実行
     void Dispatch(const AppAction& action);
 
     // reducer を介さない経路から effect を単発発火するヘルパー。
-    // App 内で発生する連鎖処理の最後で SyncTocActive 等を emit する際に使う。
     // SideEffectList を作らずに executor の単発 API へ直送し、毎呼び出しの
     // pmr vector アロケーションを避ける (ホット経路: OnDeferredLayout, OnPaint, OnSizing 等)。
     template <typename T>
@@ -191,35 +181,29 @@ private:
         effect_executor_.ExecuteOne(side_effect_detail::WrapIntoDomain(std::forward<T>(e)));
     }
 
-    // Init用コールバック構築ヘルパー
     ResourceManager::Callbacks BuildResourceManagerCallbacks();
     SearchBarController::Callbacks BuildSearchBarCallbacks();
 
     void EnsureScrollTarget();
 
-    // DIP変換
     struct DipPoint {
         float x, y;
     };
     DipPoint PixelToDip(int px, int py) const noexcept;
 
-    // ヒットテスト
     using HitResult = HitTestService::HitResult;
     HitResult HitTest(int screen_x, int screen_y);
     std::optional<std::pmr::wstring> GetLinkAtHit(const HitResult& hit) const;
     MdPaneHitContext BuildMdPaneHitContext(int px, int py, const PaneLayout& pane_layout) const noexcept;
 
-    // リンク・アンカーナビゲーション
     void HandleLinkClick(std::wstring_view url);
 
-    // クリップボード・選択
     void SetClipboardText(std::wstring_view text) const;
     void CopySelectionToClipboard() const;
     void CopyCodeBlockToClipboard(int node_index) const;
     void SaveDiagramAsPng(int node_index);
     void CopyDiagramAsSvg(int node_index);
 
-    // クリックハンドラ (OnLButtonDownから抽出)
     bool HandleTitleBarClick(float dip_x, float dip_y);
     void HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const PaneLayout& layout);
     void HandleFilePaneClick(float dip_x, float dip_y, const PaneLayout& layout);
@@ -227,10 +211,8 @@ private:
     static bool IsOverPaneScrollbar(float dip_x, const PaneRect& rect,
                                     float total_content, const PaneScrollInfo& scroll_info) noexcept;
 
-    // スクロールバーヘルパー
     PaneScrollInfo ComputePaneScrollInfo(const PaneRect& rect, float total_content) const;
 
-    // レイアウト / スクロール
     void ScheduleDeferredLayoutIfNeeded();
     void InvalidateMdPane(const PaneRect& md_rect);
     void InvalidateHitPositions();
@@ -243,7 +225,6 @@ private:
 
     void SyncTocActiveAndAutoScroll();
 
-    // ファイル読み込み (file_load_service_に委譲)
     void ReloadCurrentFile();
     void DoReloadCurrentFile();
     void DoLoadMarkdownFile();
@@ -289,15 +270,13 @@ private:
     void FinishThemeOrZoomChange();
 
 private:
-    // Win32ハンドル
     HWND hwnd_ = nullptr;
 
     CursorManager cursors_;
 
-    // コアサービス
     Renderer renderer_;
     TaskScheduler scheduler_;
-    MermaidFileCache file_cache_; // mermaid_renderer_より先に宣言（破棄順序の保証）
+    MermaidFileCache file_cache_; // mermaid_renderer_ より先に宣言する（mermaid_renderer_ は破棄時に file_cache_ を参照する）
     MermaidRenderer mermaid_renderer_;
     ImageLoader image_loader_;
     FileWatcher file_watcher_;
@@ -308,10 +287,8 @@ private:
     SessionService session_{ config_ };
     FileLoadService file_load_service_{ doc_service_ };
 
-    // ---- 全状態を集約 ----
     AppState state_;
 
-    // ---- サービス（状態ではなく振る舞い） ----
     HitTestService hit_test_;
     std::optional<LayoutService> layout_service_;
     ResourceManager resource_manager_;
@@ -324,6 +301,7 @@ private:
     // キーは PNG キャッシュと同じ NodeDiagramHash。LatexMath は SVG コピー対象外。
     static constexpr size_t MAX_SVG_CACHE_ENTRIES = 64;
     LruCache<uint64_t, std::pmr::wstring> svg_cache_{ MAX_SVG_CACHE_ENTRIES };
-    // 連続クリック中の重複リクエスト抑止
+    // SVG レンダリングは非同期で 1 秒程度かかる。同じノードを連打されても
+    // 1 件のリクエストに集約するためのフラグ。
     bool svg_copy_in_flight_ = false;
 };

--- a/src/app/app_clipboard.cpp
+++ b/src/app/app_clipboard.cpp
@@ -41,10 +41,6 @@ void App::OnLButtonDblClk(int px, int py)
     InvalidateMdPane(layout.md_rect);
 }
 
-// ============================================================
-// 選択 / クリップボード
-// ============================================================
-
 void App::SetClipboardText(std::wstring_view text) const
 {
     WriteClipboardText(hwnd_, text);
@@ -103,7 +99,6 @@ void App::SaveDiagramAsPng(int node_index)
         return;
     }
 
-    // PNGデータをファイルに書き出す
     if (WriteAllBytes(filename, png.data.get(), png.size)) {
         ShowToast(i18n::S().toast_image_saved);
     }

--- a/src/app/app_constants.h
+++ b/src/app/app_constants.h
@@ -35,7 +35,7 @@ inline constexpr UINT SEARCH_FOCUS = WM_APP + 4;
 inline constexpr UINT SEARCH_UNFOCUS = WM_APP + 5;
 inline constexpr UINT PARSE_COMPLETE = WM_APP + 6;
 
-// カスタムメッセージの上限（この値未満が有効範囲）
+// カスタムメッセージの上限。アプリ独自メッセージかどうかの判定に [WM_APP, END) を使う。
 inline constexpr UINT END = WM_APP + 7;
 
 } // namespace app_msg

--- a/src/app/app_events.h
+++ b/src/app/app_events.h
@@ -10,15 +10,13 @@
 #include <optional>
 
 // プラットフォーム非依存のピクセル矩形。App::OnDpiChanged 境界で
-// Win32 の RECT から各フィールドの値をコピーして生成する。
+// Win32 の RECT から詰め替えて reducer に渡す。
 struct PixelRect {
     int32_t left;
     int32_t top;
     int32_t right;
     int32_t bottom;
 };
-
-// ──── イベント (プラットフォーム非依存のユーザー入力) ────
 
 struct KeyDownEvent {
     int key;
@@ -33,8 +31,6 @@ struct MouseWheelEvent {
     PaneZone zone = PaneZone::MdPane;
 };
 
-// ──── アクション: コマンド系 (アプリが実行すべき操作) ────
-
 enum class ScrollType : uint8_t {
     LineUp,
     LineDown,
@@ -44,17 +40,14 @@ enum class ScrollType : uint8_t {
     End
 };
 
-// キーボード/スクロールバースクロール (Shellがtypeから具体的なdeltaを算出)
 struct KeyScrollAction {
     ScrollType type;
 };
 
-// ホイール/タッチパッドの直接スクロール (アニメーションなし)
 struct DirectScrollByAction {
     float delta;
 };
 
-// ペイン (ファイル/目次) スクロール
 struct ScrollPaneAction {
     PaneZone pane;
     float delta;
@@ -65,7 +58,6 @@ struct CopyFormattedClipboardAction {};
 struct SelectAllAction {};
 struct ClearSelectionAction {};
 
-// サイドペインの切り替え
 enum class PaneTarget : uint8_t {
     File,
     Toc
@@ -94,7 +86,6 @@ constexpr PaneZone ToPaneZone(PaneTarget target) noexcept
     return target == PaneTarget::File ? PaneZone::FilePane : PaneZone::TocPane;
 }
 
-// ズーム操作
 enum class ZoomDirection : uint8_t {
     In,
     Out,
@@ -115,8 +106,6 @@ struct CloseSearchBarAction {};
 struct SearchNextAction {};
 struct SearchPrevAction {};
 struct NoOpAction {};
-
-// ──── アクション: マウスイベント系 ────
 
 struct MouseLeaveAction {};
 struct MdPaneNavHoverAction {
@@ -194,7 +183,6 @@ struct FilePaneFileClickedAction {
 struct TocItemClickedAction {
     std::pmr::wstring anchor_id;
 };
-// リンクからのアンカーナビゲーション（アンカー ID / スラグ）。
 struct NavigateAnchorAction {
     std::pmr::wstring anchor_id;
 };
@@ -213,7 +201,6 @@ struct DropFilesAction {
     std::pmr::wstring path;
 };
 
-// ツールチップ更新（ホバー対象が変わった時に発行）。
 // target.IsEmpty() なら非表示要求。px/py はクライアント座標。
 struct UpdateTooltipAction {
     TooltipTarget target;
@@ -221,10 +208,7 @@ struct UpdateTooltipAction {
     int py;
 };
 
-// ツールチップを即時クリア（タイマー停止 + 状態リセット）。
 struct ClearTooltipAction {};
-
-// ──── アクション: システムイベント系 ────
 
 struct ResizeAction {
     uint32_t width;
@@ -242,16 +226,12 @@ struct ExitSizeMoveAction {};
 struct CaptureChangedAction {};
 struct DestroyAction {};
 
-// ──── アクション: タイマー・非同期コールバック系 ────
-
 struct TimerAction {
     uintptr_t timer_id;
 };
 struct FileWatchAction {};
 struct ParseCompleteAction {};
 struct ImageLoadedAction {};
-
-// ──── アクション: 検索系 ────
 
 struct SearchTextChangedAction {
     std::pmr::wstring text;
@@ -266,10 +246,7 @@ struct ImeCompositionAction {
     std::pmr::wstring text;
 };
 
-// ──── AppAction: 全アクションの統一型 ────
-
 using AppAction = std::variant<
-    // コマンド系
     NoOpAction,
     KeyScrollAction,
     DirectScrollByAction,
@@ -290,7 +267,6 @@ using AppAction = std::variant<
     CloseSearchBarAction,
     SearchNextAction,
     SearchPrevAction,
-    // マウスイベント系
     MouseLeaveAction,
     MdPaneNavHoverAction,
     MdPaneButtonHoverChangedAction,
@@ -321,7 +297,6 @@ using AppAction = std::variant<
     DropFilesAction,
     UpdateTooltipAction,
     ClearTooltipAction,
-    // システムイベント系
     ResizeAction,
     DpiChangedAction,
     ActivateAction,
@@ -329,12 +304,10 @@ using AppAction = std::variant<
     ExitSizeMoveAction,
     CaptureChangedAction,
     DestroyAction,
-    // タイマー・非同期系
     TimerAction,
     FileWatchAction,
     ParseCompleteAction,
     ImageLoadedAction,
-    // 検索系
     SearchTextChangedAction,
     ToggleCaseSensitiveAction,
     ToggleHighlightAction,

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -11,10 +11,6 @@
 #include <algorithm>
 #include <utility>
 
-// ============================================================
-// ファイル読み込み
-// ============================================================
-
 void App::LoadHelpDocument()
 {
     if (IsHelpPath(state_.document.doc.GetFilePath())) {
@@ -37,7 +33,6 @@ void App::LoadHelpDocument()
 
     state_.file_explorer.SetCurrentFile(L"");
 
-    // ビューポート優先レイアウト + 遅延処理
     // 旧ドキュメントで合成された scroll_target は直後の ViewportLayout →
     // ApplyScrollTarget で旧ノード位置から scroll_y を再評価してしまうため、
     // SetScrollY(0) より前に破棄する必要がある。
@@ -108,9 +103,8 @@ bool App::DeferIfPartialWrite(const std::pmr::wstring& path, size_t read_size)
 }
 
 // reducer を経由せず App 層で直接実行する。ファイル I/O + 同期/非同期ロード分岐 +
-// パース + レイアウト初期化を含む大きな命令的ワークフローで、hybrid モデル
-// （reducer.h 参照）の service 経路扱い。reducer 化すると effect variant と
-// executor が肥大化するため意図的に分離している。
+// パース + レイアウト初期化を含む大きな命令的ワークフローで、reducer 化すると
+// effect variant と executor が肥大化するため意図的に service 経路として分離している。
 void App::LoadMarkdownFile(std::wstring_view path)
 {
     EmitEffect(effect::KillTimer{ app_timer::FILE_RELOAD_DEBOUNCE });
@@ -135,7 +129,6 @@ void App::DoLoadMarkdownFile()
 {
     MENDO_PROFILE("DoLoadMarkdownFile");
 
-    // ヘルプ仮想パスの場合は専用ルートへ
     if (IsHelpPath(file_load_service_.GetLoadingPath())) {
         LoadHelpDocument();
         return;
@@ -174,7 +167,7 @@ void App::OnParseComplete()
     auto result = file_load_service_.TakeAsyncResult();
     if (!result) {
         MENDO_TRACE("OnParseComplete: no result (cancelled or load failed)");
-        // LoadFile失敗時、FileWatcherがpausedのまま残るのを防ぐ
+        // 失敗パスでも paused 状態の FileWatcher を必ず再開させる。
         EmitEffect(effect::ResumeFileWatch{});
         HandleLoadFailureFallback();
         return;
@@ -208,7 +201,6 @@ void App::OnParseComplete()
         state_.reload_diff_pos = decision.diff_pos;
     }
     else {
-        // 別ファイルの非同期ロードではリロード用の差分スクロールを使わない
         state_.reload_diff_pos = std::wstring_view::npos;
     }
 
@@ -231,12 +223,10 @@ void App::FinishLoadMarkdownFile(bool heights_estimated)
         state_.file_explorer.SetCurrentFile(state_.document.doc.GetFilePath());
     }
 
-    // ビューポート優先レイアウト: 可視範囲のみ計測し、残りは遅延処理に委ねる。
     const auto pane_layout = GetPaneLayout();
     const float md_width = pane_layout.md_rect.width;
     const float md_height = pane_layout.md_rect.height;
 
-    // スクロール位置の復元
     float scroll_y = 0.0f;
 
     const bool has_reload_diff = (state_.reload_diff_pos != std::wstring_view::npos);
@@ -254,8 +244,8 @@ void App::FinishLoadMarkdownFile(bool heights_estimated)
                      heights_estimated ? 1 : 0);
     }
 
-    // cache.Reset()直後は全ノードの高さが0のため、スクロール復元前に
-    // ノード高さを推定し、Mermaid/画像キャッシュの実測値で補正する
+    // cache.Reset() 直後は全ノードの高さが 0 のため、スクロール復元前に
+    // ノード高さを推定し、Mermaid/画像キャッシュの実測値で補正する。
     if (has_reload_diff || state_.view.scroll_restore.HasNodeRestore()) {
         if (!heights_estimated) {
             MENDO_PROFILE("EstimateNodeHeights");
@@ -301,10 +291,6 @@ void App::FinishLoadMarkdownFile(bool heights_estimated)
     EmitEffect(effect::StartFileWatch{ state_.document.doc.GetFilePath() });
 }
 
-// ============================================================
-// リロード
-// ============================================================
-
 void App::ReloadCurrentFile()
 {
     const auto& path = state_.document.doc.GetFilePath();
@@ -342,7 +328,6 @@ void App::DoReloadCurrentFile()
 
     CancelPendingResources();
 
-    // ファイルを読み込み、旧コンテンツとの差分位置をコピーなしで計算
     auto load_result = [this]() {
         MENDO_PROFILE("Reload::LoadFile");
         return FileLoader::LoadFile(state_.document.doc.GetFilePath());
@@ -404,9 +389,9 @@ void App::FinishReload(size_t diff_pos)
     MENDO_TRACEF("FinishReload: desired_scroll=%.1f diff_pos=%zu",
                  desired_scroll, diff_pos);
 
-    // スクロール位置を設定してからViewportLayoutを呼ぶことで、
-    // 変更箇所周辺の可視ノードが優先的に計測される。
-    // リロード時は直前の navigation target を破棄し、ピクセル位置で固定する。
+    // スクロール位置を先に設定してから ViewportLayout を呼ぶことで、変更箇所周辺の
+    // 可視ノードが優先的に計測される。リロード時は直前の navigation target を破棄し、
+    // ピクセル位置で固定する。
     state_.view.viewport.ClearScrollTarget();
     state_.view.viewport.SetScrollY(desired_scroll);
 
@@ -434,10 +419,6 @@ void App::FinishReload(size_t diff_pos)
 
     EmitEffect(effect::ResumeFileWatch{});
 }
-
-// ============================================================
-// ファイル読み込みヘルパー
-// ============================================================
 
 float App::CalcScrollForDiff(size_t diff_pos, float viewport_height) const
 {

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -1,4 +1,3 @@
-// App の初期化処理 (Init) と ResourceManager / SearchBarController 用のコールバック組み立て。
 #include "app.h"
 #include "app_constants.h"
 #include "file_loader.h"
@@ -18,11 +17,10 @@ bool App::Init(HWND hwnd)
 
     layout_service_.emplace(renderer_.GetLayout(), state_.view.viewport);
 
-    // PixelToDip用にDPIスケールをキャッシュ (OnDpiChangedで更新)
+    // PixelToDip 用に DPI スケールをキャッシュ（OnDpiChanged でも更新する）。
     const float init_dpi = static_cast<float>(GetDpiForWindow(hwnd_));
     state_.window.cached_dpi_scale = (init_dpi > 0.0f) ? (init_dpi / DEFAULT_DPI) : 1.0f;
 
-    // タスクスケジューラを初期化（画像デコード・キャッシュ書き込み共用）
     scheduler_.Init(mermaid_util::ComputeWorkerCount(
         std::thread::hardware_concurrency()));
 
@@ -129,7 +127,7 @@ bool App::Init(HWND hwnd)
     image_loader_.Init(renderer_.GetRenderTarget(), renderer_.GetWICFactory());
     image_loader_.InitAsync(hwnd_, app_msg::IMAGE_LOADED, scheduler_);
 
-    // D2Dデバイスロスト時にレンダーターゲットが再作成されたら、各ローダーを更新
+    // D2D デバイスロストでレンダーターゲットが再作成されたら、各ローダーへ伝搬する。
     renderer_.SetDeviceLostCallback([this](ID2D1RenderTarget* new_rt) {
         mermaid_renderer_.SetRenderTarget(new_rt);
         image_loader_.CancelPending();
@@ -173,10 +171,6 @@ bool App::Init(HWND hwnd)
 
     return true;
 }
-
-// ============================================================
-// Init用コールバック構築
-// ============================================================
 
 ResourceManager::Callbacks App::BuildResourceManagerCallbacks()
 {

--- a/src/app/app_mouse.cpp
+++ b/src/app/app_mouse.cpp
@@ -6,10 +6,6 @@
 #include "resource.h"
 #include "ui_constants.h"
 
-// ============================================================
-// ヒットテスト / リンク抽出 (クリック・ホバー双方で使用)
-// ============================================================
-
 App::HitResult App::HitTest(int screen_x, int screen_y)
 {
     return hit_test_.HitTest(BuildMdPaneHitContext(screen_x, screen_y, GetPaneLayout()));
@@ -34,10 +30,6 @@ std::optional<std::pmr::wstring> App::GetLinkAtHit(const HitResult& hit) const
 
     return FindLinkAtPosition(state_.document.doc.GetNodes()[hit.node_index], hit.text_pos);
 }
-
-// ============================================================
-// タイトルバー クリック
-// ============================================================
 
 bool App::HandleTitleBarClick(float dip_x, float dip_y)
 {
@@ -74,15 +66,12 @@ bool App::HandleTitleBarClick(float dip_x, float dip_y)
     case TitleBarHitZone::Close:
         EmitEffect(effect::PostWindowMessage{ WM_CLOSE, 0, 0 });
         break;
-    default: // タイトルバーの他の領域はWM_NCHITTESTで処理済み
+    default:
+        // タイトルバーのドラッグ領域などは WM_NCHITTEST で処理済み。
         break;
     }
     return true;
 }
-
-// ============================================================
-// L ボタン ディスパッチャ
-// ============================================================
 
 void App::OnLButtonDown(int px, int py)
 {
@@ -164,10 +153,6 @@ void App::OnLButtonUp(int px, int py)
     }
 }
 
-// ============================================================
-// マウス移動ディスパッチャ
-// ============================================================
-
 void App::OnMouseMove(int px, int py)
 {
     auto* rt = renderer_.GetRenderTarget();
@@ -179,7 +164,6 @@ void App::OnMouseMove(int px, int py)
     const float dip_x = dip.x;
     const auto size = rt->GetSize();
 
-    // 検索バー内ドラッグ選択
     if (state_.search.search_bar_ctrl.IsDragging()) {
         const auto layout = GetPaneLayout();
         const auto& r = layout.md_rect;
@@ -227,10 +211,6 @@ void App::OnMouseMove(int px, int py)
     }
     Dispatch(TextSelectionMovedAction{ hit.node_index, hit.text_pos });
 }
-
-// ============================================================
-// R ボタン (ジェスチャー) / X ボタン (ナビゲーション)
-// ============================================================
 
 bool App::OnRButtonDown(int px, int py)
 {

--- a/src/app/app_mouse_click.cpp
+++ b/src/app/app_mouse_click.cpp
@@ -7,13 +7,8 @@
 #include "pane_layout.h"
 #include "ui_constants.h"
 
-// ============================================================
-// MD ペイン — クリック
-// ============================================================
-
 void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const PaneLayout& pane_layout)
 {
-    // 検索バーのクリック処理
     if (state_.search.search_state.IsVisible()) {
         const auto& r = pane_layout.md_rect;
         const auto sbl = ComputeSearchBarLayout(r.x, r.width, r.y + r.height, !state_.search.search_state.GetQuery().empty());
@@ -60,7 +55,7 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
         Dispatch(NavigateForwardAction{});
         return;
     }
-    // コードブロック系ボタン（コピー/SVGコピー/保存）を1回の可視ノード走査でまとめて判定。
+    // コピー/SVG コピー/保存ボタンを 1 回の可視ノード走査でまとめて判定する。
     const auto hit_ctx = BuildMdPaneHitContext(px, py, pane_layout);
     const auto btn_hit = hit_test_.CodeBlockButtonsHitTest(hit_ctx);
     if (btn_hit.copy_node >= 0) {
@@ -75,7 +70,6 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
         SaveDiagramAsPng(btn_hit.save_node);
         return;
     }
-    // MDペインスクロールバーのクリック判定
     if (IsOverMdScrollbar(dip_x, dip_y, pane_layout)) {
         Dispatch(MdScrollbarDragStartedAction{ dip_y, layout_service_->GetTotalHeight() });
         return;
@@ -85,20 +79,12 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
     Dispatch(TextSelectionStartedAction{ hit.node_index, hit.text_pos, px, py });
 }
 
-// ============================================================
-// サイドペイン共通 — ペインスクロールバーの当たり判定
-// ============================================================
-
 bool App::IsOverPaneScrollbar(float dip_x, const PaneRect& rect, float total_content, const PaneScrollInfo& scroll_info) noexcept
 {
     const float local_x = dip_x - rect.x;
     const float hit_left = rect.width - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN - PANE_SCROLLBAR_HIT_PADDING;
     return local_x >= hit_left && total_content > scroll_info.content_height;
 }
-
-// ============================================================
-// ファイルペイン — クリック
-// ============================================================
 
 void App::RefreshFilePane()
 {
@@ -149,10 +135,6 @@ void App::HandleFilePaneClick(float dip_x, float dip_y, const PaneLayout& layout
         }
     }
 }
-
-// ============================================================
-// 目次ペイン — クリック
-// ============================================================
 
 void App::HandleTocPaneClick(float dip_x, float dip_y, const PaneLayout& layout)
 {

--- a/src/app/app_mouse_hover.cpp
+++ b/src/app/app_mouse_hover.cpp
@@ -6,10 +6,6 @@
 #include "pane_layout.h"
 #include "ui_constants.h"
 
-// ============================================================
-// MD ペイン — スクロールバー判定
-// ============================================================
-
 bool App::IsOverMdScrollbar(float dip_x, float dip_y, const PaneLayout& layout) const noexcept
 {
     if (!layout_service_) {
@@ -34,13 +30,8 @@ bool App::IsOverMdScrollbar(float dip_x, float dip_y)
     return IsOverMdScrollbar(dip_x, dip_y, GetPaneLayout());
 }
 
-// ============================================================
-// MD ペイン — ホバー
-// ============================================================
-
 void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const PaneLayout& pane_layout)
 {
-    // 検索バー上のホバー処理
     if (state_.search.search_state.IsVisible()) {
         const auto& r = pane_layout.md_rect;
         const auto sbl = ComputeSearchBarLayout(r.x, r.width, r.y + r.height, !state_.search.search_state.GetQuery().empty());
@@ -61,7 +52,6 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
         }
     }
 
-    // スクロールバー領域では矢印カーソル
     if (IsOverMdScrollbar(dip_x, dip_y, pane_layout)) {
         SetCursor(cursors_.Arrow());
         Dispatch(UpdateTooltipAction{ TooltipTarget{}, px, py });
@@ -76,8 +66,8 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
         return;
     }
 
-    // コピー/保存/SVGコピーボタンのホバー判定（距離 + 時間スロットリングで不要な再計算を回避）。
-    // 1 回の可視ノード走査で 3 つを同時に判定する。
+    // 距離+時間スロットリングで再計算を抑え、1 回の可視ノード走査でコピー/保存/SVG コピー
+    // ボタンのホバーを同時に判定する。
     const auto hit_ctx = BuildMdPaneHitContext(px, py, pane_layout);
     auto& ht = state_.interaction.hover_throttle;
     HoveredButtons new_hover = state_.interaction.hovered;
@@ -114,13 +104,11 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
         return;
     }
 
-    // リンク・画像のヒットテスト
     if (ht.TryMarkMoved(ht.last_md_hit_pos, ht.last_md_hit_tick, px, py)) {
         const auto hit = HitTest(px, py);
         const auto link = GetLinkAtHit(hit);
         ht.last_md_cursor_hand = link.has_value();
 
-        // リンクまたは画像のツールチップ
         TooltipTarget tt;
         if (link.has_value()) {
             tt.zone = TooltipTarget::Zone::MdLink;
@@ -144,10 +132,6 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
     SetCursor(ht.last_md_cursor_hand ? cursors_.Hand() : cursors_.IBeam());
 }
 
-// ============================================================
-// 全体 — ホバー (OnMouseHover)
-// ============================================================
-
 void App::OnMouseHover(int px, int py)
 {
     using mendo::app_mouse::BuildTitleBarTooltip;
@@ -167,7 +151,6 @@ void App::OnMouseHover(int px, int py)
     const float dip_x = dip.x;
     const float dip_y = dip.y;
 
-    // タイトルバーのホバー処理
     if (dip_y < state_.window.titlebar.GetHeight()) {
         const auto tb_zone = state_.window.titlebar.HitTest(dip_x, dip_y);
         SetCursor(cursors_.Arrow());
@@ -177,7 +160,6 @@ void App::OnMouseHover(int px, int py)
         Dispatch(UpdateTooltipAction{ BuildTitleBarTooltip(tb_zone, IsZoomed(hwnd_)), px, py });
         return;
     }
-    // タイトルバー外に出たらホバーをリセット
     if (state_.window.titlebar.SetHovered(TitleBarHitZone::None)) {
         InvalidateTitleBar();
     }
@@ -193,7 +175,7 @@ void App::OnMouseHover(int px, int py)
     int new_file_hover = -1;
     int new_toc_hover = -1;
 
-    // ペインゾーン外に出たら閉じる/更新ボタンのホバーをリセット
+    // ペインゾーン外に出たらヘッダーボタンのホバーをリセット（無効化忘れ防止）。
     if (zone != PaneZone::FilePane) {
         bool changed = state_.view.panes.SetFileCloseHovered(false);
         changed |= state_.view.panes.SetFileRefreshHovered(false);

--- a/src/app/app_navigate.cpp
+++ b/src/app/app_navigate.cpp
@@ -3,10 +3,6 @@
 #include "document_utils.h"
 #include <algorithm>
 
-// ============================================================
-// リンクナビゲーション
-// ============================================================
-
 void App::HandleLinkClick(std::wstring_view url)
 {
     if (url.empty()) {
@@ -26,10 +22,6 @@ void App::HandleLinkClick(std::wstring_view url)
     }
 }
 
-// ============================================================
-// ダークモード
-// ============================================================
-
 void App::SyncPaneThemeCache()
 {
     state_.window.cached_theme = renderer_.GetTheme().ToReducerConstants();
@@ -43,7 +35,6 @@ void App::FinishThemeOrZoomChange()
     float md_width = layout.md_rect.width;
     float md_height = layout.md_rect.height;
 
-    // 表示領域を優先的にレイアウトし、残りは遅延処理に委ねる
     EmitEffect(effect::ViewportLayout{ md_width, md_height });
 
     EmitEffect(effect::SyncMaxScroll{ md_height });
@@ -64,7 +55,6 @@ void App::HandleApplyThemeChange(const effect::ApplyThemeChange& e)
         theme_service_.SaveZoomLevel(e.zoom_index);
     }
     else {
-        // DarkMode
         theme_service_.ToggleDarkMode();
         renderer_.SetTheme(theme_service_.CreateTheme(state_.view.viewport.GetZoomIndex()));
         const bool dark = theme_service_.IsDarkMode();

--- a/src/app/app_scroll.cpp
+++ b/src/app/app_scroll.cpp
@@ -7,10 +7,6 @@
 #include <windows.h>
 #include <algorithm>
 
-// ============================================================
-// スクロールバー・スクロール
-// ============================================================
-
 void App::InvalidateHitPositions()
 {
     state_.interaction.hover_throttle.Reset();
@@ -44,7 +40,7 @@ void App::SyncTocActiveAndAutoScroll()
         return;
     }
 
-    // アクティブ見出しが目次ペインの表示範囲外なら自動スクロール
+    // アクティブ見出しが目次ペインの表示範囲から外れていたら、自動スクロールで追従する。
     const float item_y = static_cast<float>(new_active) * theme.pane_item_height;
     const float total = static_cast<float>(state_.document.doc.GetToc().GetEntries().size()) * theme.pane_item_height;
     const auto info = ComputePaneScrollInfo(layout.toc_rect, total);
@@ -53,7 +49,7 @@ void App::SyncTocActiveAndAutoScroll()
     float& sy = toc_scroll.scroll_y;
     sy = std::clamp(sy, 0.0f, info.max_scroll);
     if (info.content_height > 0.0f) {
-        // フォーカスを表示領域の5等分中、区画2〜4(1/5〜4/5)に留める
+        // フォーカスを表示領域の 1/5〜4/5 帯に留める（端ぴったりだと前後が見えにくい）。
         const float zone_upper = info.content_height * (1.0f / 5.0f);
         const float zone_lower = info.content_height * (4.0f / 5.0f);
         if (item_y < sy + zone_upper) {
@@ -71,7 +67,7 @@ void App::InvalidateMdPane(const PaneRect& md_rect)
         Invalidate();
         return;
     }
-    // MDペインは本文領域のみ無効化する。タイトルバーは別途 InvalidateTitleBar() を使う。
+    // MD ペインの本文領域のみ無効化（タイトルバーは別途 InvalidateTitleBar() で扱う）。
     InvalidatePane(md_rect);
 }
 
@@ -85,10 +81,6 @@ void App::EnsureScrollTarget()
     state_.view.viewport.EnsureScrollTarget(
         state_.document.layout_cache, state_.document.doc.GetNodes().size());
 }
-
-// ============================================================
-// 遅延レイアウト
-// ============================================================
 
 void App::ScheduleDeferredLayoutIfNeeded()
 {
@@ -167,9 +159,9 @@ void App::OnDeferredLayout()
     if (!more) {
         EmitEffect(effect::KillTimer{ app_timer::DEFERRED_LAYOUT });
 
-        // 遅延レイアウト完了: Mermaidファイルキャッシュからの読み込みを
-        // 時間予算付きバッチで処理する。同期ディスクI/O + PNGデコードが
-        // UIスレッドを長時間ブロックするのを防ぐ。
+        // 遅延レイアウト完了後、Mermaid ファイルキャッシュからの読み込みを時間予算付き
+        // バッチで処理する。同期ディスク I/O + PNG デコードが UI スレッドを長時間
+        // ブロックするのを防ぐ。
         resource_manager_.ScheduleMermaidBatch();
 
         EmitEffect(effect::SyncMaxScroll{ md_height });

--- a/src/app/app_state.h
+++ b/src/app/app_state.h
@@ -21,13 +21,11 @@
 #include <string_view>
 #include <memory_resource>
 
-// ---- ドメイン状態: ドキュメントとレイアウトキャッシュ ----
 struct DocumentState {
     Document doc;
     LayoutCache layout_cache;
 };
 
-// ---- 表示・スクロール・ペインの状態 ----
 struct ViewState {
     ViewportManager viewport;
     PaneController panes;
@@ -36,7 +34,6 @@ struct ViewState {
     float cached_total_height = 0.0f;
 };
 
-// ---- ユーザー入力・操作の状態 ----
 struct InteractionState {
     MouseGesture gesture;
     SwipeDetector swipe_detector;
@@ -47,13 +44,11 @@ struct InteractionState {
     NavButtonHover nav_hover = NavButtonHover::None;
 };
 
-// ---- 検索の状態 ----
 struct SearchGroup {
     SearchState search_state;
     SearchBarController search_bar_ctrl;
 };
 
-// ---- ウィンドウ・テーマの状態 ----
 struct WindowState {
     TitleBar titlebar;
     bool is_sizing = false;
@@ -62,29 +57,25 @@ struct WindowState {
     ThemeConstants cached_theme;
 };
 
-// アプリケーションの全状態を集約する構造体
+// アプリケーションの全状態を集約する構造体。
 struct AppState {
-    // ---- サブグループ ----
     DocumentState document;
     ViewState view;
     InteractionState interaction;
     SearchGroup search;
     WindowState window;
 
-    // ---- UIコンポーネント ----
     FileExplorer file_explorer;
     ContextMenu ctx_menu;
     int active_toc_index = -1;
 
-    // ---- リロード管理 ----
     // wstring_view::npos と string_view::npos は同じ値（static_cast<size_t>(-1)）だが、
     // 意味的に wide テキストへのオフセットなので wstring_view 側で揃える。
     size_t reload_diff_pos = std::wstring_view::npos;
-    // 短縮タイマーで再リロード予約済み (DeferPrefixShrink / partial-read race)。
+    // 短縮タイマーで再リロード予約済み（DeferPrefixShrink / partial-read race）。
     // ローディングアニメーションを抑制するために参照される。
     bool pending_reload_retry = false;
 
-    // ---- ペインレイアウトキャッシュ ----
     std::pmr::wstring cached_title_text = L"mendo";
     PaneLayout cached_pane_layout{};
     float cached_window_width_for_layout = 0.0f;

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -45,7 +45,6 @@ void EmitScrollEffects(AppState& state, SideEffectList& effects, float old_scrol
     }
 }
 
-// ノード・オフセットをスクロールターゲットとして反映し、関連する副作用 effect を emit する。
 // TOC クリック / ナビゲーション復帰 / アンカー遷移でこの関数を通ることで、
 // tooltip クリア・invalidation・bitmap manage・TOC 同期の並びが常に一貫する。
 void ApplyScrollTargetAndEmit(AppState& state, SideEffectList& effects, int node, float offset)
@@ -94,10 +93,6 @@ SidePaneContext GetSidePaneContext(AppState& state, PaneTarget pane)
     };
 }
 
-// ============================================================
-// ナビゲーション
-// ============================================================
-
 void ApplyNavResult(AppState& state, SideEffectList& effects, NavEntry&& entry)
 {
     if (!entry.file_path.empty() && !path_util::iequal(entry.file_path, state.document.doc.GetFilePath())) {
@@ -125,10 +120,6 @@ void ReduceNavigateForward(AppState& state, SideEffectList& effects)
     }
 }
 
-// ============================================================
-// スクロール系アクション
-// ============================================================
-
 void ReduceKeyScroll(AppState& state, SideEffectList& effects, const KeyScrollAction& a)
 {
     const float old_scroll = state.view.viewport.GetScrollY();
@@ -151,7 +142,7 @@ void ReduceKeyScroll(AppState& state, SideEffectList& effects, const KeyScrollAc
         state.view.viewport.ApplyScrollTarget(state.document.layout_cache);
         break;
     case ScrollType::End:
-        // 末尾は max_scroll に依存するためピクセル指定。target は無効化される
+        // 末尾は max_scroll に依存するためピクセル指定。scroll target は無効化される。
         state.view.viewport.ScrollTo(state.view.viewport.GetMaxScroll());
         break;
     default:
@@ -182,10 +173,6 @@ void ReduceScrollPane(AppState& state, SideEffectList& effects, const ScrollPane
         PushEffect(effects, effect::InvalidateWindow{});
     }
 }
-
-// ============================================================
-// ペイン・選択・クリップボード
-// ============================================================
 
 void ReduceTogglePane(AppState& state, SideEffectList& effects, const TogglePaneAction& a)
 {
@@ -238,10 +225,6 @@ void ReduceCopyFormattedClipboard(const AppState& state, SideEffectList& effects
     PushEffect(effects, effect::ClipboardWriteHtml{ ExtractSelectedTextAsHtml(nodes, sel, state.window.cached_theme.is_dark), ExtractSelectedText(nodes, sel) });
 }
 
-// ============================================================
-// ズーム・テーマ
-// ============================================================
-
 void ReduceZoom(AppState& state, SideEffectList& effects, const ZoomAction& a)
 {
     {
@@ -268,7 +251,7 @@ void ReduceZoom(AppState& state, SideEffectList& effects, const ZoomAction& a)
     state.view.panes.ApplyZoom(zoom_ratio);
     state.document.layout_cache.InvalidateAllLayouts();
     if (anchor.IsValid()) {
-        // offset もズーム比でスケールし、ノード内の同じ位置が可視先頭に留まるようにする
+        // offset もズーム比でスケールしないと、ノード内の同じ位置が可視先頭に残らない。
         state.view.viewport.SetScrollTarget(anchor.node, anchor.offset * zoom_ratio);
     }
     PushEffect(
@@ -286,7 +269,7 @@ void ReduceToggleDarkMode(AppState& state, SideEffectList& effects)
     // 色のみの変更なのでテキストレイアウトは維持し、effects と Mermaid bitmap のみ破棄する。
     state.document.layout_cache.InvalidateEffectsAndDiagramBitmaps(state.document.doc.GetNodes());
     if (anchor.IsValid()) {
-        // Mermaid 再レンダリングで微小な高さ変化が起きるので target で追従する
+        // Mermaid 再レンダリングで微小な高さ変化が起きるので target で追従する。
         state.view.viewport.SetScrollTarget(anchor.node, anchor.offset);
     }
     PushEffect(
@@ -296,10 +279,6 @@ void ReduceToggleDarkMode(AppState& state, SideEffectList& effects)
             .zoom_index = static_cast<uint8_t>(state.view.viewport.GetZoomIndex()),
         });
 }
-
-// ============================================================
-// ウィンドウ・システムイベント
-// ============================================================
 
 void ReduceActivate(AppState& state, SideEffectList& effects, const ActivateAction& a)
 {
@@ -360,10 +339,6 @@ void ReduceHWheel(AppState& state, SideEffectList& effects, const HWheelAction& 
     }
 }
 
-// ============================================================
-// 検索系アクション
-// ============================================================
-
 void ReduceSearchStep(AppState& state, bool forward)
 {
     if (state.search.search_state.IsVisible()) {
@@ -390,7 +365,8 @@ void ReduceMdPaneNavHover(AppState& state, SideEffectList& effects, const MdPane
         return;
     }
     state.interaction.nav_hover = a.nav_hover;
-    // ナビボタンホバー時は、コピー/保存/SVGコピーボタンホバー状態をクリア（重ならないように）
+    // ナビボタンホバー時はコピー/保存/SVG コピーのホバーをクリアし、ホバーが二重に
+    // 表示されないようにする。
     if (a.nav_hover != NavButtonHover::None) {
         state.interaction.hovered = HoveredButtons{};
     }
@@ -405,10 +381,6 @@ void ReduceMdPaneButtonHoverChanged(AppState& state, SideEffectList& effects, co
     state.interaction.hovered = a.hovered;
     PushEffect(effects, effect::InvalidateWindow{});
 }
-
-// ============================================================
-// スプリッタードラッグ
-// ============================================================
 
 void ReduceSplitterDragStarted(AppState& state, SideEffectList& effects, const SplitterDragStartedAction& a)
 {
@@ -452,10 +424,6 @@ void ReduceSplitterDragEnded(AppState& state, SideEffectList& effects)
     PushEffect(effects, effect::PerformResizeEnd{});
 }
 
-// ============================================================
-// 検索バー入力ドラッグ
-// ============================================================
-
 void ReduceSearchInputDragStarted(AppState& state, SideEffectList& effects, const SearchInputDragStartedAction& a)
 {
     state.search.search_bar_ctrl.StartDrag(a.caret_pos);
@@ -493,10 +461,6 @@ void ReduceSearchInputDragEnded(AppState& state, SideEffectList& effects)
     PushEffect(effects, effect::ReleaseCapture{});
 }
 
-// ============================================================
-// MD ペイン スクロールバードラッグ
-// ============================================================
-
 void ReduceMdScrollbarDragStarted(AppState& state, SideEffectList& effects, const MdScrollbarDragStartedAction& a)
 {
     state.view.panes.StartDrag(PaneController::DragTarget::MdScrollbar);
@@ -507,11 +471,12 @@ void ReduceMdScrollbarDragStarted(AppState& state, SideEffectList& effects, cons
     const auto info = ComputeScrollInfo(md_rect, 0.0f, a.total_height);
     const float thumb_y = ComputeThumbY(info, state.view.viewport.GetScrollY());
     if (a.dip_y >= thumb_y && a.dip_y <= thumb_y + info.thumb_height) {
-        // つまみ上を掴んだ場合はつかみ位置のオフセットのみ記録してスクロール位置は据え置き。
+        // つまみ上を掴んだ場合はつかみ位置のオフセットのみ記録してスクロール位置は据え置く。
         state.view.panes.SetDragScrollOffset(a.dip_y - thumb_y);
         return;
     }
-    // つまみ外クリック: つまみ中心にジャンプしてスクロール位置を更新する。
+    // つまみ外クリック時はつまみ中心へジャンプ。以降の Move でつまみ中心追従するよう
+    // オフセットを thumb_height/2 に設定しておく。
     state.view.panes.SetDragScrollOffset(info.thumb_height * 0.5f);
     const float new_thumb_y = a.dip_y - state.view.panes.GetDragScrollOffset();
     const float old_scroll = state.view.viewport.GetScrollY();
@@ -543,10 +508,6 @@ void ReduceMdScrollbarDragEnded(AppState& state, SideEffectList& effects)
     PushEffect(effects, effect::PerformResizeEnd{});
     PushEffect(effects, effect::BitmapManage{});
 }
-
-// ============================================================
-// サイドペイン (File/Toc) スクロールバードラッグ
-// ============================================================
 
 void ReducePaneScrollbarDragStarted(AppState& state, SideEffectList& effects, const PaneScrollbarDragStartedAction& a)
 {
@@ -593,10 +554,6 @@ void ReducePaneScrollbarDragEnded(AppState& state, SideEffectList& effects)
     PushEffect(effects, effect::ReleaseCapture{});
 }
 
-// ============================================================
-// 本文ペイン テキスト選択ドラッグ
-// ============================================================
-
 void ReduceTextSelectionStarted(AppState& state, SideEffectList& effects, const TextSelectionStartedAction& a)
 {
     state.view.viewport.SetClickStart(a.click_x, a.click_y);
@@ -640,10 +597,6 @@ void ReduceTextSelectionEnded(AppState& state, SideEffectList& effects, const Te
     PushEffect(effects, effect::InvalidateWindow{});
 }
 
-// ============================================================
-// 右クリックジェスチャー
-// ============================================================
-
 void ReduceRightClickGestureStarted(AppState& state, SideEffectList& effects, const RightClickGestureStartedAction& a)
 {
     state.interaction.gesture.OnRButtonDown(a.dip_x, a.dip_y);
@@ -682,10 +635,6 @@ void ReduceRightClickGestureCompleted(AppState& state, SideEffectList& effects, 
     PushEffect(effects, effect::InvalidateWindow{});
 }
 
-// ============================================================
-// ファイルペイン アイテムクリック
-// ============================================================
-
 void ReduceFilePaneDirectoryClicked(AppState& state, SideEffectList& effects, const FilePaneDirectoryClickedAction& a)
 {
     state.file_explorer.SetDirectory(a.full_path);
@@ -702,10 +651,6 @@ void ReduceFilePaneFileClicked(AppState& state, SideEffectList& effects, const F
     PushCurrentNavEntry(state);
     PushEffect(effects, effect::LoadFile{ a.full_path });
 }
-
-// ============================================================
-// TOC アイテムクリック
-// ============================================================
 
 namespace {
 void ScrollToResolvedAnchor(AppState& state, SideEffectList& effects, int idx)
@@ -740,7 +685,7 @@ void ReduceTocItemClicked(AppState& state, SideEffectList& effects, const TocIte
 
 void ReduceNavigateAnchor(AppState& state, SideEffectList& effects, const NavigateAnchorAction& a)
 {
-    // nav 履歴の push は呼び出し側 (App::HandleLinkClick) で行われる
+    // nav 履歴の push は呼び出し側 (App::HandleLinkClick) で行われる。
     ScrollToAnchor(state, effects, a.anchor_id);
 }
 
@@ -763,10 +708,6 @@ void ReduceRestoreScrollAfterLoad(AppState& state, SideEffectList& /*effects*/, 
     }
 }
 
-// ============================================================
-// ファイル・ナビゲーション系アクション
-// ============================================================
-
 void ReduceDropFiles(AppState& state, SideEffectList& effects, const DropFilesAction& a)
 {
     if (!state.document.doc.GetFilePath().empty()) {
@@ -782,10 +723,6 @@ void ReduceShowHelp(AppState& state, SideEffectList& effects)
     }
     PushEffect(effects, effect::LoadFile{ std::pmr::wstring(HELP_PATH) });
 }
-
-// ============================================================
-// タイマー
-// ============================================================
 
 void ReduceTimer(AppState& state, SideEffectList& effects, const TimerAction& a)
 {
@@ -849,10 +786,6 @@ void ReduceTimer(AppState& state, SideEffectList& effects, const TimerAction& a)
 }
 
 } // namespace
-
-// ============================================================
-// Reducer: メインディスパッチ
-// ============================================================
 
 SideEffectList Reduce(AppState& state, const AppAction& action)
 {

--- a/src/app/render_composer.cpp
+++ b/src/app/render_composer.cpp
@@ -13,7 +13,8 @@ GestureRenderState BuildGestureState(const AppState& state)
                                                                                            : 0;
     gs.overlay_alpha = state.interaction.gesture.GetOverlayAlpha();
 
-    // タッチパッドスワイプのオーバーレイ（マウスジェスチャーが非アクティブの場合のみ）
+    // マウスジェスチャーが非アクティブな場合のみ、タッチパッドスワイプ用の
+    // オーバーレイで上書きする（同時表示を避ける）。
     if (!gs.overlay_visible && state.interaction.swipe_detector.IsOverlayVisible()) {
         gs.overlay_visible = true;
         gs.direction = state.interaction.swipe_detector.GetOverlayDirection();

--- a/src/app/resource_manager.cpp
+++ b/src/app/resource_manager.cpp
@@ -71,10 +71,6 @@ void ResourceManager::Init(
     cb_ = std::move(cb);
 }
 
-// ============================================================
-// 画像リソース
-// ============================================================
-
 int ResourceManager::ApplyCachedImages(bool respect_viewport)
 {
     const std::pmr::wstring doc_dir = doc_->GetDirectory();
@@ -121,7 +117,7 @@ int ResourceManager::ApplyCachedImages(bool respect_viewport)
             continue;
         }
 
-        // 解決済みパスのキャッシュを確認し、再計算を回避
+        // 解決済みパスのキャッシュを確認し、再計算を回避する。
         auto [path_it, inserted] = resolved_image_paths_.try_emplace(i);
         auto& abs_str = std::get<1>(*path_it);
         if (inserted) {
@@ -185,10 +181,6 @@ void ResourceManager::OnImageLoadComplete()
     }
 }
 
-// ============================================================
-// Mermaidリソース
-// ============================================================
-
 void ResourceManager::InvalidateMermaidForWidthChange(float content_width)
 {
     if (content_width <= 0.0f) {
@@ -214,7 +206,7 @@ void ResourceManager::InvalidateMermaidForWidthChange(float content_width)
         if (any_invalidated) {
             mermaid_->ClearCache();
         }
-        // 旧幅で処理中のin-flightリクエストを無効化し、完了時に旧bitmapで上書きされるのを防ぐ
+        // 旧幅で処理中の in-flight リクエストを無効化し、完了時に旧 bitmap で上書きされるのを防ぐ。
         mermaid_->CancelPending();
     }
     last_mermaid_content_width_ = content_width;
@@ -350,10 +342,6 @@ void ResourceManager::ProcessMermaidBatch()
     }
 }
 
-// ============================================================
-// ビットマップ管理
-// ============================================================
-
 void ResourceManager::EvictOffscreenBitmaps()
 {
     const float viewport_top = viewport_->GetScrollY();
@@ -368,7 +356,6 @@ void ResourceManager::EvictOffscreenBitmaps()
 
     const size_t node_count = doc_->GetNodes().size();
 
-    // テキストレイアウトの解放
     const int first_keep = FindFirstVisibleNodeIndex(*cache_, node_count, evict_top);
     int last_keep = first_keep;
     for (int i = first_keep; i < static_cast<int>(node_count); i++) {
@@ -381,8 +368,8 @@ void ResourceManager::EvictOffscreenBitmaps()
     cache_->EvictTextLayouts(static_cast<size_t>(first_keep), static_cast<size_t>(last_keep));
 
     // image/diagram bitmap の evict も可視範囲外（[0, first_keep) と
-    // [last_keep, node_count)）だけを走査する。IndexSlice で image/diagram 配列の
-    // 該当部分を切り出して、各々 bitmap をリセット。
+    // [last_keep, node_count)）だけを走査する。IndexSlice で配列の該当部分を
+    // 切り出して、各々 bitmap をリセット。
     const auto& image_indices = doc_->GetImageNodeIndices();
     const auto img_keep = VisibleSlice(image_indices, static_cast<size_t>(first_keep), static_cast<size_t>(last_keep));
     for (auto it = image_indices.begin(); it != img_keep.begin; ++it) {
@@ -422,15 +409,15 @@ void ResourceManager::EvictOffscreenBitmaps()
 void ResourceManager::FlushPendingResources()
 {
     // 完了した非同期デコード結果をキャッシュに格納する。
-    // 結果がある場合はコールバック経由で pending_flush_ が設定される。
+    // 結果があればコールバック経由で pending_flush_ が設定される。
     image_loader_->ProcessCompletedDecodes();
 
     if (!pending_flush_) {
         return;
     }
     pending_flush_ = false;
-    // last_flush_time_ は ScheduleBitmapManage 以外の経路（OnBitmapManageTimer 等）
-    // からのフラッシュでも一元的に更新する
+    // ScheduleBitmapManage 以外（OnBitmapManageTimer 等）からのフラッシュでも
+    // last_flush_time_ を一元的に更新し、両経路で 50ms スロットリングが効くようにする。
     last_flush_time_ = std::chrono::steady_clock::now();
 
     bool changed = (ApplyCachedImages() > 0);
@@ -463,7 +450,8 @@ void ResourceManager::OnBitmapManageTimer()
     cb_.kill_timer(TIMER_BITMAP_MANAGE);
 
     EvictOffscreenBitmaps();
-    pending_flush_ = true; // evict後に可視範囲のリソースを再読み込みする
+    // evict 直後は可視範囲のリソース再読み込みが必要なので強制フラッシュする。
+    pending_flush_ = true;
     FlushPendingResources();
 
     cb_.invalidate();

--- a/src/app/resource_manager.h
+++ b/src/app/resource_manager.h
@@ -39,9 +39,8 @@ public:
               ThemeService& theme_service,
               Callbacks cb);
 
-    // --- 画像リソース ---
-    // respect_viewport=true: 可視範囲のみ走査し、未キャッシュは非同期ロード起動。通常描画用。
-    // respect_viewport=false: 全画像を走査、未キャッシュは無視。リロード時のスクロール計算前用。
+    // respect_viewport=true: 可視範囲のみ走査し、未キャッシュは非同期ロード起動（通常描画用）。
+    // respect_viewport=false: 全画像を走査、未キャッシュは無視（リロード時のスクロール計算前用）。
     int ApplyCachedImages(bool respect_viewport = true);
     int ApplyCachedImagesForReload()
     {
@@ -51,20 +50,17 @@ public:
     void OnAppImageLoaded();
     void OnImageLoadComplete();
 
-    // --- Mermaidリソース ---
     int RequestMermaidRenders();
     void OnMermaidRenderComplete();
     void CancelMermaidBatch();
     void ScheduleMermaidBatch();
     void ProcessMermaidBatch();
 
-    // --- ビットマップ管理 ---
     void EvictOffscreenBitmaps();
     void FlushPendingResources();
     void ScheduleBitmapManage();
     void OnBitmapManageTimer();
 
-    // --- ファイル切替時クリーンアップ ---
     void ClearResolvedPaths() noexcept
     {
         resolved_image_paths_.clear();

--- a/src/app/side_effect.h
+++ b/src/app/side_effect.h
@@ -14,7 +14,6 @@
 
 namespace effect {
 
-// ---- UI / 描画 / 入力系 ----
 struct InvalidateWindow {};
 struct InvalidateTitleBar {};
 struct SetCapture {};
@@ -49,7 +48,6 @@ struct ShowContextMenu {
     int screen_y;
 };
 
-// ---- ウィンドウ / テーマ系 ----
 struct ShowWindowCmd {
     int cmd;
 };
@@ -88,7 +86,6 @@ struct RendererSetDpi {
     float dpi;
 };
 
-// ---- ナビゲーション / 外部操作系 ----
 struct ShellOpen {
     std::pmr::wstring url;
 };
@@ -98,7 +95,6 @@ struct LoadFile {
 struct ReloadFile {};
 struct OpenFileDialog {};
 
-// ---- レイアウト / ペイン / TOC 系 ----
 struct DeferredLayout {};
 struct BitmapManage {};
 struct MermaidBatch {};
@@ -117,7 +113,6 @@ struct SyncMaxScroll {
     float md_pane_height;
 };
 
-// ---- リソース / ファイル監視系 ----
 struct LoadImages {};
 struct RequestMermaidRenders {};
 struct CancelMermaidBatch {};
@@ -130,7 +125,6 @@ struct StopFileWatch {};
 struct ResumeFileWatch {};
 struct CheckFileChanges {};
 
-// ---- タイマー系 ----
 struct SetTimer {
     UINT_PTR id;
     UINT ms;
@@ -144,13 +138,10 @@ struct ProcessMermaidBatchTimer {};
 struct ProcessBitmapManage {};
 struct MermaidInitRetry {};
 
-// ---- ライフサイクル / 永続化系 ----
 struct Destroy {};
 struct HandleParseComplete {};
 
 } // namespace effect
-
-// ---- ドメイン variant ----
 
 using UiEffect = std::variant<
     effect::InvalidateWindow,
@@ -217,7 +208,7 @@ using LifecycleEffect = std::variant<
     effect::Destroy,
     effect::HandleParseComplete>;
 
-// ---- SideEffect: ドメイン variant を束ねる二段 variant ----
+// ドメイン variant を束ねる二段 variant。
 using SideEffect = std::variant<
     UiEffect,
     WindowEffect,
@@ -228,8 +219,6 @@ using SideEffect = std::variant<
     LifecycleEffect>;
 
 using SideEffectList = std::pmr::vector<SideEffect>;
-
-// ---- ドメイン振り分けヘルパー ----
 
 namespace side_effect_detail {
 

--- a/src/app/side_effect_executor.h
+++ b/src/app/side_effect_executor.h
@@ -41,7 +41,6 @@ public:
     void ExecuteOne(const SideEffect& e);
 
 private:
-    // ドメインごとの内側 variant ハンドラ。ExecuteOne から委譲される。
     void ExecuteUi(const UiEffect& e);
     void ExecuteWindow(const WindowEffect& e);
     void ExecuteNavigation(const NavigationEffect& e);

--- a/src/app/win32_host_impl.cpp
+++ b/src/app/win32_host_impl.cpp
@@ -4,7 +4,7 @@
 #include <memory_resource>
 #include <shellapi.h>
 
-// app.h のインクルードは循環依存を招くため前方宣言で代替
+// app.h を直接 include すると循環依存になるため、関数宣言だけ前方参照する。
 void ApplyDarkModeToWindow(HWND hwnd, bool dark);
 
 void Win32Host::Init(HWND hwnd, CursorManager& cursors) noexcept

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -18,7 +18,6 @@ public:
     static Document FromMarkdown(std::pmr::wstring wide, size_t byte_size, std::wstring_view path);
     static Document FromMarkdown(std::pmr::string utf8, std::wstring_view path);
 
-    // アクセサ
     constexpr const std::pmr::vector<Node>& GetNodes() const noexcept
     {
         return nodes_;

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -57,7 +57,6 @@ enum class TableAlign : uint8_t {
     Right = 3,
 };
 
-// テーブルセルデータ（純粋なドメインデータ — レイアウトキャッシュなし）
 struct TableCell {
     std::pmr::wstring text;
     std::pmr::vector<TextRun> runs;
@@ -74,17 +73,14 @@ struct NodeTableData {
     std::pmr::vector<TableRow> rows;
 };
 
-// 見出し専用データ（Headingノードのみ確保してメモリを節約）
 struct NodeHeadingData {
     std::pmr::wstring anchor_id; // 内部リンク向けGitHubスタイルのスラグ
 };
 
-// コードブロック専用データ（CodeBlockノードのみ確保してメモリを節約）
 struct NodeCodeData {
     std::pmr::vector<SyntaxToken> syntax_tokens;
 };
 
-// 画像専用データ（Imageノードのみ確保）
 struct NodeImageData {
     std::pmr::wstring src; // 画像ソースパス（Markdown内の記述）
     float width = 0.0f;    // 元画像の幅（ピクセル）
@@ -169,7 +165,6 @@ struct Node {
         line_count = line_count_value;
     }
 
-    // ---- 拡張データへのアクセサ ----
     // get_if 風に *_data() でポインタを返す。所持していなければ nullptr。
     constexpr NodeTableData* table_data() noexcept
     {
@@ -266,7 +261,6 @@ struct Node {
         return hd ? std::wstring_view{ hd->anchor_id } : std::wstring_view{};
     }
 
-    // ---- link_urls アクセサ ----
     std::pmr::vector<std::pmr::wstring>& ensure_link_urls()
     {
         if (!link_urls) {

--- a/src/core/syntax.cpp
+++ b/src/core/syntax.cpp
@@ -33,8 +33,6 @@ namespace {
 using ascii_util::IsAsciiDigit;
 using ascii_util::IsAsciiHexDigit;
 
-// ---- ヘルパー関数 ----
-
 // 識別子先頭文字: ASCII 英字 + '_' に加え、CJK 等の非 ASCII (>= U+0080) も許可する。
 // ascii_util の純粋 ASCII ヘルパに乗らないので syntax 固有として残す。
 bool IsIdentStart(wchar_t c)
@@ -46,10 +44,6 @@ bool IsIdentChar(wchar_t c)
 {
     return IsIdentStart(c) || IsAsciiDigit(c);
 }
-
-// キーワード・型名テーブルは syntax_keywords.h にある（各言語の KEYWORDS/TYPES）。
-
-// ---- レキサーヘルパー ----
 
 void EmitToken(std::pmr::vector<SyntaxToken>& tokens, uint32_t start, uint32_t length, SyntaxTokenType type)
 {
@@ -195,8 +189,6 @@ size_t ScanBlockComment(std::wstring_view text, size_t pos, wchar_t close1, wcha
     }
     return text.size();
 }
-
-// ---- 汎用トークナイザ ----
 
 struct LexerConfig {
     bool line_comment_slash = false;   // //
@@ -503,8 +495,6 @@ std::pmr::vector<SyntaxToken> TokenizeImpl(
     return tokens;
 }
 
-// ---- 言語別 LexerConfig 定数 ----
-
 inline constexpr LexerConfig CPP_LEXER_CONFIG{
     .line_comment_slash = true,
     .block_comment = true,
@@ -557,8 +547,6 @@ inline constexpr LexerConfig JSON_LEXER_CONFIG{
 };
 
 } // namespace
-
-// ---- 公開API ----
 
 SyntaxLanguage DetectLanguage(std::wstring_view info_string)
 {

--- a/src/io/config_service.cpp
+++ b/src/io/config_service.cpp
@@ -12,10 +12,6 @@
 #pragma comment(lib, "shell32.lib")
 #pragma comment(lib, "ole32.lib")
 
-// ============================================================
-// ディレクトリ・パスヘルパー
-// ============================================================
-
 void ConfigService::SetConfigDirOverride(const std::filesystem::path& dir)
 {
     config_dir_override_ = dir;
@@ -57,10 +53,6 @@ std::filesystem::path ConfigService::GetConfigPath(std::wstring_view filename) c
     }
     return dir / filename;
 }
-
-// ============================================================
-// Load / Flush / Clear
-// ============================================================
 
 void ConfigService::Load()
 {
@@ -108,10 +100,6 @@ void ConfigService::Clear() noexcept
 {
     data_.clear();
 }
-
-// ============================================================
-// 型付きアクセサ
-// ============================================================
 
 const std::string* ConfigService::FindValue(std::string_view section, std::string_view key) const
 {
@@ -184,8 +172,7 @@ std::pmr::wstring SessionService::LoadLastFilePath() const
     if (path.empty()) {
         return {};
     }
-    // 安全なローカルファイルパスであることを検証
-    // UNCパス (\\server\...) やデバイスパス (\\.\, \\?\) をブロック
+    // UNCパス (\\server\...) やデバイスパス (\\.\, \\?\) をブロックしてローカルパスのみ許可。
     if (path.size() >= 2 && path[0] == L'\\' && path[1] == L'\\') {
         return {};
     }

--- a/src/io/file_explorer.cpp
+++ b/src/io/file_explorer.cpp
@@ -42,7 +42,6 @@ void FileExplorer::Refresh()
     // ".." はソート対象外で常に先頭。後段ソートはこの範囲を除く。
     const size_t sort_begin = entries_.size();
 
-    // ディレクトリ内の全アイテムを列挙
     const std::filesystem::path dir_base{ directory_ };
     const auto pattern = dir_base / L"*";
     WIN32_FIND_DATAW fd;
@@ -58,11 +57,9 @@ void FileExplorer::Refresh()
         if (name == L"." || name == L"..") {
             continue;
         }
-        // システムファイルをスキップ
         if (fd.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM) {
             continue;
         }
-        // エントリ数上限
         if (entries_.size() - sort_begin >= MAX_ENTRIES) {
             break;
         }

--- a/src/io/image_loader.cpp
+++ b/src/io/image_loader.cpp
@@ -74,7 +74,6 @@ bool ImageLoader::LoadImage(const std::wstring& abs_path, DiagramEntry& out)
         return false;
     }
 
-    // キャッシュ確認
     if (auto* cached_ptr = cache_.Find(abs_path)) {
         out.bitmap = cached_ptr->bitmap;
         out.width = cached_ptr->width;
@@ -93,7 +92,6 @@ bool ImageLoader::LoadImage(const std::wstring& abs_path, DiagramEntry& out)
         return false;
     }
 
-    // ピクセルサイズを DIP に変換してキャッシュに登録
     const auto [width, height] = CreateAndCacheImage(abs_path, created->bitmap, created->pixel_width, created->pixel_height);
     out.bitmap = std::move(created->bitmap);
     out.width = width;

--- a/src/io/ini_parser.h
+++ b/src/io/ini_parser.h
@@ -27,7 +27,7 @@ inline IniData Parse(std::string_view text)
         }
         std::string_view line = text.substr(pos, eol - pos);
 
-        // 次の行の開始位置を計算（\r\n を1行として処理）
+        // \r\n を 1 行として進める（CRLF/CR/LF を統一して扱う）。
         pos = eol;
         if (pos < text.size() && text[pos] == '\r') {
             ++pos;
@@ -36,19 +36,16 @@ inline IniData Parse(std::string_view text)
             ++pos;
         }
 
-        // 先頭の空白を除去
         const size_t start = line.find_first_not_of(" \t");
         if (start == std::string_view::npos) {
-            continue; // 空行
+            continue;
         }
         line = line.substr(start);
 
-        // コメント行
         if (line[0] == ';' || line[0] == '#') {
             continue;
         }
 
-        // セクションヘッダー
         if (line[0] == '[') {
             const size_t close = line.find(']', 1);
             if (close != std::string_view::npos) {
@@ -57,13 +54,11 @@ inline IniData Parse(std::string_view text)
             continue;
         }
 
-        // キー=値
         const size_t eq = line.find('=');
         if (eq == std::string_view::npos) {
-            continue; // 不正な行は無視
+            continue;
         }
 
-        // キーの末尾の空白を除去
         const std::string_view key_part = line.substr(0, eq);
         const size_t key_end = key_part.find_last_not_of(" \t");
         std::string key;
@@ -74,12 +69,10 @@ inline IniData Parse(std::string_view text)
             continue;
         }
 
-        // 値の先頭の空白を除去
         const std::string_view val_part = line.substr(eq + 1);
         const size_t val_start = val_part.find_first_not_of(" \t");
         std::string value;
         if (val_start != std::string_view::npos) {
-            // 値の末尾の空白を除去
             const size_t val_end = val_part.find_last_not_of(" \t");
             value = std::string(val_part.substr(val_start, val_end - val_start + 1));
         }

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -15,9 +15,15 @@ static constexpr float MIN_DIAGRAM_PLACEHOLDER_HEIGHT = 60.0f;
 // セル幅がこれ以下の差分なら前回の計測高さを再利用する
 static constexpr float CELL_WIDTH_EPSILON = 0.5f;
 
-static HRESULT CreateFormat(IDWriteFactory* factory, const wchar_t* family,
-                            float size, DWRITE_FONT_WEIGHT weight,
-                            IDWriteTextFormat** out)
+// 1 行目の高さを取得し entry にキャッシュする。layout 自体は変えない。
+static void CacheFirstLineHeight(IDWriteTextLayout* layout, NodeLayoutEntry& entry) noexcept
+{
+    DWRITE_LINE_METRICS lm{};
+    UINT32 lc = 0;
+    entry.first_line_height = (SUCCEEDED(layout->GetLineMetrics(&lm, 1, &lc)) && lc > 0) ? lm.height : 0.0f;
+}
+
+static HRESULT CreateFormat(IDWriteFactory* factory, const wchar_t* family, float size, DWRITE_FONT_WEIGHT weight, IDWriteTextFormat** out)
 {
     return factory->CreateTextFormat(
         family, nullptr, weight,
@@ -264,15 +270,17 @@ void DWriteTextMeasurer::MeasureNode(Node& node, NodeLayoutEntry& entry, float m
             entry.text_layout->GetMetrics(&metrics);
             entry.height = metrics.height;
             entry.layout_dirty = false;
-            // 折り返し行が変わるためエフェクト位置 / 検索ハイライト矩形は無効化する。
+            CacheFirstLineHeight(entry.text_layout.Get(), entry);
+            // 折り返し行が変わるためエフェクト位置 / ハイライト矩形は無効化する。
             // text_layout 自体は破棄しない (フォーマット属性は保持される)。
             entry.effects_applied = false;
             entry.clear_inline_code_bgs();
-            entry.invalidate_search_hl_cache();
+            entry.invalidate_per_frame_hl_caches();
             return;
         }
         // 失敗時はスローパスでフルに作り直す。
         entry.text_layout.Reset();
+        entry.first_line_height = 0.0f;
     }
 
     ComPtr<IDWriteTextLayout> layout;
@@ -287,10 +295,9 @@ void DWriteTextMeasurer::MeasureNode(Node& node, NodeLayoutEntry& entry, float m
         return;
     }
 
-    // ラン単位のフォーマットを適用
     ApplyRunFormatting(layout.Get(), node.runs, node.type);
 
-    // Alert ノード: アイコン文字のフォントウェイトを設定
+    // Alert ノードのアイコン文字のフォントウェイトを設定
     if (node.type == NodeType::BlockQuote && node.alert_type != AlertType::None && node.alert_label_length > 0) {
         const UINT32 icon_len = static_cast<UINT32>(GetAlertIcon(node.alert_type).size());
         const DWRITE_TEXT_RANGE icon_range{ 0, icon_len };
@@ -308,12 +315,14 @@ void DWriteTextMeasurer::MeasureNode(Node& node, NodeLayoutEntry& entry, float m
         node.syntax_tokens_mut() = Tokenize(text, node.code_language);
     }
 
+    CacheFirstLineHeight(layout.Get(), entry);
+
     entry.text_layout = std::move(layout);
     entry.height = metrics.height;
     entry.layout_dirty = false;
     entry.effects_applied = false;
     entry.clear_inline_code_bgs();
-    entry.invalidate_search_hl_cache();
+    entry.invalidate_per_frame_hl_caches();
 }
 
 void DWriteTextMeasurer::MeasureTableCells(Node& node, NodeLayoutEntry& entry, std::pmr::vector<float>& natural_widths)
@@ -360,7 +369,7 @@ void DWriteTextMeasurer::FinalizeTableLayout(Node& node, NodeLayoutEntry& entry,
     const float available = max_width - (static_cast<float>(col_count) + 1.0f) * border_width - static_cast<float>(col_count) * cell_padding * 2.0f;
     ComputeColumnWidths(tl.col_widths, natural_widths, available, col_count);
 
-    // セル毎の適用幅/高さキャッシュを確保（幅不変なら GetMetrics を省略）
+    // 適用幅/高さキャッシュ。幅不変なら GetMetrics を省ける。
     const size_t cell_total = tl.cell_layouts.size();
     if (tl.cell_heights.size() != cell_total) {
         tl.cell_heights.assign(cell_total, 0.0f);
@@ -407,7 +416,7 @@ void DWriteTextMeasurer::FinalizeTableLayout(Node& node, NodeLayoutEntry& entry,
         node.SetText(BuildLinearizedTableText(node.table_rows()));
     }
 
-    // ヒットテスト高速化: 行Y累積と列X累積を事前計算
+    // ヒットテスト高速化用に行Y累積と列X累積を事前計算
     tl.row_cum_y.resize(row_count + 1);
     {
         float ry = 0.0f;
@@ -427,7 +436,7 @@ void DWriteTextMeasurer::FinalizeTableLayout(Node& node, NodeLayoutEntry& entry,
         tl.col_cum_x[col_count] = cx;
     }
 
-    // 行ごとのフラットテキストオフセットをプリコンピュート（ヒットテスト高速化用）
+    // ヒットテスト高速化用に行ごとのフラットテキストオフセットをプリコンピュート
     tl.row_flat_offsets.resize(row_count);
     uint32_t flat_offset = 0;
     for (size_t r = 0; r < row_count; r++) {
@@ -437,6 +446,9 @@ void DWriteTextMeasurer::FinalizeTableLayout(Node& node, NodeLayoutEntry& entry,
             flat_offset++; // 改行区切り
         }
     }
+
+    // col_cum_x の末尾は border_width + Σ(col_w + 2*pad + border) と一致するため再計算しない。
+    tl.cached_table_width = tl.col_cum_x.back();
 
     entry.height = total_height;
     entry.layout_dirty = false;
@@ -478,9 +490,10 @@ void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float 
         return;
     }
 
-    // セル layout の再作成 or SetMaxWidth で metrics が変わるため、
-    // 検索ハイライト矩形のキャッシュは捨てる。
-    entry.invalidate_search_hl_cache();
+    // セル layout の再作成 or SetMaxWidth で metrics が変わるため、ハイライト矩形の
+    // キャッシュは捨てる。選択ハイライトキャッシュは本文ノード専用だが、ノード型変更等で
+    // 残っている可能性に備えて落としておく。
+    entry.invalidate_per_frame_hl_caches();
 
     entry.effects_applied = false;
     auto& tl = entry.ensure_table_layout();
@@ -491,12 +504,12 @@ void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float 
     // 第1パス（テキストレイアウト作成）をスキップして列幅再計算だけ行う。
     const bool has_existing_layouts = has_compatible_layouts;
     if (has_existing_layouts) {
-        // キャッシュ済み自然幅を使用し、DirectWrite呼び出しを回避
         if (tl.natural_col_widths.size() == col_count) {
+            // キャッシュ済み自然幅を使用し、DirectWrite呼び出しを回避
             FinalizeTableLayout(node, entry, max_width, col_count, tl.natural_col_widths);
         }
         else {
-            // キャッシュなし: 既存レイアウトから自然幅を再取得
+            // 既存レイアウトから自然幅を再取得
             std::pmr::vector<float> natural_widths(col_count, 0.0f);
             for (size_t r = 0; r < row_count; r++) {
                 const auto cell_count = rows[r].cells.size();
@@ -522,7 +535,7 @@ void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float 
         std::pmr::vector<float> natural_widths(col_count, 0.0f);
         MeasureTableCells(node, entry, natural_widths);
 
-        // 自然幅をキャッシュ（リサイズ高速パス用）
+        // リサイズ高速パス用に自然幅をキャッシュ
         tl.natural_col_widths = std::move(natural_widths);
 
         // 第2パス: 列幅を設定し、行の高さを計測

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -6,7 +6,6 @@
 #include <cmath>
 #include <ranges>
 
-// マジックナンバーの名前付き定数
 static constexpr float MIN_COLUMN_WIDTH = 30.0f;
 static constexpr float COLUMN_WIDTH_PADDING = 4.0f;
 static constexpr float Y_POSITION_EPSILON = 0.01f; // Y座標の早期終了判定用許容誤差（DIP単位）
@@ -51,8 +50,6 @@ static float GetSpacingBelow(const Node& node, const Theme& theme) noexcept
     }
     std::unreachable();
 }
-
-// ---- フリー関数 ----
 
 void ComputeColumnWidths(std::pmr::vector<float>& out, const std::pmr::vector<float>& natural_widths, float available_width, size_t col_count)
 {
@@ -136,7 +133,6 @@ float EstimateNodeHeight(const Node& node, const Theme& theme) noexcept
     case NodeType::ListItem:
     case NodeType::BlockQuote:
     case NodeType::TaskListItem:
-        // テキストの行数からおおよその高さを推定
         if (!node.HasText()) {
             return theme.paragraph_spacing;
         }
@@ -189,10 +185,9 @@ YPositionResult RecomputeYPositions(std::pmr::vector<Node>& nodes, LayoutCache& 
 
         y += GetSpacingAbove(nodes[i], theme);
 
-        // 早期終了: safe_exit_after 以降でY位置が一致すれば、
-        // 以降のノードのY位置は変わらない。
+        // safe_exit_after 以降でY位置が一致すれば、以降のノードのY位置は変わらないので早期終了する。
         if (i > safe_exit_after && std::abs(entry.y_position - y) < Y_POSITION_EPSILON) {
-            // 残りのダーティノードを確認（Y更新より軽量なフラグチェックのみ）
+            // Y更新より軽量なフラグチェックのみで残りのダーティノードを確認
             if (!result.has_dirty_nodes) {
                 result.has_dirty_nodes = std::ranges::any_of(
                     std::views::iota(i, node_count),
@@ -212,8 +207,6 @@ YPositionResult RecomputeYPositions(std::pmr::vector<Node>& nodes, LayoutCache& 
     result.total_height = y + theme.margin_top;
     return result;
 }
-
-// ---- LayoutEngine クラス ----
 
 bool LayoutEngine::Init(ITextMeasurer* measurer, const Theme& theme)
 {
@@ -262,7 +255,6 @@ void LayoutEngine::ComputeLayout(std::pmr::vector<Node>& nodes, LayoutCache& cac
 
         if (needs_layout) {
             if (partial) {
-                // 部分モードでは、可視ノードのレイアウトのみ計算する
                 const float node_bottom = y + entry.height; // 古い高さを使って推定
                 const bool visible = (node_bottom >= viewport_top && y <= viewport_bottom);
                 if (visible) {
@@ -297,6 +289,7 @@ void LayoutEngine::ComputeLayout(std::pmr::vector<Node>& nodes, LayoutCache& cac
                             // 後続ノード位置(entry.height ベース)を越えて重なるのを防ぐ。
                             if (node.type == NodeType::Table && entry.has_table_layout()) {
                                 entry.table_layout->col_widths.clear();
+                                entry.table_layout->cached_table_width = 0.0f;
                             }
                         }
                     }
@@ -313,14 +306,13 @@ void LayoutEngine::ComputeLayout(std::pmr::vector<Node>& nodes, LayoutCache& cac
             any_dirty = true;
         }
 
-        // このパスで直接 Y 位置を設定する
         y += GetSpacingAbove(node, *theme_);
         entry.y_position = y;
         y += entry.height;
         y += GetSpacingBelow(node, *theme_);
 
-        // 早期終了: 部分モードで幅の変更がなく、ビューポートを超えた後に
-        // 高さの変更もなければ、残りの Y 位置は変わらない。
+        // 部分モードで幅の変更がなく、ビューポートを超えた後に
+        // 高さの変更もなければ、残りの Y 位置は変わらないので早期終了する。
         if (partial && !width_changed && !any_height_changed && y > viewport_bottom) {
             // 中断地点より先にダーティノードが存在する可能性を保守的に仮定する。
             // ProcessDirtyBatch が存在しない場合は速やかに確認・クリアする。
@@ -342,8 +334,9 @@ void LayoutEngine::ComputeLayout(std::pmr::vector<Node>& nodes, LayoutCache& cac
 
 void LayoutEngine::LayoutNodes(std::pmr::vector<Node>& nodes, LayoutCache& cache, float viewport_width)
 {
-    last_viewport_width_ = 0.0f;                                                              // 幅の変更検出を強制する
-    ComputeLayout(nodes, cache, viewport_width + theme_->margin_left + theme_->margin_right); // 逆変換: content→viewport
+    last_viewport_width_ = 0.0f; // 幅の変更検出を強制する
+    // 逆変換: content→viewport
+    ComputeLayout(nodes, cache, viewport_width + theme_->margin_left + theme_->margin_right);
 }
 
 bool LayoutEngine::EnsureVisibleLayout(std::pmr::vector<Node>& nodes, LayoutCache& cache, float viewport_width, float viewport_top, float viewport_bottom)
@@ -352,7 +345,6 @@ bool LayoutEngine::EnsureVisibleLayout(std::pmr::vector<Node>& nodes, LayoutCach
     bool any_updated = false;
     int last_measured = -1;
 
-    // 下端が viewport_top 以上の最初のノードを見つける
     const auto node_count = nodes.size();
     const int lo = FindFirstVisibleNodeIndex(cache, node_count, viewport_top);
 
@@ -411,8 +403,7 @@ bool LayoutEngine::ProcessDirtyBatch(std::pmr::vector<Node>& nodes, LayoutCache&
             continue;
         }
 
-        // 時間予算チェック: MeasureNodeの前に判定し、超過分を抑える。
-        // 最低1ノードは処理する（進行を保証）。
+        // MeasureNode の前に判定し超過分を抑えるが、進行保証のため最低1ノードは処理する。
         if (has_budget && processed > 0) {
             const auto elapsed = std::chrono::steady_clock::now() - start;
             if (std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count() >= time_budget_us) {
@@ -450,7 +441,6 @@ bool LayoutEngine::ProcessDirtyBatch(std::pmr::vector<Node>& nodes, LayoutCache&
         has_dirty_nodes_ = false;
     }
 
-    // すべてのダーティノードが処理されたら last_viewport_width_ を更新する
     if (!has_dirty_nodes_) {
         last_viewport_width_ = viewport_width;
     }

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -79,7 +79,7 @@ private:
     bool has_dirty_nodes_ = false;
 };
 
-// LayoutEngine + ViewportManager の組み合わせを薄くラップして、
+// LayoutEngine + ViewportManager の組み合わせを薄くラップし、
 // スクロール target 管理付きのレイアウト操作を提供する。
 class LayoutService {
 public:

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -42,6 +42,9 @@ struct TableLayoutData {
     // FinalizeTableLayout に最後に渡された max_width。CELL_WIDTH_EPSILON 以内の
     // 差分なら全体の再計算を完全スキップできる。負値 = 未設定。
     float last_applied_max_width = -1.0f;
+    // 列幅 + パディング + 罫線の合計。FinalizeTableLayout で確定後不変なので
+    // GenTable から毎フレーム fold_left せずキャッシュを参照する。
+    float cached_table_width = 0.0f;
 
     // フラットインデックスへの変換
     constexpr size_t CellIndex(size_t row, size_t col) const noexcept
@@ -93,9 +96,23 @@ struct SearchHlCache {
     uint32_t gen = 0;
 };
 
+// 選択ハイライト矩形のフレーム間キャッシュ。本文ノード（テーブル外）でのみ使用。
+// (layout, start, length) が一致する間は HitTestTextRange 再計算をスキップする。
+// 新規構築時の layout_ptr=nullptr は確実にミス判定になるため、validity フラグは持たない。
+// text_layout 失効時は invalidate_selection_hl_cache() で unique_ptr ごと破棄する契約。
+struct SelectionHlCache {
+    std::pmr::vector<D2D1_RECT_F> rects;
+    IDWriteTextLayout* layout_ptr = nullptr;
+    uint32_t start = 0;
+    uint32_t length = 0;
+};
+
 struct NodeLayoutEntry {
     float y_position = 0.0f;
     float height = 0.0f;
+    // GetLineMetrics(&lm, 1, &lc) の結果をキャッシュ。0 なら未確定 (フォールバック計算する)。
+    // MeasureNode で text_layout 確定時に同時に求める。
+    float first_line_height = 0.0f;
     Microsoft::WRL::ComPtr<IDWriteTextLayout> text_layout;
     bool layout_dirty = true;
     bool effects_applied = false;
@@ -105,6 +122,8 @@ struct NodeLayoutEntry {
 
     // 検索ヒットがあるノードでのみ確保される。描画中に書き換えるため mutable。
     mutable std::unique_ptr<SearchHlCache> search_hl_cache;
+    // 選択中のノードでのみ確保される。描画中に書き換えるため mutable。
+    mutable std::unique_ptr<SelectionHlCache> selection_hl_cache;
 
     SearchHlCache& ensure_search_hl_cache() const
     {
@@ -117,6 +136,27 @@ struct NodeLayoutEntry {
     void invalidate_search_hl_cache() const noexcept
     {
         search_hl_cache.reset();
+    }
+
+    SelectionHlCache& ensure_selection_hl_cache() const
+    {
+        if (!selection_hl_cache) {
+            selection_hl_cache = std::make_unique<SelectionHlCache>();
+        }
+        return *selection_hl_cache;
+    }
+
+    void invalidate_selection_hl_cache() const noexcept
+    {
+        selection_hl_cache.reset();
+    }
+
+    // text_layout の wrap や format 属性が変わった際に、行折り返し由来のキャッシュ
+    // (検索ハイライト矩形 / 選択ハイライト矩形) を一括で落とす。
+    void invalidate_per_frame_hl_caches() const noexcept
+    {
+        invalidate_search_hl_cache();
+        invalidate_selection_hl_cache();
     }
 
     TableLayoutData& ensure_table_layout()
@@ -275,17 +315,12 @@ public:
         for (auto& e : entries_) {
             e.text_layout.Reset();
             e.effects_applied = false;
+            e.first_line_height = 0.0f;
             e.clear_inline_code_bgs();
-            e.invalidate_search_hl_cache();
+            e.invalidate_per_frame_hl_caches();
             if (e.table_layout) {
-                e.table_layout->cell_layouts.clear();
+                ResetTableLayoutGeometry(*e.table_layout);
                 e.table_layout->cell_inline_code_bgs.clear();
-                e.table_layout->row_bgs_computed.clear();
-                e.table_layout->natural_col_widths.clear();
-                e.table_layout->cell_heights.clear();
-                e.table_layout->cell_applied_widths.clear();
-                e.table_layout->col_count = 0;
-                e.table_layout->last_applied_max_width = -1.0f;
             }
         }
         effects_generation_++;
@@ -355,15 +390,10 @@ public:
         for (auto& e : entries_) {
             e.layout_dirty = true;
             e.text_layout.Reset();
-            e.invalidate_search_hl_cache();
+            e.first_line_height = 0.0f;
+            e.invalidate_per_frame_hl_caches();
             if (e.table_layout) {
-                e.table_layout->cell_layouts.clear();
-                e.table_layout->row_bgs_computed.clear();
-                e.table_layout->natural_col_widths.clear();
-                e.table_layout->cell_heights.clear();
-                e.table_layout->cell_applied_widths.clear();
-                e.table_layout->col_count = 0;
-                e.table_layout->last_applied_max_width = -1.0f;
+                ResetTableLayoutGeometry(*e.table_layout);
             }
         }
         effects_generation_++;
@@ -381,6 +411,21 @@ public:
     }
 
 private:
+    // 列幅 / 行高さ / セルメトリクス系の派生キャッシュを既定値に戻す。
+    // cell_inline_code_bgs は呼び出し側で必要に応じて別途クリアする
+    // (DPI 変更パスは bg を作り直すまで維持する設計)。
+    static void ResetTableLayoutGeometry(TableLayoutData& tl) noexcept
+    {
+        tl.cell_layouts.clear();
+        tl.row_bgs_computed.clear();
+        tl.natural_col_widths.clear();
+        tl.cell_heights.clear();
+        tl.cell_applied_widths.clear();
+        tl.col_count = 0;
+        tl.last_applied_max_width = -1.0f;
+        tl.cached_table_width = 0.0f;
+    }
+
     static void EvictEntryLayout(NodeLayoutEntry& e) noexcept
     {
         if (!e.text_layout && !e.table_layout) {
@@ -388,10 +433,11 @@ private:
         }
         e.text_layout.Reset();
         e.effects_applied = false;
+        e.first_line_height = 0.0f;
         e.clear_inline_code_bgs();
         e.table_layout.reset();
         e.layout_dirty = true;
-        e.invalidate_search_hl_cache();
+        e.invalidate_per_frame_hl_caches();
     }
 
     std::pmr::vector<NodeLayoutEntry> entries_;

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -135,7 +135,9 @@ struct NodeLayoutEntry {
 
     void invalidate_search_hl_cache() const noexcept
     {
-        search_hl_cache.reset();
+        if (search_hl_cache) {
+            search_hl_cache.reset();
+        }
     }
 
     SelectionHlCache& ensure_selection_hl_cache() const
@@ -148,7 +150,9 @@ struct NodeLayoutEntry {
 
     void invalidate_selection_hl_cache() const noexcept
     {
-        selection_hl_cache.reset();
+        if (selection_hl_cache) {
+            selection_hl_cache.reset();
+        }
     }
 
     // text_layout の wrap や format 属性が変わった際に、行折り返し由来のキャッシュ
@@ -306,18 +310,6 @@ public:
     {
         assert(i < diagrams_.size());
         return diagrams_[i];
-    }
-
-    // 全エントリの selection_hl_cache を破棄する。
-    // Why: SelectionHlCache は描画時に lazy 確保され、選択範囲外に出たノードでは
-    // 自動破棄経路が無いため、長時間利用で過去に選択したノード分の unique_ptr/rects
-    // が居残ってメモリが漸増する。CommandGenerator 側で「選択範囲が縮小/解除された
-    // フレーム」を検出して、対象ノードの cache を巻き戻すのに使う。
-    void ClearAllSelectionHlCaches() const noexcept
-    {
-        for (const auto& e : entries_) {
-            e.invalidate_selection_hl_cache();
-        }
     }
 
     // すべてのテキストレイアウトとエフェクトを無効化する（テーマ/ズーム変更時）。

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -308,6 +308,18 @@ public:
         return diagrams_[i];
     }
 
+    // 全エントリの selection_hl_cache を破棄する。
+    // Why: SelectionHlCache は描画時に lazy 確保され、選択範囲外に出たノードでは
+    // 自動破棄経路が無いため、長時間利用で過去に選択したノード分の unique_ptr/rects
+    // が居残ってメモリが漸増する。CommandGenerator 側で「選択範囲が縮小/解除された
+    // フレーム」を検出して、対象ノードの cache を巻き戻すのに使う。
+    void ClearAllSelectionHlCaches() const noexcept
+    {
+        for (const auto& e : entries_) {
+            e.invalidate_selection_hl_cache();
+        }
+    }
+
     // すべてのテキストレイアウトとエフェクトを無効化する（テーマ/ズーム変更時）。
     // ダイアグラム/Mermaid キャッシュの処理は呼び出し側で別途行うこと。
     void InvalidateAllLayouts() noexcept

--- a/src/render/command_executor.cpp
+++ b/src/render/command_executor.cpp
@@ -8,12 +8,20 @@ ID2D1SolidColorBrush* CommandExecutor::GetBrush(ID2D1RenderTarget* rt, D2D1_COLO
         brush_pool_.clear();
         use_counter_ = 0;
         bound_rt_ = rt;
+        last_brush_ = nullptr;
     }
     const uint32_t key = command_executor_internal::PackColor(color);
+    // 直前と同色なら hash lookup を完全にスキップ。同色連続発行（罫線、ハイライト、
+    // 同テーマ色のテキスト等）が多いためヒット率が高い。
+    if (last_brush_ && key == last_brush_key_) {
+        return last_brush_;
+    }
     const uint64_t now = ++use_counter_;
     if (const auto it = brush_pool_.find(key); it != brush_pool_.end()) {
         it->second.last_used = now;
-        return it->second.brush.Get();
+        last_brush_key_ = key;
+        last_brush_ = it->second.brush.Get();
+        return last_brush_;
     }
     if (brush_pool_.size() >= MAX_POOLED_BRUSHES) {
         // LRU: 全消去によるフレームスパイクを避けるため最古エントリ 1 つだけ追い出す。
@@ -23,6 +31,10 @@ ID2D1SolidColorBrush* CommandExecutor::GetBrush(ID2D1RenderTarget* rt, D2D1_COLO
                 oldest = it;
             }
         }
+        // 追い出すエントリが直前キャッシュと一致する場合はキャッシュも無効化する
+        if (last_brush_ == oldest->second.brush.Get()) {
+            last_brush_ = nullptr;
+        }
         brush_pool_.erase(oldest);
     }
     Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush;
@@ -30,7 +42,9 @@ ID2D1SolidColorBrush* CommandExecutor::GetBrush(ID2D1RenderTarget* rt, D2D1_COLO
         return nullptr;
     }
     auto [it, _] = brush_pool_.emplace(key, BrushEntry{ std::move(brush), now });
-    return it->second.brush.Get();
+    last_brush_key_ = key;
+    last_brush_ = it->second.brush.Get();
+    return last_brush_;
 }
 
 void CommandExecutor::Execute(const DrawCommandList& cmds, ID2D1RenderTarget* rt)
@@ -76,7 +90,7 @@ void CommandExecutor::Execute(const DrawCommandList& cmds, ID2D1RenderTarget* rt
                 if (c.format && c.text_len > 0) {
                     auto* b = GetBrush(rt, c.color);
                     if (b) {
-                        rt->DrawText(c.text, static_cast<UINT32>(c.text_len), c.format, c.rect, b);
+                        rt->DrawText(c.text(), static_cast<UINT32>(c.text_len), c.format, c.rect, b);
                     }
                 }
             },

--- a/src/render/command_executor.h
+++ b/src/render/command_executor.h
@@ -57,4 +57,9 @@ private:
     std::unordered_map<uint32_t, BrushEntry> brush_pool_;
     uint64_t use_counter_ = 0;
     ID2D1RenderTarget* bound_rt_ = nullptr;
+    // 同色連続発行（罫線、ハイライト等）の hash lookup を省くための直前ブラシキャッシュ。
+    // last_brush_==nullptr が「キャッシュ無効」を示し、PackColor の値域全体を
+    // 非衝突に使えるようにする。
+    uint32_t last_brush_key_ = 0;
+    ID2D1SolidColorBrush* last_brush_ = nullptr;
 };

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -68,6 +68,23 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     frame_selection_ = &selection;
     frame_hovered_ = hovered;
 
+    // 前フレームの選択範囲のうち、今回の範囲外に出たノードの selection_hl_cache を破棄する。
+    // 「解除」「縮小」「別範囲への移動」をまとめて拾い、長時間利用での漸増を防ぐ。
+    {
+        const int new_start = selection.active ? selection.start_node : -1;
+        const int new_end = selection.active ? selection.end_node : -1;
+        if (prev_sel_start_node_ >= 0) {
+            const int upper = std::min(prev_sel_end_node_, static_cast<int>(cache.size()) - 1);
+            for (int i = prev_sel_start_node_; i <= upper; i++) {
+                if (new_start < 0 || i < new_start || i > new_end) {
+                    cache[i].invalidate_selection_hl_cache();
+                }
+            }
+        }
+        prev_sel_start_node_ = new_start;
+        prev_sel_end_node_ = new_end;
+    }
+
     const int node_count = static_cast<int>(nodes.size());
     if (first_visible < 0) {
         first_visible = FindFirstVisibleNodeIndex(cache, nodes.size(), frame_viewport_top_);

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -73,8 +73,7 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     {
         const int new_start = selection.active ? selection.start_node : -1;
         const int new_end = selection.active ? selection.end_node : -1;
-        if ((new_start != prev_sel_start_node_ || new_end != prev_sel_end_node_) &&
-            prev_sel_start_node_ >= 0) {
+        if ((new_start != prev_sel_start_node_ || new_end != prev_sel_end_node_) && prev_sel_start_node_ >= 0) {
             const int upper = std::min(prev_sel_end_node_, static_cast<int>(cache.size()) - 1);
             for (int i = prev_sel_start_node_; i <= upper; i++) {
                 if (new_start < 0 || i < new_start || i > new_end) {

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -21,17 +21,12 @@ static inline D2D1_RECT_F RectFromHitTest(const DWRITE_HIT_TEST_METRICS& m, floa
         origin_y + m.top + m.height);
 }
 
-static float GetFirstLineHeight(IDWriteTextLayout* layout, float font_size)
+// MeasureNode 時に確定済みの first_line_height を優先利用する。
+// 0（未確定）なら DirectWrite に問い合わせず font_size ベースのフォールバックで済ませ、
+// 描画ホットパスから COM 越境呼び出しを排除する。
+static float GetFirstLineHeight(const NodeLayoutEntry& entry, float font_size) noexcept
 {
-    float h = font_size * FALLBACK_LINE_HEIGHT_FACTOR;
-    if (layout) {
-        DWRITE_LINE_METRICS lm;
-        UINT32 lc;
-        if (SUCCEEDED(layout->GetLineMetrics(&lm, 1, &lc)) && lc > 0) {
-            h = lm.height;
-        }
-    }
-    return h;
+    return (entry.first_line_height > 0.0f) ? entry.first_line_height : font_size * FALLBACK_LINE_HEIGHT_FACTOR;
 }
 
 const DrawCommandList& CommandGenerator::GenerateMdPane(
@@ -47,8 +42,12 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     cmds_ = DrawCommandList{ frame_resource_.resource() };
     frame_resource_.Reset();
     auto& cmds = cmds_;
+    // 倍々成長による monotonic 死蔵を抑える。+16 は last_cmds_size_<8 で 12.5% が 0 に丸まる
+    // 小規模フレーム向けの下駄。
+    if (last_cmds_size_ > 0) {
+        cmds.reserve(last_cmds_size_ + last_cmds_size_ / 8 + 16);
+    }
 
-    // MDペインの境界でクリップ
     const D2D1_RECT_F md_clip = D2D1::RectF(
         md_pane_rect.x, md_pane_rect.y,
         md_pane_rect.x + md_pane_rect.width, md_pane_rect.y + md_pane_rect.height);
@@ -69,7 +68,6 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     frame_selection_ = &selection;
     frame_hovered_ = hovered;
 
-    // 最初の可視ノードを二分探索で検索（事前計算済みのインデックスがあればそれを使用）
     const int node_count = static_cast<int>(nodes.size());
     if (first_visible < 0) {
         first_visible = FindFirstVisibleNodeIndex(cache, nodes.size(), frame_viewport_top_);
@@ -89,6 +87,7 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     cmds.emplace_back(SetTransformCmd{ D2D1::Matrix3x2F::Identity() });
     cmds.emplace_back(PopClipCmd{});
     frame_selection_ = nullptr;
+    last_cmds_size_ = cmds_.size();
     return cmds_;
 }
 
@@ -96,7 +95,6 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
                                     const Node& node, const NodeLayoutEntry& entry, const DiagramEntry& diagram,
                                     int node_index)
 {
-    // ビューポート外のノードをカリング
     // h1/h2は見出し下線がentry.heightの外に描画されるため、カリング境界を拡張する。
     float node_bottom = entry.y_position + entry.height;
     if (node.type == NodeType::Heading && node.heading_level <= 2) {
@@ -211,13 +209,11 @@ void CommandGenerator::GenNodeTextDecorations(DrawCommandList& cmds, const Node&
 
     const D2D1_COLOR_F base_color = GetNodeBaseColor(node);
 
-    // インラインコードの背景
     GenInlineCodeBgs(cmds, entry.view_inline_code_bgs(), text_x, entry.y_position, theme_->code_bg_color);
 
     // 検索マッチのハイライト（選択より先に描画し、選択が最前面になるようにする）
     GenSearchHighlights(cmds, entry, node_index, text_x, entry.y_position);
 
-    // 選択範囲のハイライト
     const auto& selection = *frame_selection_;
     if (selection.active && node_index >= selection.start_node && node_index <= selection.end_node) {
         uint32_t sel_start = 0;
@@ -229,14 +225,12 @@ void CommandGenerator::GenNodeTextDecorations(DrawCommandList& cmds, const Node&
             sel_end = selection.end_pos;
         }
         if (sel_end > sel_start) {
-            GenSelectionHighlight(cmds, entry.text_layout.Get(), sel_start, sel_end - sel_start, text_x, entry.y_position);
+            GenSelectionHighlightCached(cmds, entry, sel_start, sel_end - sel_start, text_x, entry.y_position);
         }
     }
 
-    // メインテキスト
     cmds.emplace_back(DrawTextLayoutCmd{ D2D1::Point2F(text_x, entry.y_position), entry.text_layout.Get(), base_color });
 
-    // タスクリストのチェックボックス
     if (node.type == NodeType::TaskListItem && formats_.icon_font) {
         const wchar_t icon = node.task_checked ? L'\u2611' : L'\u2610'; // ☑ / ☐
         const float icon_size = theme_->font_size_body;
@@ -248,8 +242,6 @@ void CommandGenerator::GenNodeTextDecorations(DrawCommandList& cmds, const Node&
             theme_->text_color));
     }
 }
-
-// ---- サブジェネレータ ----
 
 void CommandGenerator::GenHorizontalRule(DrawCommandList& cmds, const NodeLayoutEntry& entry, float x, float w)
 {
@@ -313,9 +305,8 @@ void CommandGenerator::GenOverlayButton(DrawCommandList& cmds, D2D1_RECT_F btn, 
 void CommandGenerator::GenListBullet(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, float x)
 {
     if (node.list_number > 0) {
-        // 順序付きリストの番号（1行目に合わせて配置）
         if (formats_.list_number) {
-            const float first_line_h = GetFirstLineHeight(entry.text_layout.Get(), theme_->font_size_body);
+            const float first_line_h = GetFirstLineHeight(entry, theme_->font_size_body);
             wchar_t num_buf[16];
             const auto fmt_result = std::format_to_n(num_buf, std::size(num_buf), L"{}.", node.list_number);
             const size_t num_len = std::min(static_cast<size_t>(fmt_result.size), std::size(num_buf));
@@ -328,8 +319,8 @@ void CommandGenerator::GenListBullet(DrawCommandList& cmds, const Node& node, co
         }
     }
     else {
-        // 順序なしリストの箇条書き記号（1行目の中央に配置）
-        const float first_line_h = GetFirstLineHeight(entry.text_layout.Get(), theme_->font_size_body);
+        // 1行目の中央に配置
+        const float first_line_h = GetFirstLineHeight(entry, theme_->font_size_body);
         const float bullet_y = entry.y_position + first_line_h * 0.5f;
         const float bullet_x = x - theme_->list_bullet_offset * LIST_BULLET_X_FACTOR;
         const float r = LIST_BULLET_RADIUS;
@@ -386,13 +377,11 @@ void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds, cons
                 max_depth = nodes[j].quote_depth;
             }
             j++;
-            // ビューポート外に大きく超えたグループ末尾の走査を打ち切る。
-            // バーや背景はクリップ領域で切られるため、描画結果に影響しない。
+            // ビューポート外に大きく超えたグループ末尾は j を進めるだけにする。
+            // バー/背景はクリップで切られるため、可視外で max_depth を更新しても
+            // 描画コマンド数は変わらず CPU を浪費するだけ。
             if (group_bottom > viewport_bottom) {
                 while (j < node_count && nodes[j].blockquote_group == group) {
-                    if (nodes[j].quote_depth > max_depth) {
-                        max_depth = nodes[j].quote_depth;
-                    }
                     j++;
                 }
                 break;
@@ -466,9 +455,14 @@ void CommandGenerator::GenDiagramPlaceholder(DrawCommandList& cmds, float x, flo
     }
 }
 
-void CommandGenerator::EmitHighlightRects(DrawCommandList& cmds,
-                                          IDWriteTextLayout* layout, uint32_t start, uint32_t length,
-                                          float origin_x, float origin_y, D2D1_COLOR_F color)
+void CommandGenerator::EmitHighlightRects(
+    DrawCommandList& cmds,
+    IDWriteTextLayout* layout,
+    uint32_t start,
+    uint32_t length,
+    float origin_x,
+    float origin_y,
+    D2D1_COLOR_F color)
 {
     if (!layout || length == 0) {
         return;
@@ -483,6 +477,41 @@ void CommandGenerator::EmitHighlightRects(DrawCommandList& cmds,
 void CommandGenerator::GenSelectionHighlight(DrawCommandList& cmds, IDWriteTextLayout* layout, uint32_t start, uint32_t length, float origin_x, float origin_y)
 {
     EmitHighlightRects(cmds, layout, start, length, origin_x, origin_y, SELECTION_COLOR);
+}
+
+void CommandGenerator::CollectHitTestRects(IDWriteTextLayout* layout, uint32_t start, uint32_t length, std::pmr::vector<D2D1_RECT_F>& out)
+{
+    auto& buf = GetHitTestBuffer();
+    const UINT32 count = FetchHitTestMetrics(layout, start, length, buf);
+    out.reserve(out.size() + count);
+    for (UINT32 i = 0; i < count; i++) {
+        out.emplace_back(RectFromHitTest(buf[i]));
+    }
+}
+
+void CommandGenerator::GenSelectionHighlightCached(DrawCommandList& cmds, const NodeLayoutEntry& entry, uint32_t start, uint32_t length, float origin_x, float origin_y)
+{
+    auto* layout = entry.text_layout.Get();
+    if (!layout || length == 0) {
+        return;
+    }
+    auto& cache = entry.ensure_selection_hl_cache();
+    if (cache.layout_ptr != layout || cache.start != start || cache.length != length) {
+        cache.rects.clear();
+        CollectHitTestRects(layout, start, length, cache.rects);
+        cache.layout_ptr = layout;
+        cache.start = start;
+        cache.length = length;
+    }
+    for (const auto& r : cache.rects) {
+        cmds.emplace_back(FillRectCmd{
+            D2D1::RectF(
+                origin_x + r.left,
+                origin_y + r.top,
+                origin_x + r.right,
+                origin_y + r.bottom),
+            SELECTION_COLOR });
+    }
 }
 
 void CommandGenerator::GenSearchHighlights(DrawCommandList& cmds, const NodeLayoutEntry& entry, int node_index, float origin_x, float origin_y, int table_row, int table_col)
@@ -519,7 +548,6 @@ void CommandGenerator::RebuildSearchHlCache(SearchHlCache& cache, const NodeLayo
     cache.rect_ends.clear();
     cache.rect_ends.reserve(node_match_count);
 
-    auto& buf = GetHitTestBuffer();
     for (size_t mi = first_global; mi < first_global + node_match_count; ++mi) {
         const auto& m = matches[mi];
         IDWriteTextLayout* l = nullptr;
@@ -532,19 +560,22 @@ void CommandGenerator::RebuildSearchHlCache(SearchHlCache& cache, const NodeLayo
         // m.table_row >= 0 && !has_table_layout() のケースは layout 失効中の
         // 暫定状態で、l は nullptr のまま空 rect として記録する（次回再構築時に修復）。
         if (l && m.length > 0) {
-            const UINT32 count = FetchHitTestMetrics(l, m.start, m.length, buf);
-            for (UINT32 k = 0; k < count; ++k) {
-                cache.rects.emplace_back(RectFromHitTest(buf[k]));
-            }
+            CollectHitTestRects(l, m.start, m.length, cache.rects);
         }
         cache.rect_ends.push_back(static_cast<uint32_t>(cache.rects.size()));
     }
     cache.gen = search_generation_;
 }
 
-void CommandGenerator::EmitSearchHlCommands(DrawCommandList& cmds, const SearchHlCache& cache,
-                                            std::span<const SearchMatch> matches, size_t first_global,
-                                            float origin_x, float origin_y, int table_row, int table_col)
+void CommandGenerator::EmitSearchHlCommands(
+    DrawCommandList& cmds,
+    const SearchHlCache& cache,
+    std::span<const SearchMatch> matches,
+    size_t first_global,
+    float origin_x,
+    float origin_y,
+    int table_row,
+    int table_col)
 {
     // 呼び出し側（セル/ノード本体）に属する match のみ描画する。
     const size_t node_match_count = cache.rect_ends.size();
@@ -575,8 +606,6 @@ void CommandGenerator::EmitSearchHlCommands(DrawCommandList& cmds, const SearchH
     }
 }
 
-// ---- Table generator ----
-
 void CommandGenerator::GenTableRowBg(DrawCommandList& cmds, bool is_header, bool is_even_row, float x, float y, float table_width, float row_h, float border)
 {
     if (is_header) {
@@ -591,11 +620,16 @@ void CommandGenerator::GenTableRowBg(DrawCommandList& cmds, bool is_header, bool
     }
 }
 
-void CommandGenerator::GenTableCellContent(DrawCommandList& cmds, const TableCell& cell,
-                                           IDWriteTextLayout* cell_layout,
-                                           float text_x, float text_y,
-                                           bool has_selection, uint32_t sel_start, uint32_t sel_end,
-                                           uint32_t flat_offset)
+void CommandGenerator::GenTableCellContent(
+    DrawCommandList& cmds,
+    const TableCell& cell,
+    IDWriteTextLayout* cell_layout,
+    float text_x,
+    float text_y,
+    bool has_selection,
+    uint32_t sel_start,
+    uint32_t sel_end,
+    uint32_t flat_offset)
 {
     if (has_selection && cell_layout) {
         const uint32_t cell_len = static_cast<uint32_t>(cell.text.size());
@@ -626,10 +660,7 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
     const float viewport_top = frame_viewport_top_;
     const float viewport_bottom = frame_viewport_bottom_;
 
-    const float table_width = std::ranges::fold_left(
-        tl.col_widths,
-        border,
-        [cell_padding, border](float acc, float cw) noexcept { return acc + cw + cell_padding * 2.0f + border; });
+    const float table_width = tl.cached_table_width;
 
     bool has_selection = selection.active && (node_index >= selection.start_node) && (node_index <= selection.end_node);
     uint32_t sel_start = 0, sel_end = static_cast<uint32_t>(node.GetText().size());
@@ -677,7 +708,7 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
             D2D1::Point2F(offset_x, y), D2D1::Point2F(offset_x + table_width, y),
             theme_->hr_color, border });
 
-        // セルを描画（可視列のみコマンド生成、画面外は flat_offset のみ進める）
+        // 可視列のみコマンド生成、画面外は flat_offset のみ進める
         const float cull_left = offset_x + frame_viewport_left_;
         const float cull_right = offset_x + frame_viewport_right_;
         float cx = offset_x + border;
@@ -689,7 +720,6 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
             const bool col_visible = (col_right >= cull_left) && (cx - border <= cull_right);
 
             if (col_visible) {
-                // 垂直の罫線
                 cmds.emplace_back(DrawLineCmd{
                     D2D1::Point2F(cx - border, y), D2D1::Point2F(cx - border, y + row_h + border),
                     theme_->hr_color, border });
@@ -699,10 +729,9 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
 
                 IDWriteTextLayout* cell_layout = tl.GetCellLayout(r, c);
 
-                // セルのインラインコード背景。bg_cursor は cell_index 昇順で進む。
+                // bg_cursor は cell_index 昇順で進む。
                 bg_cursor = GenCellInlineCodeBgs(cmds, tl.cell_inline_code_bgs, bg_cursor, static_cast<uint32_t>(tl.CellIndex(r, c)), text_x, text_y, theme_->code_bg_color);
 
-                // 検索マッチのハイライト（テーブルセル）
                 GenSearchHighlights(cmds, entry, node_index, text_x, text_y, static_cast<int>(r), static_cast<int>(c));
 
                 GenTableCellContent(cmds, cell, cell_layout, text_x, text_y, has_selection, sel_start, sel_end, flat_offset);
@@ -717,7 +746,6 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
 
         TableLayoutData::AdvanceFlatOffsetInRow(row, drawn_cols, row.cells.size(), flat_offset);
 
-        // 右罫線
         cmds.emplace_back(DrawLineCmd{
             D2D1::Point2F(offset_x + table_width, y),
             D2D1::Point2F(offset_x + table_width, y + row_h + border),
@@ -729,7 +757,6 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
         }
     }
 
-    // 下罫線
     cmds.emplace_back(DrawLineCmd{
         D2D1::Point2F(offset_x, y), D2D1::Point2F(offset_x + table_width, y),
         theme_->hr_color, border });

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -68,12 +68,13 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     frame_selection_ = &selection;
     frame_hovered_ = hovered;
 
-    // 前フレームの選択範囲のうち、今回の範囲外に出たノードの selection_hl_cache を破棄する。
-    // 「解除」「縮小」「別範囲への移動」をまとめて拾い、長時間利用での漸増を防ぐ。
+    // SelectionHlCache は lazy 確保のみで自動破棄経路が無く、選択範囲外に出たノード分が
+    // 居残ってメモリが漸増する。前フレームの範囲との差分で、外れたノードを巻き戻す。
     {
         const int new_start = selection.active ? selection.start_node : -1;
         const int new_end = selection.active ? selection.end_node : -1;
-        if (prev_sel_start_node_ >= 0) {
+        if ((new_start != prev_sel_start_node_ || new_end != prev_sel_end_node_) &&
+            prev_sel_start_node_ >= 0) {
             const int upper = std::min(prev_sel_end_node_, static_cast<int>(cache.size()) - 1);
             for (int i = prev_sel_start_node_; i <= upper; i++) {
                 if (new_start < 0 || i < new_start || i > new_end) {

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -75,7 +75,6 @@ public:
         IDWriteTextFormat* placeholder_text = nullptr;
     };
 
-    // ファイル切替時にバッファを縮小する
     void ShrinkBuffers()
     {
         if (!shared_hit_test_buffer_) {
@@ -124,7 +123,6 @@ private:
     void GenNodeTextDecorations(DrawCommandList& cmds, const Node& node,
                                 const NodeLayoutEntry& entry, int node_index, float x, float text_x);
 
-    // ノードタイプに応じた本文ベースカラーを返す。
     D2D1_COLOR_F GetNodeBaseColor(const Node& node) const noexcept;
 
     void GenHorizontalRule(DrawCommandList& cmds, const NodeLayoutEntry& entry, float x, float w);
@@ -140,7 +138,13 @@ private:
     void GenBlockQuoteGroupDecorations(DrawCommandList& cmds, const std::pmr::vector<Node>& nodes, const LayoutCache& cache, int node_count, int first_visible);
     void GenDiagramPlaceholder(DrawCommandList& cmds, float x, float y, float w, float h);
     void EmitHighlightRects(DrawCommandList& cmds, IDWriteTextLayout* layout, uint32_t start, uint32_t length, float origin_x, float origin_y, D2D1_COLOR_F color);
+    // HitTestTextRange の結果をレイアウト原点相対の D2D1_RECT_F に変換し out へ append する。
+    // SearchHlCache / SelectionHlCache の rebuild に共用する。
+    void CollectHitTestRects(IDWriteTextLayout* layout, uint32_t start, uint32_t length, std::pmr::vector<D2D1_RECT_F>& out);
     void GenSelectionHighlight(DrawCommandList& cmds, IDWriteTextLayout* layout, uint32_t start, uint32_t length, float origin_x, float origin_y);
+    // 本文ノード（テーブル外）専用の選択ハイライト発行。
+    // (layout, start, length) 一致でフレーム間キャッシュをヒットさせ HitTestTextRange を省く。
+    void GenSelectionHighlightCached(DrawCommandList& cmds, const NodeLayoutEntry& entry, uint32_t start, uint32_t length, float origin_x, float origin_y);
     void GenSearchHighlights(DrawCommandList& cmds, const NodeLayoutEntry& entry, int node_index, float origin_x, float origin_y, int table_row = -1, int table_col = -1);
 
     // 検索ハイライトのキャッシュが古い場合に再構築する。
@@ -161,8 +165,13 @@ private:
     // GenerateMdPane の戻り値は同一スコープ内で即 CommandExecutor::Execute に
     // 渡されて消費される（renderer.cpp の呼び出しを参照）ため、
     // 前フレームの内容を生かしておく必要はなくシングルバッファで十分。
-    MonotonicResource frame_resource_{ 128 * 1024 };
+    // 大きめドキュメント (1 万コマンド規模) を初期バッファだけで賄えるサイズに設定し、
+    // 上流 pool への再 allocate を平常時はゼロにする。
+    MonotonicResource frame_resource_{ 1024 * 1024 };
     DrawCommandList cmds_{ frame_resource_.resource() };
+    // 直前フレームのコマンド数。次フレーム冒頭で reserve に使い、
+    // 倍々再確保で発生する死蔵バッファを抑える。
+    size_t last_cmds_size_ = 0;
 
     const std::pmr::vector<SearchMatch>* search_matches_ = nullptr;
     int current_match_index_ = -1;
@@ -180,14 +189,22 @@ private:
         assert(len <= 255 && "DrawTextCmd text exceeds uint8_t range");
         DrawTextCmd c{};
         c.text_len = static_cast<uint8_t>((std::min)(len, size_t(255)));
-        if (c.text_len > 0) {
-            auto* buf = static_cast<wchar_t*>(frame_resource_.resource()->allocate(c.text_len * sizeof(wchar_t), alignof(wchar_t)));
-            std::char_traits<wchar_t>::copy(buf, src, c.text_len);
-            c.text = buf;
-        }
         c.rect = r;
         c.format = fmt;
         c.color = col;
+        if (c.text_len == 0) {
+            return c;
+        }
+        if (c.text_len <= DrawTextCmd::INLINE_TEXT_CAPACITY) {
+            std::char_traits<wchar_t>::copy(c.inline_buf, src, c.text_len);
+            c.is_inline = true;
+        }
+        else {
+            auto* buf = static_cast<wchar_t*>(frame_resource_.resource()->allocate(c.text_len * sizeof(wchar_t), alignof(wchar_t)));
+            std::char_traits<wchar_t>::copy(buf, src, c.text_len);
+            c.text_ptr = buf;
+            c.is_inline = false;
+        }
         return c;
     }
 

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -224,4 +224,9 @@ private:
     float frame_content_width_ = 0.0f;
     const TextSelection* frame_selection_ = nullptr;
     HoveredButtons frame_hovered_;
+
+    // 前フレームの選択ノード範囲。範囲外に出たノードの selection_hl_cache を
+    // 解放するために使う。-1/-1 は「前フレームは非アクティブ」を示す。
+    int prev_sel_start_node_ = -1;
+    int prev_sel_end_node_ = -1;
 };

--- a/src/render/d2d_render_backend.cpp
+++ b/src/render/d2d_render_backend.cpp
@@ -35,8 +35,8 @@ bool D2DRenderBackend::Init(HWND hwnd)
         return false;
     }
 
-    // WICファクトリを作成（Renderer・ImageLoaderで共有）。
-    // アイコン／画像／ダイアグラムは WIC が無いと機能しないため fail-fast。
+    // Renderer・ImageLoader で共有。アイコン／画像／ダイアグラムは WIC が無いと
+    // 機能しないため fail-fast。
     hr = CoCreateInstance(
         CLSID_WICImagingFactory,
         nullptr,
@@ -174,7 +174,7 @@ void D2DRenderBackend::Resize(UINT width, UINT height) noexcept
         return;
     }
 
-    // ターゲットを解放してからリサイズ
+    // ResizeBuffers の前にターゲット参照を切る必要がある
     device_context_->SetTarget(nullptr);
 
     const HRESULT hr = swap_chain_->ResizeBuffers(0, width, height, DXGI_FORMAT_UNKNOWN, 0);

--- a/src/render/d2d_render_backend.h
+++ b/src/render/d2d_render_backend.h
@@ -25,7 +25,7 @@ public:
     virtual IWICImagingFactory* GetWICFactory() const noexcept = 0;
     virtual HWND GetHwnd() const noexcept = 0;
 
-    // スワップチェーンのPresent。EndDraw後に呼び出す。
+    // EndDraw 後に呼び出す。
     virtual void Present() noexcept = 0;
 };
 

--- a/src/render/draw_command.h
+++ b/src/render/draw_command.h
@@ -6,8 +6,6 @@
 #include <algorithm>
 #include <memory_resource>
 
-// ---- 基本描画コマンド ----
-
 struct ClearCmd {
     D2D1_COLOR_F color;
 };
@@ -36,11 +34,27 @@ struct DrawTextLayoutCmd {
 };
 
 struct DrawTextCmd {
-    const wchar_t* text = nullptr;       // 非所有; ライフタイムはMonotonicResourceが管理。
+    // 1〜INLINE_TEXT_CAPACITY 文字は inline_buf に直接格納し、
+    // monotonic resource からの小さな allocate を回避する（icon 1 文字や "1." 等の頻出ケース）。
+    // pointer と同サイズに収めることで variant 最大サイズに影響しない。
+    static constexpr uint8_t INLINE_TEXT_CAPACITY = 4;
+    union {
+        const wchar_t* text_ptr; // 非所有; ライフタイムはMonotonicResourceが管理。
+        wchar_t inline_buf[INLINE_TEXT_CAPACITY];
+    };
     IDWriteTextFormat* format = nullptr; // 非所有; ライフタイムはRendererが管理。
     D2D1_RECT_F rect{};
     D2D1_COLOR_F color{};
     uint8_t text_len = 0;
+    bool is_inline = false;
+
+    DrawTextCmd() noexcept : text_ptr(nullptr)
+    {}
+
+    const wchar_t* text() const noexcept
+    {
+        return is_inline ? inline_buf : text_ptr;
+    }
 };
 
 struct DrawBitmapCmd {
@@ -63,8 +77,6 @@ struct DrawEllipseCmd {
     float stroke_width;
 };
 
-// ---- 状態コマンド ----
-
 struct PushClipCmd {
     D2D1_RECT_F rect;
 };
@@ -74,8 +86,6 @@ struct PopClipCmd {};
 struct SetTransformCmd {
     D2D1_MATRIX_3X2_F transform;
 };
-
-// ---- バリアント + リスト ----
 
 using DrawCommand = std::variant<
     ClearCmd,

--- a/src/render/render_params.h
+++ b/src/render/render_params.h
@@ -28,7 +28,6 @@ struct ToastRenderState {
     std::wstring_view message;
 };
 
-// タイトルバー描画パラメータ。
 struct TitleBarRenderState {
     // --- 8バイトアライメント ---
     std::wstring_view title_text;
@@ -72,7 +71,6 @@ inline D2D1_RECT_F ToD2DRect(const DipRect& r) noexcept
     return std::bit_cast<D2D1_RECT_F>(r);
 }
 
-// サイドペイン描画パラメータを一つの構造体にまとめたもの。
 struct SidePaneState {
     // --- 8バイトアライメント (参照 = ポインタ) ---
     const PaneRect& file_pane_rect;
@@ -117,7 +115,6 @@ struct PaneCache {
     }
 };
 
-// 検索バー描画パラメータ
 struct SearchBarRenderState {
     // --- 8バイトアライメント ---
     std::wstring_view query;
@@ -142,7 +139,6 @@ struct SearchBarRenderState {
     bool highlight_btn_hovered = false;
 };
 
-// Renderer::Render に渡す全パラメータをまとめた構造体。
 struct RenderParams {
     // --- 8バイトアライメント (参照 = ポインタ) ---
     const std::pmr::vector<Node>& nodes;

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -23,8 +23,6 @@ bool Renderer::Init(HWND hwnd)
     RecreatePaneFormats();
     LoadAppIconBitmap();
 
-    // gesture_stroke_style_ は DrawGestureTrail 初回呼び出し時に lazy 生成
-
     measurer_.SetFactory(backend_.GetDWriteFactory());
     if (!layout_.Init(&measurer_, theme_)) {
         return false;
@@ -59,7 +57,6 @@ void Renderer::Resize(UINT width, UINT height) noexcept
 void Renderer::SetDpi(float dpi) noexcept
 {
     backend_.SetDpi(dpi);
-    // 新しいDPIでペインキャッシュを再作成
     file_pane_cache_.Reset();
     toc_pane_cache_.Reset();
 }
@@ -81,9 +78,8 @@ void Renderer::UpdateLayoutTheme()
     layout_.RecreateFormats();
 }
 
-// ---- ノード描画 ----
-// ノード描画ロジックはCommandGeneratorに抽出済み。
-// D2Dブラシが必要なApplyNodeEffectsのみ描画前パスとしてここに残る。
+// ノード描画ロジックは CommandGenerator に抽出済み。
+// D2D ブラシが必要な ApplyNodeEffects のみ描画前パスとしてここに残る。
 
 void Renderer::PrepareVisibleEffects(std::pmr::vector<Node>& nodes, LayoutCache& cache, float scroll_y, float md_pane_height)
 {
@@ -115,14 +111,14 @@ void Renderer::ApplyVisibleEffects(std::pmr::vector<Node>& nodes, LayoutCache& c
 ID2D1SolidColorBrush* Renderer::GetSyntaxBrush(SyntaxTokenType type) const noexcept
 {
     static constexpr BrushId SYNTAX_MAP[] = {
-        BrushId::Text,               // Plain（未使用、フォールバックとしてテキストブラシを返す）
-        BrushId::SyntaxKeyword,      // キーワード
-        BrushId::SyntaxType,         // 型
-        BrushId::SyntaxString,       // 文字列
-        BrushId::SyntaxNumber,       // 数値
-        BrushId::SyntaxComment,      // コメント
-        BrushId::SyntaxPreprocessor, // プリプロセッサ
-        BrushId::SyntaxFunction,     // 関数
+        BrushId::Text, // Plain（未使用、フォールバックとしてテキストブラシを返す）
+        BrushId::SyntaxKeyword,
+        BrushId::SyntaxType,
+        BrushId::SyntaxString,
+        BrushId::SyntaxNumber,
+        BrushId::SyntaxComment,
+        BrushId::SyntaxPreprocessor,
+        BrushId::SyntaxFunction,
     };
     const auto idx = std::to_underlying(type);
     if (idx >= std::size(SYNTAX_MAP)) {
@@ -195,20 +191,32 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry, float viewp
                     cell_layout->SetDrawingEffect(Brush(BrushId::Link), range);
                 }
                 // インラインコード背景: 可視かつ未計算の行のみ。
-                // cell_index 昇順を維持するため upper_bound 位置に挿入する。
-                // フレーム間で行の可視性が変わると単純 push では順序が崩れ、描画側の advancing
-                // iterator スキャンが破綻する。bg 数は通常少ないので O(N) insert は許容。
+                // cell_index 昇順を維持するため、新規行が末尾以降ならば append、
+                // それ以外（上方向スクロールで前段の行が後から追加される稀ケース）は
+                // upper_bound 位置に insert する。可視ノードが下方向に増える典型ケースは
+                // 完全 append (O(1)/elem) で済む。
                 if (need_bgs && run.code() && run.length > 0) {
                     const UINT32 count = FetchHitTestMetrics(cell_layout, run.start, run.length, hit_test_buffer_);
                     const auto cell_index = static_cast<uint32_t>(tl.CellIndex(r, c));
                     auto& bgs = tl.cell_inline_code_bgs;
-                    auto pos = std::upper_bound(
-                        bgs.begin(),
-                        bgs.end(),
-                        cell_index,
-                        [](uint32_t v, const CellInlineCodeBg& e) noexcept { return v < e.cell_index; });
-                    for (UINT32 hi = 0; hi < count; hi++) {
-                        pos = bgs.insert(pos, CellInlineCodeBg{ cell_index, MakeInlineCodeBg(hit_test_buffer_[hi]) }) + 1;
+                    const bool can_append = bgs.empty() || bgs.back().cell_index <= cell_index;
+                    if (can_append) {
+                        bgs.reserve(bgs.size() + count);
+                        for (UINT32 hi = 0; hi < count; hi++) {
+                            bgs.emplace_back(CellInlineCodeBg{ cell_index, MakeInlineCodeBg(hit_test_buffer_[hi]) });
+                        }
+                    }
+                    else {
+                        const auto func = [](uint32_t v, const CellInlineCodeBg& e) noexcept { return v < e.cell_index; };
+                        // 上方向スクロールで前段の行が後から追加される稀ケース。
+                        // 末尾に一括 push してから rotate で正しい位置に移すと、tail shift が 1 回で済む。
+                        const size_t insert_at_index = static_cast<size_t>(std::upper_bound(bgs.begin(), bgs.end(), cell_index, func) - bgs.begin());
+                        bgs.reserve(bgs.size() + count);
+                        const size_t old_size = bgs.size();
+                        for (UINT32 hi = 0; hi < count; hi++) {
+                            bgs.emplace_back(CellInlineCodeBg{ cell_index, MakeInlineCodeBg(hit_test_buffer_[hi]) });
+                        }
+                        std::rotate(bgs.begin() + insert_at_index, bgs.begin() + old_size, bgs.end());
                     }
                 }
             }
@@ -235,7 +243,6 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float viewpo
     }
     entry.effects_applied = true;
 
-    // 画像ノード: テキストエフェクト不要
     if (node.type == NodeType::Image) {
         return;
     }
@@ -244,8 +251,7 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float viewpo
         return;
     }
 
-    // コードブロックにシンタックスハイライトを適用
-    // トークン化はMeasureNode（レイアウトパス）で事前実行済み
+    // トークン化は MeasureNode（レイアウトパス）で事前実行済み
     if (node.type == NodeType::CodeBlock) {
         for (const auto& token : node.syntax_tokens()) {
             if (token.type == SyntaxTokenType::Plain) {
@@ -259,7 +265,6 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float viewpo
         }
     }
 
-    // Alertラベルの色を適用
     if (node.type == NodeType::BlockQuote && node.alert_type != AlertType::None && node.alert_label_length > 0) {
         static constexpr BrushId ALERT_BRUSH[] = {
             BrushId::AlertNote,
@@ -276,7 +281,6 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float viewpo
         }
     }
 
-    // リンクの下線/色を適用し、インラインコード背景の矩形をキャッシュ
     for (const auto& run : node.runs) {
         if (run.has_link()) {
             const DWRITE_TEXT_RANGE range{ run.start, run.length };
@@ -294,8 +298,6 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float viewpo
         }
     }
 }
-
-// ---- メイン描画 ----
 
 void Renderer::DrawSidePanes(const SidePaneState& sp)
 {
@@ -323,12 +325,10 @@ void Renderer::DrawLoading(float angle,
     rt()->BeginDraw();
     rt()->Clear(theme_.bg_color);
 
-    // カスタムタイトルバーを描画
     DrawTitleBar(titlebar);
 
     DrawSidePanes(sp);
 
-    // MDペイン中央にスピナーを描画。
     const float cx = md_pane_rect.x + md_pane_rect.width / 2.0f;
     const float cy = md_pane_rect.y + md_pane_rect.height / 2.0f;
     // alpha はドットインデックスのみに依存するためコンパイル時に決定する。
@@ -352,12 +352,11 @@ void Renderer::DrawLoading(float angle,
         text_brush->SetOpacity(1.0f);
     }
 
-    // ジェスチャーオーバーレイ（ローディング中でもフェードアウト中は表示）
+    // ローディング中でもフェードアウト中は表示
     if (gesture.overlay_visible && gesture.overlay_alpha > 0.0f) {
         DrawGestureOverlay(gesture.direction, gesture.overlay_alpha, md_pane_rect);
     }
 
-    // トースト通知
     if (toast.visible) {
         DrawToastOverlay(toast, md_pane_rect);
     }
@@ -376,16 +375,14 @@ void Renderer::Render(const RenderParams& p)
     rt()->BeginDraw();
     rt()->Clear(theme_.bg_color);
 
-    // カスタムタイトルバーを描画
     DrawTitleBar(p.titlebar);
 
     DrawSidePanes(p.side_panes);
 
-    // 最初の可視ノードを検索（ヒットテストとの座標一致のためスナップ前の scroll_y を使う）。
+    // ヒットテストとの座標一致のためスナップ前の scroll_y を使う。
     const float viewport_top = p.scroll_y;
     const int first_visible = FindFirstVisibleNodeIndex(p.cache, p.nodes.size(), viewport_top);
 
-    // Markdownコンテンツペインの描画コマンドを生成・実行。
     const float dpi_scale = backend_.GetDpi() / DEFAULT_DPI;
     {
         MENDO_PROFILE("GenerateMdPane");
@@ -396,32 +393,26 @@ void Renderer::Render(const RenderParams& p)
         }
     }
 
-    // ナビゲーションオーバーレイボタン（戻る/進む）を描画
     if (p.can_go_back || p.can_go_forward) {
         DrawNavOverlay(p.md_pane_rect, p.can_go_back, p.can_go_forward, p.nav_hovered);
     }
 
-    // ジェスチャー軌跡
     if (p.gesture.trail_active && p.gesture.trail_points && p.gesture.trail_points->size() >= 2) {
         DrawGestureTrail(*p.gesture.trail_points);
     }
 
-    // ジェスチャーオーバーレイ（アクション後のフェードアウト）
     if (p.gesture.overlay_visible && p.gesture.overlay_alpha > 0.0f) {
         DrawGestureOverlay(p.gesture.direction, p.gesture.overlay_alpha, p.md_pane_rect);
     }
 
-    // トースト通知
     if (p.toast.visible) {
         DrawToastOverlay(p.toast, p.md_pane_rect);
     }
 
-    // 検索バー
     if (p.search_bar.visible) {
         DrawSearchBar(p.search_bar, p.md_pane_rect);
     }
 
-    // Markdownペインのカスタムスクロールバー
     DrawMdScrollbar(p.md_pane_rect, p.scroll_y, p.total_content_height, p.has_dirty_nodes);
 
     if (!CheckEndDraw()) {
@@ -456,9 +447,9 @@ bool Renderer::RecreateRenderTarget()
     LoadAppIconBitmap();
     file_pane_cache_.Reset();
     toc_pane_cache_.Reset();
-    cmd_executor_ = CommandExecutor{}; // バインドされたレンダーターゲットをリセット
+    // バインドされたレンダーターゲットをリセットする
+    cmd_executor_ = CommandExecutor{};
 
-    // 依存リソース（例: MermaidRendererのビットマップ）が更新されるようオーナーに通知
     if (on_device_lost_) {
         on_device_lost_(backend_.GetRenderTarget());
     }

--- a/src/render/renderer.h
+++ b/src/render/renderer.h
@@ -110,7 +110,6 @@ public:
     // 累積適用による誤差蓄積を避けるため、ズーム変更経路はこの関数に統一する。
     void ApplyZoomFromBase(const Theme& base_theme, float new_zoom);
 
-    // LayoutEngineのテーマを更新しフォーマットを再作成する。
     void UpdateLayoutTheme();
 
     // デバイスロスト後にD2Dレンダーターゲットが再作成された際に呼び出されるコールバックを設定。
@@ -157,14 +156,15 @@ private:
     void DrawFileExplorer(const std::pmr::vector<FileEntry>& entries, const PaneRect& rect, const ScrollState& scroll, int hovered_index, bool close_hovered, bool refresh_hovered);
     void DrawToc(const std::pmr::vector<TocEntry>& entries, const std::pmr::vector<Node>& nodes, const PaneRect& rect, const ScrollState& scroll, int hovered_index, bool close_hovered, int active_index);
     void DrawSplitter(float x, float top, float bottom);
-    void DrawNavOverlay(const PaneRect& md_pane_rect, bool can_back, bool can_forward, int hovered); // 0=なし, 1=戻る, 2=進む
+    // hovered: 0=なし, 1=戻る, 2=進む
+    void DrawNavOverlay(const PaneRect& md_pane_rect, bool can_back, bool can_forward, int hovered);
     void DrawGestureTrail(const std::pmr::deque<GesturePoint>& points);
     void DrawGestureOverlay(int direction, float alpha, const PaneRect& md_pane_rect);
     void DrawToastOverlay(const ToastRenderState& toast, const PaneRect& md_pane_rect);
     void DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_pane_rect);
 
     D2DRenderBackend backend_;
-    // 簡易アクセサ（600行の描画コード内で冗長なbackend_.Get...を避けるため）
+    // 600行の描画コード内で冗長な backend_.Get... を避けるための簡易アクセサ
     ID2D1DeviceContext* rt() const noexcept
     {
         return backend_.GetRenderTarget();
@@ -193,7 +193,6 @@ private:
     // ApplyNodeEffectsでインラインコード背景を計算するためのヒットテストバッファ。
     std::pmr::vector<DWRITE_HIT_TEST_METRICS> hit_test_buffer_;
 
-    // UI テキストフォーマットをグループ化した構造体
     struct TextFormats {
         Microsoft::WRL::ComPtr<IDWriteTextFormat> icon_font;
         Microsoft::WRL::ComPtr<IDWriteTextFormat> copy_btn_icon;
@@ -213,10 +212,10 @@ private:
     };
     TextFormats fmt_;
 
-    Microsoft::WRL::ComPtr<IDWriteTextLayout> nav_back_layout_;        // ◀ のキャッシュ済みレイアウト
-    Microsoft::WRL::ComPtr<IDWriteTextLayout> nav_forward_layout_;     // ▶ のキャッシュ済みレイアウト
-    Microsoft::WRL::ComPtr<IDWriteTextLayout> gesture_back_layout_;    // "← 戻る" のキャッシュ済みレイアウト
-    Microsoft::WRL::ComPtr<IDWriteTextLayout> gesture_forward_layout_; // "→ 進む" のキャッシュ済みレイアウト
+    Microsoft::WRL::ComPtr<IDWriteTextLayout> nav_back_layout_;
+    Microsoft::WRL::ComPtr<IDWriteTextLayout> nav_forward_layout_;
+    Microsoft::WRL::ComPtr<IDWriteTextLayout> gesture_back_layout_;
+    Microsoft::WRL::ComPtr<IDWriteTextLayout> gesture_forward_layout_;
     Microsoft::WRL::ComPtr<IDWriteTextLayout> cached_toast_layout_;
     std::pmr::wstring cached_toast_text_;
 
@@ -232,6 +231,11 @@ private:
     mutable int cached_search_caret_pos_ = -1;         // IME 合成時の挿入位置（無いとき -1）
     mutable float cached_search_width_ = -1.0f;
     mutable bool cached_search_has_underline_ = false;
+    // キャレット x 位置のフレーム間キャッシュ。点滅フレームのみ caret_visible が変わる
+    // ケースで HitTestTextPosition の COM 越境呼び出しを省く。
+    // 有効性は (cached_search_layout_, effective_pos) 一致で判定する。
+    mutable int cached_search_effective_pos_ = -2; // -2 = 未確定
+    mutable float cached_search_caret_x_ = 0.0f;
     Microsoft::WRL::ComPtr<ID2D1Bitmap> app_icon_bitmap_;
     void LoadAppIconBitmap();
     Microsoft::WRL::ComPtr<ID2D1StrokeStyle> gesture_stroke_style_;

--- a/src/render/renderer_overlay.cpp
+++ b/src/render/renderer_overlay.cpp
@@ -13,23 +13,8 @@ void Renderer::DrawNavOverlay(const PaneRect& md_pane_rect, bool can_back, bool 
 
     const bool is_dark = theme_.IsDark();
 
-    // 位置: MDペインの右下にマージン付き
     const float base_x = md_pane_rect.x + md_pane_rect.width - NAV_BTN_MARGIN - NAV_BTN_SIZE * 2 - NAV_BTN_GAP - NAV_BTN_SCROLLBAR_OFFSET;
     const float base_y = md_pane_rect.y + md_pane_rect.height - NAV_BTN_MARGIN - NAV_BTN_SIZE;
-
-    if (fmt_.nav_button) {
-        auto* dw = backend_.GetDWriteFactory();
-        if (dw) {
-            if (!nav_back_layout_) {
-                static const wchar_t BACK_ICON[] = L"\x25C0";
-                dw->CreateTextLayout(BACK_ICON, 1, fmt_.nav_button.Get(), NAV_BTN_SIZE, NAV_BTN_SIZE, &nav_back_layout_);
-            }
-            if (!nav_forward_layout_) {
-                static const wchar_t FORWARD_ICON[] = L"\x25B6";
-                dw->CreateTextLayout(FORWARD_ICON, 1, fmt_.nav_button.Get(), NAV_BTN_SIZE, NAV_BTN_SIZE, &nav_forward_layout_);
-            }
-        }
-    }
 
     // SetColor は SetOpacity より重いため、固定色ブラシを is_dark で選んで
     // 透明度のみ切り替える。
@@ -41,7 +26,6 @@ void Renderer::DrawNavOverlay(const PaneRect& md_pane_rect, bool can_back, bool 
         }
         const D2D1_RECT_F rect = D2D1::RectF(x, base_y, x + NAV_BTN_SIZE, base_y + NAV_BTN_SIZE);
 
-        // 背景
         float bg_alpha;
         if (!enabled) {
             bg_alpha = is_dark ? 0.08f : 0.05f;
@@ -57,7 +41,6 @@ void Renderer::DrawNavOverlay(const PaneRect& md_pane_rect, bool can_back, bool 
         const D2D1_ROUNDED_RECT rrect = D2D1::RoundedRect(rect, NAV_BTN_CORNER, NAV_BTN_CORNER);
         rt()->FillRoundedRectangle(rrect, overlay_brush);
 
-        // 矢印テキスト（キャッシュ済みレイアウトを使用）
         float text_alpha;
         if (!enabled) {
             text_alpha = is_dark ? 0.2f : 0.15f;
@@ -75,9 +58,7 @@ void Renderer::DrawNavOverlay(const PaneRect& md_pane_rect, bool can_back, bool 
         }
     };
 
-    // 戻るボタン (◀)
     drawButton(base_x, can_back, hovered == 1, nav_back_layout_.Get());
-    // 進むボタン (▶)
     drawButton(base_x + NAV_BTN_SIZE + NAV_BTN_GAP, can_forward, hovered == 2, nav_forward_layout_.Get());
 
     if (overlay_brush) {
@@ -135,7 +116,6 @@ void Renderer::DrawGestureOverlay(int direction, float alpha, const PaneRect& md
 
     const bool is_dark = theme_.IsDark();
 
-    // MDペイン中央の矩形
     const float rect_w = GESTURE_OVERLAY_WIDTH;
     const float rect_h = GESTURE_OVERLAY_HEIGHT;
     const float cx = md_pane_rect.x + md_pane_rect.width / 2.0f;
@@ -147,20 +127,6 @@ void Renderer::DrawGestureOverlay(int direction, float alpha, const PaneRect& md
         bg_brush->SetColor(bg_color);
         const D2D1_ROUNDED_RECT rrect = D2D1::RoundedRect(rect, GESTURE_OVERLAY_CORNER, GESTURE_OVERLAY_CORNER);
         rt()->FillRoundedRectangle(rrect, bg_brush);
-    }
-
-    if (fmt_.gesture_overlay) {
-        auto* dw = backend_.GetDWriteFactory();
-        if (dw) {
-            if (!gesture_back_layout_) {
-                static const wchar_t GESTURE_BACK[] = L"\x2190 \x623B\x308B";
-                dw->CreateTextLayout(GESTURE_BACK, 4, fmt_.gesture_overlay.Get(), 280.0f, 80.0f, &gesture_back_layout_);
-            }
-            if (!gesture_forward_layout_) {
-                static const wchar_t GESTURE_FORWARD[] = L"\x2192 \x9032\x3080";
-                dw->CreateTextLayout(GESTURE_FORWARD, 4, fmt_.gesture_overlay.Get(), 280.0f, 80.0f, &gesture_forward_layout_);
-            }
-        }
     }
 
     auto* gesture_layout = (direction < 0) ? gesture_back_layout_.Get() : gesture_forward_layout_.Get();
@@ -182,7 +148,6 @@ void Renderer::DrawToastOverlay(const ToastRenderState& toast, const PaneRect& m
     const float alpha = std::min(toast.alpha, 1.0f);
     const bool is_dark = theme_.IsDark();
 
-    // MDペイン下部中央に配置
     const float rect_w = TOAST_OVERLAY_WIDTH;
     const float rect_h = TOAST_OVERLAY_HEIGHT;
     const float cx = md_pane_rect.x + md_pane_rect.width / 2.0f;
@@ -196,7 +161,7 @@ void Renderer::DrawToastOverlay(const ToastRenderState& toast, const PaneRect& m
         rt()->FillRoundedRectangle(rrect, bg_brush);
     }
 
-    // 白テキスト（キャッシュ済みレイアウトを使用。メッセージ変更時のみ再作成）
+    // メッセージ変更時のみキャッシュ済みレイアウトを再作成
     if (fmt_.toast_text) {
         if (!cached_toast_layout_ || toast.message != cached_toast_text_) {
             cached_toast_text_ = toast.message;

--- a/src/render/renderer_pane.cpp
+++ b/src/render/renderer_pane.cpp
@@ -6,8 +6,7 @@
 #include <cmath>
 #include <concepts>
 
-// PaneCacheのビットマップレンダーターゲットが必要なサイズと一致することを確認。
-// キャッシュが使用可能ならtrueを返す。
+// 戻り値: キャッシュが使用可能なら true。
 static bool EnsurePaneCacheSize(PaneCache& cache, ID2D1RenderTarget* parent, float width, float height)
 {
     if (width <= 0 || height <= 0) {
@@ -54,7 +53,7 @@ static void DrawPaneScrollbar(ID2D1RenderTarget* rt, ID2D1SolidColorBrush* thumb
     rt->FillRoundedRectangle(thumb_rect, thumb_brush);
 }
 
-// DrawSidePaneImpl に渡す描画コンテキスト。draw_item は template 経由のため別。
+// draw_item は template 経由のため別引数。
 struct SidePaneDrawContext {
     PaneCache& cache;
     ID2D1RenderTarget* main_rt;
@@ -74,7 +73,6 @@ struct SidePaneDrawContext {
     bool refresh_hovered;
 };
 
-// サイドペイン描画の共通スキャフォールド。
 template <typename DrawItemFn>
     requires std::invocable<DrawItemFn&, ID2D1RenderTarget*, int, float, float>
 static void DrawSidePaneImpl(const SidePaneDrawContext& sp, DrawItemFn draw_item)
@@ -88,11 +86,9 @@ static void DrawSidePaneImpl(const SidePaneDrawContext& sp, DrawItemFn draw_item
         rt->BeginDraw();
         rt->Clear(sp.theme.pane_bg_color);
 
-        // ヘッダー
         const D2D1_RECT_F header_bg = D2D1::RectF(0, 0, sp.rect.width, sp.theme.pane_header_height);
         rt->FillRectangle(header_bg, sp.splitter_brush);
 
-        // 閉じるボタン
         const D2D1_RECT_F close_rect = PaneCloseButtonRect(sp.rect.width, sp.theme.pane_header_height);
         if (sp.close_hovered) {
             rt->FillRectangle(close_rect, sp.close_hover_brush);
@@ -101,7 +97,7 @@ static void DrawSidePaneImpl(const SidePaneDrawContext& sp, DrawItemFn draw_item
             rt->DrawText(L"\uE8BB", 1, sp.fmt_close_icon, close_rect, sp.text_brush, D2D1_DRAW_TEXT_OPTIONS_CLIP);
         }
 
-        // 更新ボタン（閉じるボタンの左隣、ファイルペインのみ）
+        // ファイルペインのみ。閉じるボタンの左隣に置く。
         float header_text_right = close_rect.left - 4.0f;
         if (sp.show_refresh) {
             const D2D1_RECT_F refresh_rect = PaneRefreshButtonRect(sp.rect.width, sp.theme.pane_header_height);
@@ -125,14 +121,12 @@ static void DrawSidePaneImpl(const SidePaneDrawContext& sp, DrawItemFn draw_item
                 D2D1_DRAW_TEXT_OPTIONS_CLIP);
         }
 
-        // クリッピング付きコンテンツ領域
         const float content_top = sp.theme.pane_header_height;
         const float content_height = sp.rect.height - content_top;
         const D2D1_RECT_F clip = D2D1::RectF(0, content_top, sp.rect.width, sp.rect.height);
         rt->PushAxisAlignedClip(clip, D2D1_ANTIALIAS_MODE_ALIASED);
         rt->SetTransform(D2D1::Matrix3x2F::Translation(0, -sp.scroll.scroll_y));
 
-        // ビューポートカリング
         const int first = std::max(0, static_cast<int>(sp.scroll.scroll_y / sp.theme.pane_item_height));
         const int last = std::min(
             sp.item_count - 1,
@@ -146,7 +140,6 @@ static void DrawSidePaneImpl(const SidePaneDrawContext& sp, DrawItemFn draw_item
         rt->SetTransform(D2D1::Matrix3x2F::Identity());
         rt->PopAxisAlignedClip();
 
-        // スクロールバーオーバーレイ
         const float total_content = static_cast<float>(sp.item_count) * sp.theme.pane_item_height;
         DrawPaneScrollbar(rt, sp.scrollbar_thumb_brush, sp.rect.width, content_top, content_height, sp.scroll.scroll_y, total_content);
 
@@ -156,7 +149,6 @@ static void DrawSidePaneImpl(const SidePaneDrawContext& sp, DrawItemFn draw_item
         sp.cache.bitmap_rt->GetBitmap(&sp.cache.cached_bitmap);
     }
 
-    // キャッシュされたビットマップを転送
     if (sp.cache.cached_bitmap) {
         const D2D1_RECT_F dest = D2D1::RectF(sp.rect.x, sp.rect.y, sp.rect.x + sp.rect.width, sp.rect.y + sp.rect.height);
         sp.main_rt->DrawBitmap(sp.cache.cached_bitmap.Get(), dest);
@@ -248,7 +240,6 @@ void Renderer::DrawToc(const std::pmr::vector<TocEntry>& entries, const std::pmr
                          D2D1_DRAW_TEXT_OPTIONS_CLIP);
         }
 
-        // アクティブ見出しの下線
         if (i == active_index) {
             const float line_y = item_y + theme_.pane_item_height - 1.0f;
             const float line_left = 8.0f + indent;

--- a/src/render/renderer_resources.cpp
+++ b/src/render/renderer_resources.cpp
@@ -16,7 +16,6 @@ void Renderer::LoadAppIconBitmap()
         return;
     }
 
-    // HICONからD2D1ビットマップに変換（バックエンドのWICファクトリを共有使用）
     auto* wic = backend_.GetWICFactory();
     if (!wic) {
         DestroyIcon(hIcon);
@@ -133,7 +132,6 @@ ComPtr<IDWriteTextFormat> Renderer::CreatePaneFormat(
 
 void Renderer::RecreatePaneFormats()
 {
-    // テーマサイズの更新に合わせて全ペイン/UIテキストフォーマットを再作成
     constexpr DWRITE_FONT_WEIGHT W = DWRITE_FONT_WEIGHT_NORMAL;
     constexpr DWRITE_TEXT_ALIGNMENT TA_LEAD = DWRITE_TEXT_ALIGNMENT_LEADING;
     constexpr DWRITE_TEXT_ALIGNMENT TA_CTR = DWRITE_TEXT_ALIGNMENT_CENTER;
@@ -189,7 +187,6 @@ void Renderer::RecreatePaneFormats()
     }
 
     // 全レイアウトは IDWriteTextFormat にバインドされているため format 再作成と同時に破棄する。
-    // nav / gesture は次回 Draw 時に lazy 再生成（DrawNavOverlay / DrawGestureOverlay 参照）。
     nav_back_layout_.Reset();
     nav_forward_layout_.Reset();
     gesture_back_layout_.Reset();
@@ -203,11 +200,28 @@ void Renderer::RecreatePaneFormats()
     cached_search_caret_pos_ = -1;
     cached_search_width_ = -1.0f;
     cached_search_has_underline_ = false;
+    cached_search_effective_pos_ = -2;
+    cached_search_caret_x_ = 0.0f;
 
-    // ペインキャッシュを無効化して新しいサイズで再描画させる
     file_pane_cache_.Reset();
     toc_pane_cache_.Reset();
 
-    // コマンドジェネレータのフォーマットを更新
     cmd_generator_.SetFormats({ fmt_.list_number.Get(), fmt_.icon_font.Get(), fmt_.copy_btn_icon.Get(), fmt_.placeholder_text.Get() });
+
+    // ナビ/ジェスチャー用レイアウトを eager 作成。描画ホットパス上の null 分岐を排除する。
+    auto* dw = backend_.GetDWriteFactory();
+    if (dw) {
+        if (fmt_.nav_button) {
+            static constexpr wchar_t BACK_ICON[] = L"\x25C0";
+            static constexpr wchar_t FORWARD_ICON[] = L"\x25B6";
+            dw->CreateTextLayout(BACK_ICON, 1, fmt_.nav_button.Get(), NAV_BTN_SIZE, NAV_BTN_SIZE, &nav_back_layout_);
+            dw->CreateTextLayout(FORWARD_ICON, 1, fmt_.nav_button.Get(), NAV_BTN_SIZE, NAV_BTN_SIZE, &nav_forward_layout_);
+        }
+        if (fmt_.gesture_overlay) {
+            static constexpr wchar_t GESTURE_BACK[] = L"\x2190 \x623B\x308B";
+            static constexpr wchar_t GESTURE_FORWARD[] = L"\x2192 \x9032\x3080";
+            dw->CreateTextLayout(GESTURE_BACK, 4, fmt_.gesture_overlay.Get(), 280.0f, 80.0f, &gesture_back_layout_);
+            dw->CreateTextLayout(GESTURE_FORWARD, 4, fmt_.gesture_overlay.Get(), 280.0f, 80.0f, &gesture_forward_layout_);
+        }
+    }
 }

--- a/src/render/renderer_search.cpp
+++ b/src/render/renderer_search.cpp
@@ -15,7 +15,6 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
         md_pane_rect.y + md_pane_rect.height,
         !sb.query.empty());
 
-    // 背景
     const D2D1_RECT_F bar_rect = D2D1::RectF(
         md_pane_rect.x,
         sbl.bar_top,
@@ -23,14 +22,12 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
         sbl.bar_bottom);
     rt()->FillRectangle(bar_rect, Brush(BrushId::SearchBarBg));
 
-    // 上ボーダー
     rt()->DrawLine(
         D2D1::Point2F(bar_rect.left, sbl.bar_top),
         D2D1::Point2F(bar_rect.right, sbl.bar_top),
         Brush(BrushId::SearchBarBorder),
         1.0f);
 
-    // 検索アイコン
     if (fmt_.search_icon) {
         auto* brush = Brush(BrushId::SearchInputText);
         if (brush) {
@@ -40,12 +37,11 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
         }
     }
 
-    // 入力フィールド背景
     const D2D1_ROUNDED_RECT input_rrect = D2D1::RoundedRect(sbl.input_rect, SEARCH_BAR_CORNER, SEARCH_BAR_CORNER);
     const bool no_match = !sb.query.empty() && sb.total_matches == 0;
     rt()->FillRoundedRectangle(input_rrect, Brush(no_match ? BrushId::SearchNoMatchBg : BrushId::SearchInputBg));
 
-    // ボーダー（フォーカス時はリンク色で強調）
+    // フォーカス時はリンク色で強調
     if (sb.has_focus) {
         auto* focus_brush = Brush(BrushId::Link);
         if (focus_brush) {
@@ -61,8 +57,8 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
         }
     }
 
-    // 入力テキスト（レイアウトを1回だけ作成し、描画とキャレット計測を共用）
-    // IMEコンポジション中は確定済みテキスト+変換中テキストを合成して表示
+    // レイアウトを1回だけ作成し、描画とキャレット計測で共用する。
+    // IMEコンポジション中は確定済みテキスト+変換中テキストを合成して表示。
     const float text_left = sbl.input_rect.left + SEARCH_INPUT_TEXT_PAD_LEFT;
     float caret_x = text_left;
 
@@ -136,7 +132,7 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
                 cached_search_has_underline_ = true;
             }
 
-            // 選択範囲のハイライト描画（テキストの背面に描画）
+            // テキストの背面に描画
             const int text_len = static_cast<int>(display_text.size());
             const bool has_selection = !has_comp && sb.selection_start >= 0 && sb.caret_pos >= 0 && sb.selection_start != sb.caret_pos;
             if (has_selection) {
@@ -169,7 +165,7 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
                 text_layout.Get(),
                 Brush(BrushId::SearchInputText));
 
-            // キャレット位置計算: コンポジション中はその末尾、それ以外は通常のキャレット位置
+            // コンポジション中はその末尾、それ以外は通常のキャレット位置
             int effective_pos;
             if (has_comp) {
                 effective_pos = comp_start + comp_len;
@@ -180,14 +176,26 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
                     effective_pos = text_len;
                 }
             }
-            FLOAT px, py;
-            DWRITE_HIT_TEST_METRICS htm{};
-            text_layout->HitTestTextPosition(static_cast<UINT32>(effective_pos), false, &px, &py, &htm);
-            caret_x = text_left + px;
+            // layout が同じで effective_pos が一致するフレーム（典型的にはキャレット点滅
+            // 直前と同じ入力）は HitTestTextPosition を省く。layout 失効時は cache_hit が
+            // false になり、その経路で text_layout を作り直す前に effective_pos キャッシュも
+            // 落としておく必要があるため、ここでは layout 一致を直前 update 済み
+            // cached_search_layout_ で判定する。
+            if (cache_hit && cached_search_effective_pos_ == effective_pos) {
+                caret_x = cached_search_caret_x_;
+            }
+            else {
+                FLOAT px, py;
+                DWRITE_HIT_TEST_METRICS htm{};
+                text_layout->HitTestTextPosition(static_cast<UINT32>(effective_pos), false, &px, &py, &htm);
+                caret_x = text_left + px;
+                cached_search_effective_pos_ = effective_pos;
+                cached_search_caret_x_ = caret_x;
+            }
         }
     }
 
-    // キャレット描画（コンポジション中はIME側がキャレットを表示するため非表示）
+    // コンポジション中はIME側がキャレットを表示するため非表示
     if (sb.caret_visible && !has_comp) {
         caret_x = std::min(caret_x + 1.0f, sbl.input_rect.right - SEARCH_INPUT_TEXT_PAD_RIGHT);
         rt()->DrawLine(
@@ -197,7 +205,6 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
             1.0f);
     }
 
-    // ボタン描画ヘルパー
     auto drawIconBtn = [&](const D2D1_RECT_F& r, const wchar_t* icon, bool hovered, float alpha = 1.0f) {
         if (hovered) {
             rt()->FillRoundedRectangle(D2D1::RoundedRect(r, SEARCH_BAR_CORNER, SEARCH_BAR_CORNER), Brush(BrushId::TitleBarButtonHover));
@@ -233,7 +240,6 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
     drawIconBtn(sbl.up_btn, L"\uE70E", sb.up_btn_hovered, nav_alpha);
     drawIconBtn(sbl.down_btn, L"\uE70D", sb.down_btn_hovered, nav_alpha);
 
-    // マッチカウント
     if (fmt_.search_count && !sb.query.empty()) {
         wchar_t count_text[32];
         if (sb.total_matches == 0) {

--- a/src/render/renderer_titlebar.cpp
+++ b/src/render/renderer_titlebar.cpp
@@ -6,14 +6,13 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
         return;
     }
 
-    // タイトルバー背景（完全不透明でガラス効果を隠す）
+    // 完全不透明でガラス効果を隠す
     const D2D1_RECT_F bg_rect = D2D1::RectF(0.0f, 0.0f, tb.window_width, tb.height);
     rt()->FillRectangle(bg_rect, Brush(BrushId::TitleBarBg));
 
     const float text_alpha = tb.window_active ? 1.0f : 0.5f;
     const auto is_hovered = [&](TitleBarHitZone z) noexcept { return tb.hovered_zone == z; };
 
-    // アイコンボタン描画ヘルパー
     auto drawButton = [&](const DipRect& dip_rect, const wchar_t* icon, bool show_bg, BrushId bg_id, BrushId text_id, float alpha) {
         const D2D1_RECT_F rect = ToD2DRect(dip_rect);
         if (show_bg) {
@@ -29,7 +28,6 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
         }
     };
 
-    // ファイルを開くボタン
     drawButton(
         tb.open_file.rect,
         L"\uE838",
@@ -37,7 +35,6 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
         BrushId::TitleBarButtonHover,
         BrushId::TitleBarText,
         text_alpha);
-    // ヘルプボタン
     drawButton(
         tb.help.rect,
         L"\uE897",
@@ -45,7 +42,7 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
         BrushId::TitleBarButtonHover,
         BrushId::TitleBarText,
         text_alpha);
-    // ダークモード切替ボタン（ダーク時: 太陽アイコン、ライト時: 月アイコン）
+    // ダーク時: 太陽アイコン、ライト時: 月アイコン
     drawButton(
         tb.theme_toggle.rect,
         tb.is_dark_mode ? L"\uE706" : L"\uE708",
@@ -53,7 +50,7 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
         BrushId::TitleBarButtonHover,
         BrushId::TitleBarText,
         text_alpha);
-    // 検索ボタン（active > hover の優先度）
+    // active > hover の優先度
     drawButton(
         tb.search.rect,
         L"\uE721",
@@ -61,7 +58,6 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
         tb.search_active ? BrushId::TitleBarButtonActive : BrushId::TitleBarButtonHover,
         BrushId::TitleBarText,
         text_alpha);
-    // ペイン切替ボタン（active > hover の優先度）
     drawButton(
         tb.file_toggle.rect,
         L"\uE8B7",
@@ -76,7 +72,6 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
         tb.toc_pane_visible ? BrushId::TitleBarButtonActive : BrushId::TitleBarButtonHover,
         BrushId::TitleBarText,
         text_alpha);
-    // キャプションボタン
     drawButton(
         tb.minimize.rect,
         L"\uE921",
@@ -93,7 +88,7 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
         BrushId::TitleBarButtonHover,
         BrushId::TitleBarText,
         text_alpha);
-    // 閉じるボタン（ホバー時は赤背景＋白アイコン）
+    // ホバー時は赤背景＋白アイコン
     if (is_hovered(TitleBarHitZone::Close)) {
         drawButton(
             tb.close.rect, L"\uE8BB",
@@ -112,13 +107,11 @@ void Renderer::DrawTitleBar(const TitleBarRenderState& tb)
             text_alpha);
     }
 
-    // アプリアイコン
     if (app_icon_bitmap_) {
         const float icon_alpha = tb.window_active ? 1.0f : 0.5f;
         rt()->DrawBitmap(app_icon_bitmap_.Get(), ToD2DRect(tb.icon_rect), icon_alpha, D2D1_BITMAP_INTERPOLATION_MODE_LINEAR);
     }
 
-    // タイトルテキスト
     if (fmt_.titlebar_text && !tb.title_text.empty()) {
         auto* brush = Brush(BrushId::TitleBarText);
         if (brush) {

--- a/src/ui/context_menu.cpp
+++ b/src/ui/context_menu.cpp
@@ -8,10 +8,6 @@ using namespace context_menu_constants;
 
 bool ContextMenu::Impl::class_registered = false;
 
-// ============================================================
-// ウィンドウクラス登録
-// ============================================================
-
 bool ContextMenu::Impl::RegisterWindowClass()
 {
     if (class_registered) {
@@ -48,10 +44,6 @@ LRESULT CALLBACK ContextMenu::Impl::WndProc(HWND hwnd, UINT msg, WPARAM wParam, 
     }
     return DefWindowProcW(hwnd, msg, wParam, lParam);
 }
-
-// ============================================================
-// メニュー表示（モーダル）
-// ============================================================
 
 int ContextMenu::Show(HWND owner_hwnd, const ContextMenuParams& params)
 {
@@ -160,10 +152,6 @@ int ContextMenu::Show(HWND owner_hwnd, const ContextMenuParams& params)
     return s.selected_id;
 }
 
-// ============================================================
-// メッセージハンドラ
-// ============================================================
-
 LRESULT ContextMenu::Impl::HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam)
 {
     switch (msg) {
@@ -185,7 +173,6 @@ LRESULT ContextMenu::Impl::HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam)
         hovered_id = 0;
         hovered_nav = 0;
 
-        // ナビ行のボタン判定
         if (!items.empty() && items[0].type == ItemType::NavRow) {
             if (nav_layout.back_enabled && PointInRect(x, y, nav_layout.back_rect)) {
                 hovered_nav = -1;
@@ -263,10 +250,6 @@ LRESULT ContextMenu::Impl::HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam)
     }
 }
 
-// ============================================================
-// D2Dリソース
-// ============================================================
-
 bool ContextMenu::Impl::EnsureRenderTarget(float dpi)
 {
     if (rt) {
@@ -304,10 +287,6 @@ void ContextMenu::Impl::CreateBrushes()
     brush_hover = make(theme->pane_item_hover_color);
     brush_check = make(theme->link_color);
 }
-
-// ============================================================
-// 描画
-// ============================================================
 
 void ContextMenu::Impl::Paint()
 {

--- a/src/ui/context_menu.h
+++ b/src/ui/context_menu.h
@@ -33,7 +33,6 @@ struct ContextMenuParams {
 // 戻る/進むボタンの横並び表示が可能。
 class ContextMenu {
 public:
-    // メニュー項目の種類
     enum class ItemType : uint8_t {
         NavRow,
         Separator,
@@ -68,11 +67,9 @@ public:
     // メニューを表示しユーザーの選択を待つ（モーダル）
     int Show(HWND owner_hwnd, const ContextMenuParams& params);
 
-    // ヒットテスト
     int HitTest(float x, float y) const noexcept;
     int NavHitTest(float x, float y) const noexcept;
 
-    // レイアウト結果へのアクセサ
     const std::vector<Item>& GetItems() const noexcept;
     const NavRowLayout& GetNavLayout() const noexcept;
     float GetMenuWidth() const noexcept;

--- a/src/ui/context_menu_impl.h
+++ b/src/ui/context_menu_impl.h
@@ -31,7 +31,6 @@ inline constexpr wchar_t GLYPH_CHECKMARK[] = L"\xE73E";
 } // namespace context_menu_constants
 
 struct ContextMenu::Impl {
-    // ウィンドウクラス登録フラグ
     static bool class_registered;
     static bool RegisterWindowClass();
     static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
@@ -51,25 +50,20 @@ struct ContextMenu::Impl {
     int HitTest(float x, float y) const noexcept;
     int NavHitTest(float x, float y) const noexcept;
 
-    // ウィンドウ
     HWND hwnd = nullptr;
     HWND owner = nullptr;
 
-    // モーダルループ制御
     bool done = false;
     int selected_id = 0;
 
-    // ホバー状態
     int hovered_id = 0;
     int hovered_nav = 0;
 
-    // メニュー項目
     std::vector<Item> items;
     NavRowLayout nav_layout{};
     float menu_width = 0.0f;
     float menu_height = 0.0f;
 
-    // D2Dリソース
     ID2D1Factory* d2d_factory = nullptr;
     IDWriteFactory* dwrite_factory = nullptr;
     Microsoft::WRL::ComPtr<ID2D1HwndRenderTarget> rt;

--- a/src/ui/context_menu_logic.cpp
+++ b/src/ui/context_menu_logic.cpp
@@ -6,10 +6,6 @@
 using Microsoft::WRL::ComPtr;
 using namespace context_menu_constants;
 
-// ============================================================
-// 公開 API（PIMPL 経由の forward）
-// ============================================================
-
 ContextMenu::ContextMenu() : impl_(std::make_unique<Impl>())
 {}
 ContextMenu::~ContextMenu() = default;
@@ -63,10 +59,6 @@ void ContextMenu::TestComputeLayout()
     impl_->ComputeLayout();
 }
 
-// ============================================================
-// メニュー項目構築
-// ============================================================
-
 void ContextMenu::Impl::BuildItems(const ContextMenuParams& params)
 {
     items.clear();
@@ -93,10 +85,7 @@ void ContextMenu::Impl::BuildItems(const ContextMenuParams& params)
     items.emplace_back(ItemType::Text, IDM_TOGGLE_TOC_PANE, ls.menu_toc_pane, true, params.toc_pane_checked);
 }
 
-// ============================================================
-// テキストフォーマット（DWrite only、Win32 / D2D render target 非依存）
-// ============================================================
-
+// テキストフォーマット生成（DWrite only、Win32 / D2D render target 非依存）。
 void ContextMenu::Impl::CreateTextFormats(const Theme& t)
 {
     if (fmt_text && fmt_icon &&
@@ -132,10 +121,6 @@ void ContextMenu::Impl::CreateTextFormats(const Theme& t)
     cached_fmt_font_family.assign(t.font_family.begin(), t.font_family.end());
     cached_fmt_font_size = t.pane_font_size;
 }
-
-// ============================================================
-// レイアウト計算
-// ============================================================
 
 void ContextMenu::Impl::ComputeLayout()
 {
@@ -193,10 +178,6 @@ void ContextMenu::Impl::ComputeLayout()
 
     menu_height = y + PAD_Y;
 }
-
-// ============================================================
-// ヒットテスト
-// ============================================================
 
 int ContextMenu::Impl::HitTest(float x, float y) const noexcept
 {

--- a/src/ui/pane_controller.h
+++ b/src/ui/pane_controller.h
@@ -7,7 +7,6 @@
 // Win32非依存 — 完全にテスト可能。
 class PaneController {
 public:
-    // ---- ドラッグ対象 ----
     enum class DragTarget : uint8_t {
         None,
         Splitter1,
@@ -17,7 +16,6 @@ public:
         MdScrollbar
     };
 
-    // ---- 表示/非表示 ----
     constexpr bool IsFilePaneVisible() const noexcept
     {
         return show_file_;
@@ -52,7 +50,6 @@ public:
         SetTocPaneVisible(!show_toc_);
     }
 
-    // ---- 幅 ----
     constexpr float GetFilePaneWidth() const noexcept
     {
         return file_width_;
@@ -70,7 +67,6 @@ public:
         toc_width_ = std::max(w, PANE_MIN_WIDTH);
     }
 
-    // ---- スクロール ----
     constexpr ScrollState& FileScroll() noexcept
     {
         return file_scroll_;
@@ -93,11 +89,10 @@ public:
         toc_scroll_ = {};
     }
 
-    // ペインをdelta分スクロールし、実際にスクロール位置が変化した場合trueを返す
+    // 実際にスクロール位置が変化した場合 true を返す。
     bool ScrollFilePaneBy(float delta, float max_scroll) noexcept;
     bool ScrollTocPaneBy(float delta, float max_scroll) noexcept;
 
-    // ---- ホバー ----
     constexpr int GetHoveredFileIndex() const noexcept
     {
         return hovered_file_;
@@ -106,11 +101,10 @@ public:
     {
         return hovered_toc_;
     }
-    // 値が変化した場合trueを返す
+    // 値が変化した場合 true を返す。
     bool SetHoveredFileIndex(int idx) noexcept;
     bool SetHoveredTocIndex(int idx) noexcept;
 
-    // ペインヘッダー閉じるボタンのホバー状態
     constexpr bool IsFileCloseHovered() const noexcept
     {
         return file_close_hovered_;
@@ -122,7 +116,6 @@ public:
     bool SetFileCloseHovered(bool h) noexcept;
     bool SetTocCloseHovered(bool h) noexcept;
 
-    // ファイルペインヘッダー更新ボタンのホバー状態
     constexpr bool IsFileRefreshHovered() const noexcept
     {
         return file_refresh_hovered_;
@@ -130,7 +123,6 @@ public:
     bool SetFileRefreshHovered(bool h) noexcept;
 
 public:
-    // ---- ドラッグ ----
     constexpr DragTarget GetDragTarget() const noexcept
     {
         return drag_target_;
@@ -152,19 +144,16 @@ public:
         drag_scroll_offset_ = off;
     }
 
-    // スプリッター1の位置を制約する（ファイルペインの右端）
+    // スプリッター1の位置を制約する（ファイルペインの右端）。
     void DragSplitter1To(float dip_x, float total_width, float splitter_w) noexcept;
-    // スプリッター2の位置を制約する（目次ペインの右端）
+    // スプリッター2の位置を制約する（目次ペインの右端）。
     void DragSplitter2To(float dip_x, float total_width, float splitter_w) noexcept;
 
-    // ---- ズーム ----
     void ApplyZoom(float ratio) noexcept;
 
-    // ---- レイアウト ----
     PaneLayout ComputeLayout(float total_w, float total_h, float splitter_w, float top_offset = 0.0f) const noexcept;
     PaneZone DetectZone(float dip_x, float total_w, float total_h, float splitter_w) const noexcept;
 
-    // ---- 定数 ----
     static constexpr float PANE_DEFAULT_WIDTH = 220.0f;
     static constexpr float PANE_MIN_WIDTH = 100.0f;
     static constexpr float MD_PANE_MIN_WIDTH = 200.0f;

--- a/src/ui/pane_layout.cpp
+++ b/src/ui/pane_layout.cpp
@@ -13,19 +13,16 @@ PaneLayout ComputePaneLayout(float total_width, float total_height,
         pane_height = 0.0f;
     }
 
-    // ファイルペイン
     if (show_file) {
         layout.file_rect = { x, top_offset, file_pane_width, pane_height };
         x += file_pane_width + splitter_width;
     }
 
-    // 目次ペイン
     if (show_toc) {
         layout.toc_rect = { x, top_offset, toc_pane_width, pane_height };
         x += toc_pane_width + splitter_width;
     }
 
-    // MDペインは残りの幅を使用
     const float md_width = std::max(md_min_width, total_width - x);
     layout.md_rect = { x, top_offset, md_width, pane_height };
 

--- a/src/ui/pane_layout.h
+++ b/src/ui/pane_layout.h
@@ -11,14 +11,13 @@ enum class PaneZone : uint8_t {
     MdPane
 };
 
-// 計算済みペインレイアウト位置
 struct PaneLayout {
     PaneRect file_rect{};
     PaneRect toc_rect{};
     PaneRect md_rect{};
 };
 
-// ペインのスクロール情報（スクロールバーの描画と操作に使用）
+// スクロールバーの描画と操作に使う情報。
 struct PaneScrollInfo {
     float content_top = 0.0f;
     float content_height = 0.0f;

--- a/src/ui/search_bar_controller.cpp
+++ b/src/ui/search_bar_controller.cpp
@@ -13,10 +13,6 @@ void SearchBarController::Init(SearchState& state, ViewportManager& viewport, La
     cb_ = std::move(cb);
 }
 
-// ============================================================
-// イベントハンドラ
-// ============================================================
-
 void SearchBarController::OnOpen(const std::pmr::vector<Node>& nodes)
 {
     if (state_->IsVisible()) {
@@ -133,10 +129,6 @@ void SearchBarController::SetImeComposition(std::wstring_view comp)
     }
 }
 
-// ============================================================
-// タイマーハンドラ
-// ============================================================
-
 void SearchBarController::OnCaretBlinkTimer()
 {
     caret_visible_ = !caret_visible_;
@@ -151,10 +143,6 @@ void SearchBarController::OnDebounceTimer(const std::pmr::vector<Node>& nodes)
     RunSearchAndLocate(nodes, true);
     cb_.invalidate();
 }
-
-// ============================================================
-// 検索実行
-// ============================================================
 
 void SearchBarController::RunSearchAndLocate(const std::pmr::vector<Node>& nodes, bool scroll_to_match)
 {
@@ -199,10 +187,6 @@ void SearchBarController::ScrollToCurrentMatch()
     }
 }
 
-// ============================================================
-// リセット
-// ============================================================
-
 void SearchBarController::Reset()
 {
     state_->Reset();
@@ -217,19 +201,11 @@ void SearchBarController::Reset()
     cb_.kill_timer(TIMER_DEBOUNCE);
 }
 
-// ============================================================
-// ドラッグ選択
-// ============================================================
-
 void SearchBarController::StartDrag(int anchor_pos) noexcept
 {
     dragging_ = true;
     drag_anchor_ = anchor_pos;
 }
-
-// ============================================================
-// ホバー管理
-// ============================================================
 
 void SearchBarController::UpdateHoverFromZone(SearchBarHitZone zone)
 {
@@ -240,10 +216,6 @@ void SearchBarController::UpdateHoverFromZone(SearchBarHitZone zone)
         cb_.invalidate_search_bar();
     }
 }
-
-// ============================================================
-// レンダー状態構築
-// ============================================================
 
 SearchBarRenderState SearchBarController::BuildRenderState() const
 {
@@ -266,10 +238,6 @@ SearchBarRenderState SearchBarController::BuildRenderState() const
     sb.highlight_btn_hovered = (hover_ == SearchBarHitZone::Highlight);
     return sb;
 }
-
-// ============================================================
-// 内部ヘルパー
-// ============================================================
 
 void SearchBarController::RestartCaretBlink()
 {

--- a/src/ui/search_bar_controller.h
+++ b/src/ui/search_bar_controller.h
@@ -38,7 +38,6 @@ public:
     SearchBarController() = default;
     void Init(SearchState& state, ViewportManager& viewport, LayoutCache& cache, Callbacks cb);
 
-    // --- イベントハンドラ ---
     void OnOpen(const std::pmr::vector<Node>& nodes);
     void OnClose();
     void OnNext();
@@ -49,18 +48,15 @@ public:
     void SetSelection(int sel_start, int sel_end) noexcept;
     void SetImeComposition(std::wstring_view comp);
 
-    // --- タイマーハンドラ ---
     void OnCaretBlinkTimer();
     void OnDebounceTimer(const std::pmr::vector<Node>& nodes);
 
-    // --- 検索実行 ---
     void RunSearchAndLocate(const std::pmr::vector<Node>& nodes, bool scroll_to_match = false);
     void ScrollToCurrentMatch();
 
-    // --- ファイル切替時リセット ---
+    // ファイル切替時のリセット。
     void Reset();
 
-    // --- ドラッグ選択（検索入力テキスト） ---
     bool IsDragging() const noexcept
     {
         return dragging_;
@@ -79,7 +75,6 @@ public:
         dragging_ = false;
     }
 
-    // --- ホバー管理 ---
     void UpdateHoverFromZone(SearchBarHitZone zone);
     SearchBarHitZone GetHover() const noexcept
     {
@@ -90,10 +85,8 @@ public:
         hover_ = SearchBarHitZone::None;
     }
 
-    // --- レンダー状態構築 ---
     SearchBarRenderState BuildRenderState() const;
 
-    // --- アクセサ ---
     bool HasFocus() const noexcept
     {
         return has_focus_;

--- a/src/ui/search_state.cpp
+++ b/src/ui/search_state.cpp
@@ -192,7 +192,7 @@ void SearchState::SetCurrentMatchNear(float scroll_y, const LayoutCache& cache) 
 
     // matches_ は node_index 昇順、同一ノード内では start 昇順、同一テーブル内では
     // (row, col, start) 昇順で追加される。GetMatchYRange も同じ順序で単調非減少となるため
-    // 二分探索が使える (issue #97, 検索ジャンプ精度向上)。
+    // 二分探索が使える。
     const auto it = std::ranges::partition_point(matches_, [&](const SearchMatch& m) noexcept {
         if (m.node_index >= static_cast<int>(cache.size())) {
             return true;

--- a/src/ui/search_state.h
+++ b/src/ui/search_state.h
@@ -74,7 +74,6 @@ public:
     {
         return static_cast<int>(matches_.size());
     }
-    // 大文字小文字の区別
     constexpr bool IsCaseSensitive() const noexcept
     {
         return case_sensitive_;
@@ -88,7 +87,6 @@ public:
         case_sensitive_ = !case_sensitive_;
     }
 
-    // ハイライト表示のON/OFF
     constexpr bool IsHighlightEnabled() const noexcept
     {
         return highlight_enabled_;

--- a/src/util/lru_cache.h
+++ b/src/util/lru_cache.h
@@ -45,7 +45,6 @@ public:
             return;
         }
 
-        // 既存キーの更新
         for (size_t i = 0; i < size_; i++) {
             if (keys_[i] == key) {
                 values_[i] = std::move(value);
@@ -54,7 +53,6 @@ public:
             }
         }
 
-        // 容量超過時は最古エントリを破棄して上書き
         if (size_ >= max_entries_) {
             const size_t oldest = FindOldestIndex();
             keys_[oldest] = key;
@@ -63,7 +61,6 @@ public:
             return;
         }
 
-        // 新規追加
         keys_.push_back(key);
         values_.push_back(std::move(value));
         generations_.push_back(++generation_counter_);

--- a/src/util/memory_resource.h
+++ b/src/util/memory_resource.h
@@ -29,7 +29,9 @@ inline void InitGlobalMemoryResource()
 class MonotonicResource {
 public:
     explicit MonotonicResource(std::size_t initial_size = 16 * 1024)
-        : buffer_(std::make_unique<std::byte[]>(initial_size)), monotonic_(buffer_.get(), initial_size, std::pmr::get_default_resource())
+        // make_unique<T[]> は値初期化で N バイトを memset するため、
+        // monotonic 用のスクラッチには make_unique_for_overwrite で default 初期化させる。
+        : buffer_(std::make_unique_for_overwrite<std::byte[]>(initial_size)), monotonic_(buffer_.get(), initial_size, std::pmr::get_default_resource())
     {
     }
 

--- a/tests/mock_text_measurer.h
+++ b/tests/mock_text_measurer.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "text_measurer.h"
+#include "ui_constants.h"
 #include <cmath>
 
 // DirectWriteなしでLayoutEngineをテストするためのモックテキスト計測器。
@@ -93,10 +94,14 @@ public:
 
         auto& tl = entry.ensure_table_layout();
         const auto row_count = node.table_rows().size();
-        tl.col_widths.assign(col_count, max_width / static_cast<float>(col_count));
+        const float col_w = max_width / static_cast<float>(col_count);
+        tl.col_widths.assign(col_count, col_w);
         tl.row_heights.assign(row_count, table_row_height);
         tl.col_count = col_count;
         tl.cell_layouts.resize(row_count * col_count);
+        // GenTable は tl.cached_table_width を直接読むため、production の
+        // FinalizeTableLayout と同じ式 (border + Σ(cw + 2*pad + border)) で同期する。
+        tl.cached_table_width = TABLE_BORDER_WIDTH + static_cast<float>(col_count) * (col_w + TABLE_CELL_PADDING * 2.0f + TABLE_BORDER_WIDTH);
 
         // dwrite_measurer.cpp と同じ規約で行先頭オフセットを埋める。
         tl.row_flat_offsets.resize(row_count);


### PR DESCRIPTION
## Summary

このPRには **2 種類の変更** が混在しています (Copilot 指摘 #2 を受けて分割せず説明を実態に合わせる方針):

### 1. コメント整理 (60 ファイル)
CLAUDE.md のコメント方針 (デフォルトはコメントなし、WHY が非自明な場合のみ残す) に沿って価値の薄いコメントを除去。

### 2. 描画/レイアウトのホットパス最適化
- `TableLayoutData::cached_table_width`: 列幅+パディング+罫線の合計をキャッシュ。GenTable から毎フレーム fold せず参照
- `NodeLayoutEntry::SearchHlCache` / `SelectionHlCache`: 検索/選択ハイライト矩形のフレーム間キャッシュ。HitTestTextRange 再計算をスキップ
- `NodeLayoutEntry::first_line_height`: MeasureNode 時の GetLineMetrics 結果を保持し、描画時の COM 越境を排除
- `DrawTextCmd` の inline buffer 化 (1〜4 文字は monotonic resource を経由せず格納)
- `CommandExecutor` の直前ブラシキャッシュ (GetBrush 高速化)
- `CommandGenerator::frame_resource_` を 1 MiB に増量 + 直前フレームサイズ基準で reserve

### 3. Copilotレビュー指摘 #1 への対応 (本PR内で追加修正)
`SelectionHlCache` は描画時に lazy 確保されるが、選択範囲外に出たノードでは自動破棄経路が無く、長時間利用でメモリが漸増する懸念があったため:
- `LayoutCache::ClearAllSelectionHlCaches()` を追加
- `CommandGenerator` が前フレームの選択ノード範囲を保持し、新しい範囲外に出たノードの cache を毎フレーム invalidate
- 解除/縮小/別範囲への移動をまとめて拾う

## 削除した代表的なコメントパターン
- 識別子と同義のラベル/セクションヘッダー (`// 戻るボタン (◀)`, `// アクセサ` 等)
- WHAT を説明するだけのコメント (`// nullptr チェック`, `// PNG をファイルに書き出す` 等)
- 装飾目的だけの `// ====` 区切り
- PR/issue 番号への単なる参照

## 残したもの (WHY 寄り)
- `parser.cpp` の md4c / PMR メモリ意図
- DirectWrite / D2D の API 由来制約 (例: `ResizeBuffers の前にターゲット参照を切る`)
- Win32 ファイル監視の race / partial-read 説明 (`app_file.cpp`)
- マジックナンバーの根拠 (DPI、タイミング、容量上限)
- `i18n.h` の翻訳テーブル
- テスト内の「issue #N — このバグの再現」のような根拠付き参照

## Test plan

- [x] Release 構成でビルド成功
- [x] `mendo_tests.exe` の 2063 件すべて pass
- [ ] 長時間利用での選択操作 (ドラッグ多回数 → 解除) 後にメモリ蓄積が無いことを実機確認
- [ ] レビュアーで誤って削除された WHY コメントがないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)