### PR TITLE
perf: Node/NodeLayoutEntry の unique_ptr を pmr プールに集約

### DIFF
--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -103,9 +103,10 @@ struct Node {
 
     // Table と Image のデータは Node 全体の少数派 (画像/表のあるノードのみ) なので、
     // variant に詰め込むと最大 alternative である NodeImageData が全 Node の sizeof を支配する。
-    // unique_ptr で外出しすると variant 上限が下がり、持たないノードは null pointer のオーバー
-    // ヘッドだけで済む。default deleter で自動解放されるため Node 自身は copy/move/dtor の手書き
-    // 不要 (= unique_ptr メンバの存在で Node は move-only になる)。
+    // pmr_unique_ptr で外出しすると variant 上限が下がり、持たないノードは null pointer の
+    // オーバーヘッドだけで済む。PmrDefaultDeleter (ステートレス) が pmr default_resource に
+    // 自動返却するため Node 自身は copy/move/dtor の手書き不要 (= スマートポインタメンバの
+    // 存在で Node は move-only になる)。
     // Parser invariant: type == NodeType::Table のとき table_ != nullptr。MeasureTable や
     // HitTestTable は type 判定だけで table_data() を参照するため、parser はテーブル開始時に
     // 必ず ensure_table() を呼ぶこと。

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <utility>
 #include <variant>
+#include "pmr_unique_ptr.h"
 #include "small_vector.h"
 #include "syntax.h"
 #include "text_types.h"
@@ -108,13 +109,13 @@ struct Node {
     // Parser invariant: type == NodeType::Table のとき table_ != nullptr。MeasureTable や
     // HitTestTable は type 判定だけで table_data() を参照するため、parser はテーブル開始時に
     // 必ず ensure_table() を呼ぶこと。
-    std::unique_ptr<NodeTableData> table_;
-    std::unique_ptr<NodeImageData> image_;
+    mendo::pmr_unique_ptr<NodeTableData> table_;
+    mendo::pmr_unique_ptr<NodeImageData> image_;
 
     // リンク URL の集合。リンクを含むノードでのみ確保される。
     // Why: `Node::runs` が link_url_index で参照する URL テーブル。リンクを持つノードは
     // 全体の少数派 (見出し/段落の一部) なので、空時は 8B ポインタ 1 本に抑える。
-    std::unique_ptr<std::pmr::vector<std::pmr::wstring>> link_urls_;
+    mendo::pmr_unique_ptr<std::pmr::vector<std::pmr::wstring>> link_urls_;
 
     // ノード種別ごとの拡張データ。Heading/Code のみ variant に格納 (上限 24B + tag 8B = 32B)。
     using Extra = std::variant<std::monostate, NodeHeadingData, NodeCodeData>;
@@ -233,14 +234,14 @@ struct Node {
     constexpr NodeTableData* ensure_table()
     {
         if (!table_) {
-            table_ = std::make_unique<NodeTableData>();
+            table_ = mendo::MakePmrUnique<NodeTableData>();
         }
         return table_.get();
     }
     constexpr NodeImageData* ensure_image()
     {
         if (!image_) {
-            image_ = std::make_unique<NodeImageData>();
+            image_ = mendo::MakePmrUnique<NodeImageData>();
         }
         return image_.get();
     }
@@ -277,7 +278,7 @@ struct Node {
     constexpr std::pmr::vector<std::pmr::wstring>& ensure_link_urls()
     {
         if (!link_urls_) {
-            link_urls_ = std::make_unique<std::pmr::vector<std::pmr::wstring>>();
+            link_urls_ = mendo::MakePmrUnique<std::pmr::vector<std::pmr::wstring>>();
         }
         return *link_urls_;
     }

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "document_types.h"
+#include "pmr_unique_ptr.h"
 #include <vector>
 #include <memory_resource>
 #include <wrl/client.h>
@@ -117,18 +118,18 @@ struct NodeLayoutEntry {
     bool layout_dirty = true;
     bool effects_applied = false;
     // インラインコード持ちノードでのみ確保される。空の vector ヘッダ (24B/個) を全ノード分背負わない。
-    std::unique_ptr<std::pmr::vector<InlineCodeBg>> inline_code_bgs;
-    std::unique_ptr<TableLayoutData> table_layout; // テーブルのみ確保
+    mendo::pmr_unique_ptr<std::pmr::vector<InlineCodeBg>> inline_code_bgs;
+    mendo::pmr_unique_ptr<TableLayoutData> table_layout; // テーブルのみ確保
 
     // 検索ヒットがあるノードでのみ確保される。描画中に書き換えるため mutable。
-    mutable std::unique_ptr<SearchHlCache> search_hl_cache;
+    mutable mendo::pmr_unique_ptr<SearchHlCache> search_hl_cache;
     // 選択中のノードでのみ確保される。描画中に書き換えるため mutable。
-    mutable std::unique_ptr<SelectionHlCache> selection_hl_cache;
+    mutable mendo::pmr_unique_ptr<SelectionHlCache> selection_hl_cache;
 
     constexpr SearchHlCache& ensure_search_hl_cache() const
     {
         if (!search_hl_cache) {
-            search_hl_cache = std::make_unique<SearchHlCache>();
+            search_hl_cache = mendo::MakePmrUnique<SearchHlCache>();
         }
         return *search_hl_cache;
     }
@@ -143,7 +144,7 @@ struct NodeLayoutEntry {
     constexpr SelectionHlCache& ensure_selection_hl_cache() const
     {
         if (!selection_hl_cache) {
-            selection_hl_cache = std::make_unique<SelectionHlCache>();
+            selection_hl_cache = mendo::MakePmrUnique<SelectionHlCache>();
         }
         return *selection_hl_cache;
     }
@@ -166,7 +167,7 @@ struct NodeLayoutEntry {
     constexpr TableLayoutData& ensure_table_layout()
     {
         if (!table_layout) {
-            table_layout = std::make_unique<TableLayoutData>();
+            table_layout = mendo::MakePmrUnique<TableLayoutData>();
         }
         return *table_layout;
     }
@@ -178,7 +179,7 @@ struct NodeLayoutEntry {
     constexpr std::pmr::vector<InlineCodeBg>& ensure_inline_code_bgs()
     {
         if (!inline_code_bgs) {
-            inline_code_bgs = std::make_unique<std::pmr::vector<InlineCodeBg>>();
+            inline_code_bgs = mendo::MakePmrUnique<std::pmr::vector<InlineCodeBg>>();
         }
         return *inline_code_bgs;
     }

--- a/src/util/pmr_unique_ptr.h
+++ b/src/util/pmr_unique_ptr.h
@@ -34,6 +34,9 @@ struct PmrDefaultDeleter {
     }
 };
 
+// 注意: 本エイリアスとファクトリは pmr default_resource 専用。任意の memory_resource を
+// 受けたい場合は polymorphic_allocator<T>::new_object / delete_object を直接使うか、
+// resource ポインタを保持する別 deleter を導入すること (現状そのユースケースは無い)。
 template <class T>
 using pmr_unique_ptr = std::unique_ptr<T, PmrDefaultDeleter<T>>;
 
@@ -45,6 +48,9 @@ template <class T, class... Args>
     return pmr_unique_ptr<T>{ alloc.new_object<T>(std::forward<Args>(args)...) };
 }
 
-static_assert(sizeof(pmr_unique_ptr<int>) == sizeof(int*), "pmr_unique_ptr should remain pointer-sized via EBO");
+// EBO により ステートレス deleter は容量を消費せず std::unique_ptr<T> と同じ sizeof
+// に保たれる ことを保証する。Node / NodeLayoutEntry の sizeof は本不変式に依存する。
+static_assert(sizeof(pmr_unique_ptr<int>) == sizeof(std::unique_ptr<int>),
+              "pmr_unique_ptr must be the same size as std::unique_ptr (EBO)");
 
 } // namespace mendo

--- a/src/util/pmr_unique_ptr.h
+++ b/src/util/pmr_unique_ptr.h
@@ -1,0 +1,50 @@
+#pragma once
+#include <memory>
+#include <memory_resource>
+#include <type_traits>
+#include <utility>
+
+namespace mendo {
+
+// std::pmr::get_default_resource() を使うステートレスな unique_ptr 用 deleter。
+//
+// Why: Node / NodeLayoutEntry が抱える unique_ptr は make_unique<T>() 経由で
+// operator new に流れていた。Document 全体の pmr::vector<Node> は global
+// synchronized_pool 上にあるので、子要素 (NodeTableData / TableLayoutData 等)
+// も同じプールに載せると割当源を一本化できる。プールは同サイズ要求を freelist で
+// 再利用するため、ドキュメント再ロード時の short-lived な小さな確保が OS heap を
+// 経由しなくなる。
+//
+// 制約:
+//   - default_resource が allocate / deallocate の間で変更されないこと。
+//     mendo は main() の InitGlobalMemoryResource() でしか set_default_resource を
+//     呼ばないので安全。テストは default のまま (new_delete_resource) なので、
+//     allocate と deallocate が同じ resource で対称になる。
+//   - Deleter はステートレス。EBO により unique_ptr のサイズはポインタ分に保たれる。
+template <class T>
+struct PmrDefaultDeleter {
+    static_assert(!std::is_array_v<T>, "pmr_unique_ptr does not support T[]");
+
+    static void operator()(T* p) noexcept
+    {
+        if (!p) {
+            return;
+        }
+        std::pmr::polymorphic_allocator<>{ std::pmr::get_default_resource() }.delete_object(p);
+    }
+};
+
+template <class T>
+using pmr_unique_ptr = std::unique_ptr<T, PmrDefaultDeleter<T>>;
+
+// pmr default_resource から T を構築する unique_ptr ファクトリ。
+template <class T, class... Args>
+[[nodiscard]] pmr_unique_ptr<T> MakePmrUnique(Args&&... args)
+{
+    std::pmr::polymorphic_allocator<> alloc{ std::pmr::get_default_resource() };
+    return pmr_unique_ptr<T>{ alloc.new_object<T>(std::forward<Args>(args)...) };
+}
+
+static_assert(sizeof(pmr_unique_ptr<int>) == sizeof(int*), "pmr_unique_ptr should remain pointer-sized via EBO");
+
+} // namespace mendo

--- a/src/util/utility.h
+++ b/src/util/utility.h
@@ -16,8 +16,10 @@ struct overloaded : Ts... {
 };
 
 // optional に確保される pmr::vector を std::span として安全に view する。
-// 空 vector ヘッダ (24B/個) を全要素分背負わないため `unique_ptr<pmr::vector<T>>`
-// として保持しているメンバを、呼び出し側で nullptr 分岐なしに走査できるようにする。
+// 空 vector ヘッダ (24B/個) を全要素分背負わないため
+// `unique_ptr<pmr::vector<T>, Deleter>` として保持しているメンバを、呼び出し側で
+// nullptr 分岐なしに走査できるようにする。Deleter は型推論パラメータなので
+// std::unique_ptr / mendo::pmr_unique_ptr のどちらでも受けられる。
 template <class T, class Deleter>
 constexpr std::span<const T> SpanOrEmpty(const std::unique_ptr<std::pmr::vector<T>, Deleter>& p) noexcept
 {

--- a/src/util/utility.h
+++ b/src/util/utility.h
@@ -18,8 +18,8 @@ struct overloaded : Ts... {
 // optional に確保される pmr::vector を std::span として安全に view する。
 // 空 vector ヘッダ (24B/個) を全要素分背負わないため `unique_ptr<pmr::vector<T>>`
 // として保持しているメンバを、呼び出し側で nullptr 分岐なしに走査できるようにする。
-template <class T>
-constexpr std::span<const T> SpanOrEmpty(const std::unique_ptr<std::pmr::vector<T>>& p) noexcept
+template <class T, class Deleter>
+constexpr std::span<const T> SpanOrEmpty(const std::unique_ptr<std::pmr::vector<T>, Deleter>& p) noexcept
 {
     return p ? std::span<const T>{ *p } : std::span<const T>{};
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ add_executable(mendo_tests
     test_ascii_util.cpp
     test_html_entity.cpp
     test_small_vector.cpp
+    test_pmr_unique_ptr.cpp
 )
 
 target_link_libraries(mendo_tests PRIVATE

--- a/tests/test_pmr_unique_ptr.cpp
+++ b/tests/test_pmr_unique_ptr.cpp
@@ -1,0 +1,189 @@
+#include "pmr_unique_ptr.h"
+#include <gtest/gtest.h>
+#include <atomic>
+#include <memory>
+#include <memory_resource>
+#include <utility>
+
+using mendo::MakePmrUnique;
+using mendo::PmrDefaultDeleter;
+using mendo::pmr_unique_ptr;
+
+namespace {
+
+// 確保/解放回数を観測するための memory_resource。
+// scoped_default_resource と組み合わせて、MakePmrUnique がプロセスデフォルトを正しく
+// 経由しているか / 解放が同じ resource にぶら下がるかを確かめる。
+class CountingResource : public std::pmr::memory_resource {
+public:
+    std::atomic<size_t> alloc_count{ 0 };
+    std::atomic<size_t> dealloc_count{ 0 };
+    std::atomic<size_t> live_bytes{ 0 };
+
+private:
+    void* do_allocate(size_t bytes, size_t alignment) override
+    {
+        alloc_count.fetch_add(1, std::memory_order_relaxed);
+        live_bytes.fetch_add(bytes, std::memory_order_relaxed);
+        return std::pmr::new_delete_resource()->allocate(bytes, alignment);
+    }
+    void do_deallocate(void* p, size_t bytes, size_t alignment) override
+    {
+        dealloc_count.fetch_add(1, std::memory_order_relaxed);
+        live_bytes.fetch_sub(bytes, std::memory_order_relaxed);
+        std::pmr::new_delete_resource()->deallocate(p, bytes, alignment);
+    }
+    bool do_is_equal(const std::pmr::memory_resource& other) const noexcept override
+    {
+        return this == &other;
+    }
+};
+
+class ScopedDefaultResource {
+public:
+    explicit ScopedDefaultResource(std::pmr::memory_resource* mr) noexcept
+        : prev_(std::pmr::set_default_resource(mr))
+    {
+    }
+    ~ScopedDefaultResource() noexcept { std::pmr::set_default_resource(prev_); }
+    ScopedDefaultResource(const ScopedDefaultResource&) = delete;
+    ScopedDefaultResource& operator=(const ScopedDefaultResource&) = delete;
+
+private:
+    std::pmr::memory_resource* prev_;
+};
+
+struct CtorTracker {
+    inline static int alive = 0;
+    int value;
+    explicit CtorTracker(int v) : value{ v } { ++alive; }
+    ~CtorTracker() { --alive; }
+    CtorTracker(const CtorTracker&) = delete;
+    CtorTracker& operator=(const CtorTracker&) = delete;
+};
+
+struct ThrowingCtor {
+    inline static int alive = 0;
+    explicit ThrowingCtor(bool should_throw)
+    {
+        if (should_throw) {
+            throw std::runtime_error{ "ctor failure" };
+        }
+        ++alive;
+    }
+    ~ThrowingCtor() { --alive; }
+};
+
+} // namespace
+
+TEST(PmrUniquePtr, EboPreservesSize)
+{
+    static_assert(sizeof(pmr_unique_ptr<int>) == sizeof(std::unique_ptr<int>));
+    static_assert(sizeof(pmr_unique_ptr<CtorTracker>) == sizeof(void*));
+}
+
+TEST(PmrUniquePtr, MakeAllocatesAndConstructs)
+{
+    CountingResource mr;
+    ScopedDefaultResource guard{ &mr };
+
+    {
+        auto p = MakePmrUnique<CtorTracker>(42);
+        ASSERT_TRUE(p);
+        EXPECT_EQ(p->value, 42);
+        EXPECT_EQ(CtorTracker::alive, 1);
+        EXPECT_EQ(mr.alloc_count.load(), 1u);
+        EXPECT_EQ(mr.dealloc_count.load(), 0u);
+    }
+
+    EXPECT_EQ(CtorTracker::alive, 0);
+    EXPECT_EQ(mr.alloc_count.load(), 1u);
+    EXPECT_EQ(mr.dealloc_count.load(), 1u);
+    EXPECT_EQ(mr.live_bytes.load(), 0u);
+}
+
+TEST(PmrUniquePtr, ResetReleasesViaSameResource)
+{
+    CountingResource mr;
+    ScopedDefaultResource guard{ &mr };
+
+    auto p = MakePmrUnique<CtorTracker>(7);
+    EXPECT_EQ(mr.alloc_count.load(), 1u);
+    p.reset();
+    EXPECT_FALSE(p);
+    EXPECT_EQ(CtorTracker::alive, 0);
+    EXPECT_EQ(mr.dealloc_count.load(), 1u);
+    EXPECT_EQ(mr.live_bytes.load(), 0u);
+}
+
+TEST(PmrUniquePtr, NullDeleterIsNoop)
+{
+    CountingResource mr;
+    ScopedDefaultResource guard{ &mr };
+
+    pmr_unique_ptr<CtorTracker> p;
+    EXPECT_FALSE(p);
+    p.reset();
+    EXPECT_EQ(mr.alloc_count.load(), 0u);
+    EXPECT_EQ(mr.dealloc_count.load(), 0u);
+}
+
+TEST(PmrUniquePtr, MoveTransfersOwnership)
+{
+    CountingResource mr;
+    ScopedDefaultResource guard{ &mr };
+
+    auto p1 = MakePmrUnique<CtorTracker>(1);
+    auto* raw = p1.get();
+    auto p2 = std::move(p1);
+    EXPECT_FALSE(p1);
+    EXPECT_EQ(p2.get(), raw);
+    EXPECT_EQ(mr.dealloc_count.load(), 0u);
+    EXPECT_EQ(CtorTracker::alive, 1);
+
+    p2.reset();
+    EXPECT_EQ(mr.dealloc_count.load(), 1u);
+}
+
+TEST(PmrUniquePtr, ThrowingCtorReleasesAllocation)
+{
+    CountingResource mr;
+    ScopedDefaultResource guard{ &mr };
+
+    EXPECT_THROW({ (void)MakePmrUnique<ThrowingCtor>(true); }, std::runtime_error);
+    EXPECT_EQ(ThrowingCtor::alive, 0);
+    EXPECT_EQ(mr.alloc_count.load(), 1u);
+    EXPECT_EQ(mr.dealloc_count.load(), 1u);
+    EXPECT_EQ(mr.live_bytes.load(), 0u);
+}
+
+TEST(PmrUniquePtr, RoutesViaCurrentDefaultResource)
+{
+    CountingResource mr_a;
+    CountingResource mr_b;
+
+    {
+        ScopedDefaultResource ga{ &mr_a };
+        auto p = MakePmrUnique<CtorTracker>(99);
+        EXPECT_EQ(mr_a.alloc_count.load(), 1u);
+        EXPECT_EQ(mr_b.alloc_count.load(), 0u);
+        // p の解放は ga スコープ内 = default_resource = mr_a を経由する。
+    }
+    EXPECT_EQ(mr_a.dealloc_count.load(), 1u);
+    EXPECT_EQ(mr_b.dealloc_count.load(), 0u);
+}
+
+TEST(PmrUniquePtr, InteropWithPmrVector)
+{
+    CountingResource mr;
+    ScopedDefaultResource guard{ &mr };
+
+    auto p = MakePmrUnique<std::pmr::vector<int>>();
+    ASSERT_TRUE(p);
+    p->push_back(1);
+    p->push_back(2);
+    EXPECT_EQ(p->size(), 2u);
+    p.reset();
+
+    EXPECT_EQ(mr.live_bytes.load(), 0u);
+}


### PR DESCRIPTION
## Summary

- `mendo::pmr_unique_ptr<T>` と `MakePmrUnique<T>` を `src/util/pmr_unique_ptr.h` に新設
- `Node` (3 本) と `NodeLayoutEntry` (4 本) の `std::unique_ptr` を `pmr_unique_ptr` に切替え、`std::make_unique` を `MakePmrUnique` に置換
- `SpanOrEmpty` (`src/util/utility.h`) を Deleter テンプレ化し、新旧 unique_ptr 双方を受けられるよう拡張

## Why

従来 `Node` / `NodeLayoutEntry` 内の `std::unique_ptr` は `std::make_unique` 経由で `operator new` (OS heap) に流れていた一方、内部の `std::pmr` コンテナは global `synchronized_pool_resource` を使っており、**親オブジェクトと内部要素の割当源が割れていた**。

`pmr_unique_ptr` はステートレス deleter (`std::pmr::get_default_resource()` を deallocate 時に参照) で同じプールに集約する。プールは同サイズ要求を freelist で再利用するため、ドキュメント再ロード時の short-lived な小さな確保 (NodeTableData ~24B、NodeImageData ~32B、TableLayoutData ~数百B、SearchHl/SelectionHlCache ~50B、空 vector ヘッダ 24B) が OS heap を経由しなくなる。

## 実装メモ

- **sizeof 不変**: `PmrDefaultDeleter` は空型なので EBO により `pmr_unique_ptr<T>` は `void*` サイズのまま (`static_assert` で固定)。`Node` / `NodeLayoutEntry` の sizeof は変わらない。
- **本体はライブラリ実装に委譲**: `std::pmr::polymorphic_allocator<>::new_object` / `delete_object` (C++20) を使い、try/catch・placement new・手書き `~T()` 呼び出しは排除。例外時の deallocate も標準ライブラリ側で処理される。
- **alloc/dealloc 対称性**: `default_resource` は `main()` 起動時の `InitGlobalMemoryResource()` でのみ設定され、その後変更されない。テストは default のまま (`new_delete_resource`) なので alloc/dealloc は同一 resource。
- **uses-allocator 整合性**: `polymorphic_allocator::new_object` の uses-allocator construction により、`pmr::vector<...>` を直接 `MakePmrUnique` する経路では allocator が明示的に渡される (NodeTableData のような単純集約型は default 構築 → 内部 pmr メンバが default_resource を取得、結果は同等)。
- **対象外**: `App` / `Impl` (PIMPL)、`uint8_t[]` / `byte[]` バッファは pmr ルーティング不要のため変更しない。

## Test plan

- [x] `cmake --build build --config Release` 成功
- [x] `mendo_tests.exe` 全 2059 / 118 suite PASS
- [x] sizeof 不変式の `static_assert` (`sizeof(pmr_unique_ptr<int>) == sizeof(int*)`) コンパイル時検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)