### PR TITLE
feat: Tracy プロファイラを opt-in で統合し主要ホットパスを計装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -365,6 +365,8 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 
-build/
+# CMake out-of-source ビルドツリー全般
+# (build/, build_tracy/, build_no_tracy/ など派生ビルドも追跡対象から除外)
+build*/
 CMakeSettings.json
 .claude/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,36 @@ if(MSVC)
     set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "${CMAKE_STATIC_LINKER_FLAGS_RELEASE} /LTCG")
 endif()
 
-# ---- WebView2 SDK（Mermaid図表レンダリング用） ----
+# ---- Tracy プロファイラ（オプション） ----
+# 開発時のフレーム/ゾーン計測用。Release 配布では OFF が前提。
+# ON にすると <tracy/Tracy.hpp> が <windows.h> を引き込むため、
+# Tracy の zone/frame マクロは profiler.h 経由でラップして使う。
+option(MENDO_USE_TRACY "Build with Tracy profiler client" OFF)
+
 include(FetchContent)
+if(MENDO_USE_TRACY)
+    # Tracy v0.13.1 のソース取得（add_subdirectory 相当）。
+    # TRACY_ENABLE はクライアント側計装の有効化スイッチで、Tracy の CMakeLists
+    # 内で TracyClient のコンパイル定義として伝播する。
+    # TRACY_ON_DEMAND は Tracy GUI が接続するまで計測バッファを溜めない設定。
+    # アプリ起動だけでメモリを食わないので開発用に都合がよい。
+    set(TRACY_ENABLE    ON CACHE BOOL "" FORCE)
+    set(TRACY_ON_DEMAND ON CACHE BOOL "" FORCE)
+    set(TRACY_STATIC    ON CACHE BOOL "" FORCE)
+    FetchContent_Declare(
+        tracy
+        URL https://github.com/wolfpld/tracy/archive/refs/tags/v0.13.1.tar.gz
+    )
+    FetchContent_MakeAvailable(tracy)
+    # CRT 設定をプロジェクト全体と揃える（/MT[d]）。
+    if(MSVC AND TARGET TracyClient)
+        set_target_properties(TracyClient PROPERTIES
+            MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+        target_compile_options(TracyClient PRIVATE /W0)
+    endif()
+endif()
+
+# ---- WebView2 SDK（Mermaid図表レンダリング用） ----
 FetchContent_Declare(
     webview2
     URL https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/1.0.2903.40
@@ -150,11 +178,16 @@ add_library(mendo_core STATIC
 target_include_directories(mendo_core PUBLIC ${MENDO_SRC_DIRS} third_party/md4c)
 target_compile_definitions(mendo_core PUBLIC
     UNICODE _UNICODE NOMINMAX WIN32_LEAN_AND_MEAN
-    $<$<CONFIG:Release>:MENDO_PROFILE_ENABLED=0>
 )
 target_link_libraries(mendo_core PUBLIC
     md4c d2d1 dwrite windowscodecs shlwapi comctl32
 )
+if(MENDO_USE_TRACY)
+    # MENDO_USE_TRACY: profiler.h のマクロを Tracy 呼び出しに展開するスイッチ。
+    # TRACY_ENABLE   : Tracy ヘッダ側の計測コード生成を有効化（Tracy 自体の規約）。
+    target_compile_definitions(mendo_core PUBLIC MENDO_USE_TRACY TRACY_ENABLE)
+    target_link_libraries(mendo_core PUBLIC Tracy::TracyClient)
+endif()
 if(MSVC)
     target_compile_options(mendo_core PRIVATE /W4 /utf-8)
 endif()

--- a/README.en.md
+++ b/README.en.md
@@ -133,6 +133,17 @@ cmake --build build --config Release
 build/tests/Release/mendo_tests.exe
 ```
 
+### Build with Tracy Profiler (developers)
+
+Embeds [Tracy](https://github.com/wolfpld/tracy) v0.13.1 for frame timing, zone tracing, and counter time-series plots. Tracy is built in `TRACY_ON_DEMAND` mode, so instrumentation is a no-op until a Tracy GUI client connects.
+
+```
+cmake -B build_tracy -DMENDO_USE_TRACY=ON
+cmake --build build_tracy --config Release
+```
+
+Launch the Tracy GUI (download from [Releases](https://github.com/wolfpld/tracy/releases)) and then run `build_tracy/Release/mendo.exe` to connect. Tracy is only linked and instrumented when `MENDO_USE_TRACY=ON`; the default build (OFF) is completely unaffected.
+
 ## Usage
 
 ```

--- a/README.md
+++ b/README.md
@@ -132,6 +132,17 @@ cmake --build build --config Release
 build/tests/Release/mendo_tests.exe
 ```
 
+### Tracyプロファイラ有効ビルド（開発者向け）
+
+[Tracy](https://github.com/wolfpld/tracy) v0.13.1 を組み込み、フレーム時間・ゾーン計測・カウンタ時系列プロットを取得できます。Tracy GUI 接続前は計測コードが no-op になる `TRACY_ON_DEMAND` モードで組み込まれます。
+
+```
+cmake -B build_tracy -DMENDO_USE_TRACY=ON
+cmake --build build_tracy --config Release
+```
+
+Tracy GUI（[Releases](https://github.com/wolfpld/tracy/releases) からダウンロード）を起動した状態で `build_tracy/Release/mendo.exe` を実行すると接続できます。`MENDO_USE_TRACY=ON` のときのみ Tracy がリンク・計装され、デフォルト（OFF）のビルド成果物には一切影響しません。
+
 ## 使い方
 
 ```

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -98,6 +98,46 @@ IN THE SOFTWARE.
 
 ---
 
+## Tracy Profiler
+
+- **Description**: Frame profiler for games and other real-time applications
+- **Website**: https://github.com/wolfpld/tracy
+- **License**: BSD 3-Clause
+- **Obtained via**: CMake FetchContent (v0.13.1)
+- **Usage**: Optional, opt-in via `-DMENDO_USE_TRACY=ON` (not included in default release binary)
+
+```
+Tracy Profiler (https://github.com/wolfpld/tracy) is licensed under the
+3-clause BSD license.
+
+Copyright (c) 2017-2025, Bartosz Taudul <wolf@nereid.pl>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+---
+
 ## Google Test
 
 - **Description**: C++ testing framework

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -212,6 +212,7 @@ void App::OnPaint()
     }
 
     EndPaint(hwnd_, &ps);
+    MENDO_FRAME_MARK();
 }
 
 void App::OnResize(UINT width, UINT height)

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -1,6 +1,7 @@
 #include "dwrite_measurer.h"
 #include "layout.h"
 #include "parser.h"
+#include "profiler.h"
 #include "syntax.h"
 #include "ui_constants.h"
 #include <algorithm>
@@ -139,6 +140,7 @@ void DWriteTextMeasurer::ApplyRunFormatting(IDWriteTextLayout* layout, std::span
     if (runs.empty()) {
         return;
     }
+    MENDO_PROFILE("ApplyRunFormatting");
     const bool apply_code = (!node_type || *node_type != NodeType::CodeBlock);
     const bool apply_code_size = apply_code && (!node_type || *node_type != NodeType::Heading);
     const bool apply_link = !node_type;
@@ -189,6 +191,7 @@ void DWriteTextMeasurer::ApplyRunFormatting(IDWriteTextLayout* layout, std::span
 
 void DWriteTextMeasurer::MeasureNode(Node& node, NodeLayoutEntry& entry, float max_width)
 {
+    MENDO_PROFILE("MeasureNode");
     if (!dwrite_ || !theme_) {
         return;
     }
@@ -260,6 +263,7 @@ void DWriteTextMeasurer::MeasureNode(Node& node, NodeLayoutEntry& entry, float m
     // BiDi 解析と shaping を走らせるためリサイズ時の最大コスト要因で、SetMaxWidth は
     // ラインブレーク再計算のみで済むので大幅に軽い。
     if (entry.text_layout) {
+        MENDO_PROFILE("MeasureNode.fastpath");
         HRESULT hr = entry.text_layout->SetMaxWidth(layout_width);
         if (SUCCEEDED(hr)) {
             hr = entry.text_layout->SetMaxHeight(dynamic_max_height);
@@ -283,13 +287,16 @@ void DWriteTextMeasurer::MeasureNode(Node& node, NodeLayoutEntry& entry, float m
     }
 
     ComPtr<IDWriteTextLayout> layout;
-    const HRESULT hr = dwrite_->CreateTextLayout(
-        text.c_str(),
-        static_cast<UINT32>(text.size()),
-        fmt,
-        layout_width,
-        dynamic_max_height,
-        &layout);
+    const HRESULT hr = [&] {
+        MENDO_PROFILE("CreateTextLayout");
+        return dwrite_->CreateTextLayout(
+            text.c_str(),
+            static_cast<UINT32>(text.size()),
+            fmt,
+            layout_width,
+            dynamic_max_height,
+            &layout);
+    }();
     if (FAILED(hr)) {
         return;
     }
@@ -311,6 +318,7 @@ void DWriteTextMeasurer::MeasureNode(Node& node, NodeLayoutEntry& entry, float m
     if (node.type == NodeType::CodeBlock && node.syntax_tokens().empty() &&
         node.code_language != SyntaxLanguage::None &&
         !IsDiagramLanguage(node.code_language)) {
+        MENDO_PROFILE("Tokenize");
         node.syntax_tokens_mut() = Tokenize(text, node.code_language);
     }
 
@@ -326,6 +334,7 @@ void DWriteTextMeasurer::MeasureNode(Node& node, NodeLayoutEntry& entry, float m
 
 void DWriteTextMeasurer::MeasureTableCells(Node& node, NodeLayoutEntry& entry, std::pmr::vector<float>& natural_widths)
 {
+    MENDO_PROFILE("MeasureTableCells");
     IDWriteTextFormat* const fmt = fmt_body_.Get();
     IDWriteTextFormat* const fmt_bold = fmt_h_[3].Get();
     auto& rows = node.table_rows();
@@ -343,10 +352,13 @@ void DWriteTextMeasurer::MeasureTableCells(Node& node, NodeLayoutEntry& entry, s
 
             IDWriteTextFormat* const cell_fmt = cell.is_header ? fmt_bold : fmt;
             const size_t ci = tl.CellIndex(r, c);
-            dwrite_->CreateTextLayout(
-                cell.text.c_str(), static_cast<UINT32>(cell.text.size()),
-                cell_fmt, CODE_BLOCK_NO_WRAP_WIDTH, LAYOUT_MAX_HEIGHT,
-                &tl.cell_layouts[ci]);
+            {
+                MENDO_PROFILE("CreateTextLayout.cell");
+                dwrite_->CreateTextLayout(
+                    cell.text.c_str(), static_cast<UINT32>(cell.text.size()),
+                    cell_fmt, CODE_BLOCK_NO_WRAP_WIDTH, LAYOUT_MAX_HEIGHT,
+                    &tl.cell_layouts[ci]);
+            }
 
             if (tl.cell_layouts[ci]) {
                 ApplyRunFormatting(tl.cell_layouts[ci].Get(), cell.runs, std::nullopt);
@@ -361,6 +373,7 @@ void DWriteTextMeasurer::MeasureTableCells(Node& node, NodeLayoutEntry& entry, s
 void DWriteTextMeasurer::FinalizeTableLayout(Node& node, NodeLayoutEntry& entry, float max_width,
                                              size_t col_count, std::pmr::vector<float>& natural_widths)
 {
+    MENDO_PROFILE("FinalizeTableLayout");
     const float cell_padding = TABLE_CELL_PADDING;
     const float border_width = TABLE_BORDER_WIDTH;
     auto& tl = *entry.table_layout;
@@ -457,6 +470,7 @@ void DWriteTextMeasurer::FinalizeTableLayout(Node& node, NodeLayoutEntry& entry,
 
 void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float max_width)
 {
+    MENDO_PROFILE("MeasureTable");
     if (!dwrite_ || !theme_) {
         return;
     }

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -1,5 +1,6 @@
 #include "layout.h"
 #include "document.h"
+#include "profiler.h"
 #include <algorithm>
 #include <cassert>
 #include <chrono>
@@ -143,11 +144,13 @@ float EstimateNodeHeight(const Node& node, const Theme& theme) noexcept
 
 void EstimateNodeHeights(const std::pmr::vector<Node>& nodes, LayoutCache& cache, const Theme& theme) noexcept
 {
+    MENDO_PROFILE("EstimateNodeHeights");
     // ノードの種類に応じた既定の高さを割り当て、Y座標を累積計算する。
     // DirectWriteを一切呼ばないため、数千ノードでも数百マイクロ秒で完了する。
     // layout_dirtyフラグは変更しない（後続のViewportLayoutが正しく計測できるようにする）。
     assert(cache.size() >= nodes.size());
     const auto node_count = nodes.size();
+    MENDO_PLOT("layout.estimate.node_count", static_cast<int64_t>(node_count));
 
     float y = theme.margin_top;
     for (size_t i = 0; i < node_count; i++) {
@@ -165,6 +168,7 @@ void EstimateNodeHeights(const std::pmr::vector<Node>& nodes, LayoutCache& cache
 YPositionResult RecomputeYPositions(std::pmr::vector<Node>& nodes, LayoutCache& cache, const Theme& theme,
                                     size_t from_index, bool has_earlier_dirty, size_t safe_exit_after) noexcept
 {
+    MENDO_PROFILE("RecomputeYPositions");
     YPositionResult result;
     result.has_dirty_nodes = has_earlier_dirty;
     const auto node_count = nodes.size();
@@ -226,6 +230,7 @@ bool LayoutEngine::RecreateFormats()
 
 void LayoutEngine::ComputeLayout(std::pmr::vector<Node>& nodes, LayoutCache& cache, float viewport_width, float viewport_top, float viewport_bottom)
 {
+    MENDO_PROFILE("LayoutEngine::ComputeLayout");
     const auto node_count = nodes.size();
     cache.Resize(node_count);
 
@@ -330,6 +335,11 @@ void LayoutEngine::ComputeLayout(std::pmr::vector<Node>& nodes, LayoutCache& cac
     if (any_measured) {
         cache.IncrementEffectsGeneration();
     }
+
+    MENDO_PLOT("layout.compute.partial", static_cast<int64_t>(partial));
+    MENDO_PLOT("layout.compute.width_changed", static_cast<int64_t>(width_changed));
+    MENDO_PLOT("layout.compute.node_count", static_cast<int64_t>(node_count));
+    MENDO_PLOT("layout.compute.broke_early", static_cast<int64_t>(broke_early));
 }
 
 void LayoutEngine::LayoutNodes(std::pmr::vector<Node>& nodes, LayoutCache& cache, float viewport_width)
@@ -341,6 +351,7 @@ void LayoutEngine::LayoutNodes(std::pmr::vector<Node>& nodes, LayoutCache& cache
 
 bool LayoutEngine::EnsureVisibleLayout(std::pmr::vector<Node>& nodes, LayoutCache& cache, float viewport_width, float viewport_top, float viewport_bottom)
 {
+    MENDO_PROFILE("LayoutEngine::EnsureVisibleLayout");
     const float content_width = theme_->ContentWidth(viewport_width);
     bool any_updated = false;
     int last_measured = -1;
@@ -376,6 +387,7 @@ bool LayoutEngine::ProcessDirtyBatch(std::pmr::vector<Node>& nodes, LayoutCache&
                                      float viewport_width, int batch_size, int time_budget_us,
                                      float viewport_top, float viewport_height, float buffer_screens)
 {
+    MENDO_PROFILE("LayoutEngine::ProcessDirtyBatch");
     const float content_width = theme_->ContentWidth(viewport_width);
     const auto node_count = nodes.size();
     int processed = 0;
@@ -424,6 +436,8 @@ bool LayoutEngine::ProcessDirtyBatch(std::pmr::vector<Node>& nodes, LayoutCache&
             break;
         }
     }
+
+    MENDO_PLOT("layout.dirty_batch.processed", static_cast<int64_t>(processed));
 
     if (processed == 0) {
         has_dirty_nodes_ = false;

--- a/src/render/command_executor.cpp
+++ b/src/render/command_executor.cpp
@@ -1,5 +1,29 @@
 #include "command_executor.h"
+#include "profiler.h"
 #include "utility.h"
+
+namespace {
+
+// 累積カウンタ（UI スレッド単一前提のため非アトミック）。
+struct BrushStats {
+    int64_t fastpath_hit = 0; // last_brush_ 直前キャッシュヒット
+    int64_t pool_hit = 0;     // brush_pool_ 内ヒット (PackColor で同一色)
+    int64_t pool_miss = 0;    // 新規 CreateSolidColorBrush
+    int64_t pool_evict = 0;   // LRU で 1 件追い出し
+    int64_t rt_switch = 0;    // RT 切替によるプール全クリア
+};
+BrushStats g_brush_stats;
+
+void PublishBrushStats() noexcept
+{
+    MENDO_PLOT("brush.fastpath_hit", g_brush_stats.fastpath_hit);
+    MENDO_PLOT("brush.pool_hit", g_brush_stats.pool_hit);
+    MENDO_PLOT("brush.pool_miss", g_brush_stats.pool_miss);
+    MENDO_PLOT("brush.pool_evict", g_brush_stats.pool_evict);
+    MENDO_PLOT("brush.rt_switch", g_brush_stats.rt_switch);
+}
+
+} // namespace
 
 ID2D1SolidColorBrush* CommandExecutor::GetBrush(ID2D1RenderTarget* rt, D2D1_COLOR_F color)
 {
@@ -9,11 +33,13 @@ ID2D1SolidColorBrush* CommandExecutor::GetBrush(ID2D1RenderTarget* rt, D2D1_COLO
         use_counter_ = 0;
         bound_rt_ = rt;
         last_brush_ = nullptr;
+        ++g_brush_stats.rt_switch;
     }
     const uint32_t key = command_executor_internal::PackColor(color);
     // 直前と同色なら hash lookup を完全にスキップ。同色連続発行（罫線、ハイライト、
     // 同テーマ色のテキスト等）が多いためヒット率が高い。
     if (last_brush_ && key == last_brush_key_) {
+        ++g_brush_stats.fastpath_hit;
         return last_brush_;
     }
     const uint64_t now = ++use_counter_;
@@ -21,6 +47,7 @@ ID2D1SolidColorBrush* CommandExecutor::GetBrush(ID2D1RenderTarget* rt, D2D1_COLO
         it->second.last_used = now;
         last_brush_key_ = key;
         last_brush_ = it->second.brush.Get();
+        ++g_brush_stats.pool_hit;
         return last_brush_;
     }
     if (brush_pool_.size() >= MAX_POOLED_BRUSHES) {
@@ -36,7 +63,9 @@ ID2D1SolidColorBrush* CommandExecutor::GetBrush(ID2D1RenderTarget* rt, D2D1_COLO
             last_brush_ = nullptr;
         }
         brush_pool_.erase(oldest);
+        ++g_brush_stats.pool_evict;
     }
+    ++g_brush_stats.pool_miss;
     Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush;
     if (FAILED(rt->CreateSolidColorBrush(color, &brush)) || !brush) {
         return nullptr;
@@ -49,6 +78,8 @@ ID2D1SolidColorBrush* CommandExecutor::GetBrush(ID2D1RenderTarget* rt, D2D1_COLO
 
 void CommandExecutor::Execute(const DrawCommandList& cmds, ID2D1RenderTarget* rt)
 {
+    MENDO_PROFILE("CommandExecutor::Execute");
+    MENDO_PLOT("draw.command_count", static_cast<int64_t>(cmds.size()));
     if (!rt) {
         return;
     }
@@ -125,4 +156,7 @@ void CommandExecutor::Execute(const DrawCommandList& cmds, ID2D1RenderTarget* rt
         }, cmd);
         // clang-format on
     }
+
+    PublishBrushStats();
+    MENDO_PLOT("brush.pool_size", static_cast<int64_t>(brush_pool_.size()));
 }

--- a/src/render/command_executor.cpp
+++ b/src/render/command_executor.cpp
@@ -2,6 +2,7 @@
 #include "profiler.h"
 #include "utility.h"
 
+#ifdef MENDO_USE_TRACY
 namespace {
 
 // 累積カウンタ（UI スレッド単一前提のため非アトミック）。
@@ -24,6 +25,7 @@ void PublishBrushStats() noexcept
 }
 
 } // namespace
+#endif
 
 ID2D1SolidColorBrush* CommandExecutor::GetBrush(ID2D1RenderTarget* rt, D2D1_COLOR_F color)
 {
@@ -33,13 +35,13 @@ ID2D1SolidColorBrush* CommandExecutor::GetBrush(ID2D1RenderTarget* rt, D2D1_COLO
         use_counter_ = 0;
         bound_rt_ = rt;
         last_brush_ = nullptr;
-        ++g_brush_stats.rt_switch;
+        MENDO_COUNT_INC(g_brush_stats.rt_switch);
     }
     const uint32_t key = command_executor_internal::PackColor(color);
     // 直前と同色なら hash lookup を完全にスキップ。同色連続発行（罫線、ハイライト、
     // 同テーマ色のテキスト等）が多いためヒット率が高い。
     if (last_brush_ && key == last_brush_key_) {
-        ++g_brush_stats.fastpath_hit;
+        MENDO_COUNT_INC(g_brush_stats.fastpath_hit);
         return last_brush_;
     }
     const uint64_t now = ++use_counter_;
@@ -47,7 +49,7 @@ ID2D1SolidColorBrush* CommandExecutor::GetBrush(ID2D1RenderTarget* rt, D2D1_COLO
         it->second.last_used = now;
         last_brush_key_ = key;
         last_brush_ = it->second.brush.Get();
-        ++g_brush_stats.pool_hit;
+        MENDO_COUNT_INC(g_brush_stats.pool_hit);
         return last_brush_;
     }
     if (brush_pool_.size() >= MAX_POOLED_BRUSHES) {
@@ -63,9 +65,9 @@ ID2D1SolidColorBrush* CommandExecutor::GetBrush(ID2D1RenderTarget* rt, D2D1_COLO
             last_brush_ = nullptr;
         }
         brush_pool_.erase(oldest);
-        ++g_brush_stats.pool_evict;
+        MENDO_COUNT_INC(g_brush_stats.pool_evict);
     }
-    ++g_brush_stats.pool_miss;
+    MENDO_COUNT_INC(g_brush_stats.pool_miss);
     Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush;
     if (FAILED(rt->CreateSolidColorBrush(color, &brush)) || !brush) {
         return nullptr;
@@ -157,6 +159,6 @@ void CommandExecutor::Execute(const DrawCommandList& cmds, ID2D1RenderTarget* rt
         // clang-format on
     }
 
-    PublishBrushStats();
+    MENDO_IF_TRACY(PublishBrushStats());
     MENDO_PLOT("brush.pool_size", static_cast<int64_t>(brush_pool_.size()));
 }

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -1,11 +1,35 @@
 #include "command_generator.h"
 #include "i18n.h"
 #include "layout.h"
+#include "profiler.h"
 #include "ui_constants.h"
 #include <algorithm>
 #include <format>
 #include <ranges>
 #include <utility>
+
+namespace {
+
+// 累積カウンタ + 直近フレーム値（UI スレッド単一前提のため非アトミック）。
+struct CmdGenStats {
+    int64_t hittest_range = 0;     // FetchHitTestMetrics (HitTestTextRange) 呼び出し
+    int64_t sel_hl_cache_hit = 0;  // SelectionHlCache ヒット
+    int64_t sel_hl_cache_miss = 0; // SelectionHlCache ミス (HitTestTextRange を回す)
+    int64_t search_hl_rebuild = 0; // SearchHlCache 再構築
+    int64_t last_visible_node_count = 0; // 累積ではなく直近フレームのスナップショット
+};
+CmdGenStats g_cmd_gen_stats;
+
+void PublishCmdGenStats() noexcept
+{
+    MENDO_PLOT("cmdgen.hittest_range", g_cmd_gen_stats.hittest_range);
+    MENDO_PLOT("cmdgen.sel_hl_cache_hit", g_cmd_gen_stats.sel_hl_cache_hit);
+    MENDO_PLOT("cmdgen.sel_hl_cache_miss", g_cmd_gen_stats.sel_hl_cache_miss);
+    MENDO_PLOT("cmdgen.search_hl_rebuild", g_cmd_gen_stats.search_hl_rebuild);
+    MENDO_PLOT("cmdgen.visible_node_count", g_cmd_gen_stats.last_visible_node_count);
+}
+
+} // namespace
 
 // h1/h2 見出し下線を描画するY座標を heading_spacing_below_h1h2 のこの比率で決める。
 // 値を小さくすると下線は見出し文字に近づき、下線と次行の間隔が広がる。
@@ -94,17 +118,21 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     // ノード単体ごとではなく一括で描画することで、複数行の引用ブロックが連続した見た目になる。
     GenBlockQuoteGroupDecorations(cmds, nodes, cache, node_count, first_visible);
 
+    int visible_count = 0;
     for (int i = first_visible; i < node_count; i++) {
         if (cache[i].y_position > frame_viewport_bottom_) {
             break;
         }
         GenerateNode(cmds, nodes[i], cache[i], cache.GetDiagram(i), i);
+        ++visible_count;
     }
 
     cmds.emplace_back(SetTransformCmd{ D2D1::Matrix3x2F::Identity() });
     cmds.emplace_back(PopClipCmd{});
     frame_selection_ = nullptr;
     last_cmds_size_ = cmds_.size();
+    g_cmd_gen_stats.last_visible_node_count = visible_count;
+    PublishCmdGenStats();
     return cmds_;
 }
 
@@ -485,6 +513,7 @@ void CommandGenerator::EmitHighlightRects(
         return;
     }
     auto& buf = GetHitTestBuffer();
+    ++g_cmd_gen_stats.hittest_range;
     const UINT32 count = FetchHitTestMetrics(layout, start, length, buf);
     for (UINT32 i = 0; i < count; i++) {
         cmds.emplace_back(FillRectCmd{ RectFromHitTest(buf[i], origin_x, origin_y), color });
@@ -499,6 +528,7 @@ void CommandGenerator::GenSelectionHighlight(DrawCommandList& cmds, IDWriteTextL
 void CommandGenerator::CollectHitTestRects(IDWriteTextLayout* layout, uint32_t start, uint32_t length, std::pmr::vector<D2D1_RECT_F>& out)
 {
     auto& buf = GetHitTestBuffer();
+    ++g_cmd_gen_stats.hittest_range;
     const UINT32 count = FetchHitTestMetrics(layout, start, length, buf);
     out.reserve(out.size() + count);
     for (UINT32 i = 0; i < count; i++) {
@@ -514,11 +544,15 @@ void CommandGenerator::GenSelectionHighlightCached(DrawCommandList& cmds, const 
     }
     auto& cache = entry.ensure_selection_hl_cache();
     if (cache.layout_ptr != layout || cache.start != start || cache.length != length) {
+        ++g_cmd_gen_stats.sel_hl_cache_miss;
         cache.rects.clear();
         CollectHitTestRects(layout, start, length, cache.rects);
         cache.layout_ptr = layout;
         cache.start = start;
         cache.length = length;
+    }
+    else {
+        ++g_cmd_gen_stats.sel_hl_cache_hit;
     }
     for (const auto& r : cache.rects) {
         cmds.emplace_back(FillRectCmd{
@@ -561,6 +595,7 @@ void CommandGenerator::RebuildSearchHlCache(SearchHlCache& cache, const NodeLayo
         return;
     }
 
+    ++g_cmd_gen_stats.search_hl_rebuild;
     cache.rects.clear();
     cache.rect_ends.clear();
     cache.rect_ends.reserve(node_match_count);

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -8,6 +8,7 @@
 #include <ranges>
 #include <utility>
 
+#ifdef MENDO_USE_TRACY
 namespace {
 
 // 累積カウンタ + 直近フレーム値（UI スレッド単一前提のため非アトミック）。
@@ -30,6 +31,7 @@ void PublishCmdGenStats() noexcept
 }
 
 } // namespace
+#endif
 
 // h1/h2 見出し下線を描画するY座標を heading_spacing_below_h1h2 のこの比率で決める。
 // 値を小さくすると下線は見出し文字に近づき、下線と次行の間隔が広がる。
@@ -131,8 +133,8 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     cmds.emplace_back(PopClipCmd{});
     frame_selection_ = nullptr;
     last_cmds_size_ = cmds_.size();
-    g_cmd_gen_stats.last_visible_node_count = visible_count;
-    PublishCmdGenStats();
+    MENDO_COUNT_SET(g_cmd_gen_stats.last_visible_node_count, visible_count);
+    MENDO_IF_TRACY(PublishCmdGenStats());
     return cmds_;
 }
 
@@ -513,7 +515,7 @@ void CommandGenerator::EmitHighlightRects(
         return;
     }
     auto& buf = GetHitTestBuffer();
-    ++g_cmd_gen_stats.hittest_range;
+    MENDO_COUNT_INC(g_cmd_gen_stats.hittest_range);
     const UINT32 count = FetchHitTestMetrics(layout, start, length, buf);
     for (UINT32 i = 0; i < count; i++) {
         cmds.emplace_back(FillRectCmd{ RectFromHitTest(buf[i], origin_x, origin_y), color });
@@ -528,7 +530,7 @@ void CommandGenerator::GenSelectionHighlight(DrawCommandList& cmds, IDWriteTextL
 void CommandGenerator::CollectHitTestRects(IDWriteTextLayout* layout, uint32_t start, uint32_t length, std::pmr::vector<D2D1_RECT_F>& out)
 {
     auto& buf = GetHitTestBuffer();
-    ++g_cmd_gen_stats.hittest_range;
+    MENDO_COUNT_INC(g_cmd_gen_stats.hittest_range);
     const UINT32 count = FetchHitTestMetrics(layout, start, length, buf);
     out.reserve(out.size() + count);
     for (UINT32 i = 0; i < count; i++) {
@@ -544,7 +546,7 @@ void CommandGenerator::GenSelectionHighlightCached(DrawCommandList& cmds, const 
     }
     auto& cache = entry.ensure_selection_hl_cache();
     if (cache.layout_ptr != layout || cache.start != start || cache.length != length) {
-        ++g_cmd_gen_stats.sel_hl_cache_miss;
+        MENDO_COUNT_INC(g_cmd_gen_stats.sel_hl_cache_miss);
         cache.rects.clear();
         CollectHitTestRects(layout, start, length, cache.rects);
         cache.layout_ptr = layout;
@@ -552,7 +554,7 @@ void CommandGenerator::GenSelectionHighlightCached(DrawCommandList& cmds, const 
         cache.length = length;
     }
     else {
-        ++g_cmd_gen_stats.sel_hl_cache_hit;
+        MENDO_COUNT_INC(g_cmd_gen_stats.sel_hl_cache_hit);
     }
     for (const auto& r : cache.rects) {
         cmds.emplace_back(FillRectCmd{
@@ -595,7 +597,7 @@ void CommandGenerator::RebuildSearchHlCache(SearchHlCache& cache, const NodeLayo
         return;
     }
 
-    ++g_cmd_gen_stats.search_hl_rebuild;
+    MENDO_COUNT_INC(g_cmd_gen_stats.search_hl_rebuild);
     cache.rects.clear();
     cache.rect_ends.clear();
     cache.rect_ends.reserve(node_match_count);

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <utility>
 
+#ifdef MENDO_USE_TRACY
 namespace {
 
 // 累積カウンタ（UI スレッド単一前提のため非アトミック）。
@@ -28,6 +29,7 @@ void PublishEffectStats() noexcept
 }
 
 } // namespace
+#endif
 
 using Microsoft::WRL::ComPtr;
 
@@ -129,7 +131,7 @@ void Renderer::ApplyVisibleEffects(std::pmr::vector<Node>& nodes, LayoutCache& c
         }
         ApplyNodeEffects(nodes[i], cache[i], viewport_top, viewport_bottom);
     }
-    PublishEffectStats();
+    MENDO_IF_TRACY(PublishEffectStats());
 }
 
 ID2D1SolidColorBrush* Renderer::GetSyntaxBrush(SyntaxTokenType type) const noexcept
@@ -163,7 +165,7 @@ static InlineCodeBg MakeInlineCodeBg(const DWRITE_HIT_TEST_METRICS& m) noexcept
 
 void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry, float viewport_top, float viewport_bottom)
 {
-    ++g_effect_stats.apply_table;
+    MENDO_COUNT_INC(g_effect_stats.apply_table);
     if (!node.has_table() || node.table_rows().empty() || !entry.has_table_layout()) {
         entry.effects_applied = true;
         return;
@@ -214,7 +216,7 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry, float viewp
                 if (first_pass && run.has_link()) {
                     const DWRITE_TEXT_RANGE range{ run.start, run.length };
                     cell_layout->SetDrawingEffect(Brush(BrushId::Link), range);
-                    ++g_effect_stats.set_drawing_effect;
+                    MENDO_COUNT_INC(g_effect_stats.set_drawing_effect);
                 }
                 // インラインコード背景: 可視かつ未計算の行のみ。
                 // cell_index 昇順を維持するため、新規行が末尾以降ならば append、
@@ -222,9 +224,9 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry, float viewp
                 // upper_bound 位置に insert する。可視ノードが下方向に増える典型ケースは
                 // 完全 append (O(1)/elem) で済む。
                 if (need_bgs && run.code() && run.length > 0) {
-                    ++g_effect_stats.hittest_range;
+                    MENDO_COUNT_INC(g_effect_stats.hittest_range);
                     const UINT32 count = FetchHitTestMetrics(cell_layout, run.start, run.length, hit_test_buffer_);
-                    g_effect_stats.inline_code_bg_added += count;
+                    MENDO_COUNT_ADD(g_effect_stats.inline_code_bg_added, count);
                     const auto cell_index = static_cast<uint32_t>(tl.CellIndex(r, c));
                     auto& bgs = tl.cell_inline_code_bgs;
                     const bool can_append = bgs.empty() || bgs.back().cell_index <= cell_index;
@@ -270,7 +272,7 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float viewpo
         return;
     }
     entry.effects_applied = true;
-    ++g_effect_stats.apply_node;
+    MENDO_COUNT_INC(g_effect_stats.apply_node);
 
     if (node.type == NodeType::Image) {
         return;
@@ -290,7 +292,7 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float viewpo
             if (brush) {
                 const DWRITE_TEXT_RANGE range{ token.start, token.length };
                 entry.text_layout->SetDrawingEffect(brush, range);
-                ++g_effect_stats.set_drawing_effect;
+                MENDO_COUNT_INC(g_effect_stats.set_drawing_effect);
             }
         }
     }
@@ -308,7 +310,7 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float viewpo
         if (idx < ALERT_TYPE_COUNT) {
             const DWRITE_TEXT_RANGE range{ 0, node.alert_label_length };
             entry.text_layout->SetDrawingEffect(Brush(ALERT_BRUSH[idx]), range);
-            ++g_effect_stats.set_drawing_effect;
+            MENDO_COUNT_INC(g_effect_stats.set_drawing_effect);
         }
     }
 
@@ -317,14 +319,14 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float viewpo
             const DWRITE_TEXT_RANGE range{ run.start, run.length };
             entry.text_layout->SetUnderline(TRUE, range);
             entry.text_layout->SetDrawingEffect(Brush(BrushId::Link), range);
-            ++g_effect_stats.set_drawing_effect;
+            MENDO_COUNT_INC(g_effect_stats.set_drawing_effect);
         }
         if (run.code() && node.type != NodeType::CodeBlock && run.length > 0) {
-            ++g_effect_stats.hittest_range;
+            MENDO_COUNT_INC(g_effect_stats.hittest_range);
             const UINT32 count = FetchHitTestMetrics(entry.text_layout.Get(), run.start, run.length, hit_test_buffer_);
             if (count > 0) {
                 auto& bgs = entry.ensure_inline_code_bgs();
-                g_effect_stats.inline_code_bg_added += count;
+                MENDO_COUNT_ADD(g_effect_stats.inline_code_bg_added, count);
                 for (UINT32 i = 0; i < count; i++) {
                     bgs.emplace_back(MakeInlineCodeBg(hit_test_buffer_[i]));
                 }

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -6,6 +6,29 @@
 #include <cmath>
 #include <utility>
 
+namespace {
+
+// 累積カウンタ（UI スレッド単一前提のため非アトミック）。
+struct EffectStats {
+    int64_t set_drawing_effect = 0; // ApplyNodeEffects/ApplyTableEffects 内の SetDrawingEffect
+    int64_t hittest_range = 0;      // インラインコード背景計算の HitTestTextRange
+    int64_t apply_node = 0;         // ApplyNodeEffects 呼び出し
+    int64_t apply_table = 0;        // ApplyTableEffects 呼び出し
+    int64_t inline_code_bg_added = 0; // ノード/セルに追加されたインラインコード背景数
+};
+EffectStats g_effect_stats;
+
+void PublishEffectStats() noexcept
+{
+    MENDO_PLOT("effect.set_drawing_effect", g_effect_stats.set_drawing_effect);
+    MENDO_PLOT("effect.hittest_range", g_effect_stats.hittest_range);
+    MENDO_PLOT("effect.apply_node", g_effect_stats.apply_node);
+    MENDO_PLOT("effect.apply_table", g_effect_stats.apply_table);
+    MENDO_PLOT("effect.inline_code_bg_added", g_effect_stats.inline_code_bg_added);
+}
+
+} // namespace
+
 using Microsoft::WRL::ComPtr;
 
 #pragma comment(lib, "d2d1.lib")
@@ -106,6 +129,7 @@ void Renderer::ApplyVisibleEffects(std::pmr::vector<Node>& nodes, LayoutCache& c
         }
         ApplyNodeEffects(nodes[i], cache[i], viewport_top, viewport_bottom);
     }
+    PublishEffectStats();
 }
 
 ID2D1SolidColorBrush* Renderer::GetSyntaxBrush(SyntaxTokenType type) const noexcept
@@ -139,6 +163,7 @@ static InlineCodeBg MakeInlineCodeBg(const DWRITE_HIT_TEST_METRICS& m) noexcept
 
 void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry, float viewport_top, float viewport_bottom)
 {
+    ++g_effect_stats.apply_table;
     if (!node.has_table() || node.table_rows().empty() || !entry.has_table_layout()) {
         entry.effects_applied = true;
         return;
@@ -189,6 +214,7 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry, float viewp
                 if (first_pass && run.has_link()) {
                     const DWRITE_TEXT_RANGE range{ run.start, run.length };
                     cell_layout->SetDrawingEffect(Brush(BrushId::Link), range);
+                    ++g_effect_stats.set_drawing_effect;
                 }
                 // インラインコード背景: 可視かつ未計算の行のみ。
                 // cell_index 昇順を維持するため、新規行が末尾以降ならば append、
@@ -196,7 +222,9 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry, float viewp
                 // upper_bound 位置に insert する。可視ノードが下方向に増える典型ケースは
                 // 完全 append (O(1)/elem) で済む。
                 if (need_bgs && run.code() && run.length > 0) {
+                    ++g_effect_stats.hittest_range;
                     const UINT32 count = FetchHitTestMetrics(cell_layout, run.start, run.length, hit_test_buffer_);
+                    g_effect_stats.inline_code_bg_added += count;
                     const auto cell_index = static_cast<uint32_t>(tl.CellIndex(r, c));
                     auto& bgs = tl.cell_inline_code_bgs;
                     const bool can_append = bgs.empty() || bgs.back().cell_index <= cell_index;
@@ -242,6 +270,7 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float viewpo
         return;
     }
     entry.effects_applied = true;
+    ++g_effect_stats.apply_node;
 
     if (node.type == NodeType::Image) {
         return;
@@ -261,6 +290,7 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float viewpo
             if (brush) {
                 const DWRITE_TEXT_RANGE range{ token.start, token.length };
                 entry.text_layout->SetDrawingEffect(brush, range);
+                ++g_effect_stats.set_drawing_effect;
             }
         }
     }
@@ -278,6 +308,7 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float viewpo
         if (idx < ALERT_TYPE_COUNT) {
             const DWRITE_TEXT_RANGE range{ 0, node.alert_label_length };
             entry.text_layout->SetDrawingEffect(Brush(ALERT_BRUSH[idx]), range);
+            ++g_effect_stats.set_drawing_effect;
         }
     }
 
@@ -286,11 +317,14 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float viewpo
             const DWRITE_TEXT_RANGE range{ run.start, run.length };
             entry.text_layout->SetUnderline(TRUE, range);
             entry.text_layout->SetDrawingEffect(Brush(BrushId::Link), range);
+            ++g_effect_stats.set_drawing_effect;
         }
         if (run.code() && node.type != NodeType::CodeBlock && run.length > 0) {
+            ++g_effect_stats.hittest_range;
             const UINT32 count = FetchHitTestMetrics(entry.text_layout.Get(), run.start, run.length, hit_test_buffer_);
             if (count > 0) {
                 auto& bgs = entry.ensure_inline_code_bgs();
+                g_effect_stats.inline_code_bg_added += count;
                 for (UINT32 i = 0; i < count; i++) {
                     bgs.emplace_back(MakeInlineCodeBg(hit_test_buffer_[i]));
                 }

--- a/src/util/profiler.h
+++ b/src/util/profiler.h
@@ -15,6 +15,10 @@
 //   MENDO_PROFILE(label)             : スコープ計測。label は文字列リテラル必須。
 //   MENDO_FRAME_MARK()               : フレーム境界マーカー。OnPaint 末尾で 1 回呼ぶ。
 //   MENDO_PLOT(label, value)         : 数値の時系列プロット。double / int 受け入れ可。
+//   MENDO_COUNT_INC(counter)         : 累積カウンタの ++。Tracy OFF で no-op (DCE 担保)。
+//   MENDO_COUNT_ADD(counter, n)      : 累積カウンタへの加算。Tracy OFF で no-op。
+//   MENDO_COUNT_SET(counter, value)  : 累積でない直近値の代入。Tracy OFF で no-op。
+//   MENDO_IF_TRACY(...)              : Tracy ON のときだけ展開する任意コード。
 //   MENDO_TRACE(msg)                 : リテラルメッセージ（reload 系トレース）。
 //   MENDO_TRACEF(fmt, ...)           : printf 形式トレース。
 //   MENDO_STATF(fmt, ...)            : printf 形式の統計値ログ。
@@ -27,6 +31,7 @@
 
 #include <tracy/Tracy.hpp>
 #include <cstdio>
+#include <cstring>
 
 // Tracy の ZoneScopedN は固定変数名 `___tracy_scoped_zone` を生成するため、
 // 同一スコープに 2 個書くと再定義エラーになる。__LINE__ で固有名を作る
@@ -36,16 +41,27 @@
 #define MENDO_FRAME_MARK() FrameMark
 #define MENDO_PLOT(label, value) TracyPlot(label, value)
 
+// 累積カウンタ系。Tracy OFF では完全に no-op になるため、対象カウンタが
+// 他から参照されない限り、変数定義ごと dead code として消える。
+#define MENDO_COUNT_INC(counter) (++(counter))
+#define MENDO_COUNT_ADD(counter, n) ((counter) += (n))
+#define MENDO_COUNT_SET(counter, value) ((counter) = (value))
+#define MENDO_IF_TRACY(...) __VA_ARGS__
+
 // printf 形式のメッセージは sprintf してから TracyMessage に渡す。
-// 既存の MENDO_TRACE/STATF はすべて ASCII リテラル + 整数/小数フォーマットなので
-// char バッファで足りる。256B を超えるメッセージは _TRUNCATE で切り詰められる。
+// _snprintf_s は _TRUNCATE 指定時、収まれば書き込んだ文字数を返し、切り詰めが
+// 起きると -1 を返す（バッファ自体は NUL 終端される）。-1 を 0 と同様に
+// 捨てると長メッセージが silently drop されるため、切り詰め時は実長を取り直す。
 #define MENDO_LOGF(prefix, fmt, ...)                                            \
     do {                                                                        \
         char _mendo_buf[256];                                                   \
         const int _mendo_n = _snprintf_s(_mendo_buf, sizeof(_mendo_buf),        \
                                          _TRUNCATE, prefix fmt, __VA_ARGS__);   \
-        if (_mendo_n > 0) {                                                     \
-            TracyMessage(_mendo_buf, static_cast<size_t>(_mendo_n));            \
+        const size_t _mendo_len = (_mendo_n >= 0)                               \
+            ? static_cast<size_t>(_mendo_n)                                     \
+            : strnlen(_mendo_buf, sizeof(_mendo_buf) - 1);                      \
+        if (_mendo_len > 0) {                                                   \
+            TracyMessage(_mendo_buf, _mendo_len);                               \
         }                                                                       \
     } while (0)
 
@@ -60,6 +76,10 @@
 #define MENDO_PROFILE(label) ((void)0)
 #define MENDO_FRAME_MARK() ((void)0)
 #define MENDO_PLOT(label, value) ((void)0)
+#define MENDO_COUNT_INC(counter) ((void)0)
+#define MENDO_COUNT_ADD(counter, n) ((void)0)
+#define MENDO_COUNT_SET(counter, value) ((void)0)
+#define MENDO_IF_TRACY(...)
 #define MENDO_LOGF(prefix, fmt, ...) ((void)0)
 #define MENDO_TRACE(msg) ((void)0)
 #define MENDO_TRACEF(fmt, ...) ((void)0)

--- a/src/util/profiler.h
+++ b/src/util/profiler.h
@@ -1,9 +1,6 @@
 #pragma once
-#include <windows.h>
-#include <cstdio>
 
-// 処理ブロックごとの時間計測ユーティリティ。
-// OutputDebugStringW でタイミング情報を出力する（DebugView や VS 出力ウィンドウで確認可能）。
+// 計測ユーティリティ。バックエンドは Tracy のみ。
 //
 // 使い方:
 //   {
@@ -11,73 +8,59 @@
 //       ... 計測対象の処理 ...
 //   }
 //
-// MENDO_PROFILE_ENABLED を 0 にするとすべての計測コードが消える。
-#ifndef MENDO_PROFILE_ENABLED
-#define MENDO_PROFILE_ENABLED 1
-#endif
-
-#if MENDO_PROFILE_ENABLED
-
-class ScopedProfileTimer {
-public:
-    explicit ScopedProfileTimer(const wchar_t* label) noexcept : label_(label)
-    {
-        QueryPerformanceCounter(&start_);
-    }
-
-    ~ScopedProfileTimer() noexcept
-    {
-        LARGE_INTEGER end;
-        QueryPerformanceCounter(&end);
-
-        const double elapsed_us = static_cast<double>(end.QuadPart - start_.QuadPart) * 1'000'000.0 / static_cast<double>(Frequency().QuadPart);
-
-        wchar_t buf[256];
-        if (elapsed_us >= 1000.0) {
-            _snwprintf_s(buf, _TRUNCATE, L"[mendo-profile] %s: %.2f ms\n", label_, elapsed_us / 1000.0);
-        }
-        else {
-            _snwprintf_s(buf, _TRUNCATE, L"[mendo-profile] %s: %.1f us\n", label_, elapsed_us);
-        }
-        OutputDebugStringW(buf);
-    }
-
-    ScopedProfileTimer(const ScopedProfileTimer&) = delete;
-    ScopedProfileTimer& operator=(const ScopedProfileTimer&) = delete;
-
-private:
-    static const LARGE_INTEGER& Frequency() noexcept
-    {
-        static const LARGE_INTEGER freq = [] {
-            LARGE_INTEGER f;
-            QueryPerformanceFrequency(&f);
-            return f;
-        }();
-        return freq;
-    }
-
-    const wchar_t* label_;
-    LARGE_INTEGER start_;
-};
+// CMake -DMENDO_USE_TRACY=ON で有効化される。OFF のときは全マクロが no-op に展開され、
+// バイナリにも一切のコードが残らない。
+//
+// マクロ一覧:
+//   MENDO_PROFILE(label)             : スコープ計測。label は文字列リテラル必須。
+//   MENDO_FRAME_MARK()               : フレーム境界マーカー。OnPaint 末尾で 1 回呼ぶ。
+//   MENDO_PLOT(label, value)         : 数値の時系列プロット。double / int 受け入れ可。
+//   MENDO_TRACE(msg)                 : リテラルメッセージ（reload 系トレース）。
+//   MENDO_TRACEF(fmt, ...)           : printf 形式トレース。
+//   MENDO_STATF(fmt, ...)            : printf 形式の統計値ログ。
+//   MENDO_LOGF(prefix, fmt, ...)     : 任意プレフィックスでログ出力。
 
 #define MENDO_PROFILE_CONCAT2(a, b) a##b
 #define MENDO_PROFILE_CONCAT(a, b) MENDO_PROFILE_CONCAT2(a, b)
-#define MENDO_PROFILE(label) ScopedProfileTimer MENDO_PROFILE_CONCAT(_mendo_timer_, __LINE__)(L##label)
 
+#ifdef MENDO_USE_TRACY
+
+#include <tracy/Tracy.hpp>
+#include <cstdio>
+
+// Tracy の ZoneScopedN は固定変数名 `___tracy_scoped_zone` を生成するため、
+// 同一スコープに 2 個書くと再定義エラーになる。__LINE__ で固有名を作る
+// ZoneNamedN を使って同一関数内で複数 MENDO_PROFILE を書ける形にする。
+#define MENDO_PROFILE(label) \
+    ZoneNamedN(MENDO_PROFILE_CONCAT(_mendo_zone_, __LINE__), label, true)
+#define MENDO_FRAME_MARK() FrameMark
+#define MENDO_PLOT(label, value) TracyPlot(label, value)
+
+// printf 形式のメッセージは sprintf してから TracyMessage に渡す。
+// 既存の MENDO_TRACE/STATF はすべて ASCII リテラル + 整数/小数フォーマットなので
+// char バッファで足りる。256B を超えるメッセージは _TRUNCATE で切り詰められる。
 #define MENDO_LOGF(prefix, fmt, ...)                                            \
     do {                                                                        \
-        wchar_t _mendo_buf[256];                                                \
-        _snwprintf_s(_mendo_buf, _TRUNCATE, prefix L##fmt L"\n", __VA_ARGS__);  \
-        OutputDebugStringW(_mendo_buf);                                         \
+        char _mendo_buf[256];                                                   \
+        const int _mendo_n = _snprintf_s(_mendo_buf, sizeof(_mendo_buf),        \
+                                         _TRUNCATE, prefix fmt, __VA_ARGS__);   \
+        if (_mendo_n > 0) {                                                     \
+            TracyMessage(_mendo_buf, static_cast<size_t>(_mendo_n));            \
+        }                                                                       \
     } while (0)
 
-#define MENDO_TRACE(msg) OutputDebugStringW(L"[mendo-reload] " L##msg L"\n")
-#define MENDO_TRACEF(fmt, ...) MENDO_LOGF(L"[mendo-reload] ", fmt, __VA_ARGS__)
-#define MENDO_STATF(fmt, ...) MENDO_LOGF(L"[mendo-stat] ", fmt, __VA_ARGS__)
+// TracyMessageL はリテラル前提（NULL 終端の文字列をそのまま参照保持する）。
+#define MENDO_TRACE(msg) TracyMessageL("[mendo-reload] " msg)
+#define MENDO_TRACEF(fmt, ...) MENDO_LOGF("[mendo-reload] ", fmt, __VA_ARGS__)
+#define MENDO_STATF(fmt, ...) MENDO_LOGF("[mendo-stat] ", fmt, __VA_ARGS__)
 
 #else
 
+// MENDO_USE_TRACY 未定義時は全マクロを完全に消す。
 #define MENDO_PROFILE(label) ((void)0)
+#define MENDO_FRAME_MARK() ((void)0)
+#define MENDO_PLOT(label, value) ((void)0)
+#define MENDO_LOGF(prefix, fmt, ...) ((void)0)
 #define MENDO_TRACE(msg) ((void)0)
 #define MENDO_TRACEF(fmt, ...) ((void)0)
 #define MENDO_STATF(fmt, ...) ((void)0)


### PR DESCRIPTION
## Summary

- Tracy v0.13.1 を `-DMENDO_USE_TRACY=ON` の opt-in で組み込み (デフォルト OFF)。プロファイラを使わない通常ビルドの成果物には一切影響しない
- 旧 `OutputDebugStringW` 経路の `ScopedProfileTimer` と wstring マクロを撤廃し、`profiler.h` を Tracy バックエンド単一に整理 (`MENDO_PROFILE_ENABLED` の概念も廃止)
- パース/レイアウト/描画の主要ホットパスにゾーンとカウンタプロットを差し込み、Tracy GUI でフレームグラフ・per-call 時間・カウンタ時系列が見えるように

## 計装の主な追加点

| 層 | ゾーン | カウンタ (TracyPlot) |
|---|---|---|
| `dwrite_measurer` | MeasureNode / .fastpath / CreateTextLayout / .cell / Tokenize / MeasureTable* / FinalizeTableLayout / ApplyRunFormatting | — |
| `layout` | ComputeLayout / EnsureVisibleLayout / ProcessDirtyBatch / RecomputeYPositions / EstimateNodeHeights | partial / width_changed / node_count / broke_early / dirty_batch.processed |
| `command_executor` | Execute | brush.fastpath_hit / pool_hit / pool_miss / pool_evict / rt_switch / pool_size / draw.command_count |
| `command_generator` | — | cmdgen.hittest_range / sel_hl_cache_hit/miss / search_hl_rebuild / visible_node_count |
| `renderer` | — | effect.set_drawing_effect / hittest_range / apply_node / apply_table / inline_code_bg_added |
| `app` | — | (OnPaint 末尾に `MENDO_FRAME_MARK`) |

## ビルド方法

```
cmake -B build_tracy -DMENDO_USE_TRACY=ON
cmake --build build_tracy --config Release
```

Tracy GUI ([Releases](https://github.com/wolfpld/tracy/releases)) を起動した状態で `build_tracy/Release/mendo.exe` を実行すると接続できる。`TRACY_ON_DEMAND` モードで組み込んでいるため GUI 接続前は計測コードが no-op。

## ドキュメント

- README (日/英) に Tracy 有効ビルド手順を追記
- THIRD_PARTY_LICENSES.md に Tracy v0.13.1 (BSD 3-Clause) を追記
- .gitignore: `build/` → `build*/` で派生ビルドツリー (build_tracy/ 等) も追跡対象外に

## Test plan

- [x] Release (Tracy OFF, 既定) ビルド成功 — 2,211,840 B
- [x] Release (Tracy ON) ビルド成功 — 2,358,272 B (+146 KB の Tracy ランタイム増加)
- [x] `mendo_tests.exe` 2087/2087 PASS
- [ ] Tracy GUI で接続して frame graph / zone / plot が表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)