### PR TITLE
fix(highlight): 選択/検索ハイライトの UTF-8/UTF-16 ずれを修正 (#182)

### DIFF
--- a/src/layout/doc_dwrite_bridge.h
+++ b/src/layout/doc_dwrite_bridge.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <dwrite.h>
 #include <memory_resource>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -49,6 +50,38 @@ private:
     // utf16_offsets_[i] (i = 0..utf8_size) = doc 内 byte i に対応する wide offset。
     // 番兵: utf16_offsets_[utf8_size] = wide_size。
     std::pmr::vector<uint32_t> utf16_offsets_;
+};
+
+// 直近に渡された文字列に対する WideViewForDWrite を再利用する identity ベースキャッシュ。
+// std::string_view の (data ポインタ + size) で同一性を判定し、異なる文字列が来た時のみ
+// 再構築する。連続フレームで同じノード/セルの選択や検索ハイライトを描画する典型ケースで
+// UTF-8→UTF-16 decode を 1 回に抑える。data ポインタの寿命が切れる可能性がある場合は
+// Reset() を明示的に呼んでキャッシュを破棄すること。
+class WideViewCache {
+public:
+    const WideViewForDWrite& Get(std::string_view text)
+    {
+        if (text.data() != text_.data() || text.size() != text_.size()) {
+            wv_.emplace(text);
+            text_ = text;
+        }
+        return *wv_;
+    }
+
+    DWRITE_TEXT_RANGE WideRange(std::string_view text, uint32_t doc_start, uint32_t doc_length)
+    {
+        return Get(text).WideRange(doc_start, doc_length);
+    }
+
+    void Reset() noexcept
+    {
+        wv_.reset();
+        text_ = {};
+    }
+
+private:
+    std::string_view text_;
+    std::optional<WideViewForDWrite> wv_;
 };
 
 // IDWriteFactory::CreateTextLayout の境界ラッパー。

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -113,6 +113,12 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
         prev_sel_start_node_ = new_start;
         prev_sel_end_node_ = new_end;
     }
+    // テーブルセル decode キャッシュは selection が非アクティブの間は不要かつ
+    // ドキュメント切り替えで dangling になる懸念があるため、その間は解放しておく。
+    if (!selection.active) {
+        cell_wv_text_ = {};
+        cell_wv_.reset();
+    }
 
     const int node_count = static_cast<int>(nodes.size());
     if (first_visible < 0) {
@@ -277,12 +283,7 @@ void CommandGenerator::GenNodeTextDecorations(DrawCommandList& cmds, const Node&
             sel_end = selection.end_pos;
         }
         if (sel_end > sel_start) {
-            // selection は UTF-8 byte offset 保持。HitTestTextRange は UTF-16 code unit を要求するため変換する。
-            const mendo::WideViewForDWrite wv{ node.GetText() };
-            const auto wr = wv.WideRange(sel_start, sel_end - sel_start);
-            if (wr.length > 0) {
-                GenSelectionHighlightCached(cmds, entry, wr.startPosition, wr.length, text_x, entry_text_top);
-            }
+            GenSelectionHighlightCached(cmds, node, entry, sel_start, sel_end - sel_start, text_x, entry_text_top);
         }
     }
 
@@ -557,20 +558,27 @@ void CommandGenerator::CollectHitTestRects(IDWriteTextLayout* layout, uint32_t s
     }
 }
 
