### PR TITLE
perf(startup): ウィンドウ生成と並列にファイル I/O + パースを実行 (#179)

### DIFF
--- a/src/app/app.h
+++ b/src/app/app.h
@@ -40,6 +40,11 @@ public:
     std::pmr::wstring LoadLastFilePath() const;
     void ShowDirectory(std::wstring_view dir_path);
 
+    // 起動時にウィンドウ生成と並列で I/O + パースを開始する。Init 末尾の
+    // OnInitComplete で hwnd が解禁されると、worker は PostMessage(PARSE_COMPLETE)
+    // を発行し、通常の async load 経路に合流する。
+    void StartPreloadAsync(std::pmr::wstring path);
+
     void OnPaint();
     void OnResize(UINT width, UINT height);
     void OnMouseWheel(int px, int py, short delta, bool ctrl = false);

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -129,6 +129,11 @@ void App::LoadMarkdownFile(std::wstring_view path)
     }
 }
 
+void App::StartPreloadAsync(std::pmr::wstring path)
+{
+    file_load_service_.StartPreloadAsync(std::move(path));
+}
+
 void App::DoLoadMarkdownFile()
 {
     MENDO_PROFILE("DoLoadMarkdownFile");
@@ -173,6 +178,9 @@ void App::OnParseComplete()
         MENDO_TRACE("OnParseComplete: no result (cancelled or load failed)");
         // 失敗パスでも paused 状態の FileWatcher を必ず再開させる。
         EmitEffect(effect::ResumeFileWatch{});
+        if (auto err = file_load_service_.TakeAsyncError()) {
+            ShowToast(FileLoadErrorMessage(*err, i18n::S()));
+        }
         HandleLoadFailureFallback();
         return;
     }

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -216,10 +216,11 @@ void App::OnParseComplete()
         state_.reload_diff_pos = std::wstring_view::npos;
     }
 
+    const bool heights_estimated = result->heights_estimated;
     state_.document.doc = std::move(result->doc);
     state_.document.layout_cache = std::move(result->cache);
 
-    FinishLoadMarkdownFile(/* heights_estimated = */ true);
+    FinishLoadMarkdownFile(heights_estimated);
 }
 
 void App::FinishLoadMarkdownFile(bool heights_estimated)

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -182,22 +182,21 @@ bool App::Init(HWND hwnd)
 
     // small file は preload が App::Init より先に完了している場合が多い。直後の
     // ShowWindow/UpdateWindow が同期 WM_PAINT を発行するため、ここで結果を取り込んで
