### PR TITLE
fix(reload): ファイル下部更新時のジャンプ位置ズレを修正 (#185)

### DIFF
--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -433,7 +433,7 @@ float App::CalcScrollForDiff(size_t diff_pos, float viewport_height) const
 {
     MENDO_TRACEF("CalcScrollForDiff: diff_pos=%zu node_count=%zu", diff_pos, state_.document.doc.GetNodes().size());
     return CalcScrollYForDiff(
-        state_.document.doc.GetNodes(), state_.document.layout_cache, renderer_.GetTheme(),
+        state_.document.doc.GetNodes(), state_.document.layout_cache,
         std::string_view{ state_.document.doc.GetRawText() },
         diff_pos, viewport_height, state_.view.viewport.GetScrollY());
 }

--- a/src/core/reload.cpp
+++ b/src/core/reload.cpp
@@ -1,7 +1,5 @@
 #include "reload.h"
 #include "layout_cache.h"
-#include "layout_computer.h"
-#include "theme.h"
 #include <algorithm>
 #include <cstdint>
 #include <ranges>
@@ -70,7 +68,6 @@ int FindNodeBySourceOffset(const std::pmr::vector<Node>& nodes, uint32_t diff_of
 float CalcScrollYForDiff(
     const std::pmr::vector<Node>& nodes,
     const LayoutCache& cache,
-    const Theme& theme,
     std::string_view content,
     size_t diff_pos,
     float viewport_height,
@@ -81,7 +78,10 @@ float CalcScrollYForDiff(
         return fallback_scroll;
     }
 
-    float node_y = mendo::layout::TextTopOf(cache, static_cast<size_t>(changed_node), nodes[changed_node], theme);
+    // ノード上端 Y は cache[i].text_top フィールドを直読する。Fenwick PrefixSum 経由
+    // (TextTopOf) は float 加算順が違うためノード数が増えると誤差が累積し、
+    // ファイル下部更新時に着地点が大きくズレる (issue#185)。
+    float node_y = cache[changed_node].text_top;
     const float node_h = cache[changed_node].height;
 
     const uint32_t node_start = nodes[changed_node].source_offset;

--- a/src/core/reload.h
+++ b/src/core/reload.h
@@ -13,7 +13,6 @@
 #include <vector>
 
 class LayoutCache;
-struct Theme;
 
 // 新旧コンテンツの最初の差分 UTF-8 byte 位置を返す。同一の場合は npos。
 size_t FindFirstDifference(std::string_view old_text, std::string_view new_text) noexcept;
@@ -46,11 +45,9 @@ ReloadDecision AnalyzeReloadDiff(std::string_view old_text, std::string_view new
 
 // diff 位置のノードに基づくスクロールY座標を計算する。
 // ノードが見つからない場合は fallback_scroll を返す。
-// theme はノードのテキスト上端 Y を Fenwick から取り出すために必要。
 float CalcScrollYForDiff(
     const std::pmr::vector<Node>& nodes,
     const LayoutCache& cache,
-    const Theme& theme,
     std::string_view content,
     size_t diff_pos,
     float viewport_height,

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -1685,7 +1685,8 @@ TEST(CalcScrollYForDiff, ParsedMarkdownIntegration)
     auto nodes = ParseMarkdown(std::string_view{ md }).nodes;
     ASSERT_GE(nodes.size(), 4u);
 
-    // ノード高さを設定 (Theme{} 前提で TextTopOf == GetBlockTop == PrefixSum、Heading 以外は spacing_above=0)
+    // 等間隔 cache (text_top=0,50,100,...) を構築。spacing/Heading 個別寸法は無視し、
+    // CalcScrollYForDiff が cache[i].text_top をどう参照するかだけを見る統合テスト。
     auto cache = MakeUniformCache(static_cast<int>(nodes.size()), 50.0f);
 
     // "Second paragraph" の先頭で diff

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -1575,8 +1575,7 @@ TEST(CalcScrollYForDiff, FallbackWhenNoNodes)
 {
     std::pmr::vector<Node> nodes;
     LayoutCache cache;
-    Theme theme{};
-    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, theme, "content", 0, 500.0f, 42.0f), 42.0f);
+    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, "content", 0, 500.0f, 42.0f), 42.0f);
 }
 
 TEST(CalcScrollYForDiff, FallbackWhenNodeNotFound)
@@ -1585,9 +1584,8 @@ TEST(CalcScrollYForDiff, FallbackWhenNodeNotFound)
     auto nodes = MakeNodes(3, 100);
     nodes[0].source_offset = 50;
     auto cache = MakeUniformCache(3);
-    Theme theme{};
     // diff_pos=10 < 全ノードの最小 offset(50) → -1 → fallback
-    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, theme, "content", 10, 500.0f, 99.0f), 99.0f);
+    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, "content", 10, 500.0f, 99.0f), 99.0f);
 }
 
 TEST(CalcScrollYForDiff, ScrollsToNodeStartWithMargin)