-void CommandGenerator::GenSelectionHighlightCached(DrawCommandList& cmds, const NodeLayoutEntry& entry, uint32_t start, uint32_t length, float origin_x, float origin_y)
+void CommandGenerator::GenSelectionHighlightCached(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, uint32_t doc_start, uint32_t doc_length, float origin_x, float origin_y)
 {
     auto* layout = entry.text_layout.Get();
-    if (!layout || length == 0) {
+    if (!layout || doc_length == 0) {
         return;
     }
     auto& cache = entry.ensure_selection_hl_cache();
-    if (cache.layout_ptr != layout || cache.start != start || cache.length != length) {
+    // キャッシュキーは UTF-8 byte 単位 (selection 状態と直接対応)。
+    // miss 時のみ UTF-8→UTF-16 decode と HitTestTextRange を実行することで、
+    // 選択範囲が静止しているフレームでは decode を完全にスキップする。
+    if (cache.layout_ptr != layout || cache.start != doc_start || cache.length != doc_length) {
         MENDO_COUNT_INC(g_cmd_gen_stats.sel_hl_cache_miss);
         cache.rects.clear();
-        CollectHitTestRects(layout, start, length, cache.rects);
+        const mendo::WideViewForDWrite wv{ node.GetText() };
+        const auto wr = wv.WideRange(doc_start, doc_length);
+        if (wr.length > 0) {
+            CollectHitTestRects(layout, wr.startPosition, wr.length, cache.rects);
+        }
         cache.layout_ptr = layout;
-        cache.start = start;
-        cache.length = length;
+        cache.start = doc_start;
+        cache.length = doc_length;
     }
     else {
         MENDO_COUNT_INC(g_cmd_gen_stats.sel_hl_cache_hit);
@@ -732,8 +740,12 @@ void CommandGenerator::GenTableCellContent(
         const uint32_t ov_end = std::min(sel_end, flat_offset + cell_len);
         if (ov_end > ov_start) {
             // sel_start/sel_end は UTF-8 byte offset。HitTestTextRange 用に UTF-16 へ変換する。
-            const mendo::WideViewForDWrite wv{ cell_text };
-            const auto wr = wv.WideRange(ov_start - flat_offset, ov_end - ov_start);
+            // 同一セルがフレーム間で選択中の典型ケースで cell_wv_ をヒットさせ decode を省く。
+            if (cell_text.data() != cell_wv_text_.data() || cell_text.size() != cell_wv_text_.size()) {
+                cell_wv_.emplace(cell_text);
+                cell_wv_text_ = cell_text;
+            }
+            const auto wr = cell_wv_->WideRange(ov_start - flat_offset, ov_end - ov_start);
             if (wr.length > 0) {
                 GenSelectionHighlight(cmds, cell_layout, wr.startPosition, wr.length, text_x, text_y);
             }

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -1,5 +1,4 @@
 #include "command_generator.h"
-#include "doc_dwrite_bridge.h"
 #include "i18n.h"
 #include "layout.h"
 #include "layout_computer.h"
@@ -7,7 +6,6 @@
 #include "ui_constants.h"
 #include <algorithm>
 #include <format>
-#include <optional>
 #include <ranges>
 #include <utility>
 
@@ -113,12 +111,12 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
         prev_sel_start_node_ = new_start;
         prev_sel_end_node_ = new_end;
     }
-    // テーブルセル decode キャッシュは selection が非アクティブの間は不要かつ
-    // ドキュメント切り替えで dangling になる懸念があるため、その間は解放しておく。
-    if (!selection.active) {
-        cell_wv_text_ = {};
-        cell_wv_.reset();
+    // ドキュメント切り替え (= nodes バッファのアドレス変化) や selection 解除のタイミングで
+    // cell_wv_ が抱える string_view が dangling 化しうるため、ここで明示的にリセットする。
+    if (!selection.active || nodes.data() != prev_nodes_data_) {
+        cell_wv_.Reset();
     }
+    prev_nodes_data_ = nodes.data();
 
     const int node_count = static_cast<int>(nodes.size());
     if (first_visible < 0) {
@@ -630,10 +628,9 @@ void CommandGenerator::RebuildSearchHlCache(SearchHlCache& cache, const Node& no
     cache.rect_ends.reserve(node_match_count);
 
     const auto* tbl = node.table_data();
-    // 同一テキストの WideViewForDWrite を使い回し、同ノード/セル内の複数マッチでの
-    // UTF-8→UTF-16 decode を 1 回に抑える。matches は (node, table_row, table_col) 昇順。
-    std::string_view cached_text;
-    std::optional<mendo::WideViewForDWrite> wv;
+    // matches は (node, table_row, table_col) 昇順。同ノード/同セル連続マッチで
+    // UTF-8→UTF-16 decode を 1 回に抑えるため WideViewCache を使う。
+    mendo::WideViewCache wv_cache;
 
     for (size_t mi = first_global; mi < first_global + node_match_count; ++mi) {
         const auto& m = matches[mi];
@@ -653,12 +650,7 @@ void CommandGenerator::RebuildSearchHlCache(SearchHlCache& cache, const Node& no
         // 暫定状態で、l は nullptr のまま空 rect として記録する（次回再構築時に修復）。
         if (l && m.length > 0 && !match_text.empty()) {
             // SearchMatch::start, length は UTF-8 byte 単位 (ascii_util::Find の戻り値)。
-            // HitTestTextRange は UTF-16 code unit を要求するため変換する。
-            if (match_text.data() != cached_text.data() || match_text.size() != cached_text.size()) {
-                wv.emplace(match_text);
-                cached_text = match_text;
-            }
-            const auto wr = wv->WideRange(m.start, m.length);
+            const auto wr = wv_cache.WideRange(match_text, m.start, m.length);
             if (wr.length > 0) {
                 CollectHitTestRects(l, wr.startPosition, wr.length, cache.rects);
             }
@@ -740,12 +732,7 @@ void CommandGenerator::GenTableCellContent(
         const uint32_t ov_end = std::min(sel_end, flat_offset + cell_len);
         if (ov_end > ov_start) {
             // sel_start/sel_end は UTF-8 byte offset。HitTestTextRange 用に UTF-16 へ変換する。
-            // 同一セルがフレーム間で選択中の典型ケースで cell_wv_ をヒットさせ decode を省く。
-            if (cell_text.data() != cell_wv_text_.data() || cell_text.size() != cell_wv_text_.size()) {
-                cell_wv_.emplace(cell_text);
-                cell_wv_text_ = cell_text;
-            }
-            const auto wr = cell_wv_->WideRange(ov_start - flat_offset, ov_end - ov_start);
+            const auto wr = cell_wv_.WideRange(cell_text, ov_start - flat_offset, ov_end - ov_start);
             if (wr.length > 0) {
                 GenSelectionHighlight(cmds, cell_layout, wr.startPosition, wr.length, text_x, text_y);
             }

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -1,4 +1,5 @@
 #include "command_generator.h"
+#include "doc_dwrite_bridge.h"
 #include "i18n.h"
 #include "layout.h"
 #include "layout_computer.h"
@@ -6,6 +7,7 @@
 #include "ui_constants.h"
 #include <algorithm>
 #include <format>
+#include <optional>
 #include <ranges>
 #include <utility>
 
@@ -262,7 +264,7 @@ void CommandGenerator::GenNodeTextDecorations(DrawCommandList& cmds, const Node&
     GenInlineCodeBgs(cmds, entry.view_inline_code_bgs(), text_x, entry_text_top, theme_->code_bg_color);
 
     // 検索マッチのハイライト（選択より先に描画し、選択が最前面になるようにする）
-    GenSearchHighlights(cmds, entry, node_index, text_x, entry_text_top);
+    GenSearchHighlights(cmds, node, entry, node_index, text_x, entry_text_top);
 
     const auto& selection = *frame_selection_;
     if (selection.active && node_index >= selection.start_node && node_index <= selection.end_node) {
@@ -275,7 +277,12 @@ void CommandGenerator::GenNodeTextDecorations(DrawCommandList& cmds, const Node&
             sel_end = selection.end_pos;
         }
         if (sel_end > sel_start) {
-            GenSelectionHighlightCached(cmds, entry, sel_start, sel_end - sel_start, text_x, entry_text_top);
+            // selection は UTF-8 byte offset 保持。HitTestTextRange は UTF-16 code unit を要求するため変換する。
+            const mendo::WideViewForDWrite wv{ node.GetText() };
+            const auto wr = wv.WideRange(sel_start, sel_end - sel_start);
+            if (wr.length > 0) {
+                GenSelectionHighlightCached(cmds, entry, wr.startPosition, wr.length, text_x, entry_text_top);
+            }
         }
     }
 
@@ -579,7 +586,7 @@ void CommandGenerator::GenSelectionHighlightCached(DrawCommandList& cmds, const 
     }
 }
 
-void CommandGenerator::GenSearchHighlights(DrawCommandList& cmds, const NodeLayoutEntry& entry, int node_index, float origin_x, float origin_y, int table_row, int table_col)
+void CommandGenerator::GenSearchHighlights(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, int node_index, float origin_x, float origin_y, int table_row, int table_col)
 {
     if (!search_matches_ || search_matches_->empty()) {
         return;
@@ -594,11 +601,11 @@ void CommandGenerator::GenSearchHighlights(DrawCommandList& cmds, const NodeLayo
     const size_t node_match_count = static_cast<size_t>(range.size());
 
     auto& cache = entry.ensure_search_hl_cache();
-    RebuildSearchHlCache(cache, entry, matches, first_global, node_match_count);
+    RebuildSearchHlCache(cache, node, entry, matches, first_global, node_match_count);
     EmitSearchHlCommands(cmds, cache, matches, first_global, origin_x, origin_y, table_row, table_col);
 }
 
-void CommandGenerator::RebuildSearchHlCache(SearchHlCache& cache, const NodeLayoutEntry& entry,
+void CommandGenerator::RebuildSearchHlCache(SearchHlCache& cache, const Node& node, const NodeLayoutEntry& entry,
                                             std::span<const SearchMatch> matches, size_t first_global, size_t node_match_count)
 {
     // キャッシュミス時のみ HitTestTextRange を一括発行。layout 変更時は
@@ -614,19 +621,39 @@ void CommandGenerator::RebuildSearchHlCache(SearchHlCache& cache, const NodeLayo
     cache.rect_ends.clear();
     cache.rect_ends.reserve(node_match_count);
 
+    const auto* tbl = node.table_data();
+    // 同一テキストの WideViewForDWrite を使い回し、同ノード/セル内の複数マッチでの
+    // UTF-8→UTF-16 decode を 1 回に抑える。matches は (node, table_row, table_col) 昇順。
+    std::string_view cached_text;
+    std::optional<mendo::WideViewForDWrite> wv;
+
     for (size_t mi = first_global; mi < first_global + node_match_count; ++mi) {
         const auto& m = matches[mi];
         IDWriteTextLayout* l = nullptr;
+        std::string_view match_text;
         if (m.table_row >= 0 && entry.has_table_layout()) {
             l = entry.table_layout->GetCellLayout(static_cast<size_t>(m.table_row), static_cast<size_t>(m.table_col));
+            if (tbl) {
+                match_text = tbl->GetCellText(static_cast<size_t>(m.table_row), static_cast<size_t>(m.table_col));
+            }
         }
         else if (m.table_row < 0) {
             l = entry.text_layout.Get();
+            match_text = node.GetText();
         }
         // m.table_row >= 0 && !has_table_layout() のケースは layout 失効中の
         // 暫定状態で、l は nullptr のまま空 rect として記録する（次回再構築時に修復）。
-        if (l && m.length > 0) {
-            CollectHitTestRects(l, m.start, m.length, cache.rects);
+        if (l && m.length > 0 && !match_text.empty()) {
+            // SearchMatch::start, length は UTF-8 byte 単位 (ascii_util::Find の戻り値)。
+            // HitTestTextRange は UTF-16 code unit を要求するため変換する。
+            if (match_text.data() != cached_text.data() || match_text.size() != cached_text.size()) {
+                wv.emplace(match_text);
+                cached_text = match_text;
+            }
+            const auto wr = wv->WideRange(m.start, m.length);
+            if (wr.length > 0) {
+                CollectHitTestRects(l, wr.startPosition, wr.length, cache.rects);
+            }
         }
         cache.rect_ends.push_back(static_cast<uint32_t>(cache.rects.size()));
     }
@@ -704,7 +731,12 @@ void CommandGenerator::GenTableCellContent(
         const uint32_t ov_start = std::max(sel_start, flat_offset);
         const uint32_t ov_end = std::min(sel_end, flat_offset + cell_len);
         if (ov_end > ov_start) {
-            GenSelectionHighlight(cmds, cell_layout, ov_start - flat_offset, ov_end - ov_start, text_x, text_y);
+            // sel_start/sel_end は UTF-8 byte offset。HitTestTextRange 用に UTF-16 へ変換する。
+            const mendo::WideViewForDWrite wv{ cell_text };
+            const auto wr = wv.WideRange(ov_start - flat_offset, ov_end - ov_start);
+            if (wr.length > 0) {
+                GenSelectionHighlight(cmds, cell_layout, wr.startPosition, wr.length, text_x, text_y);
+            }
         }
     }
     if (cell_layout) {
@@ -791,7 +823,7 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
                 // bg_cursor は cell_index 昇順で進む。
                 bg_cursor = GenCellInlineCodeBgs(cmds, tl.cell_inline_code_bgs, bg_cursor, static_cast<uint32_t>(tl.CellIndex(r, c)), text_x, text_y, theme_->code_bg_color);
 
-                GenSearchHighlights(cmds, entry, node_index, text_x, text_y, static_cast<int>(r), static_cast<int>(c));
+                GenSearchHighlights(cmds, node, entry, node_index, text_x, text_y, static_cast<int>(r), static_cast<int>(c));
 
                 const auto cell_text = tbl->GetCellText(r, c);
                 const uint32_t cell_flat = tbl->CellTextStart(r, c);

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -142,11 +142,11 @@ private:
     // 本文ノード（テーブル外）専用の選択ハイライト発行。
     // (layout, start, length) 一致でフレーム間キャッシュをヒットさせ HitTestTextRange を省く。
     void GenSelectionHighlightCached(DrawCommandList& cmds, const NodeLayoutEntry& entry, uint32_t start, uint32_t length, float origin_x, float origin_y);
-    void GenSearchHighlights(DrawCommandList& cmds, const NodeLayoutEntry& entry, int node_index, float origin_x, float origin_y, int table_row = -1, int table_col = -1);
+    void GenSearchHighlights(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, int node_index, float origin_x, float origin_y, int table_row = -1, int table_col = -1);
 
     // 検索ハイライトのキャッシュが古い場合に再構築する。
     // matches[first_global, first_global + node_match_count) が当該ノードのマッチ。
-    void RebuildSearchHlCache(SearchHlCache& cache, const NodeLayoutEntry& entry,
+    void RebuildSearchHlCache(SearchHlCache& cache, const Node& node, const NodeLayoutEntry& entry,
                               std::span<const SearchMatch> matches, size_t first_global, size_t node_match_count);
 
     // 構築済みキャッシュから FillRectCmd を発行する。

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -9,9 +9,7 @@
 #include "memory_resource.h"
 #include "search_state.h"
 #include <cassert>
-#include <optional>
 #include <span>
-#include <string_view>
 
 // HitTestTextRange 初期バッファ容量。1 行中の inline code run が
 // 折り返される想定最大数に合わせる。描画 hot path 中の resize を避けるのが目的。
@@ -228,8 +226,9 @@ private:
     int prev_sel_end_node_ = -1;
 
     // テーブルセル選択ハイライトの UTF-8→UTF-16 decode を、同一セルの間で再利用する。
-    // string_view の identity (data() ポインタ + size) でキャッシュ判定するため、
-    // ドキュメント切り替えで concat_text が解放されると次フレーム冒頭で空 view にリセットする。
-    std::string_view cell_wv_text_;
-    std::optional<mendo::WideViewForDWrite> cell_wv_;
+    // ドキュメント切り替えや selection 解除のタイミングで dangling string_view を
+    // 抱えないよう、GenerateMdPane 冒頭で Reset() する。
+    mendo::WideViewCache cell_wv_;
+    // ドキュメント切り替えを検出するための、前フレームに渡された nodes バッファ先頭。
+    const Node* prev_nodes_data_ = nullptr;
 };

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "doc_dwrite_bridge.h"
 #include "draw_command.h"
 #include "document_types.h"
 #include "layout_cache.h"
@@ -8,7 +9,9 @@
 #include "memory_resource.h"
 #include "search_state.h"
 #include <cassert>
+#include <optional>
 #include <span>
+#include <string_view>
 
 // HitTestTextRange 初期バッファ容量。1 行中の inline code run が
 // 折り返される想定最大数に合わせる。描画 hot path 中の resize を避けるのが目的。
@@ -140,8 +143,9 @@ private:
     void CollectHitTestRects(IDWriteTextLayout* layout, uint32_t start, uint32_t length, std::pmr::vector<D2D1_RECT_F>& out);
     void GenSelectionHighlight(DrawCommandList& cmds, IDWriteTextLayout* layout, uint32_t start, uint32_t length, float origin_x, float origin_y);
     // 本文ノード（テーブル外）専用の選択ハイライト発行。
-    // (layout, start, length) 一致でフレーム間キャッシュをヒットさせ HitTestTextRange を省く。
-    void GenSelectionHighlightCached(DrawCommandList& cmds, const NodeLayoutEntry& entry, uint32_t start, uint32_t length, float origin_x, float origin_y);
+    // (layout, doc_start, doc_length) 一致でフレーム間キャッシュをヒットさせ
+    // HitTestTextRange と UTF-8→UTF-16 decode の両方を省く。doc_start / doc_length は UTF-8 byte 単位。
+    void GenSelectionHighlightCached(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, uint32_t doc_start, uint32_t doc_length, float origin_x, float origin_y);
     void GenSearchHighlights(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, int node_index, float origin_x, float origin_y, int table_row = -1, int table_col = -1);
 
     // 検索ハイライトのキャッシュが古い場合に再構築する。
@@ -222,4 +226,10 @@ private:
     // 解放するために使う。-1/-1 は「前フレームは非アクティブ」を示す。
     int prev_sel_start_node_ = -1;
     int prev_sel_end_node_ = -1;
+
+    // テーブルセル選択ハイライトの UTF-8→UTF-16 decode を、同一セルの間で再利用する。
+    // string_view の identity (data() ポインタ + size) でキャッシュ判定するため、
+    // ドキュメント切り替えで concat_text が解放されると次フレーム冒頭で空 view にリセットする。
+    std::string_view cell_wv_text_;
+    std::optional<mendo::WideViewForDWrite> cell_wv_;
 };

--- a/tests/test_command_generator_highlight.cpp
+++ b/tests/test_command_generator_highlight.cpp
@@ -8,6 +8,8 @@
 #include "dwrite_test_base.h"
 #include "search_state.h"
 #include "text_types.h"
+#include <initializer_list>
+#include <optional>
 #include <variant>
 #include <vector>
 

--- a/tests/test_command_generator_highlight.cpp
+++ b/tests/test_command_generator_highlight.cpp
@@ -25,6 +25,21 @@ std::vector<size_t> ExtractCmdKinds(const DrawCommandList& cmds)
     return kinds;
 }
 
+std::optional<D2D1_RECT_F> FindFirstFillRectByColor(const DrawCommandList& cmds,
+                                                    std::initializer_list<D2D1_COLOR_F> colors)
+{
+    for (const auto& c : cmds) {
+        if (auto* fr = std::get_if<FillRectCmd>(&c)) {
+            for (const auto& col : colors) {
+                if (ColorEq(fr->color, col)) {
+                    return fr->rect;
+                }
+            }
+        }
+    }
+    return std::nullopt;
+}
+
 class HighlightOrderTest : public DWriteTestBase {
 protected:
     CommandGenerator gen_;
@@ -171,4 +186,55 @@ TEST_F(HighlightOrderTest, ExtractCmdKindsIsOrdered)
     for (size_t i = 0; i < cmds.size(); ++i) {
         EXPECT_EQ(kinds[i], cmds[i].index());
     }
+}
+
+// SearchMatch::start, length は UTF-8 byte 単位。HitTestTextRange は UTF-16 code unit
+// を要求するため、変換漏れがあると非 ASCII 後方の ASCII マッチで矩形位置が破綻する。
+// 「あいうabc」の "abc" を検索して、ASCII 単独 "abc" と同等幅の矩形が出ることで担保する。
+TEST_F(HighlightOrderTest, SearchHighlightHandlesUtf8MultibyteOffset)
+{
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
+
+    auto pl1 = ParseAndLayout("abc");
+    std::pmr::vector<SearchMatch> matches1;
+    matches1.push_back({ 0, 0, 3, -1, -1 });
+    gen_.SetSearchMatches(&matches1, 0, 1);
+    const auto& cmds1 = gen_.GenerateMdPane(pl1.nodes, pl1.cache, pane, 0.0f, TextSelection{});
+    const auto rect1 = FindFirstFillRectByColor(cmds1,
+        { theme_.search_highlight_color, theme_.search_highlight_current_color });
+    ASSERT_TRUE(rect1.has_value());
+
+    // "あいう" は UTF-8 で 9 byte / UTF-16 で 3 code unit。
+    auto pl2 = ParseAndLayout("\xE3\x81\x82\xE3\x81\x84\xE3\x81\x86" "abc");
+    std::pmr::vector<SearchMatch> matches2;
+    matches2.push_back({ 0, 9, 3, -1, -1 });
+    gen_.SetSearchMatches(&matches2, 0, 1);
+    const auto& cmds2 = gen_.GenerateMdPane(pl2.nodes, pl2.cache, pane, 0.0f, TextSelection{});
+    const auto rect2 = FindFirstFillRectByColor(cmds2,
+        { theme_.search_highlight_color, theme_.search_highlight_current_color });
+    ASSERT_TRUE(rect2.has_value()) << "非 ASCII オフセット後の ASCII マッチが描画されるべき";
+    EXPECT_NEAR(rect2->right - rect2->left, rect1->right - rect1->left, 2.0f)
+        << "ハイライト幅は ASCII 単独時と一致すべき";
+}
+
+// 選択範囲も UTF-8 byte 単位で保持されるため、同じ取り違えバグを抱えうる。
+// "あいうabc" の "abc" を選択して、矩形幅が ASCII 単独時と一致することで担保する。
+TEST_F(HighlightOrderTest, SelectionHighlightHandlesUtf8MultibyteOffset)
+{
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
+
+    auto pl1 = ParseAndLayout("abc");
+    TextSelection sel1 = TextSelection::MakeOrdered(0, 0, 0, 3);
+    sel1.active = true;
+    const auto& cmds1 = gen_.GenerateMdPane(pl1.nodes, pl1.cache, pane, 0.0f, sel1);
+    const auto rect1 = FindFirstFillRectByColor(cmds1, { SELECTION_COLOR });
+    ASSERT_TRUE(rect1.has_value());
+
+    auto pl2 = ParseAndLayout("\xE3\x81\x82\xE3\x81\x84\xE3\x81\x86" "abc");
+    TextSelection sel2 = TextSelection::MakeOrdered(0, 9, 0, 12);
+    sel2.active = true;
+    const auto& cmds2 = gen_.GenerateMdPane(pl2.nodes, pl2.cache, pane, 0.0f, sel2);
+    const auto rect2 = FindFirstFillRectByColor(cmds2, { SELECTION_COLOR });
+    ASSERT_TRUE(rect2.has_value());
+    EXPECT_NEAR(rect2->right - rect2->left, rect1->right - rect1->left, 2.0f);
 }


### PR DESCRIPTION
## Summary

- 選択ハイライト・検索ハイライトの矩形位置が、非 ASCII 文字を含むテキストで実際の範囲よりも広く描画されるバグを修正 (#182)
- 原因: `TextSelection` と `SearchMatch` のオフセットは UTF-8 byte 単位で保持しているが、`IDWriteTextLayout::HitTestTextRange` は UTF-16 code unit を要求するため、日本語等で取り違えが発生していた。コピーは UTF-8 byte offset で正しく動作するため、見た目だけがずれる症状
- `WideViewForDWrite::WideRange` で UTF-8 byte → UTF-16 code unit に変換してから `HitTestTextRange` 系ヘルパーへ渡すように修正
- 検索ハイライトでは同一ノード/セルの連続マッチで `WideViewForDWrite` を使い回し、decode 回数を抑制
- リグレッションテスト 2 件追加 (修正前のコードに対しては矩形幅 0 で失敗することを確認)

## Test plan

- [x] `cmake --build build --config Release` 成功
- [x] `mendo_tests.exe --gtest_brief=1` で全 2155 テスト pass
- [x] 修正前のソースで新規 2 テストが失敗すること (`stash` した状態で実行) を確認
- [x] 日本語混じり markdown を実機で開き、マウスドラッグ選択時に背景色がカーソル位置と一致すること
- [x] 同上、検索クエリ "abc" 等で全角文字後方の ASCII マッチがハイライトされること

## Out of scope (別 issue として起票済み)

- #188: WideViewForDWrite の重複 decode 削減 (selection / HitTest / clipboard 等で同パターンの decode を共通化)
- #189: SearchMatch を UTF-16 単位 / 取得手段に依存しない形に再設計 (描画レイヤから tbl->GetCellText 等の呼び出しを引き剥がす)

🤖 Generated with [Claude Code](https://claude.com/claude-code)