-    // おかないと初回フレームが空ウィンドウになってしまう。完了済みなら同期適用、
-    // 未完了なら従来通り OnInitComplete で hwnd を worker に通知して PostMessage 経路へ。
-    if (file_load_service_.HasPreload()) {
-        if (file_load_service_.IsPreloadDone()) {
-            file_load_service_.JoinPreload();
-            OnParseComplete();
+    // おかないと初回フレームが空ウィンドウになってしまう。
+    using PreloadAttachResult = FileLoadService::PreloadAttachResult;
+    switch (file_load_service_.AttachOrApplyPreload(hwnd_, app_msg::PARSE_COMPLETE)) {
+    case PreloadAttachResult::AppliedSync:
+        OnParseComplete();
+        break;
+    case PreloadAttachResult::AttachedAsync:
+        if (DocumentService::NeedsLoadingAnimation(file_load_service_.GetLoadingPath())) {
+            file_load_service_.BeginLoadingAnimation();
+            EmitEffect(effect::SetTimer{ app_timer::LOADING_ANIM, app_timer::FRAME_INTERVAL_MS });
+            Invalidate();
         }
-        else {
-            const std::pmr::wstring preload_path{ file_load_service_.GetLoadingPath() };
-            if (DocumentService::NeedsLoadingAnimation(preload_path)) {
-                file_load_service_.StartLoading(preload_path);
-                EmitEffect(effect::SetTimer{ app_timer::LOADING_ANIM, app_timer::FRAME_INTERVAL_MS });
-                Invalidate();
-            }
-            file_load_service_.OnInitComplete(hwnd_, app_msg::PARSE_COMPLETE);
-        }
+        break;
+    case PreloadAttachResult::None:
+        break;
     }
 
     return true;

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -180,6 +180,18 @@ bool App::Init(HWND hwnd)
 
     state_.search.search_bar_ctrl.Init(state_.search.search_state, state_.view.viewport, state_.document.layout_cache, BuildSearchBarCallbacks());
 
+    // 起動時 preload は scheduler/Theme 不要な path で I/O+パースを先行させる。
+    // ここで hwnd を引き渡して PostMessage(PARSE_COMPLETE) を解禁する。
+    if (file_load_service_.HasPreload()) {
+        const std::pmr::wstring preload_path{ file_load_service_.GetLoadingPath() };
+        if (DocumentService::NeedsLoadingAnimation(preload_path)) {
+            file_load_service_.StartLoading(preload_path);
+            EmitEffect(effect::SetTimer{ app_timer::LOADING_ANIM, app_timer::FRAME_INTERVAL_MS });
+            Invalidate();
+        }
+        file_load_service_.OnInitComplete(hwnd_, app_msg::PARSE_COMPLETE);
+    }
+
     return true;
 }
 

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -180,16 +180,24 @@ bool App::Init(HWND hwnd)
 
     state_.search.search_bar_ctrl.Init(state_.search.search_state, state_.view.viewport, state_.document.layout_cache, BuildSearchBarCallbacks());
 
-    // 起動時 preload は scheduler/Theme 不要な path で I/O+パースを先行させる。
-    // ここで hwnd を引き渡して PostMessage(PARSE_COMPLETE) を解禁する。
+    // small file は preload が App::Init より先に完了している場合が多い。直後の
+    // ShowWindow/UpdateWindow が同期 WM_PAINT を発行するため、ここで結果を取り込んで
+    // おかないと初回フレームが空ウィンドウになってしまう。完了済みなら同期適用、
+    // 未完了なら従来通り OnInitComplete で hwnd を worker に通知して PostMessage 経路へ。
     if (file_load_service_.HasPreload()) {
-        const std::pmr::wstring preload_path{ file_load_service_.GetLoadingPath() };
-        if (DocumentService::NeedsLoadingAnimation(preload_path)) {
-            file_load_service_.StartLoading(preload_path);
-            EmitEffect(effect::SetTimer{ app_timer::LOADING_ANIM, app_timer::FRAME_INTERVAL_MS });
-            Invalidate();
+        if (file_load_service_.IsPreloadDone()) {
+            file_load_service_.JoinPreload();
+            OnParseComplete();
         }
-        file_load_service_.OnInitComplete(hwnd_, app_msg::PARSE_COMPLETE);
+        else {
+            const std::pmr::wstring preload_path{ file_load_service_.GetLoadingPath() };
+            if (DocumentService::NeedsLoadingAnimation(preload_path)) {
+                file_load_service_.StartLoading(preload_path);
+                EmitEffect(effect::SetTimer{ app_timer::LOADING_ANIM, app_timer::FRAME_INTERVAL_MS });
+                Invalidate();
+            }
+            file_load_service_.OnInitComplete(hwnd_, app_msg::PARSE_COMPLETE);
+        }
     }
 
     return true;

--- a/src/core/document_service.h
+++ b/src/core/document_service.h
@@ -9,7 +9,7 @@ public:
     explicit DocumentService(FileWatcher& watcher) noexcept : watcher_(watcher)
     {}
 
-    std::expected<Document, FileLoadError> LoadFile(const std::pmr::wstring& path);
+    static std::expected<Document, FileLoadError> LoadFile(const std::pmr::wstring& path);
     void StartWatching(const std::pmr::wstring& path, FileWatcher::ChangeCallback cb);
     void StopWatching() noexcept;
     void CheckForChanges();

--- a/src/io/file_load_service.cpp
+++ b/src/io/file_load_service.cpp
@@ -4,6 +4,19 @@
 #include "profiler.h"
 #include "ui_constants.h"
 
+FileLoadService::~FileLoadService()
+{
+    // jthread は destructor で join するが、worker が cv.wait でブロック中だと
+    // デッドロックするため、明示的に abort 通知してから抜ける。
+    if (preload_ctx_) {
+        {
+            const std::lock_guard lk(preload_ctx_->mtx);
+            preload_ctx_->aborted = true;
+        }
+        preload_ctx_->cv.notify_all();
+    }
+}
+
 void FileLoadService::StartLoading(std::pmr::wstring path)
 {
     loading_path_ = std::move(path);
@@ -39,12 +52,16 @@ std::expected<void, FileLoadError> FileLoadService::ExecuteLoad(Document& doc, L
     return {};
 }
 
+void FileLoadService::ResetAsyncState()
+{
+    const std::lock_guard lock(async_mutex_);
+    async_result_.reset();
+    async_error_.reset();
+}
+
 void FileLoadService::StartAsyncLoad(TaskScheduler& scheduler, HWND hwnd, UINT msg_id, const Theme& theme)
 {
-    {
-        const std::lock_guard lock(async_mutex_);
-        async_result_.reset();
-    }
+    ResetAsyncState();
     async_in_flight_ = true;
     const uint32_t gen = async_gen_.fetch_add(1, std::memory_order_relaxed) + 1;
 
@@ -60,6 +77,10 @@ void FileLoadService::StartAsyncLoad(TaskScheduler& scheduler, HWND hwnd, UINT m
         auto load_result = FileLoader::LoadFile(path);
         if (!load_result) {
             if (async_gen_.load(std::memory_order_relaxed) == gen) {
+                {
+                    const std::lock_guard lock(async_mutex_);
+                    async_error_ = load_result.error();
+                }
                 PostMessage(hwnd, msg_id, 0, 0);
             }
             return;
@@ -94,4 +115,63 @@ std::optional<AsyncLoadResult> FileLoadService::TakeAsyncResult()
     auto result = std::move(async_result_);
     async_result_.reset();
     return result;
+}
+
+std::optional<FileLoadError> FileLoadService::TakeAsyncError() noexcept
+{
+    const std::lock_guard lock(async_mutex_);
+    auto err = async_error_;
+    async_error_.reset();
+    return err;
+}
+
+void FileLoadService::StartPreloadAsync(std::pmr::wstring path)
+{
+    ResetAsyncState();
+    async_in_flight_ = true;
+    loading_path_ = path;
+
+    auto ctx = std::make_shared<PreloadContext>();
+    preload_ctx_ = ctx;
+
+    // EstimateNodeHeights は Theme 依存のためここでは行わず、OnParseComplete 経由で
+    // FinishLoadMarkdownFile が後で実行する。
+    preload_thread_ = std::jthread([this, ctx, path = std::move(path)](std::stop_token st) mutable {
+        MENDO_PROFILE("Preload::worker");
+
+        auto load_result = DocumentService::LoadFile(path);
+        if (load_result) {
+            LayoutCache cache;
+            cache.Reset(load_result->GetNodes().size(), /* shrink = */ false);
+            const std::lock_guard lock(async_mutex_);
+            async_result_.emplace(AsyncLoadResult{ std::move(*load_result), std::move(cache) });
+        }
+        else {
+            const std::lock_guard lock(async_mutex_);
+            async_error_ = load_result.error();
+        }
+
+        std::unique_lock lk(ctx->mtx);
+        ctx->cv.wait(lk, [&] { return ctx->hwnd != nullptr || ctx->aborted || st.stop_requested(); });
+        if (ctx->aborted || st.stop_requested()) {
+            return;
+        }
+        const HWND h = ctx->hwnd;
+        const UINT m = ctx->msg_id;
+        lk.unlock();
+        PostMessage(h, m, 0, 0);
+    });
+}
+
+void FileLoadService::OnInitComplete(HWND hwnd, UINT msg_id)
+{
+    if (!preload_ctx_) {
+        return;
+    }
+    {
+        const std::lock_guard lk(preload_ctx_->mtx);
+        preload_ctx_->hwnd = hwnd;
+        preload_ctx_->msg_id = msg_id;
+    }
+    preload_ctx_->cv.notify_one();
 }

--- a/src/io/file_load_service.cpp
+++ b/src/io/file_load_service.cpp
@@ -4,24 +4,34 @@
 #include "profiler.h"
 #include "ui_constants.h"
 
+void FileLoadService::PreloadContext::SignalAbort()
+{
+    {
+        const std::lock_guard lk(mtx);
+        aborted = true;
+    }
+    cv.notify_all();
+}
+
 FileLoadService::~FileLoadService()
 {
     // jthread は destructor で join するが、worker が cv.wait でブロック中だと
     // デッドロックするため、明示的に abort 通知してから抜ける。
     if (preload_ctx_) {
-        {
-            const std::lock_guard lk(preload_ctx_->mtx);
-            preload_ctx_->aborted = true;
-        }
-        preload_ctx_->cv.notify_all();
+        preload_ctx_->SignalAbort();
     }
 }
 
 void FileLoadService::StartLoading(std::pmr::wstring path)
 {
     loading_path_ = std::move(path);
-    loading_ = true;
+    BeginLoadingAnimation();
     async_in_flight_ = true;
+}
+
+void FileLoadService::BeginLoadingAnimation() noexcept
+{
+    loading_ = true;
     loading_angle_ = 0.0f;
 }
 
@@ -102,7 +112,7 @@ void FileLoadService::StartAsyncLoad(TaskScheduler& scheduler, HWND hwnd, UINT m
 
         {
             const std::lock_guard lock(async_mutex_);
-            async_result_.emplace(AsyncLoadResult{ std::move(doc), std::move(cache) });
+            async_result_.emplace(AsyncLoadResult{ std::move(doc), std::move(cache), /* heights_estimated = */ true });
         }
 
         PostMessage(hwnd, msg_id, 0, 0);
@@ -144,7 +154,7 @@ void FileLoadService::StartPreloadAsync(std::pmr::wstring path)
             LayoutCache cache;
             cache.Reset(load_result->GetNodes().size(), /* shrink = */ false);
             const std::lock_guard lock(async_mutex_);
-            async_result_.emplace(AsyncLoadResult{ std::move(*load_result), std::move(cache) });
+            async_result_.emplace(AsyncLoadResult{ std::move(*load_result), std::move(cache), /* heights_estimated = */ false });
         }
         else {
             const std::lock_guard lock(async_mutex_);
@@ -190,13 +200,22 @@ void FileLoadService::JoinPreload()
     if (!preload_ctx_) {
         return;
     }
-    {
-        const std::lock_guard lk(preload_ctx_->mtx);
-        preload_ctx_->aborted = true;
-    }
-    preload_ctx_->cv.notify_all();
+    preload_ctx_->SignalAbort();
     if (preload_thread_.joinable()) {
         preload_thread_.join();
     }
     preload_ctx_.reset();
+}
+
+FileLoadService::PreloadAttachResult FileLoadService::AttachOrApplyPreload(HWND hwnd, UINT msg_id)
+{
+    if (!preload_ctx_) {
+        return PreloadAttachResult::None;
+    }
+    if (IsPreloadDone()) {
+        JoinPreload();
+        return PreloadAttachResult::AppliedSync;
+    }
+    OnInitComplete(hwnd, msg_id);
+    return PreloadAttachResult::AttachedAsync;
 }

--- a/src/io/file_load_service.cpp
+++ b/src/io/file_load_service.cpp
@@ -175,3 +175,28 @@ void FileLoadService::OnInitComplete(HWND hwnd, UINT msg_id)
     }
     preload_ctx_->cv.notify_one();
 }
+
+bool FileLoadService::IsPreloadDone()
+{
+    if (!preload_ctx_) {
+        return false;
+    }
+    const std::lock_guard lock(async_mutex_);
+    return async_result_.has_value() || async_error_.has_value();
+}
+
+void FileLoadService::JoinPreload()
+{
+    if (!preload_ctx_) {
+        return;
+    }
+    {
+        const std::lock_guard lk(preload_ctx_->mtx);
+        preload_ctx_->aborted = true;
+    }
+    preload_ctx_->cv.notify_all();
+    if (preload_thread_.joinable()) {
+        preload_thread_.join();
+    }
+    preload_ctx_.reset();
+}

--- a/src/io/file_load_service.h
+++ b/src/io/file_load_service.h
@@ -91,6 +91,12 @@ public:
     {
         return preload_ctx_ != nullptr;
     }
+    // worker が I/O+パースを終えて async_result_/async_error_ に書き込み済みか判定。
+    // ShowWindow/UpdateWindow より前に true なら同期適用パスへ分岐できる (small file)。
+    bool IsPreloadDone();
+    // worker を abort 通知で停止させ join する。preload_ctx_ も解放するため
+    // HasPreload() は以降 false を返す。同期適用パスから呼ぶ。
+    void JoinPreload();
 
     // ---- パスアクセス ----
 

--- a/src/io/file_load_service.h
+++ b/src/io/file_load_service.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "document_service.h"
 #include "document.h"
+#include "file_loader.h"
 #include "layout_cache.h"
 #include "task_scheduler.h"
 #include <string>
@@ -8,6 +9,9 @@
 #include <expected>
 #include <mutex>
 #include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <thread>
 
 struct Theme;
 
@@ -17,11 +21,24 @@ struct AsyncLoadResult {
     LayoutCache cache;
 };
 
+// preload 用の hwnd 通知コンテキスト。worker は cv.wait で hwnd セットを待ってから
+// PostMessage する。main 側の早期終了時は aborted=true + cv.notify でデッドロックを避ける。
+// hwnd != nullptr が「OnInitComplete 済み」を兼ねる。
+struct PreloadContext {
+    std::mutex mtx;
+    std::condition_variable cv;
+    HWND hwnd = nullptr;
+    UINT msg_id = 0;
+    bool aborted = false;
+};
+
 // ファイル読み込みのオーケストレーションとローディングアニメーション状態を管理。
 class FileLoadService {
 public:
-    explicit constexpr FileLoadService(DocumentService& doc_service) noexcept : doc_service_(doc_service)
+    explicit FileLoadService(DocumentService& doc_service) noexcept : doc_service_(doc_service)
     {}
+
+    ~FileLoadService();
 
     // ---- ローディングアニメーション状態 ----
 
@@ -52,10 +69,27 @@ public:
 
     void StartAsyncLoad(TaskScheduler& scheduler, HWND hwnd, UINT msg_id, const Theme& theme);
     std::optional<AsyncLoadResult> TakeAsyncResult();
+    // 直近の非同期ロードが返したエラー (失敗時のみ有効)。
+    // OnParseComplete の null パスで取り出してトースト表示に使う。
+    std::optional<FileLoadError> TakeAsyncError() noexcept;
     void CancelAsyncLoad() noexcept
     {
         async_gen_.fetch_add(1, std::memory_order_relaxed);
         async_in_flight_ = false;
+    }
+
+    // ---- 起動時 preload (App::Init 前から走らせる経路) ----
+
+    // hwnd なしで I/O + パースをワーカースレッドに投入する。
+    // EstimateNodeHeights は Theme 依存なので skip し、heights_estimated=false で
+    // OnParseComplete に流す。
+    void StartPreloadAsync(std::pmr::wstring path);
+    // App::Init 完了後に hwnd を渡して PostMessage を解禁する。
+    // worker がまだパース中なら完了後に PostMessage、完了済みなら即 PostMessage。
+    void OnInitComplete(HWND hwnd, UINT msg_id);
+    bool HasPreload() const noexcept
+    {
+        return preload_ctx_ != nullptr;
     }
 
     // ---- パスアクセス ----
@@ -78,8 +112,16 @@ private:
     float loading_angle_ = 0.0f;
     std::pmr::wstring loading_path_;
 
-    // 非同期読み込み用
     std::mutex async_mutex_;
     std::optional<AsyncLoadResult> async_result_;
+    std::optional<FileLoadError> async_error_;
     std::atomic<uint32_t> async_gen_{ 0 };
+
+    // 宣言順: preload_thread_ を preload_ctx_ より前に置く。reverse-destruction で
+    // preload_ctx_ → preload_thread_ (join) → async_mutex_ ... の順に破壊され、
+    // worker が async_mutex_ を触るのは join 完了より前に保証される。
+    std::jthread preload_thread_;
+    std::shared_ptr<PreloadContext> preload_ctx_;
+
+    void ResetAsyncState();
 };

--- a/src/io/file_load_service.h
+++ b/src/io/file_load_service.h
@@ -15,21 +15,12 @@
 
 struct Theme;
 
-// ワーカースレッドでのパース結果（Document + 推定高さ済み LayoutCache）
+// ワーカースレッドでのパース結果。heights_estimated=false は preload (Theme 不在) から
+// 来たケースで、UI スレッド側で EstimateNodeHeights を補完する必要がある。
 struct AsyncLoadResult {
     Document doc;
     LayoutCache cache;
-};
-
-// preload 用の hwnd 通知コンテキスト。worker は cv.wait で hwnd セットを待ってから
-// PostMessage する。main 側の早期終了時は aborted=true + cv.notify でデッドロックを避ける。
-// hwnd != nullptr が「OnInitComplete 済み」を兼ねる。
-struct PreloadContext {
-    std::mutex mtx;
-    std::condition_variable cv;
-    HWND hwnd = nullptr;
-    UINT msg_id = 0;
-    bool aborted = false;
+    bool heights_estimated = true;
 };
 
 // ファイル読み込みのオーケストレーションとローディングアニメーション状態を管理。
@@ -58,6 +49,9 @@ public:
     }
 
     void StartLoading(std::pmr::wstring path);
+    // path が既にセット済みの状態でアニメーションだけ起動する。preload 経由で
+    // loading_path_ を二重代入したくないケース用。
+    void BeginLoadingAnimation() noexcept;
     void StopLoading() noexcept;
     void TickLoadingAnimation() noexcept;
 
@@ -84,23 +78,21 @@ public:
     // EstimateNodeHeights は Theme 依存なので skip し、heights_estimated=false で
     // OnParseComplete に流す。
     void StartPreloadAsync(std::pmr::wstring path);
-    // App::Init 完了後に hwnd を渡して PostMessage を解禁する。
-    // worker がまだパース中なら完了後に PostMessage、完了済みなら即 PostMessage。
-    void OnInitComplete(HWND hwnd, UINT msg_id);
-    bool HasPreload() const noexcept
-    {
-        return preload_ctx_ != nullptr;
-    }
-    // worker が I/O+パースを終えて async_result_/async_error_ に書き込み済みか判定。
-    // ShowWindow/UpdateWindow より前に true なら同期適用パスへ分岐できる (small file)。
-    bool IsPreloadDone();
-    // worker を abort 通知で停止させ join する。preload_ctx_ も解放するため
-    // HasPreload() は以降 false を返す。同期適用パスから呼ぶ。
-    void JoinPreload();
+
+    enum class PreloadAttachResult {
+        None,           // preload 未起動 → 呼び出し側は何もしない
+        AppliedSync,    // 同期取り込み完了 → 呼び出し側は OnParseComplete 相当を実行
+        AttachedAsync,  // worker に hwnd 通知済み → 呼び出し側は必要なら anim を起動
+    };
+
+    // App::Init 末尾で呼ぶ。preload の状態に応じて以下のいずれかを行う:
+    //   完了済み: JoinPreload (= AppliedSync)。呼び出し側で OnParseComplete を発火。
+    //   未完了:   worker に hwnd を渡して PostMessage を解禁 (= AttachedAsync)。
+    PreloadAttachResult AttachOrApplyPreload(HWND hwnd, UINT msg_id);
 
     // ---- パスアクセス ----
 
-    constexpr std::wstring_view GetLoadingPath() const noexcept
+    constexpr const std::pmr::wstring& GetLoadingPath() const noexcept
     {
         return loading_path_;
     }
@@ -110,6 +102,25 @@ public:
     }
 
 private:
+    // worker は cv.wait で hwnd セットを待ってから PostMessage する。
+    // main 側の早期終了時は aborted=true + cv.notify_all でデッドロックを避ける。
+    struct PreloadContext {
+        std::mutex mtx;
+        std::condition_variable cv;
+        HWND hwnd = nullptr;
+        UINT msg_id = 0;
+        bool aborted = false;
+
+        void SignalAbort();
+    };
+
+    // worker が I/O+パースを終えて async_result_/async_error_ に書き込み済みか判定。
+    bool IsPreloadDone();
+    // worker を abort 通知で停止させ join する。preload_ctx_ も解放する。
+    void JoinPreload();
+    // worker に hwnd を渡し PostMessage を解禁する。
+    void OnInitComplete(HWND hwnd, UINT msg_id);
+
     // 不変条件: loading_ が true なら async_in_flight_ も true。
     // worker thread は async_gen_ (atomic) と async_result_ (mutex 保護) のみ触る。
     DocumentService& doc_service_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,6 @@
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nCmdShow)
 {
     MENDO_IF_TRACY(Sleep(1000)); // Tracy の起動待ち
-    // グローバル同期プールリソースを初期化（最初に呼び出す）
     InitGlobalMemoryResource();
 
     SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
@@ -29,55 +28,64 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nC
     config.Load();
     i18n::Init(config.LoadWString("General", "Language"));
 
+    // 起動時のドキュメント決定フロー:
+    //   引数が有効なファイル  → そのファイルを開く
+    //   引数なし              → 前回ファイル復元、無ければヘルプ
+    //   引数あり かつ無効     → 前回復元せず直接ヘルプ (ユーザの指定意図を尊重)
+    int argc = 0;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+    const bool arg_given = argv && argc > 1 && argv[1][0] != L'\0';
+    const DWORD arg_attrs = arg_given ? GetFileAttributesW(argv[1]) : INVALID_FILE_ATTRIBUTES;
+    const bool has_valid_file = arg_attrs != INVALID_FILE_ATTRIBUTES && !(arg_attrs & FILE_ATTRIBUTE_DIRECTORY);
+
+    std::pmr::wstring preload_path;
+    bool restore_scroll = false;
+    if (has_valid_file) {
+        preload_path.assign(argv[1]);
+    }
+    else if (!arg_given) {
+        // SessionService::LoadLastFilePath は UNC/デバイスパスや実在しないパスを除外する。
+        SessionService session{ config };
+        preload_path = session.LoadLastFilePath();
+        if (!preload_path.empty()) {
+            restore_scroll = true;
+        }
+    }
+
     int result;
     {
         Win32Window window(config);
+
+        // ウィンドウクラス登録 + CreateWindowExW + App::Init (D3D/D2D/DWrite) と並列に
+        // I/O + Markdown パースを進める。worker は App::Init 末尾で hwnd を受け取り
+        // PostMessage(PARSE_COMPLETE) を発行、メッセージループ内で OnParseComplete に合流する。
+        if (!preload_path.empty()) {
+            window.StartPreloadAsync(preload_path);
+        }
+
         {
             MENDO_PROFILE("wWinMain - Create Window");
             if (!window.Create(hInstance, nCmdShow)) {
                 CoUninitialize();
                 return 1;
             }
-
-            // 起動時のドキュメント決定フロー:
-            //   引数が有効なファイル  → そのファイルを開く
-            //   引数なし              → 前回ファイル復元、無ければヘルプ
-            //   引数あり かつ無効     → 前回復元せず直接ヘルプ (ユーザの指定意図を尊重)
-            // CommandLineToArgvWで正規のパースを行い、引用符やスペースを正しく処理する。
-            // 引数が --version 等のフラグ文字列でも確実にヘルプへ落とすため
-            // GetFileAttributesW で実在を検証する。
-            // ディレクトリが渡されても「有効なファイル」扱いしないよう属性ビットで除外。
-            int argc = 0;
-            LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-            const bool arg_given = argv && argc > 1 && argv[1][0] != L'\0';
-            const DWORD arg_attrs = arg_given ? GetFileAttributesW(argv[1]) : INVALID_FILE_ATTRIBUTES;
-            const bool has_valid_file = arg_attrs != INVALID_FILE_ATTRIBUTES && !(arg_attrs & FILE_ATTRIBUTE_DIRECTORY);
-
-            if (has_valid_file) {
-                window.LoadMarkdownFile(argv[1]);
-            }
-            else {
-                std::pmr::wstring last;
-                if (!arg_given) {
-                    last = window.LoadLastFilePath();
-                }
-                if (!last.empty()) {
-                    window.RestoreScrollPosition();
-                    window.LoadMarkdownFile(last);
-                }
-                else {
-                    wchar_t cwd[MAX_PATH];
-                    if (GetCurrentDirectoryW(MAX_PATH, cwd)) {
-                        window.ShowDirectory(cwd);
-                    }
-                    window.LoadHelpDocument();
-                }
-            }
-
-            if (argv) {
-                LocalFree(argv);
-            }
         }
+
+        if (restore_scroll) {
+            window.RestoreScrollPosition();
+        }
+        if (preload_path.empty()) {
+            wchar_t cwd[MAX_PATH];
+            if (GetCurrentDirectoryW(MAX_PATH, cwd)) {
+                window.ShowDirectory(cwd);
+            }
+            window.LoadHelpDocument();
+        }
+
+        if (argv) {
+            LocalFree(argv);
+        }
+
         result = window.RunMessageLoop();
     } // Win32Window破棄（COMオブジェクト解放）をCoUninitializeの前に完了させる
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,20 @@
 #include <shellapi.h>
 #include <shellscalingapi.h>
 #include <commctrl.h>
+#include <memory>
+
+namespace {
+
+struct LocalFreeDeleter {
+    void operator()(LPWSTR* p) const noexcept
+    {
+        if (p) {
+            LocalFree(p);
+        }
+    }
+};
+
+} // namespace
 
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nCmdShow)
 {
@@ -32,8 +46,10 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nC
     //   引数が有効なファイル  → そのファイルを開く
     //   引数なし              → 前回ファイル復元、無ければヘルプ
     //   引数あり かつ無効     → 前回復元せず直接ヘルプ (ユーザの指定意図を尊重)
+    // unique_ptr で管理することで、window.Create 失敗の早期 return でも LocalFree される。
     int argc = 0;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+    const std::unique_ptr<LPWSTR, LocalFreeDeleter> argv_owner(CommandLineToArgvW(GetCommandLineW(), &argc));
+    LPWSTR* const argv = argv_owner.get();
     const bool arg_given = argv && argc > 1 && argv[1][0] != L'\0';
     const DWORD arg_attrs = arg_given ? GetFileAttributesW(argv[1]) : INVALID_FILE_ATTRIBUTES;
     const bool has_valid_file = arg_attrs != INVALID_FILE_ATTRIBUTES && !(arg_attrs & FILE_ATTRIBUTE_DIRECTORY);
@@ -80,10 +96,6 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nC
                 window.ShowDirectory(cwd);
             }
             window.LoadHelpDocument();
