### PR TITLE
perf(search): SearchMatch に UTF-16 オフセットを保存し描画 hot path から decode を排除 (#188, #189)

### DIFF
--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -108,6 +108,12 @@ HitTestService::HitResult HitTestService::HitTest(const MdPaneHitContext& ctx) c
         return result;
     }
 
+    if (ctx.nodes.data() != prev_nodes_data_) {
+        md_wv_cache_.Reset();
+        cell_wv_cache_.Reset();
+        prev_nodes_data_ = ctx.nodes.data();
+    }
+
     const uint32_t gen = ctx.cache.GetEffectsGeneration();
     if (last_md_hit_.Matches(ctx, gen)) {
         return last_md_hit_.result;
@@ -148,7 +154,7 @@ HitTestService::HitResult HitTestService::HitTest(const MdPaneHitContext& ctx) c
 
             result.node_index = candidate;
             // metrics.textPosition (UTF-16 code unit) を text_pos (UTF-8 byte) に還元する。
-            const mendo::WideViewForDWrite wv{ node.GetText() };
+            const auto& wv = md_wv_cache_.Get(node.GetText());
             result.text_pos = wv.DocOffsetFromWideOffset(metrics.textPosition + (is_trailing ? 1 : 0));
             last_md_hit_.Store(ctx, gen, result);
             return result;
@@ -215,7 +221,7 @@ HitTestService::HitResult HitTestService::HitTestTable(
             &metrics);
 
         // metrics.textPosition (UTF-16 code unit) を cell text の UTF-8 byte offset に還元してから flat_offset に加算。
-        const mendo::WideViewForDWrite wv{ tbl->GetCellText(r, c) };
+        const auto& wv = cell_wv_cache_.Get(tbl->GetCellText(r, c));
         const auto cell_doc_off = wv.DocOffsetFromWideOffset(metrics.textPosition + (is_trailing ? 1 : 0));
         result.text_pos = flat_offset + cell_doc_off;
     }

--- a/src/input/hit_test_service.h
+++ b/src/input/hit_test_service.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "doc_dwrite_bridge.h"
 #include "document_types.h"
 #include "layout_cache.h"
 #include "layout_computer.h"
@@ -174,4 +175,11 @@ private:
     mutable HitCache<int> last_copy_hit_{ .result = -1 };
     mutable HitCache<int> last_save_hit_{ .result = -1 };
     mutable HitCache<int> last_svg_copy_hit_{ .result = -1 };
