### PR TITLE
perf: Node variant 縮小と parser ホットパス最適化

### DIFF
--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -105,6 +105,9 @@ struct Node {
     // unique_ptr で外出しすると variant 上限が下がり、持たないノードは null pointer のオーバー
     // ヘッドだけで済む。default deleter で自動解放されるため Node 自身は copy/move/dtor の手書き
     // 不要 (= unique_ptr メンバの存在で Node は move-only になる)。
+    // Parser invariant: type == NodeType::Table のとき table_ != nullptr。MeasureTable や
+    // HitTestTable は type 判定だけで table_data() を参照するため、parser はテーブル開始時に
+    // 必ず ensure_table() を呼ぶこと。
     std::unique_ptr<NodeTableData> table_;
     std::unique_ptr<NodeImageData> image_;
 

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -100,17 +100,21 @@ inline constexpr uint32_t kUnsetSourceOffset = std::numeric_limits<uint32_t>::ma
 struct Node {
     TextRunList runs;
 
+    // Table と Image のデータは Node 全体の少数派 (画像/表のあるノードのみ) なので、
+    // variant に詰め込むと最大 alternative である NodeImageData が全 Node の sizeof を支配する。
+    // unique_ptr で外出しすると variant 上限が下がり、持たないノードは null pointer のオーバー
+    // ヘッドだけで済む。default deleter で自動解放されるため Node 自身は copy/move/dtor の手書き
+    // 不要 (= unique_ptr メンバの存在で Node は move-only になる)。
+    std::unique_ptr<NodeTableData> table_;
+    std::unique_ptr<NodeImageData> image_;
+
     // リンク URL の集合。リンクを含むノードでのみ確保される。
     // Why: `Node::runs` が link_url_index で参照する URL テーブル。リンクを持つノードは
     // 全体の少数派 (見出し/段落の一部) なので、空時は 8B ポインタ 1 本に抑える。
-    std::unique_ptr<std::pmr::vector<std::pmr::wstring>> link_urls;
+    std::unique_ptr<std::pmr::vector<std::pmr::wstring>> link_urls_;
 
-    // ノード種別ごとの拡張データ。同時に持てるのは 1 種類のみ。
-    // Why: 旧設計では 4 つの unique_ptr を常に保持していたため、ほとんどのノード
-    // (Paragraph/ListItem 等で 87% を占める) で 32B のポインタ群が null のまま
-    // 死蔵していた。variant に統合することで、データを持つノードでは別ヒープ
-    // への malloc を 1 回省略でき、断片化と allocator オーバーヘッドが減る。
-    using Extra = std::variant<std::monostate, NodeTableData, NodeImageData, NodeHeadingData, NodeCodeData>;
+    // ノード種別ごとの拡張データ。Heading/Code のみ variant に格納 (上限 24B + tag 8B = 32B)。
+    using Extra = std::variant<std::monostate, NodeHeadingData, NodeCodeData>;
     Extra extra;
 
     // --- 4 バイトアライメント ---
@@ -174,19 +178,19 @@ struct Node {
     // get_if 風に *_data() でポインタを返す。所持していなければ nullptr。
     constexpr NodeTableData* table_data() noexcept
     {
-        return std::get_if<NodeTableData>(&extra);
+        return table_.get();
     }
     constexpr const NodeTableData* table_data() const noexcept
     {
-        return std::get_if<NodeTableData>(&extra);
+        return table_.get();
     }
     constexpr NodeImageData* image_data() noexcept
     {
-        return std::get_if<NodeImageData>(&extra);
+        return image_.get();
     }
     constexpr const NodeImageData* image_data() const noexcept
     {
-        return std::get_if<NodeImageData>(&extra);
+        return image_.get();
     }
     constexpr NodeHeadingData* heading_data() noexcept
     {
@@ -207,11 +211,11 @@ struct Node {
 
     constexpr bool has_table() const noexcept
     {
-        return std::holds_alternative<NodeTableData>(extra);
+        return static_cast<bool>(table_);
     }
     constexpr bool has_image() const noexcept
     {
-        return std::holds_alternative<NodeImageData>(extra);
+        return static_cast<bool>(image_);
     }
     constexpr bool has_heading() const noexcept
     {
@@ -222,29 +226,29 @@ struct Node {
         return std::holds_alternative<NodeCodeData>(extra);
     }
 
-    // ensure_*: 既に同じ型を持っていれば内部参照を、違う型を持っていれば差し替えて新規確保した参照を返す。
-    constexpr NodeTableData* ensure_table() noexcept
+    // ensure_*: 既に存在すれば内部参照、無ければ新規確保して返す。
+    constexpr NodeTableData* ensure_table()
     {
-        if (!has_table()) {
-            return &extra.emplace<NodeTableData>();
+        if (!table_) {
+            table_ = std::make_unique<NodeTableData>();
         }
-        return std::get_if<NodeTableData>(&extra);
+        return table_.get();
     }
-    constexpr NodeImageData* ensure_image() noexcept
+    constexpr NodeImageData* ensure_image()
     {
-        if (!has_image()) {
-            return &extra.emplace<NodeImageData>();
+        if (!image_) {
+            image_ = std::make_unique<NodeImageData>();
         }
-        return std::get_if<NodeImageData>(&extra);
+        return image_.get();
     }
-    constexpr NodeHeadingData* ensure_heading() noexcept
+    constexpr NodeHeadingData* ensure_heading()
     {
         if (!has_heading()) {
             return &extra.emplace<NodeHeadingData>();
         }
         return std::get_if<NodeHeadingData>(&extra);
     }
-    constexpr NodeCodeData* ensure_code() noexcept
+    constexpr NodeCodeData* ensure_code()
     {
         if (!has_code()) {
             return &extra.emplace<NodeCodeData>();
@@ -267,16 +271,16 @@ struct Node {
         return hd ? std::wstring_view{ hd->anchor_id } : std::wstring_view{};
     }
 
-    std::pmr::vector<std::pmr::wstring>& ensure_link_urls()
+    constexpr std::pmr::vector<std::pmr::wstring>& ensure_link_urls()
     {
-        if (!link_urls) {
-            link_urls = std::make_unique<std::pmr::vector<std::pmr::wstring>>();
+        if (!link_urls_) {
+            link_urls_ = std::make_unique<std::pmr::vector<std::pmr::wstring>>();
         }
-        return *link_urls;
+        return *link_urls_;
     }
-    std::span<const std::pmr::wstring> view_link_urls() const noexcept
+    constexpr std::span<const std::pmr::wstring> view_link_urls() const noexcept
     {
-        return SpanOrEmpty(link_urls);
+        return SpanOrEmpty(link_urls_);
     }
 
     const std::pmr::vector<SyntaxToken>& syntax_tokens() const noexcept

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -741,11 +741,12 @@ ParseResult ParseMarkdown(std::wstring_view markdown_text)
     // ノード単位のスクラッチを 1 回確保しておくと、長段落・コードブロックでの再確保を抑えられる。
     ctx.current_text.reserve(SCRATCH_RESERVE);
     ctx.nodes.reserve(std::clamp(markdown_text.size() / 48, size_t{ 64 }, size_t{ 16384 }));
-    ctx.heading_indices.reserve(std::clamp(markdown_text.size() / 256, size_t{ 8 }, size_t{ 512 }));
+    // heading_indices と anchor_counts は同じ「見出し数」が入るので reserve の見積もりも揃える。
+    // 1MB あたり 256 個程度で実測の数十〜数百に収まる。
+    ctx.heading_indices.reserve(std::clamp(markdown_text.size() / 4096, size_t{ 8 }, size_t{ 256 }));
     ctx.image_indices.reserve(std::clamp(markdown_text.size() / 512, size_t{ 4 }, size_t{ 256 }));
     ctx.diagram_indices.reserve(std::clamp(markdown_text.size() / 1024, size_t{ 4 }, size_t{ 128 }));
     ctx.blockquote_indices.reserve(std::clamp(markdown_text.size() / 512, size_t{ 4 }, size_t{ 256 }));
-    // 1MB あたり 256 個程度を見出し数の目安に。実測では数十〜数百に収まるので過大確保しない。
     ctx.anchor_counts.reserve(std::clamp(markdown_text.size() / 4096, size_t{ 8 }, size_t{ 256 }));
 
     MD_PARSER parser{};

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -741,13 +741,14 @@ ParseResult ParseMarkdown(std::wstring_view markdown_text)
     // ノード単位のスクラッチを 1 回確保しておくと、長段落・コードブロックでの再確保を抑えられる。
     ctx.current_text.reserve(SCRATCH_RESERVE);
     ctx.nodes.reserve(std::clamp(markdown_text.size() / 48, size_t{ 64 }, size_t{ 16384 }));
-    // heading_indices と anchor_counts は同じ「見出し数」が入るので reserve の見積もりも揃える。
-    // 1MB あたり 256 個程度で実測の数十〜数百に収まる。
-    ctx.heading_indices.reserve(std::clamp(markdown_text.size() / 4096, size_t{ 8 }, size_t{ 256 }));
+    // 1MB あたり 256 個程度を見出し数の目安に。実測の数十〜数百に収まる。
+    // heading_indices と anchor_counts は 1 見出し 1 エントリで対になるので同じヒントを使う。
+    const size_t heading_hint = std::clamp(markdown_text.size() / 4096, size_t{ 8 }, size_t{ 256 });
+    ctx.heading_indices.reserve(heading_hint);
+    ctx.anchor_counts.reserve(heading_hint);
     ctx.image_indices.reserve(std::clamp(markdown_text.size() / 512, size_t{ 4 }, size_t{ 256 }));
     ctx.diagram_indices.reserve(std::clamp(markdown_text.size() / 1024, size_t{ 4 }, size_t{ 128 }));
     ctx.blockquote_indices.reserve(std::clamp(markdown_text.size() / 512, size_t{ 4 }, size_t{ 256 }));
-    ctx.anchor_counts.reserve(std::clamp(markdown_text.size() / 4096, size_t{ 8 }, size_t{ 256 }));
 
     MD_PARSER parser{};
     parser.abi_version = 0;

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -102,10 +102,18 @@ struct ParseContext {
     int paragraph_display_math_count = 0;
     bool paragraph_has_other_content = false;
     std::pmr::wstring display_math_buf{ &pool };
+    // display_math_buf に append された範囲の改行数。昇格時の line_count 設定に使い、
+    // current_text 全体を std::ranges::count で走査するコストを避ける。
+    uint32_t display_math_newlines = 0;
 
     // md_parse() に渡した入力バッファ。source_offset 計算と OnText の text ポインタ範囲判定に使う。
     const wchar_t* markdown_base = nullptr;
     size_t markdown_size = 0;
+
+    // 現在ノードの source_offset が既に設定済みか。
+    // OnText の uint32 比較 (current_node->source_offset == kUnsetSourceOffset) を毎テキストで
+    // 評価する代わりに、BeginNode でリセット → 範囲内マッチで設定 → 以降は素通しでよい。
+    bool node_source_offset_set = false;
 
     // 現在ノードの Wide スクラッチを text_ にコピーし、スクラッチをクリアする。
     // BeginNode 直前と各 OnLeaveBlock の current_node 解除直前に呼ぶ。
@@ -138,6 +146,7 @@ struct ParseContext {
             current_node->quote_outer_indent = static_cast<int8_t>(std::min(outermost_quote_indent, kInt8Max));
         }
         // runs は SBO=4 で初期確保ゼロを狙う。reserve すると SBO の利点が消えるので呼ばない。
+        node_source_offset_set = false;
     }
 
     TextRun MakeRun(uint32_t start, uint32_t length)
@@ -161,14 +170,12 @@ struct ParseContext {
             current_link_url_index = -1;
             return;
         }
-        if (auto* existing_urls = current_node->link_urls.get()) {
-            const auto& urls = *existing_urls;
-            const size_t n = urls.size();
-            for (size_t i = 0; i < n; ++i) {
-                if (std::wstring_view{ urls[i] } == url) {
-                    current_link_url_index = static_cast<int16_t>(i);
-                    return;
-                }
+        const auto existing = current_node->view_link_urls();
+        const size_t n = existing.size();
+        for (size_t i = 0; i < n; ++i) {
+            if (std::wstring_view{ existing[i] } == url) {
+                current_link_url_index = static_cast<int16_t>(i);
+                return;
             }
         }
         auto& urls = current_node->ensure_link_urls();
@@ -267,7 +274,7 @@ bool TryPromoteParagraphToDisplayMath(ParseContext* ctx)
     node->code_language = SyntaxLanguage::LatexMath;
     ctx->current_text.assign(ctx->display_math_buf.data(), ctx->display_math_buf.size());
     node->runs.clear();
-    node->line_count = static_cast<int>(std::ranges::count(ctx->current_text, L'\n'));
+    node->line_count = static_cast<int>(ctx->display_math_newlines);
     ctx->diagram_indices.emplace_back(ctx->current_node_index);
     return true;
 }
@@ -298,6 +305,7 @@ int OnEnterBlock(MD_BLOCKTYPE type, void* detail, void* userdata)
         ctx->paragraph_display_math_count = 0;
         ctx->paragraph_has_other_content = false;
         ctx->display_math_buf.clear();
+        ctx->display_math_newlines = 0;
         ctx->in_display_math = false;
         break;
 
@@ -357,6 +365,9 @@ int OnEnterBlock(MD_BLOCKTYPE type, void* detail, void* userdata)
 
     case MD_BLOCK_TABLE:
         ctx->BeginNode(NodeType::Table);
+        // 後続の TR/TH/TD で nullable チェックなく参照できるよう先に確保する。
+        // これに依存して TR/TH/TD は has_table() ガードを省いている。
+        ctx->current_node->ensure_table();
         ctx->in_table = true;
         break;
 
@@ -370,14 +381,13 @@ int OnEnterBlock(MD_BLOCKTYPE type, void* detail, void* userdata)
 
     case MD_BLOCK_TR:
         if (auto* cn = ctx->current_node; cn && cn->type == NodeType::Table) {
-            cn->ensure_table();
             cn->table_rows().emplace_back();
         }
         break;
 
     case MD_BLOCK_TH:
     case MD_BLOCK_TD: {
-        if (auto* cn = ctx->current_node; cn && cn->type == NodeType::Table && cn->has_table() && !cn->table_rows().empty()) {
+        if (auto* cn = ctx->current_node; cn && cn->type == NodeType::Table && !cn->table_rows().empty()) {
             auto& row = cn->table_rows().back();
             ctx->current_cell = &row.cells.emplace_back();
             ctx->current_cell->is_header = (type == MD_BLOCK_TH);
@@ -644,12 +654,14 @@ int OnText(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, void* userdata)
     // _T(""), _T("\n"), _T(" ") といった内部静的リテラルを text として渡すことがある。
     // 異なる array 同士のポインタ減算は UB なので、範囲判定もオフセット計算も uintptr_t の
     // 整数演算で行う (std::less<T*> の total order はアドレスの数値順と一致する保証がない)。
-    if (ctx->current_node->source_offset == kUnsetSourceOffset) {
+    // 範囲外マッチ (静的リテラル) のときは flag を立てず、後続の実体テキストで上書きできるようにする。
+    if (!ctx->node_source_offset_set) [[unlikely]] {
         const auto text_addr = reinterpret_cast<uintptr_t>(text);
         const auto base_addr = reinterpret_cast<uintptr_t>(ctx->markdown_base);
         const auto end_addr = base_addr + ctx->markdown_size * sizeof(wchar_t);
         if (text_addr >= base_addr && text_addr < end_addr) {
             ctx->current_node->source_offset = static_cast<uint32_t>((text_addr - base_addr) / sizeof(wchar_t));
+            ctx->node_source_offset_set = true;
         }
     }
 
@@ -668,6 +680,14 @@ int OnText(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, void* userdata)
         ctx->AppendWide(chunk);
         if (ctx->in_display_math && ctx->paragraph_display_math_count == 0 &&
             !ctx->paragraph_has_other_content) {
+            // size==1 のとき md4c が \n をそのまま渡してくるケースが多いのでスカラ比較で済ませ、
+            // size>1 のときだけ std::ranges::count にフォールバックする両対応。
+            if (chunk.size() == 1) {
+                ctx->display_math_newlines += static_cast<uint32_t>(chunk[0] == L'\n');
+            }
+            else {
+                ctx->display_math_newlines += static_cast<uint32_t>(std::ranges::count(chunk, L'\n'));
+            }
             ctx->display_math_buf.append(chunk);
         }
         break;
@@ -725,7 +745,8 @@ ParseResult ParseMarkdown(std::wstring_view markdown_text)
     ctx.image_indices.reserve(std::clamp(markdown_text.size() / 512, size_t{ 4 }, size_t{ 256 }));
     ctx.diagram_indices.reserve(std::clamp(markdown_text.size() / 1024, size_t{ 4 }, size_t{ 128 }));
     ctx.blockquote_indices.reserve(std::clamp(markdown_text.size() / 512, size_t{ 4 }, size_t{ 256 }));
-    ctx.anchor_counts.reserve(std::clamp(markdown_text.size() / 256, size_t{ 8 }, size_t{ 512 }));
+    // 1MB あたり 256 個程度を見出し数の目安に。実測では数十〜数百に収まるので過大確保しない。
+    ctx.anchor_counts.reserve(std::clamp(markdown_text.size() / 4096, size_t{ 8 }, size_t{ 256 }));
 
     MD_PARSER parser{};
     parser.abi_version = 0;

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -125,7 +125,7 @@ struct NodeLayoutEntry {
     // 選択中のノードでのみ確保される。描画中に書き換えるため mutable。
     mutable std::unique_ptr<SelectionHlCache> selection_hl_cache;
 
-    SearchHlCache& ensure_search_hl_cache() const
+    constexpr SearchHlCache& ensure_search_hl_cache() const
     {
         if (!search_hl_cache) {
             search_hl_cache = std::make_unique<SearchHlCache>();
@@ -133,14 +133,14 @@ struct NodeLayoutEntry {
         return *search_hl_cache;
     }
 
-    void invalidate_search_hl_cache() const noexcept
+    constexpr void invalidate_search_hl_cache() const noexcept
     {
         if (search_hl_cache) {
             search_hl_cache.reset();
         }
     }
 
-    SelectionHlCache& ensure_selection_hl_cache() const
+    constexpr SelectionHlCache& ensure_selection_hl_cache() const
     {
         if (!selection_hl_cache) {
             selection_hl_cache = std::make_unique<SelectionHlCache>();
@@ -148,7 +148,7 @@ struct NodeLayoutEntry {
         return *selection_hl_cache;
     }
 
-    void invalidate_selection_hl_cache() const noexcept
+    constexpr void invalidate_selection_hl_cache() const noexcept
     {
         if (selection_hl_cache) {
             selection_hl_cache.reset();
@@ -157,13 +157,13 @@ struct NodeLayoutEntry {
 
     // text_layout の wrap や format 属性が変わった際に、行折り返し由来のキャッシュ
     // (検索ハイライト矩形 / 選択ハイライト矩形) を一括で落とす。
-    void invalidate_per_frame_hl_caches() const noexcept
+    constexpr void invalidate_per_frame_hl_caches() const noexcept
     {
         invalidate_search_hl_cache();
         invalidate_selection_hl_cache();
     }
 
-    TableLayoutData& ensure_table_layout()
+    constexpr TableLayoutData& ensure_table_layout()
     {
         if (!table_layout) {
             table_layout = std::make_unique<TableLayoutData>();
@@ -175,18 +175,20 @@ struct NodeLayoutEntry {
         return table_layout != nullptr;
     }
 
-    std::pmr::vector<InlineCodeBg>& ensure_inline_code_bgs()
+    constexpr std::pmr::vector<InlineCodeBg>& ensure_inline_code_bgs()
     {
         if (!inline_code_bgs) {
             inline_code_bgs = std::make_unique<std::pmr::vector<InlineCodeBg>>();
         }
         return *inline_code_bgs;
     }
-    void clear_inline_code_bgs() noexcept
+
+    constexpr void clear_inline_code_bgs() noexcept
     {
         inline_code_bgs.reset();
     }
-    std::span<const InlineCodeBg> view_inline_code_bgs() const noexcept
+
+    constexpr std::span<const InlineCodeBg> view_inline_code_bgs() const noexcept
     {
         return SpanOrEmpty(inline_code_bgs);
     }

--- a/src/util/utility.h
+++ b/src/util/utility.h
@@ -19,7 +19,7 @@ struct overloaded : Ts... {
 // 空 vector ヘッダ (24B/個) を全要素分背負わないため `unique_ptr<pmr::vector<T>>`
 // として保持しているメンバを、呼び出し側で nullptr 分岐なしに走査できるようにする。
 template <class T>
-inline std::span<const T> SpanOrEmpty(const std::unique_ptr<std::pmr::vector<T>>& p) noexcept
+constexpr std::span<const T> SpanOrEmpty(const std::unique_ptr<std::pmr::vector<T>>& p) noexcept
 {
     return p ? std::span<const T>{ *p } : std::span<const T>{};
 }

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -3,6 +3,7 @@
 #include "command_generator.h"
 #include "dwrite_test_base.h"
 #include "parser.h"
+#include "test_helpers.h"
 
 class LayoutTest : public DWriteTestBase {};
 

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -989,6 +989,27 @@ TEST(Parser, LatexDisplayMathMultiline)
     EXPECT_NE(body.find(L"E = mc^2"), std::wstring::npos);
 }
 
+TEST(Parser, LatexDisplayMathLineCountMatchesNewlines)
+{
+    // OnText で事前集計した display_math_newlines を line_count に流用しているため、
+    // 旧実装 (current_text 全走査の std::ranges::count) と同じ値を保つことを回帰テストする。
+    const std::wstring_view sources[] = {
+        L"$$E = mc^2$$",
+        L"$$\nE = mc^2\n$$",
+        L"$$\na\nb\nc\n$$",
+    };
+    for (const auto src : sources) {
+        SCOPED_TRACE(std::wstring{ src });
+        auto result = ParseMarkdown(src);
+        ASSERT_EQ(result.nodes.size(), 1u);
+        ASSERT_EQ(result.nodes[0].type, NodeType::CodeBlock);
+        ASSERT_EQ(result.nodes[0].code_language, SyntaxLanguage::LatexMath);
+        const auto text = result.nodes[0].GetText();
+        const auto expected = static_cast<int>(std::ranges::count(text, L'\n'));
+        EXPECT_EQ(result.nodes[0].line_count, expected);
+    }
+}
+
 TEST(Parser, LatexDisplayMathSurroundingParagraphs)
 {
     // 前後に通常段落がある場合も、純粋な $$...$$ 段落のみ昇格される


### PR DESCRIPTION
## Summary
- `Node::extra` の variant から重い alternative である `NodeTableData` / `NodeImageData` を `std::unique_ptr` メンバ (`table_` / `image_`) に外出しして variant 上限を縮小。
- `OnText` の source_offset 設定済み判定を `current_node->source_offset == kUnsetSourceOffset` (uint32 比較 + ポインタ間接) から `ParseContext::node_source_offset_set` (bool 1 命令) に置換、`[[unlikely]]` ヒント付き。
- `TryPromoteParagraphToDisplayMath` の `line_count` 計算を `std::ranges::count(current_text, '\n')` の全走査から、`OnText` の MD_TEXT_LATEXMATH 経路で事前集計する `display_math_newlines` カウンタに置換。
- `MD_BLOCK_TABLE` 入りで `ensure_table()` を一度呼んで以降の TR/TH/TD では `has_table()` ガードを撤去 (`type == NodeType::Table` のとき `table_` non-null の不変式)。
- LATEXMATH chunk の改行カウントで `chunk.size() == 1` のときはスカラ比較で済ませる fastpath を追加 (size>1 は `std::ranges::count` フォールバック)。
- `anchor_counts.reserve` の見積もりを `markdown_size / 256` (上限 512) から `/4096` (上限 256) に縮小、過大確保を回避。
- `link_urls` を `link_urls_` にリネームして lazy 確保系メンバの命名規約 (`table_`/`image_`/`text_`) に揃え、parser 側は `view_link_urls()` アクセサ経由に統一。
- `ensure_*` / `view_*` / `SpanOrEmpty` を `constexpr` 化 (C++23 P2273 で `make_unique` も constexpr)。

## Test plan
- [x] `cmake --build build --config Release` 警告なしクリーン
- [x] `mendo_tests.exe --gtest_brief=1` で 2058 tests / 118 suites 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)