### PR TITLE
fix(copy): 選択末尾の文字化けを修正 (#183)

### DIFF
--- a/src/layout/doc_dwrite_bridge.cpp
+++ b/src/layout/doc_dwrite_bridge.cpp
@@ -1,5 +1,6 @@
 #include "doc_dwrite_bridge.h"
 #include "memory_resource.h"
+#include <algorithm>
 #include <limits>
 
 namespace mendo {
@@ -99,19 +100,11 @@ doc_offset WideViewForDWrite::DocOffsetFromWideOffset(uint32_t wide_off) const n
     if (wide_off >= utf16_offsets_.back()) {
         return static_cast<doc_offset>(utf16_offsets_.size() - 1);
     }
-    // 単調増加なので二分探索。
-    size_t lo = 0;
-    size_t hi = utf16_offsets_.size();
-    while (lo + 1 < hi) {
-        const size_t mid = lo + (hi - lo) / 2;
-        if (utf16_offsets_[mid] <= wide_off) {
-            lo = mid;
-        }
-        else {
-            hi = mid;
-        }
-    }
-    return static_cast<doc_offset>(lo);
+    // utf16_offsets_ は弱増加 (continuation byte は同じ wide_pos)。lower_bound で
+    // wide_off に対応する文字の leading byte 位置を取る。upper_bound 相当だと末尾文字の
+    // continuation byte を返してしまい、抽出末尾が UTF-8 不正で文字化けする (#183)。
+    const auto it = std::lower_bound(utf16_offsets_.begin(), utf16_offsets_.end(), wide_off);
+    return static_cast<doc_offset>(it - utf16_offsets_.begin());
 }
 
 HRESULT CreateDocTextLayout(IDWriteFactory* factory, const WideViewForDWrite& view,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,7 @@ add_executable(mendo_tests
     test_parallel_measure.cpp
     test_parallel_measure_stress.cpp
     test_view_stats.cpp
+    test_doc_dwrite_bridge.cpp
 )
 
 target_link_libraries(mendo_tests PRIVATE

--- a/tests/test_doc_dwrite_bridge.cpp
+++ b/tests/test_doc_dwrite_bridge.cpp
@@ -1,0 +1,124 @@
+#include <gtest/gtest.h>
+#include "doc_dwrite_bridge.h"
+
+using mendo::WideViewForDWrite;
+
+// ─────────────────────────────────────────────
+// WideOffsetFromDocOffset / DocOffsetFromWideOffset
+// ─────────────────────────────────────────────
+
+TEST(WideViewForDWrite, EmptyText)
+{
+    WideViewForDWrite wv{ "" };
+    EXPECT_TRUE(wv.wide().empty());
+    EXPECT_EQ(wv.WideOffsetFromDocOffset(0), 0u);
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(0), 0u);
+}
+
+TEST(WideViewForDWrite, AsciiOnly)
+{
+    WideViewForDWrite wv{ "Hello" };
+    EXPECT_EQ(wv.wide(), L"Hello");
+    for (uint32_t i = 0; i <= 5; ++i) {
+        EXPECT_EQ(wv.WideOffsetFromDocOffset(i), i);
+        EXPECT_EQ(wv.DocOffsetFromWideOffset(i), i);
+    }
+}
+
+TEST(WideViewForDWrite, Cjk3ByteRoundTrip)
+{
+    // テスト = 3 文字, UTF-8 9 bytes, UTF-16 3 wide units
+    WideViewForDWrite wv{ "テスト" };
+    EXPECT_EQ(wv.wide(), L"テスト");
+
+    // doc → wide: leading byte の累積 wide 数
+    EXPECT_EQ(wv.WideOffsetFromDocOffset(0), 0u);
+    EXPECT_EQ(wv.WideOffsetFromDocOffset(3), 1u);
+    EXPECT_EQ(wv.WideOffsetFromDocOffset(6), 2u);
+    EXPECT_EQ(wv.WideOffsetFromDocOffset(9), 3u);
+
+    // wide → doc: 対応する文字の leading byte 位置 (= continuation byte は返さない)
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(0), 0u);
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(1), 3u);
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(2), 6u);
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(3), 9u);
+}
+
+TEST(WideViewForDWrite, Latin2ByteRoundTrip)
+{
+    // é = U+00E9 (UTF-8 2 bytes, UTF-16 1 wide unit), あいだに ASCII を挟む
+    WideViewForDWrite wv{ "aébc" };
+    EXPECT_EQ(wv.wide(), L"aébc");
+
+    // 'a'=0..1, 'é'=1..3, 'b'=3..4, 'c'=4..5 (utf8 byte / utf16 wide)
+    EXPECT_EQ(wv.WideOffsetFromDocOffset(0), 0u);
+    EXPECT_EQ(wv.WideOffsetFromDocOffset(1), 1u);
+    EXPECT_EQ(wv.WideOffsetFromDocOffset(3), 2u);
+    EXPECT_EQ(wv.WideOffsetFromDocOffset(4), 3u);
+    EXPECT_EQ(wv.WideOffsetFromDocOffset(5), 4u);
+
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(0), 0u);
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(1), 1u);
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(2), 3u);
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(3), 4u);
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(4), 5u);
+}
+
+TEST(WideViewForDWrite, SurrogatePairRoundTrip)
+{
+    // 😀 = U+1F600 (UTF-8 4 bytes, UTF-16 2 wide units = surrogate pair)
+    WideViewForDWrite wv{ "A\xF0\x9F\x98\x80""B" };
+    EXPECT_EQ(wv.wide().size(), 4u); // 'A' + high + low + 'B'
+
+    // doc → wide
+    EXPECT_EQ(wv.WideOffsetFromDocOffset(0), 0u);
+    EXPECT_EQ(wv.WideOffsetFromDocOffset(1), 1u); // 絵文字 leading byte
+    EXPECT_EQ(wv.WideOffsetFromDocOffset(5), 3u); // 'B' leading byte
+    EXPECT_EQ(wv.WideOffsetFromDocOffset(6), 4u);
+
+    // wide=2 (サロゲートペア中央) は絵文字 leading (1) ではなく次文字の leading (5)。
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(0), 0u);
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(1), 1u);
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(2), 5u);
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(3), 5u);
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(4), 6u);
+}
+
+// 回帰テスト: #183
+// テキスト末尾の文字を選択した際、HitTest で is_trailing=true により
+// wide_off = (文字数) - 1 + 1 = wide_size に達する直前の値が渡される。
+// 旧実装は continuation byte の index を返してしまい、ExtractSelectedText で
+// UTF-8 として不正な末尾バイト列が抽出され、貼り付け先で文字化けしていた。
+TEST(WideViewForDWrite, EndOfNonAsciiCharNeverReturnsContinuationByte)
+{
+    WideViewForDWrite wv{ "テスト" };
+    // 末尾「ト」の手前 (= 「ス」の右端) を指す wide_off=2 は
+    // 「ト」の leading byte (= 6) を返さなければならない。
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(2), 6u);
+
+    // 「テ」の右端 (= 「ス」の左端) は byte 3 (= 「ス」の leading byte)
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(1), 3u);
+}
+
+TEST(WideViewForDWrite, OutOfRangeWideOffsetClampsToBack)
+{
+    WideViewForDWrite wv{ "テスト" };
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(3), 9u);    // 番兵
+    EXPECT_EQ(wv.DocOffsetFromWideOffset(100), 9u);  // 範囲外も clamping
+}
+
+TEST(WideViewForDWrite, OutOfRangeDocOffsetClampsToBack)
+{
+    WideViewForDWrite wv{ "テスト" };
+    EXPECT_EQ(wv.WideOffsetFromDocOffset(9), 3u);    // 番兵
+    EXPECT_EQ(wv.WideOffsetFromDocOffset(100), 3u);  // 範囲外も clamping
+}
+
+TEST(WideViewForDWrite, WideRangeForCjk)
+{
+    WideViewForDWrite wv{ "テスト" };
+    // [3, 6) byte = 「ス」 = wide [1, 2)
+    const auto r = wv.WideRange(3, 3);
+    EXPECT_EQ(r.startPosition, 1u);
+    EXPECT_EQ(r.length, 1u);
+}