+
+    // HitTestPoint の UTF-16→UTF-8 逆変換を同一ノード/セル間で再利用する
+    // (ドラッグ選択時の連続呼び出しで decode を抑える)。
+    // ドキュメント切替で string_view が dangling 化するため HitTest 冒頭で Reset。
+    mutable mendo::WideViewCache md_wv_cache_;
+    mutable mendo::WideViewCache cell_wv_cache_;
+    mutable const Node* prev_nodes_data_ = nullptr;
 };

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -181,7 +181,7 @@ struct NodeLayoutEntry {
     // あれば text_offset_w (UTF-16 code unit) に対応する行 Y を精密に計算し、無ければ
     // ブロック先頭/テーブル行先頭の座標にフォールバックする。
     // Why: 長い段落内の複数マッチで同じブロック先頭 Y に丸まると「次へ」でスクロールしない。
-    // text_offset は IDWriteTextLayout::HitTestTextPosition の引数なので UTF-16 単位を渡すこと
+    // text_offset_w は IDWriteTextLayout::HitTestTextPosition の引数なので UTF-16 単位を渡すこと
     // (UTF-8 byte を渡すと非 ASCII を含む段落で行 Y がずれる)。
     std::pair<float, float> GetMatchYRange(int table_row, int table_col, uint32_t text_offset_w, float entry_text_top) const noexcept
     {

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -178,12 +178,12 @@ struct NodeLayoutEntry {
     }
 
     // マッチの絶対 Y とその行の高さを返す。text_layout（テーブルはセル layout）が
-    // あれば text_offset に対応する行 Y を精密に計算し、無ければ
+    // あれば text_offset_w (UTF-16 code unit) に対応する行 Y を精密に計算し、無ければ
     // ブロック先頭/テーブル行先頭の座標にフォールバックする。
     // Why: 長い段落内の複数マッチで同じブロック先頭 Y に丸まると「次へ」でスクロールしない。
-    // row_cum_y は row_count+1 要素（末尾は合計高さ）なので、行として有効なのは [0, row_heights.size()) のみ。
-    // entry_text_top はノード上端 Y。caller が Fenwick から計算するか entry のキャッシュ値を渡す。
-    std::pair<float, float> GetMatchYRange(int table_row, int table_col, uint32_t text_offset, float entry_text_top) const noexcept
+    // text_offset は IDWriteTextLayout::HitTestTextPosition の引数なので UTF-16 単位を渡すこと
+    // (UTF-8 byte を渡すと非 ASCII を含む段落で行 Y がずれる)。
+    std::pair<float, float> GetMatchYRange(int table_row, int table_col, uint32_t text_offset_w, float entry_text_top) const noexcept
     {
         IDWriteTextLayout* layout = nullptr;
         float base_y = entry_text_top;
@@ -206,7 +206,7 @@ struct NodeLayoutEntry {
         if (layout != nullptr) {
             FLOAT px = 0.0f, py = 0.0f;
             DWRITE_HIT_TEST_METRICS htm{};
-            if (SUCCEEDED(layout->HitTestTextPosition(text_offset, FALSE, &px, &py, &htm))) {
+            if (SUCCEEDED(layout->HitTestTextPosition(text_offset_w, FALSE, &px, &py, &htm))) {
                 const float line_h = (htm.height > 0.0f) ? htm.height : fallback_h;
                 return { base_y + py, line_h };
             }

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -112,8 +112,9 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
         prev_sel_end_node_ = new_end;
     }
     // ドキュメント切り替え (= nodes バッファのアドレス変化) や selection 解除のタイミングで
-    // cell_wv_ が抱える string_view が dangling 化しうるため、ここで明示的にリセットする。
+    // node_wv_ / cell_wv_ が抱える string_view が dangling 化しうるため、ここでリセットする。
     if (!selection.active || nodes.data() != prev_nodes_data_) {
+        node_wv_.Reset();
         cell_wv_.Reset();
     }
     prev_nodes_data_ = nodes.data();
@@ -268,7 +269,7 @@ void CommandGenerator::GenNodeTextDecorations(DrawCommandList& cmds, const Node&
     GenInlineCodeBgs(cmds, entry.view_inline_code_bgs(), text_x, entry_text_top, theme_->code_bg_color);
 
     // 検索マッチのハイライト（選択より先に描画し、選択が最前面になるようにする）
-    GenSearchHighlights(cmds, node, entry, node_index, text_x, entry_text_top);
+    GenSearchHighlights(cmds, entry, node_index, text_x, entry_text_top);
 
     const auto& selection = *frame_selection_;
     if (selection.active && node_index >= selection.start_node && node_index <= selection.end_node) {
@@ -564,13 +565,11 @@ void CommandGenerator::GenSelectionHighlightCached(DrawCommandList& cmds, const 
     }
     auto& cache = entry.ensure_selection_hl_cache();
     // キャッシュキーは UTF-8 byte 単位 (selection 状態と直接対応)。
-    // miss 時のみ UTF-8→UTF-16 decode と HitTestTextRange を実行することで、
-    // 選択範囲が静止しているフレームでは decode を完全にスキップする。
+    // miss 時は WideViewCache 経由で同一ノードの連続 miss でも decode を 1 回に抑える。
     if (cache.layout_ptr != layout || cache.start != doc_start || cache.length != doc_length) {
         MENDO_COUNT_INC(g_cmd_gen_stats.sel_hl_cache_miss);
         cache.rects.clear();
-        const mendo::WideViewForDWrite wv{ node.GetText() };
-        const auto wr = wv.WideRange(doc_start, doc_length);
+        const auto wr = node_wv_.WideRange(node.GetText(), doc_start, doc_length);
         if (wr.length > 0) {
             CollectHitTestRects(layout, wr.startPosition, wr.length, cache.rects);
         }
@@ -592,7 +591,7 @@ void CommandGenerator::GenSelectionHighlightCached(DrawCommandList& cmds, const 
     }
 }
 
-void CommandGenerator::GenSearchHighlights(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, int node_index, float origin_x, float origin_y, int table_row, int table_col)
+void CommandGenerator::GenSearchHighlights(DrawCommandList& cmds, const NodeLayoutEntry& entry, int node_index, float origin_x, float origin_y, int table_row, int table_col)
 {
     if (!search_matches_ || search_matches_->empty()) {
         return;
@@ -607,11 +606,11 @@ void CommandGenerator::GenSearchHighlights(DrawCommandList& cmds, const Node& no
     const size_t node_match_count = static_cast<size_t>(range.size());
 
     auto& cache = entry.ensure_search_hl_cache();
-    RebuildSearchHlCache(cache, node, entry, matches, first_global, node_match_count);
+    RebuildSearchHlCache(cache, entry, matches, first_global, node_match_count);
     EmitSearchHlCommands(cmds, cache, matches, first_global, origin_x, origin_y, table_row, table_col);
 }
 
-void CommandGenerator::RebuildSearchHlCache(SearchHlCache& cache, const Node& node, const NodeLayoutEntry& entry,
+void CommandGenerator::RebuildSearchHlCache(SearchHlCache& cache, const NodeLayoutEntry& entry,
                                             std::span<const SearchMatch> matches, size_t first_global, size_t node_match_count)
 {
     // キャッシュミス時のみ HitTestTextRange を一括発行。layout 変更時は
@@ -627,33 +626,19 @@ void CommandGenerator::RebuildSearchHlCache(SearchHlCache& cache, const Node& no
     cache.rect_ends.clear();
     cache.rect_ends.reserve(node_match_count);
 
-    const auto* tbl = node.table_data();
-    // matches は (node, table_row, table_col) 昇順。同ノード/同セル連続マッチで
-    // UTF-8→UTF-16 decode を 1 回に抑えるため WideViewCache を使う。
-    mendo::WideViewCache wv_cache;
-
     for (size_t mi = first_global; mi < first_global + node_match_count; ++mi) {
         const auto& m = matches[mi];
         IDWriteTextLayout* l = nullptr;
-        std::string_view match_text;
         if (m.table_row >= 0 && entry.has_table_layout()) {
             l = entry.table_layout->GetCellLayout(static_cast<size_t>(m.table_row), static_cast<size_t>(m.table_col));
-            if (tbl) {
-                match_text = tbl->GetCellText(static_cast<size_t>(m.table_row), static_cast<size_t>(m.table_col));
-            }
         }
         else if (m.table_row < 0) {
             l = entry.text_layout.Get();
-            match_text = node.GetText();
         }
         // m.table_row >= 0 && !has_table_layout() のケースは layout 失効中の
         // 暫定状態で、l は nullptr のまま空 rect として記録する（次回再構築時に修復）。
-        if (l && m.length > 0 && !match_text.empty()) {
-            // SearchMatch::start, length は UTF-8 byte 単位 (ascii_util::Find の戻り値)。
-            const auto wr = wv_cache.WideRange(match_text, m.start, m.length);
-            if (wr.length > 0) {
-                CollectHitTestRects(l, wr.startPosition, wr.length, cache.rects);
-            }
+        if (l && m.length_w > 0) {
+            CollectHitTestRects(l, m.start_w, m.length_w, cache.rects);
         }
         cache.rect_ends.push_back(static_cast<uint32_t>(cache.rects.size()));
     }
@@ -822,7 +807,7 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
                 // bg_cursor は cell_index 昇順で進む。
                 bg_cursor = GenCellInlineCodeBgs(cmds, tl.cell_inline_code_bgs, bg_cursor, static_cast<uint32_t>(tl.CellIndex(r, c)), text_x, text_y, theme_->code_bg_color);
 
-                GenSearchHighlights(cmds, node, entry, node_index, text_x, text_y, static_cast<int>(r), static_cast<int>(c));
+                GenSearchHighlights(cmds, entry, node_index, text_x, text_y, static_cast<int>(r), static_cast<int>(c));
 
                 const auto cell_text = tbl->GetCellText(r, c);
                 const uint32_t cell_flat = tbl->CellTextStart(r, c);

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -144,11 +144,11 @@ private:
     // (layout, doc_start, doc_length) 一致でフレーム間キャッシュをヒットさせ
     // HitTestTextRange と UTF-8→UTF-16 decode の両方を省く。doc_start / doc_length は UTF-8 byte 単位。
     void GenSelectionHighlightCached(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, uint32_t doc_start, uint32_t doc_length, float origin_x, float origin_y);
-    void GenSearchHighlights(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, int node_index, float origin_x, float origin_y, int table_row = -1, int table_col = -1);
+    void GenSearchHighlights(DrawCommandList& cmds, const NodeLayoutEntry& entry, int node_index, float origin_x, float origin_y, int table_row = -1, int table_col = -1);
 
     // 検索ハイライトのキャッシュが古い場合に再構築する。
     // matches[first_global, first_global + node_match_count) が当該ノードのマッチ。
-    void RebuildSearchHlCache(SearchHlCache& cache, const Node& node, const NodeLayoutEntry& entry,
+    void RebuildSearchHlCache(SearchHlCache& cache, const NodeLayoutEntry& entry,
                               std::span<const SearchMatch> matches, size_t first_global, size_t node_match_count);
 
     // 構築済みキャッシュから FillRectCmd を発行する。
@@ -225,10 +225,10 @@ private:
     int prev_sel_start_node_ = -1;
     int prev_sel_end_node_ = -1;
 
-    // テーブルセル選択ハイライトの UTF-8→UTF-16 decode を、同一セルの間で再利用する。
-    // ドキュメント切り替えや selection 解除のタイミングで dangling string_view を
-    // 抱えないよう、GenerateMdPane 冒頭で Reset() する。
+    // 選択ハイライトの UTF-8→UTF-16 decode を、本文ノードとテーブルセルそれぞれで
+    // 連続フレーム間に渡って再利用する。GenerateMdPane 冒頭の selection 状態変化
+    // (= ドキュメント切り替え or selection 解除) で Reset() し dangling を防ぐ。
+    mendo::WideViewCache node_wv_;
     mendo::WideViewCache cell_wv_;
-    // ドキュメント切り替えを検出するための、前フレームに渡された nodes バッファ先頭。
     const Node* prev_nodes_data_ = nullptr;
 };

--- a/src/ui/search_bar_controller.cpp
+++ b/src/ui/search_bar_controller.cpp
@@ -173,8 +173,8 @@ void SearchBarController::ScrollToCurrentMatch()
 
     const auto& entry = (*cache_)[match.node_index];
     // Why: ブロック先頭/行先頭に丸めると、長い段落内の複数マッチ間で同じ Y に集約され
-    //      「次へ」を押してもスクロールしない。match.start を使って行単位の Y を出す。
-    const auto [match_y, match_h] = entry.GetMatchYRange(match.table_row, match.table_col, match.start, entry.text_top);
+    //      「次へ」を押してもスクロールしない。start_w で行単位の Y を出す。
+    const auto [match_y, match_h] = entry.GetMatchYRange(match.table_row, match.table_col, match.start_w, entry.text_top);
     const float md_pane_height = cb_.get_md_pane_height();
     const float visible_height = md_pane_height - (state_->IsVisible() ? SEARCH_BAR_HEIGHT : 0.0f);
     const float scroll_y = viewport_->GetScrollY();

--- a/src/ui/search_state.cpp
+++ b/src/ui/search_state.cpp
@@ -1,5 +1,6 @@
 #include "search_state.h"
 #include "ascii_util.h"
+#include "doc_dwrite_bridge.h"
 #include <algorithm>
 
 void SearchState::SetQuery(std::string_view query)
@@ -35,9 +36,11 @@ void SearchState::ExecuteSearch(const std::pmr::vector<Node>& nodes)
             for (int r = 0; r < row_count && matches_.size() < MAX_MATCHES; r++) {
                 for (int c = 0; c < col_count && matches_.size() < MAX_MATCHES; c++) {
                     const auto cell_text = tbl->GetCellText(r, c);
-                    if (!cell_text.empty()) {
-                        FindMatches(cell_text, lower_query, i, r, c);
+                    if (cell_text.empty()) {
+                        continue;
                     }
+                    const auto search_text = case_sensitive_ ? cell_text : lower_cache_.GetCell(i, r, c);
+                    FindMatches(search_text, cell_text, lower_query, i, r, c);
                 }
             }
         }
@@ -47,7 +50,8 @@ void SearchState::ExecuteSearch(const std::pmr::vector<Node>& nodes)
                 (node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language))) {
                 continue;
             }
-            FindMatches(text, lower_query, i);
+            const auto search_text = case_sensitive_ ? text : lower_cache_.GetText(i);
+            FindMatches(search_text, text, lower_query, i);
         }
     }
     matches_truncated_ = (matches_.size() >= MAX_MATCHES);
@@ -109,30 +113,37 @@ void SearchState::EnsureLowercaseCache(const std::pmr::vector<Node>& nodes)
     cached_node_count_ = nodes.size();
 }
 
-void SearchState::FindMatches(std::string_view text, const std::pmr::string& lower_query, int node_index, int table_row, int table_col)
+void SearchState::FindMatches(std::string_view search_text, std::string_view utf16_text,
+                              const std::pmr::string& lower_query, int node_index,
+                              int table_row, int table_col)
 {
     if (matches_.size() >= MAX_MATCHES) {
         return;
     }
     const uint32_t query_len = static_cast<uint32_t>(query_.size());
+    const std::string_view query = case_sensitive_ ? std::string_view(query_) : std::string_view(lower_query);
 
-    if (case_sensitive_) {
-        size_t pos = 0;
-        while (matches_.size() < MAX_MATCHES && (pos = ascii_util::Find(text, query_, pos)) != ascii_util::npos) {
-            matches_.emplace_back(node_index, static_cast<uint32_t>(pos), query_len, table_row, table_col);
-            pos += query_len;
-        }
-    }
-    else {
-        // ドキュメント単位でキャッシュした lowercase 文字列を使う。
-        // EnsureLowercaseCache が ExecuteSearch 先頭で呼ばれている前提。
-        const std::string_view lower_text = (table_row < 0) ? lower_cache_.GetText(node_index) : lower_cache_.GetCell(node_index, table_row, table_col);
+    // utf16_text に対する WideViewForDWrite は最初のマッチ確定時にだけ作る (lazy)。
+    // マッチ 0 件のノード/セルでは UTF-8→UTF-16 decode を完全にスキップできる。
+    std::optional<mendo::WideViewForDWrite> wv;
 
-        size_t pos = 0;
-        while (matches_.size() < MAX_MATCHES && (pos = ascii_util::Find(lower_text, lower_query, pos)) != ascii_util::npos) {
-            matches_.emplace_back(node_index, static_cast<uint32_t>(pos), query_len, table_row, table_col);
-            pos += query_len;
+    size_t pos = 0;
+    while (matches_.size() < MAX_MATCHES && (pos = ascii_util::Find(search_text, query, pos)) != ascii_util::npos) {
+        const uint32_t byte_start = static_cast<uint32_t>(pos);
+        if (!wv.has_value()) {
+            wv.emplace(utf16_text);
         }
+        const auto wr = wv->WideRange(byte_start, query_len);
+        matches_.emplace_back(SearchMatch{
+            .node_index = node_index,
+            .start = byte_start,
+            .length = query_len,
+            .table_row = table_row,
+            .table_col = table_col,
+            .start_w = wr.startPosition,
+            .length_w = wr.length,
+        });
+        pos += query_len;
     }
 }
 
@@ -177,7 +188,7 @@ void SearchState::SetCurrentMatchNear(float scroll_y, const LayoutCache& cache) 
             return true;
         }
         const auto& e = cache[m.node_index];
-        const auto [y, h] = e.GetMatchYRange(m.table_row, m.table_col, m.start, e.text_top);
+        const auto [y, h] = e.GetMatchYRange(m.table_row, m.table_col, m.start_w, e.text_top);
         (void)h;
         return y < scroll_y;
     });

--- a/src/ui/search_state.h
+++ b/src/ui/search_state.h
@@ -21,7 +21,9 @@ struct SearchMatch {
     uint32_t length_w = 0;
 };
 
-// 検索状態の管理（Win32非依存）
+// 検索状態の管理。GUI 入力イベント (HWND / メッセージループ) には依存しないが、
+// SearchMatch::start_w / length_w を埋めるために実装側で doc_dwrite_bridge を経由した
+// UTF-8↔UTF-16 オフセット変換 (= DirectWrite/Win32 MultiByteToWideChar) を呼ぶ。
 class SearchState {
 public:
     constexpr bool IsVisible() const noexcept

--- a/src/ui/search_state.h
+++ b/src/ui/search_state.h
@@ -21,9 +21,7 @@ struct SearchMatch {
     uint32_t length_w = 0;
 };
 
-// 検索状態の管理。GUI 入力イベント (HWND / メッセージループ) には依存しないが、
-// SearchMatch::start_w / length_w を埋めるために実装側で doc_dwrite_bridge を経由した
-// UTF-8↔UTF-16 オフセット変換 (= DirectWrite/Win32 MultiByteToWideChar) を呼ぶ。
+// 検索状態の管理。start_w / length_w 算出のため doc_dwrite_bridge (UTF-8↔UTF-16) に依存する。
 class SearchState {
 public:
     constexpr bool IsVisible() const noexcept

--- a/src/ui/search_state.h
+++ b/src/ui/search_state.h
@@ -6,13 +6,19 @@
 #include <memory_resource>
 #include <unordered_map>
 
-// 検索マッチの位置情報
+// 検索マッチの位置情報。
+// start / length は UTF-8 byte 単位 (ascii_util::Find の戻り値)。
+// start_w / length_w は同じ範囲を UTF-16 code unit で表したもので
+// IDWriteTextLayout の HitTestTextRange / HitTestTextPosition にそのまま渡せる。
+// 不変条件: 両者は同じノード/セル内の同一範囲を指し、ExecuteSearch で同時に確定される。
 struct SearchMatch {
     int node_index;
-    uint32_t start; // node.text（またはcell.text）内の文字オフセット
+    uint32_t start;
     uint32_t length;
     int table_row = -1; // テーブルセル用（-1なら通常ノード）
     int table_col = -1;
+    uint32_t start_w = 0;
+    uint32_t length_w = 0;
 };
 
 // 検索状態の管理（Win32非依存）
@@ -103,7 +109,13 @@ public:
     void SetCurrentMatchNear(float scroll_y, const LayoutCache& cache) noexcept;
 
 private:
-    void FindMatches(std::string_view text, const std::pmr::string& lower_query, int node_index, int table_row = -1, int table_col = -1);
+    // search_text は ascii_util::Find で走査する対象 (lowercase キャッシュ or 元 UTF-8)。
+    // utf16_text は UTF-16 オフセット算出に使う元の UTF-8 (= ノード/セルテキスト)。
+    // 両者は同一バイト長で位置対応が一致するが、ASCII lowercase はインプレース変換可能なので
+    // start オフセットを共有できる。
+    void FindMatches(std::string_view search_text, std::string_view utf16_text,
+                     const std::pmr::string& lower_query, int node_index,
+                     int table_row = -1, int table_col = -1);
     void EnsureLowercaseCache(const std::pmr::vector<Node>& nodes);
 
     // マッチ一覧と関連する世代カウンタ・トランケーションフラグを同時にリセットする。

--- a/tests/test_command_generator_highlight.cpp
+++ b/tests/test_command_generator_highlight.cpp
@@ -68,8 +68,9 @@ TEST_F(HighlightOrderTest, SearchThenSelectionThenText)
 
     // node 0 の "Hello" を検索マッチに、"World" を選択範囲に設定する。
     // 範囲が重ならないことで、ハイライト矩形が独立に発行されることを保証する。
+    // ASCII のみの本文なので start_w == start / length_w == length を直接渡せる。
     std::pmr::vector<SearchMatch> matches;
-    matches.push_back({ 0, 0, 5, -1, -1 });
+    matches.push_back({ 0, 0, 5, -1, -1, 0, 5 });
     gen_.SetSearchMatches(&matches, 0, 1);
 
     TextSelection sel = TextSelection::MakeOrdered(0, 6, 0, 11);
@@ -134,8 +135,8 @@ TEST_F(HighlightOrderTest, CurrentMatchUsesCurrentColor)
 {
     auto pl = ParseAndLayout("Hello Hello");
     std::pmr::vector<SearchMatch> matches;
-    matches.push_back({ 0, 0, 5, -1, -1 });
-    matches.push_back({ 0, 6, 5, -1, -1 });
+    matches.push_back({ 0, 0, 5, -1, -1, 0, 5 });
+    matches.push_back({ 0, 6, 5, -1, -1, 6, 5 });
     gen_.SetSearchMatches(&matches, 1, 1); // 2 番目を current にする
 
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
@@ -199,7 +200,7 @@ TEST_F(HighlightOrderTest, SearchHighlightHandlesUtf8MultibyteOffset)
 
     auto pl1 = ParseAndLayout("abc");
     std::pmr::vector<SearchMatch> matches1;
-    matches1.push_back({ 0, 0, 3, -1, -1 });
+    matches1.push_back({ 0, 0, 3, -1, -1, 0, 3 });
     gen_.SetSearchMatches(&matches1, 0, 1);
     const auto& cmds1 = gen_.GenerateMdPane(pl1.nodes, pl1.cache, pane, 0.0f, TextSelection{});
     const auto rect1 = FindFirstFillRectByColor(cmds1,
@@ -209,7 +210,7 @@ TEST_F(HighlightOrderTest, SearchHighlightHandlesUtf8MultibyteOffset)
     // "あいう" は UTF-8 で 9 byte / UTF-16 で 3 code unit。
     auto pl2 = ParseAndLayout("\xE3\x81\x82\xE3\x81\x84\xE3\x81\x86" "abc");
     std::pmr::vector<SearchMatch> matches2;
-    matches2.push_back({ 0, 9, 3, -1, -1 });
+    matches2.push_back({ 0, 9, 3, -1, -1, 3, 3 });
     gen_.SetSearchMatches(&matches2, 0, 1);
     const auto& cmds2 = gen_.GenerateMdPane(pl2.nodes, pl2.cache, pane, 0.0f, TextSelection{});
     const auto rect2 = FindFirstFillRectByColor(cmds2,


### PR DESCRIPTION
## Summary

#188 (WideViewForDWrite の重複 decode 削減) と #189 (SearchMatch の UTF-16 化) を A 案でまとめて対応。

- **#189 A案**: `SearchMatch` に `start_w` / `length_w` (UTF-16 code unit) を追加。`SearchState::ExecuteSearch` がノード/セル単位 1 回の decode で確定し、`CommandGenerator::RebuildSearchHlCache` から `WideViewForDWrite` 構築と `tbl->GetCellText` を削除して描画専用判定に絞った。
- **#188 A案 残**: `HitTestService` に `WideViewCache` をメンバ化し HitTestPoint 連続呼び出し時の decode を抑制。`GenSelectionHighlightCached` も `node_wv_` 経由に変更し selection ドラッグ中の連続 miss でも node あたり 1 回に。
- **副次バグ修正**: `GetMatchYRange` が UTF-16 を期待する `HitTestTextPosition` に UTF-8 byte の `m.start` を渡していたずれを `m.start_w` に切替えて修正。非 ASCII を含む段落の「次へ」スクロール位置が正確になる。

#188 起票時に挙がった他の経路 (`renderer.cpp` ApplyEffects 系 / `renderer_pane.cpp` TOC / `selection_html.cpp`) は構成変更で既に解消済みか効果が薄いため対象外。

## 変更ファイル

- `src/ui/search_state.{h,cpp}` — SearchMatch 拡張・ExecuteSearch 統合・FindMatches で lazy decode
- `src/render/command_generator.{h,cpp}` — RebuildSearchHlCache 簡素化、`node_wv_` メンバ追加、Reset 経路統合
- `src/input/hit_test_service.{h,cpp}` — `md_wv_cache_` / `cell_wv_cache_` 追加、ドキュメント切替で Reset
- `src/layout/layout_cache.h` — `GetMatchYRange` の引数名と単位を UTF-16 に明確化
- `src/ui/search_bar_controller.cpp` — `m.start_w` 切替
- `tests/test_command_generator_highlight.cpp` — SearchMatch aggregate 初期化に start_w/length_w 追加

## Test plan

- [x] CMake Release ビルドが警告なしで完走
- [x] mendo_tests.exe 全 2155 テスト通過
- [x] 動作確認: ASCII / 非 ASCII 混在ドキュメントで検索 → 「次へ/前へ」のスクロール位置が正確
- [x] 動作確認: テーブルセル内の検索ハイライト矩形が正しい位置に出る
- [x] 動作確認: ドラッグ選択中のフレームレートに退行がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)