-        }
-
-        if (argv) {
-            LocalFree(argv);
         }
 
         result = window.RunMessageLoop();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,8 +75,9 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nC
         // ウィンドウクラス登録 + CreateWindowExW + App::Init (D3D/D2D/DWrite) と並列に
         // I/O + Markdown パースを進める。worker は App::Init 末尾で hwnd を受け取り
         // PostMessage(PARSE_COMPLETE) を発行、メッセージループ内で OnParseComplete に合流する。
-        if (!preload_path.empty()) {
-            window.StartPreloadAsync(preload_path);
+        const bool has_preload = !preload_path.empty();
+        if (has_preload) {
+            window.StartPreloadAsync(std::move(preload_path));
         }
 
         {
@@ -90,7 +91,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nC
         if (restore_scroll) {
             window.RestoreScrollPosition();
         }
-        if (preload_path.empty()) {
+        if (!has_preload) {
             wchar_t cwd[MAX_PATH];
             if (GetCurrentDirectoryW(MAX_PATH, cwd)) {
                 window.ShowDirectory(cwd);

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -47,6 +47,10 @@ void Win32Window::ShowDirectory(std::wstring_view dir_path)
 {
     app_->ShowDirectory(dir_path);
 }
+void Win32Window::StartPreloadAsync(std::pmr::wstring path)
+{
+    app_->StartPreloadAsync(std::move(path));
+}
 
 bool Win32Window::Create(HINSTANCE hInstance, int nCmdShow)
 {

--- a/src/window/window.h
+++ b/src/window/window.h
@@ -20,6 +20,7 @@ public:
     void LoadHelpDocument();
     std::pmr::wstring LoadLastFilePath() const;
     void ShowDirectory(std::wstring_view dir_path);
+    void StartPreloadAsync(std::pmr::wstring path);
 
     // 前回セッションのスクロール位置を復元する（LoadMarkdownFileの前に呼ぶ）
     void RestoreScrollPosition();

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -819,7 +819,7 @@ TEST(Parser, HtmlEntityNbsp)
 {
     auto nodes = ParseMarkdown(MENDO_LIT("a&nbsp;b")).nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_NE(nodes[0].GetText().find(MENDO_LIT('\u00A0')), mendo::doc_string_std::npos);
+    EXPECT_NE(nodes[0].GetText().find(MENDO_LIT("\u00A0")), mendo::doc_string_std::npos);
 }
 
 // ---- ハードブレーク ----


### PR DESCRIPTION
## Summary
- 起動時のファイル I/O + Markdown パースを `Win32Window::Create()` (CreateWindowExW + App::Init の D3D/D2D/DWrite 初期化) と並列に実行
- worker は `App::Init` 末尾の `OnInitComplete` で hwnd を受け取り `PostMessage(PARSE_COMPLETE)` を発行、既存の async load 経路 (`OnParseComplete`) に合流
- 大きなファイルでもウィンドウが即座に表示され、ローディングスピナー付きでパース完了を待つ UX に

Closes #179

## 設計

### 起動フロー (新)

\`\`\`
[main]                          [worker (jthread)]
window.StartPreloadAsync(path) ──┐
                                 ├─ DocumentService::LoadFile
                                 ├─ async_result_ に詰める
                                 └─ cv.wait (hwnd 待ち)
window.Create()
  └─ App::Init
       └─ Init 末尾
          ├─ NeedsLoadingAnimation なら effect::SetTimer(LOADING_ANIM)
          └─ OnInitComplete(hwnd) ────────────────────┐
                                                      ↓
RunMessageLoop ←──── PostMessage(PARSE_COMPLETE) ──── PostMessage 発行
  └─ OnParseComplete (既存)
        ├─ TakeAsyncResult / TakeAsyncError
        └─ FinishLoadMarkdownFile
\`\`\`

### 期待される体感差

| ファイルサイズ | 旧 (直列) | 新 (並列 + PostMessage 統合) |
|---|---|---|
| <1MB | 即時表示 | 即時表示 (差なし) |
| 1-16MB | 0-50ms 遅延 | 即時表示 |
| 16-100MB | 100-600ms ブロック | 即時にウィンドウ + スピナー、完了で反映 |

## 主な変更点

- \`FileLoadService\`
  - \`StartPreloadAsync\` (jthread 直接起動。scheduler 不要)
  - \`OnInitComplete(hwnd, msg_id)\` (worker への hwnd 通知)
  - \`HasPreload\`、\`TakeAsyncError\`
  - \`PreloadContext\` (mutex + cv で hwnd 通知。abort 時は destructor が cv.notify)
  - \`ResetAsyncState\` で \`StartAsyncLoad\` と共通化
- \`DocumentService::LoadFile\` を static 化し preload worker からも再利用
- \`App::Init\` 末尾で preload 進行中ならスピナーセット + \`OnInitComplete\`
- \`OnParseComplete\` の null パスで \`TakeAsyncError()\` → \`ShowToast\` (preload 失敗時もトースト表示)
- \`main.cpp\` の起動シーケンスを簡素化 (\`StartPreloadAsync\` → \`Create\` → \`RunMessageLoop\` のフラット構造)

## 安全性

- グローバル PMR は \`synchronized_pool_resource\` のため worker から安全にアロケート可能
- \`FileLoadService\` のメンバ宣言順 (\`preload_thread_\` → \`preload_ctx_\`) により reverse-destruction で \`preload_thread_\` の join が \`async_mutex_\` 破壊より先に完了する (コメントで明記)
- destructor で \`aborted=true\` + \`cv.notify_all\` し、jthread の暗黙 join とのデッドロックを回避

## Test plan
- [x] 全 2143 ユニットテスト合格
- [x] バイナリサイズへの影響を確認 (\`std::async\`/\`std::future\` ではなく \`std::jthread\` で実装したため肥大化なし)
- [x] Tracy で \`Preload::worker\` ゾーンと \`wWinMain - Create Window\` ゾーンの並列実行を確認
- [x] 大きなファイルでローディングスピナー表示を確認
- [x] CLI 引数あり (有効ファイル) で起動 → 即座に内容表示
- [x] CLI 引数なし & 前回ファイルあり → スクロール位置復元 + 内容表示
- [x] CLI 引数あり (無効ファイル) → ヘルプ表示
- [x] CLI 引数なし & 前回ファイルなし → cwd ディレクトリ + ヘルプ表示
- [x] preload 中にファイル削除 → エラーのトースト表示 + ヘルプ

🤖 Generated with [Claude Code](https://claude.com/claude-code)