@@ -1596,16 +1594,15 @@ TEST(CalcScrollYForDiff, ScrollsToNodeStartWithMargin)
     auto nodes = MakeNodes(3, 100);
     auto cache = MakeUniformCache(3, 100.0f);
     std::string content(300, 'x');
-    Theme theme{};
 
     // diff_pos=0 → node 0, y=0, margin=500*0.2=100 → max(0, 0-100)=0
-    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, theme, content, 0, 500.0f, 0.0f), 0.0f);
+    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, content, 0, 500.0f, 0.0f), 0.0f);
 
     // diff_pos=100 → node 1, y=100, margin=100 → max(0, 100-100)=0
-    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, theme, content, 100, 500.0f, 0.0f), 0.0f);
+    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, content, 100, 500.0f, 0.0f), 0.0f);
 
     // diff_pos=200 → node 2, y=200, margin=100 → max(0, 200-100)=100
-    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, theme, content, 200, 500.0f, 0.0f), 100.0f);
+    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, content, 200, 500.0f, 0.0f), 100.0f);
 }
 
 TEST(CalcScrollYForDiff, IntraNodeFractionInterpolation)
@@ -1614,14 +1611,13 @@ TEST(CalcScrollYForDiff, IntraNodeFractionInterpolation)
     auto nodes = MakeNodes(2, 100);
     auto cache = MakeUniformCache(2, 1000.0f);
     std::string content(200, 'x');
-    Theme theme{};
 
     // diff_pos=50 → node 0 (offset=0), next_start=100
     // fraction = (50-0)/(100-0) = 0.5
     // node_y = 0 + 1000*0.5 = 500
     // margin = 100*0.2 = 20
     // result = max(0, 500-20) = 480
-    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, theme, content, 50, 100.0f, 0.0f), 480.0f);
+    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, content, 50, 100.0f, 0.0f), 480.0f);
 }
 
 TEST(CalcScrollYForDiff, FractionClampsToOne)
@@ -1630,13 +1626,12 @@ TEST(CalcScrollYForDiff, FractionClampsToOne)
     auto nodes = MakeNodes(2, 100);
     auto cache = MakeUniformCache(2, 1000.0f);
     std::string content(200, 'x');
-    Theme theme{};
 
     // diff_pos=99 → node 0, fraction=99/100=0.99
     // y = 0 + 1000*0.99 = 990, scroll = 990-20 = 970
-    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, theme, content, 99, 100.0f, 0.0f), 970.0f);
+    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, content, 99, 100.0f, 0.0f), 970.0f);
     // diff_pos=100 → node 1 (exact match), y=1000, scroll = 1000-20 = 980
-    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, theme, content, 100, 100.0f, 0.0f), 980.0f);
+    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, content, 100, 100.0f, 0.0f), 980.0f);
 }
 
 TEST(CalcScrollYForDiff, SkipsUnsetSourceOffsets)
@@ -1648,14 +1643,13 @@ TEST(CalcScrollYForDiff, SkipsUnsetSourceOffsets)
     nodes[2].source_offset = 200;
     auto cache = MakeUniformCache(3, 100.0f);
     std::string content(300, 'x');
-    Theme theme{};
 
     // diff_pos=100 → node 0 (offset=0), next valid = node 2 (offset=200)
     // fraction = (100-0)/(200-0) = 0.5
     // node_y = 0 + 100*0.5 = 50
     // margin = 500*0.2 = 100
     // result = max(0, 50-100) = 0
