### PR TITLE
perf: ascii_util::Find に qlen==1 高速パスと既存検索の置き換え

### DIFF
--- a/src/app/resource_manager.cpp
+++ b/src/app/resource_manager.cpp
@@ -7,6 +7,7 @@
 #include "mermaid_util.h"
 #include "theme_service.h"
 #include "profiler.h"
+#include "ascii_util.h"
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -113,7 +114,7 @@ int ResourceManager::ApplyCachedImages(bool respect_viewport)
         }
 
         auto* const img = node.image_data();
-        if (!img || img->src.find(L"://") != std::pmr::wstring::npos) {
+        if (!img || ascii_util::Contains(img->src, L"://")) {
             continue;
         }
 

--- a/src/io/config_service.cpp
+++ b/src/io/config_service.cpp
@@ -2,6 +2,7 @@
 #include "pane_controller.h"
 #include "string_convert.h"
 #include "file_io.h"
+#include "ascii_util.h"
 #include <algorithm>
 #include <charconv>
 #include <cmath>
@@ -44,7 +45,7 @@ std::filesystem::path ConfigService::GetConfigPath(std::wstring_view filename) c
     })) {
         return {};
     }
-    if (filename.find(L"..") != std::wstring_view::npos) {
+    if (ascii_util::Contains(filename, L"..")) {
         return {};
     }
     const auto dir = GetConfigDir();

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -5,6 +5,7 @@
 #include "utility.h"
 #include "wic_util.h"
 #include "resource.h"
+#include "ascii_util.h"
 #include <wrl/event.h>
 #include <cassert>
 #include <filesystem>
@@ -316,7 +317,7 @@ void MermaidRenderer::SetupWorker(int index)
             std::span<const std::byte> payload;
             const wchar_t* headers = nullptr;
 
-            if (url.find(L"/mermaid.min.js.gz") != std::pmr::wstring::npos) {
+            if (ascii_util::Contains(url, L"/mermaid.min.js.gz")) {
                 // gzip圧縮されたmermaid.jsを配信する。JSがDecompressionStreamで展開する
                 payload = LoadRcData(IDR_MERMAID_JS_GZ);
                 headers = L"Content-Type: application/gzip";

--- a/src/mermaid/mermaid_util.cpp
+++ b/src/mermaid/mermaid_util.cpp
@@ -2,6 +2,7 @@
 #include "document_types.h"
 #include "syntax.h"
 #include "utility.h"
+#include "ascii_util.h"
 #include <algorithm>
 #include <cmath>
 #include <format>
@@ -148,8 +149,8 @@ std::pmr::wstring mermaid_util::BuildLatexFlowchartCode(std::wstring_view latex)
 
 float mermaid_util::ParseJsonNumber(std::wstring_view json, std::wstring_view key) noexcept
 {
-    auto pos = json.find(key);
-    if (pos == std::wstring_view::npos) {
+    auto pos = ascii_util::Find(json, key);
+    if (pos == ascii_util::npos) {
         return 0.0f;
     }
     pos = json.find_first_not_of(L": "sv, pos + key.size());
@@ -196,8 +197,8 @@ mermaid_util::RequestPrefix mermaid_util::ParseRequestPrefix(std::wstring_view b
 bool mermaid_util::ParseJsonTrueFlag(std::wstring_view json, std::wstring_view key) noexcept
 {
     // 生成側が "ok":true / "ok": true の両形式を出す可能性があるため両方許容。
-    auto pos = json.find(key);
-    if (pos == std::wstring_view::npos) {
+    auto pos = ascii_util::Find(json, key);
+    if (pos == ascii_util::npos) {
         return false;
     }
     pos += key.size();

--- a/src/util/ascii_util.h
+++ b/src/util/ascii_util.h
@@ -174,6 +174,50 @@ inline size_t Find(std::wstring_view text, std::wstring_view query, size_t start
     const size_t last = tlen - qlen; // 最後の有効な開始位置 (start <= last は保証済み)
 
     size_t i = start;
+
+    // qlen == 1 専用ハイパス。最初のヒットで即 return できるため 16 wchar_t
+    // (128-bit × 2) アンロールし、ループ判定は OR 後の単一 movemask で行う。
+    // MSVC STL の wmemchr 系最適化と互角の速度を得るためのホットパス。
+    if (qlen == 1) {
+        while (i + 16 <= tlen) {
+            const __m128i c0 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(tp + i));
+            const __m128i c1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(tp + i + 8));
+            const __m128i eq0 = _mm_cmpeq_epi16(c0, bcast);
+            const __m128i eq1 = _mm_cmpeq_epi16(c1, bcast);
+            const __m128i any = _mm_or_si128(eq0, eq1);
+            if (_mm_movemask_epi8(any) != 0) {
+                const unsigned m0 = static_cast<unsigned>(_mm_movemask_epi8(eq0)) & 0x5555u;
+                unsigned long bit_idx;
+                if (m0 != 0) {
+                    _BitScanForward(&bit_idx, m0);
+                    return i + (bit_idx / 2);
+                }
+                // any != 0 かつ m0 == 0 なので m1 は必ず非零。
+                const unsigned m1 = static_cast<unsigned>(_mm_movemask_epi8(eq1)) & 0x5555u;
+                _BitScanForward(&bit_idx, m1);
+                return i + 8 + (bit_idx / 2);
+            }
+            i += 16;
+        }
+        if (i + 8 <= tlen) {
+            const __m128i c = _mm_loadu_si128(reinterpret_cast<const __m128i*>(tp + i));
+            const __m128i eq = _mm_cmpeq_epi16(c, bcast);
+            const unsigned mask = static_cast<unsigned>(_mm_movemask_epi8(eq)) & 0x5555u;
+            if (mask != 0) {
+                unsigned long bit_idx;
+                _BitScanForward(&bit_idx, mask);
+                return i + (bit_idx / 2);
+            }
+            i += 8;
+        }
+        for (; i <= last; ++i) {
+            if (tp[i] == first) {
+                return i;
+            }
+        }
+        return npos;
+    }
+
     // SIMD は tlen-7 まで読む。i > last の合致は後で弾くので tlen 基準で十分。
     while (i + 8 <= tlen) {
         const __m128i c = _mm_loadu_si128(reinterpret_cast<const __m128i*>(tp + i));
@@ -189,28 +233,25 @@ inline size_t Find(std::wstring_view text, std::wstring_view query, size_t start
             if (pos > last) {
                 return npos;
             }
-            if (qlen == 1 || std::wmemcmp(tp + pos + 1, qp + 1, qlen - 1) == 0) {
+            if (std::wmemcmp(tp + pos + 1, qp + 1, qlen - 1) == 0) {
                 return pos;
             }
         }
         i += 8;
     }
     // 末尾はスカラで処理 (i + 8 > tlen の領域)
-    if (qlen == 1) {
-        for (; i <= last; ++i) {
-            if (tp[i] == first) {
-                return i;
-            }
-        }
-    }
-    else {
-        for (; i <= last; ++i) {
-            if (tp[i] == first && std::wmemcmp(tp + i + 1, qp + 1, qlen - 1) == 0) {
-                return i;
-            }
+    for (; i <= last; ++i) {
+        if (tp[i] == first && std::wmemcmp(tp + i + 1, qp + 1, qlen - 1) == 0) {
+            return i;
         }
     }
     return npos;
+}
+
+// `Find(text, query) != npos` を読みやすく書くための薄いラッパ。
+inline bool Contains(std::wstring_view text, std::wstring_view query) noexcept
+{
+    return Find(text, query) != npos;
 }
 
 // 小文字 ASCII リテラル専用の引数型。コンパイル時に契約違反を検出する。


### PR DESCRIPTION
## Summary

- `ascii_util::Find` に **qlen==1 専用 SIMD パス** を追加。128-bit ロード × 2 で 16 wchar_t をアンロールし、ループ判定は `_mm_or_si128` 後の単一 `_mm_movemask_epi8` で行う。一致レーンの位置特定だけ `_BitScanForward` で行うため、通常パスの mask 反復・`wmemcmp` を省略できる。
- `ascii_util::Contains(text, query)` 薄いラッパを追加し、`Find(...) != npos` パターンを簡潔化。
- 既存の multi-char `wstring_view::find` / `pmr::wstring::find` 5 箇所を `ascii_util::Find` / `Contains` に置換 (`config_service.cpp`, `mermaid.cpp`, `resource_manager.cpp`, `mermaid_util.cpp` × 2)。

## Benchmark (Release / x64)

`ascii_util::Find` vs `std::wstring_view::find` (MSVC STL):

| ケース | 改善前 | 改善後 | std::find |
|---|---|---|---|
| single_char_hit (64Ki) | 3556 ns (0.50x) | **1618 ns (0.99x)** | 1606 ns |
| single_char_no_match | 3941 ns (0.48x) | **1748 ns (1.00x)** | 1739 ns |
| multi-char (mixed CJK) | — | **3216 ns (2.00x)** | 6440 ns |

multi-char ASCII の数字は誤差範囲のまま、CJK 混在でのリードも維持。

## Test plan

- [x] `mendo_tests.exe` 全 2066 テスト合格
- [x] `SimdAsciiFindTest.*` 12 テスト合格 (境界・SIMD 跨ぎ・リピート一致など)
- [x] Release ビルド警告なし (/W4 /utf-8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)