### PR DESCRIPTION
## Summary
- `DocOffsetFromWideOffset` の二分探索が upper_bound 相当だったため、末尾文字の continuation byte index を返してしまい、`ExtractSelectedText` が UTF-8 として不正なバイト列で末尾を切断していた → 貼り付け先で文字化け (#183)
- `std::lower_bound` に置換して必ず leading byte 位置を返すよう修正
- `WideViewForDWrite` のユニットテスト (`tests/test_doc_dwrite_bridge.cpp`, 9 ケース) を追加。回帰防止用に #183 のシナリオも明示

## 根因
`utf16_offsets_` は弱増加（multibyte UTF-8 の continuation byte は leading byte と同じ wide_pos を持つ）。旧実装 `utf16_offsets_[mid] <= wide_off` で最大 i を取る upper_bound 相当探索だと、例えば「テスト」の `ス` の右端をクリック (wide_off=2) で `ト` の continuation byte (index 8) が返り、抽出末尾が `ト` の途中で切れていた。

## Test plan
- [x] `cmake --build build --config Release --target mendo_tests`
- [x] `build/tests/Release/mendo_tests.exe --gtest_brief=1` → 2153 tests pass
- [x] `WideViewForDWrite.*` 9 tests 全パス（うち `EndOfNonAsciiCharNeverReturnsContinuationByte` が #183 回帰）
- [x] 実機: 日本語混じりのテキストを範囲選択 → Ctrl+C → エディタに貼り付け、末尾文字が正しく表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)