-    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, theme, content, 100, 500.0f, 0.0f), 0.0f);
+    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, content, 100, 500.0f, 0.0f), 0.0f);
 }
 
 TEST(CalcScrollYForDiff, LastNodeUsesContentSizeAsNextStart)
@@ -1665,14 +1659,13 @@ TEST(CalcScrollYForDiff, LastNodeUsesContentSizeAsNextStart)
     nodes[0].source_offset = 0;
     auto cache = MakeUniformCache(1, 1000.0f);
     std::string content(100, 'x');
-    Theme theme{};
 
     // diff_pos=50, next_start=content.size()=100
     // fraction = 50/100 = 0.5
     // node_y = 0 + 1000*0.5 = 500
     // margin = 200*0.2 = 40
     // result = max(0, 500-40) = 460
-    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, theme, content, 50, 200.0f, 0.0f), 460.0f);
+    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, content, 50, 200.0f, 0.0f), 460.0f);
 }
 
 TEST(CalcScrollYForDiff, CacheSizeMismatchFallback)
@@ -1680,10 +1673,9 @@ TEST(CalcScrollYForDiff, CacheSizeMismatchFallback)
     // ノード数とキャッシュサイズが不一致の場合のフォールバック
     auto nodes = MakeNodes(5, 100);
     auto cache = MakeUniformCache(3, 100.0f); // キャッシュは3つだけ
-    Theme theme{};
 
     // diff_pos=400 → node 4 だがキャッシュは3つ → fallback
-    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, theme, std::string(500, 'x'), 400, 500.0f, 77.0f), 77.0f);
+    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, std::string(500, 'x'), 400, 500.0f, 77.0f), 77.0f);
 }
 
 TEST(CalcScrollYForDiff, ParsedMarkdownIntegration)
@@ -1694,22 +1686,13 @@ TEST(CalcScrollYForDiff, ParsedMarkdownIntegration)
     ASSERT_GE(nodes.size(), 4u);
 
     // ノード高さを設定 (Theme{} 前提で TextTopOf == GetBlockTop == PrefixSum、Heading 以外は spacing_above=0)
-    LayoutCache cache;
-    cache.Resize(nodes.size());
-    std::pmr::vector<float> bh;
-    bh.reserve(nodes.size());
-    for (size_t i = 0; i < nodes.size(); ++i) {
-        cache[i].height = 50.0f;
-        bh.push_back(50.0f);
-    }
-    cache.BuildBlockHeights(std::span<const float>(bh.data(), bh.size()));
+    auto cache = MakeUniformCache(static_cast<int>(nodes.size()), 50.0f);
 
     // "Second paragraph" の先頭で diff
     size_t diff_pos = static_cast<size_t>(md.find("Second"));
     ASSERT_NE(diff_pos, std::string::npos);
 
-    Theme theme{};
-    float result = CalcScrollYForDiff(nodes, cache, theme, md, diff_pos, 500.0f, 0.0f);
+    float result = CalcScrollYForDiff(nodes, cache, md, diff_pos, 500.0f, 0.0f);
     // スクロール位置は 0 以上で、fallback(0) とは異なる値が期待される
     EXPECT_GE(result, 0.0f);
 }
@@ -1735,25 +1718,16 @@ TEST(CalcScrollYForDiff, PrefixGrowthScrollsTowardAppendedTail)
     auto nodes = ParseMarkdown(std::string_view{ new_md }).nodes;
     ASSERT_GE(nodes.size(), 4u);
 
-    LayoutCache cache;
-    cache.Resize(nodes.size());
-    std::pmr::vector<float> bh;
-    bh.reserve(nodes.size());
-    for (size_t i = 0; i < nodes.size(); ++i) {
-        cache[i].height = 100.0f;
-        bh.push_back(100.0f);
-    }
-    cache.BuildBlockHeights(std::span<const float>(bh.data(), bh.size()));
-    Theme theme{};
-    const float last_old_node_y = mendo::layout::TextTopOf(cache, nodes.size() - 2, nodes[nodes.size() - 2], theme);
-    const float appended_node_y = mendo::layout::TextTopOf(cache, nodes.size() - 1, nodes[nodes.size() - 1], theme);
+    auto cache = MakeUniformCache(static_cast<int>(nodes.size()), 100.0f);
+    const float last_old_node_y = cache[nodes.size() - 2].text_top;
+    const float appended_node_y = cache[nodes.size() - 1].text_top;
 
     // ユーザが先頭付近 (scroll_y=0) を見ている状態で末尾追記が起きたシナリオ。
     // 旧コード (is_prefix_only ? old_scroll : ...) では desired_scroll が
     // current_scroll(=0) のまま fallback されていた。これが issue#146 の症状。
     constexpr float viewport_height = 500.0f;
     constexpr float current_scroll = 0.0f;
-    const float result = CalcScrollYForDiff(nodes, cache, theme, new_md,
+    const float result = CalcScrollYForDiff(nodes, cache, new_md,
                                             decision.diff_pos, viewport_height, current_scroll);
 
     // 修正後: 追記境界 (旧 doc 末尾) 近辺にスクロール。current_scroll とは
@@ -1763,6 +1737,28 @@ TEST(CalcScrollYForDiff, PrefixGrowthScrollsTowardAppendedTail)
     // 着地点は最後の旧ノード〜追記ノードの境界付近 (margin で多少上)。
     EXPECT_GE(result, last_old_node_y - viewport_height * 0.2f);
     EXPECT_LE(result, appended_node_y);
+}
+
+// issue#185 回帰テスト:
+// CalcScrollYForDiff が cache[i].text_top フィールドを直読していること (Fenwick PrefixSum
+// 経由の TextTopOf は float 加算順の違いでノード数が増えるほど誤差が累積し、ビューポート
+// 側 (cache[i].text_top 直読) との乖離が「下部更新時ほど大きく」なる)。
+// フィールドを意図的に Fenwick 由来の値からズラし、CalcScrollYForDiff がフィールド側を
+// 採用していることを担保する。
+TEST(CalcScrollYForDiff, ReadsCachedTextTopFieldNotFenwick)
+{
+    auto nodes = MakeNodes(3, 100);
+    auto cache = MakeUniformCache(3, 100.0f);
+    std::string content(300, 'x');
+
+    // cache[2].text_top を Fenwick が返す値 (=200) から大きくズラす。
+    // 実機の累積誤差を模した状況で、フィールド直読なら 999 が、Fenwick 経由なら 200 が
+    // ノード上端 Y として採用される。
+    cache[2].text_top = 999.0f;
+
+    // diff_pos=200 → node 2 (ピッタリ境界) → fraction=0 → node_y=cache[2].text_top
+    // margin = 500*0.2 = 100 → 期待値 = 999 - 100 = 899
+    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, content, 200, 500.0f, 0.0f), 899.0f);
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary
- `CalcScrollYForDiff` のノード上端 Y 取得を `mendo::layout::TextTopOf` (Fenwick PrefixSum) から `cache[changed_node].text_top` の直読へ変更。ビューポート側 (8266f649 で揃えた経路) と float 加算順を揃え、ノード数増加に伴う累積誤差で「ファイル下部更新時ほど着地点がズレる」症状 (issue #185) を解消する。
- 不要になった `theme` 引数と `layout_computer.h` / `theme.h` include を整理。`reload.h` の `struct Theme;` forward decl も削除。
- 回帰テスト `CalcScrollYForDiff.ReadsCachedTextTopFieldNotFenwick` を追加し、フィールド直読が採用されていることを担保。既存の `ParsedMarkdownIntegration` / `PrefixGrowthScrollsTowardAppendedTail` は実機の `EstimateNodeHeights` 経由で `text_top` が充填される動作に合わせ、`MakeUniformCache` を流用する形に簡素化。

## 関連
8266f649 (fix(session): スクロール位置復元のズレを修正) と同じ構造の問題。今回はリロード時のジャンプ位置側を同方針で修正。

## Test plan
- [x] `cmake --build build --config Release`
- [x] `build/tests/Release/mendo_tests.exe --gtest_brief=1` → 2144 テスト全て成功
- [x] 100MB 級 Markdown ファイルの末尾を更新し、ジャンプ位置が更新箇所付近に着地することを実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)