### PR TITLE
fix(render): リスト bullet が激しいスクロール時に長方形化する不具合を修正 (#193)

### DIFF
--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -381,8 +381,9 @@ void CommandGenerator::GenListBullet(DrawCommandList& cmds, const Node& node, co
         }
     }
     else {
-        // 大きい scroll_y を SetTransform で適用すると D2D が半径3pxの楕円を bounding rect
-        // (長方形) に縮退させるため、bullet だけ Identity transform + baked 座標で描画する (#193)。
+        // 大きい scroll_y を SetTransform で適用すると D2D が小半径 (LIST_BULLET_RADIUS=3 DIP)
+        // の楕円を bounding rect (長方形) に縮退させるため、bullet だけ Identity transform +
+        // baked 座標で描画する (#193)。
         const float first_line_h = GetFirstLineHeight(entry, theme_->font_size_body);
         const float bullet_x = SnapToPhysicalPixel(
             frame_md_pane_x_ + x - theme_->list_bullet_offset * LIST_BULLET_X_FACTOR,

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -82,8 +82,11 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     // スクロール位置を物理ピクセル境界にスナップし、ClearTypeヒンティングの
     // フレーム間変動によるテキストのガタつきを防止する。
     // viewport bounds にはスナップ前の scroll_y を使い、ヒットテストとの座標一致を保つ。
-    const float snapped_y = SnapScrollToPixel(scroll_y, dpi_scale);
-    cmds.emplace_back(SetTransformCmd{ D2D1::Matrix3x2F::Translation(md_pane_rect.x, -snapped_y) });
+    const float snapped_y = SnapToPhysicalPixel(scroll_y, dpi_scale);
+    frame_md_pane_x_ = md_pane_rect.x;
+    frame_snapped_scroll_y_ = snapped_y;
+    frame_pane_transform_ = D2D1::Matrix3x2F::Translation(md_pane_rect.x, -snapped_y);
+    cmds.emplace_back(SetTransformCmd{ frame_pane_transform_ });
 
     frame_offset_x_ = theme_->margin_left;
     frame_viewport_top_ = scroll_y;
@@ -92,6 +95,7 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     frame_viewport_left_ = -theme_->margin_left;
     frame_viewport_right_ = md_pane_rect.width - theme_->margin_left;
     frame_content_width_ = theme_->ContentWidth(md_pane_rect.width);
+    frame_dpi_scale_ = dpi_scale;
     frame_selection_ = &selection;
     frame_hovered_ = hovered;
 
@@ -377,17 +381,24 @@ void CommandGenerator::GenListBullet(DrawCommandList& cmds, const Node& node, co
         }
     }
     else {
-        // 1行目の中央に配置
+        // 大きい scroll_y を SetTransform で適用すると D2D が半径3pxの楕円を bounding rect
+        // (長方形) に縮退させるため、bullet だけ Identity transform + baked 座標で描画する (#193)。
         const float first_line_h = GetFirstLineHeight(entry, theme_->font_size_body);
-        const float bullet_y = entry_text_top + first_line_h * 0.5f;
-        const float bullet_x = x - theme_->list_bullet_offset * LIST_BULLET_X_FACTOR;
+        const float bullet_x = SnapToPhysicalPixel(
+            frame_md_pane_x_ + x - theme_->list_bullet_offset * LIST_BULLET_X_FACTOR,
+            frame_dpi_scale_);
+        const float bullet_y = SnapToPhysicalPixel(
+            entry_text_top + first_line_h * 0.5f - frame_snapped_scroll_y_,
+            frame_dpi_scale_);
         const float r = LIST_BULLET_RADIUS;
+        cmds.emplace_back(SetTransformCmd{ D2D1::Matrix3x2F::Identity() });
         if (node.indent_level <= 1) {
             cmds.emplace_back(FillEllipseCmd{ D2D1::Point2F(bullet_x, bullet_y), r, r, theme_->text_color, BrushId::Text });
         }
         else {
             cmds.emplace_back(DrawEllipseCmd{ D2D1::Point2F(bullet_x, bullet_y), r, r, theme_->text_color, 1.0f, BrushId::Text });
         }
+        cmds.emplace_back(SetTransformCmd{ frame_pane_transform_ });
     }
 }
 

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -217,6 +217,12 @@ private:
     float frame_viewport_left_ = 0.0f;
     float frame_viewport_right_ = 0.0f;
     float frame_content_width_ = 0.0f;
+    float frame_dpi_scale_ = 1.0f;
+    // bullet 等で SetTransform を一時 Identity に戻したあと復元するため、
+    // フレーム冒頭で設定した Translation を保持する (#193)。
+    float frame_md_pane_x_ = 0.0f;
+    float frame_snapped_scroll_y_ = 0.0f;
+    D2D1::Matrix3x2F frame_pane_transform_ = D2D1::Matrix3x2F::Identity();
     const TextSelection* frame_selection_ = nullptr;
     HoveredButtons frame_hovered_;
 

--- a/src/ui/ui_constants.h
+++ b/src/ui/ui_constants.h
@@ -94,12 +94,13 @@ inline D2D1_RECT_F PaneRefreshButtonRect(float pane_width, float header_height) 
     return D2D1::RectF(btn_x, btn_y, btn_x + btn_size, btn_y + btn_size);
 }
 
-// スクロール位置を物理ピクセル境界にスナップする。
-// ClearTypeヒンティングのフレーム間変動によるテキストのガタつきを防止する。
+// DIP 値を物理ピクセル境界にスナップする。
+// スクロール位置に適用すれば ClearType ヒンティングのフレーム間変動による
+// テキストのガタつきを防止できる。bullet 等の小半径図形にも有効。
 // dpi_scale: DPI / DEFAULT_DPI（例: 100%→1.0, 150%→1.5, 200%→2.0）
-inline float SnapScrollToPixel(float scroll_y, float dpi_scale) noexcept
+inline float SnapToPhysicalPixel(float v, float dpi_scale) noexcept
 {
-    return std::round(scroll_y * dpi_scale) / dpi_scale;
+    return std::round(v * dpi_scale) / dpi_scale;
 }
 
 // タイトルバーのテキストフォントサイズ（DIP）。

--- a/tests/test_draw_command.cpp
+++ b/tests/test_draw_command.cpp
@@ -616,7 +616,8 @@ TEST_F(CmdGenTest, UnorderedListBulletCenteredOnFirstLine)
 
     for (const auto& cmd : cmds) {
         if (auto* e = std::get_if<FillEllipseCmd>(&cmd)) {
-            EXPECT_NEAR(e->center.y, expected_y, 0.01f);
+            // 物理ピクセル境界へのスナップで最大 0.5DIP ずれるため許容を半 DIP に緩める (#193)
+            EXPECT_NEAR(e->center.y, expected_y, 0.51f);
             return;
         }
     }
@@ -638,11 +639,12 @@ TEST_F(CmdGenTest, NestedListBulletCenteredOnFirstLine)
     int idx = 0;
     for (const auto& cmd : cmds) {
         if (auto* e = std::get_if<FillEllipseCmd>(&cmd)) {
-            EXPECT_NEAR(e->center.y, expected_y0, 0.01f) << "親リスト項目の箇条書き記号";
+            // 物理ピクセル境界へのスナップで最大 0.5DIP ずれるため許容を半 DIP に緩める (#193)
+            EXPECT_NEAR(e->center.y, expected_y0, 0.51f) << "親リスト項目の箇条書き記号";
             idx++;
         }
         else if (auto* d = std::get_if<DrawEllipseCmd>(&cmd)) {
-            EXPECT_NEAR(d->center.y, expected_y1, 0.01f) << "子リスト項目の箇条書き記号";
+            EXPECT_NEAR(d->center.y, expected_y1, 0.51f) << "子リスト項目の箇条書き記号";
             idx++;
         }
     }

--- a/tests/test_draw_command.cpp
+++ b/tests/test_draw_command.cpp
@@ -612,12 +612,12 @@ TEST_F(CmdGenTest, UnorderedListBulletCenteredOnFirstLine)
     auto cmds = gen_.GenerateMdPane(nodes, cache, md_pane, 0.0f, TextSelection{});
 
     // text_layout が null のフォールバック: first_line_h = font_size_body * 1.3
-    float expected_y = cache[0].text_top + theme_.font_size_body * 1.3f * 0.5f;
+    // bullet 中心は物理ピクセル境界へスナップされるため、期待値も同じ規則でスナップする (#193)
+    float expected_y = SnapToPhysicalPixel(cache[0].text_top + theme_.font_size_body * 1.3f * 0.5f, 1.0f);
 
     for (const auto& cmd : cmds) {
         if (auto* e = std::get_if<FillEllipseCmd>(&cmd)) {
-            // 物理ピクセル境界へのスナップで最大 0.5DIP ずれるため許容を半 DIP に緩める (#193)
-            EXPECT_NEAR(e->center.y, expected_y, 0.51f);
+            EXPECT_NEAR(e->center.y, expected_y, 0.01f);
             return;
         }
     }
@@ -633,18 +633,18 @@ TEST_F(CmdGenTest, NestedListBulletCenteredOnFirstLine)
     PaneRect md_pane{ 0, 0, 800.0f, 2000.0f };
     auto cmds = gen_.GenerateMdPane(nodes, cache, md_pane, 0.0f, TextSelection{});
 
-    float expected_y0 = cache[0].text_top + theme_.font_size_body * 1.3f * 0.5f;
-    float expected_y1 = cache[1].text_top + theme_.font_size_body * 1.3f * 0.5f;
+    // bullet 中心は物理ピクセル境界へスナップされるため、期待値も同じ規則でスナップする (#193)
+    float expected_y0 = SnapToPhysicalPixel(cache[0].text_top + theme_.font_size_body * 1.3f * 0.5f, 1.0f);
+    float expected_y1 = SnapToPhysicalPixel(cache[1].text_top + theme_.font_size_body * 1.3f * 0.5f, 1.0f);
 
     int idx = 0;
     for (const auto& cmd : cmds) {
         if (auto* e = std::get_if<FillEllipseCmd>(&cmd)) {
-            // 物理ピクセル境界へのスナップで最大 0.5DIP ずれるため許容を半 DIP に緩める (#193)
-            EXPECT_NEAR(e->center.y, expected_y0, 0.51f) << "親リスト項目の箇条書き記号";
+            EXPECT_NEAR(e->center.y, expected_y0, 0.01f) << "親リスト項目の箇条書き記号";
             idx++;
         }
         else if (auto* d = std::get_if<DrawEllipseCmd>(&cmd)) {
-            EXPECT_NEAR(d->center.y, expected_y1, 0.51f) << "子リスト項目の箇条書き記号";
+            EXPECT_NEAR(d->center.y, expected_y1, 0.01f) << "子リスト項目の箇条書き記号";
             idx++;
         }
     }

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -1573,7 +1573,8 @@ TEST_F(LayoutTest, UnorderedListBulletCenteredWithRealLayout)
 
     for (const auto& cmd : cmds) {
         if (auto* e = std::get_if<FillEllipseCmd>(&cmd)) {
-            EXPECT_NEAR(e->center.y, expected_y, 0.01f)
+            // 物理ピクセル境界へのスナップで最大 0.5DIP ずれるため許容を半 DIP に緩める (#193)
+            EXPECT_NEAR(e->center.y, expected_y, 0.51f)
                 << "箇条書き記号は1行目の中央に配置されるべき";
             return;
         }

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -1563,7 +1563,8 @@ TEST_F(LayoutTest, UnorderedListBulletCenteredWithRealLayout)
     ASSERT_TRUE(SUCCEEDED(cache[0].text_layout->GetLineMetrics(&lm, 1, &lc)));
     ASSERT_GT(lc, 0u);
 
-    float expected_y = cache[0].text_top + lm.height * 0.5f;
+    // bullet 中心は物理ピクセル境界へスナップされるため、期待値も同じ規則でスナップする (#193)
+    float expected_y = SnapToPhysicalPixel(cache[0].text_top + lm.height * 0.5f, 1.0f);
 
     CommandGenerator gen;
     gen.SetTheme(&theme_);
@@ -1573,8 +1574,7 @@ TEST_F(LayoutTest, UnorderedListBulletCenteredWithRealLayout)
 
     for (const auto& cmd : cmds) {
         if (auto* e = std::get_if<FillEllipseCmd>(&cmd)) {
-            // 物理ピクセル境界へのスナップで最大 0.5DIP ずれるため許容を半 DIP に緩める (#193)
-            EXPECT_NEAR(e->center.y, expected_y, 0.51f)
+            EXPECT_NEAR(e->center.y, expected_y, 0.01f)
                 << "箇条書き記号は1行目の中央に配置されるべき";
             return;
         }

--- a/tests/test_ui_constants.cpp
+++ b/tests/test_ui_constants.cpp
@@ -66,91 +66,91 @@ TEST(PointInRectTest, ZeroSizeRect)
 }
 
 // ═══════════════════════════════════════════════
-// SnapScrollToPixel
+// SnapToPhysicalPixel
 // ═══════════════════════════════════════════════
 
 // 整数値はスナップしても変わらない
-TEST(SnapScrollToPixelTest, IntegerValueUnchanged_100Percent)
+TEST(SnapToPhysicalPixelTest, IntegerValueUnchanged_100Percent)
 {
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(10.0f, 1.0f), 10.0f);
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(0.0f, 1.0f), 0.0f);
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(999.0f, 1.0f), 999.0f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(10.0f, 1.0f), 10.0f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(0.0f, 1.0f), 0.0f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(999.0f, 1.0f), 999.0f);
 }
 
 // 100% DPI: サブピクセル値は最寄りの整数にスナップされる
-TEST(SnapScrollToPixelTest, SubPixelSnaps_100Percent)
+TEST(SnapToPhysicalPixelTest, SubPixelSnaps_100Percent)
 {
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(10.3f, 1.0f), 10.0f);
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(10.7f, 1.0f), 11.0f);
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(10.5f, 1.0f), 11.0f); // std::round は0.5を0から離れる方向に丸める
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(10.3f, 1.0f), 10.0f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(10.7f, 1.0f), 11.0f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(10.5f, 1.0f), 11.0f); // std::round は0.5を0から離れる方向に丸める
 }
 
 // 150% DPI: 物理ピクセル境界 = 1/1.5 DIP刻み
-TEST(SnapScrollToPixelTest, SubPixelSnaps_150Percent)
+TEST(SnapToPhysicalPixelTest, SubPixelSnaps_150Percent)
 {
     float scale = 1.5f;
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(10.0f, scale), 10.0f);
-    EXPECT_NEAR(SnapScrollToPixel(10.2f, scale), 10.0f, 1e-5f);
-    EXPECT_NEAR(SnapScrollToPixel(10.4f, scale), 16.0f / 1.5f, 1e-5f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(10.0f, scale), 10.0f);
+    EXPECT_NEAR(SnapToPhysicalPixel(10.2f, scale), 10.0f, 1e-5f);
+    EXPECT_NEAR(SnapToPhysicalPixel(10.4f, scale), 16.0f / 1.5f, 1e-5f);
 }
 
 // 200% DPI: 物理ピクセル境界 = 0.5 DIP刻み
-TEST(SnapScrollToPixelTest, SubPixelSnaps_200Percent)
+TEST(SnapToPhysicalPixelTest, SubPixelSnaps_200Percent)
 {
     float scale = 2.0f;
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(10.0f, scale), 10.0f);
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(10.3f, scale), 10.5f);
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(10.1f, scale), 10.0f);
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(10.75f, scale), 11.0f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(10.0f, scale), 10.0f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(10.3f, scale), 10.5f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(10.1f, scale), 10.0f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(10.75f, scale), 11.0f);
 }
 
 // 200% DPI: ピクセル境界上の値はそのまま保持される
-TEST(SnapScrollToPixelTest, HalfDipValuesPreserved_200Percent)
+TEST(SnapToPhysicalPixelTest, HalfDipValuesPreserved_200Percent)
 {
     float scale = 2.0f;
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(10.5f, scale), 10.5f);
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(11.0f, scale), 11.0f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(10.5f, scale), 10.5f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(11.0f, scale), 11.0f);
 }
 
 // ゼロは常にゼロ
-TEST(SnapScrollToPixelTest, ZeroRemainsZero)
+TEST(SnapToPhysicalPixelTest, ZeroRemainsZero)
 {
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(0.0f, 1.0f), 0.0f);
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(0.0f, 1.5f), 0.0f);
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(0.0f, 2.0f), 0.0f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(0.0f, 1.0f), 0.0f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(0.0f, 1.5f), 0.0f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(0.0f, 2.0f), 0.0f);
 }
 
 // 大きい値でも正しくスナップされる
-TEST(SnapScrollToPixelTest, LargeValueSnaps)
+TEST(SnapToPhysicalPixelTest, LargeValueSnaps)
 {
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(12345.3f, 1.0f), 12345.0f);
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(12345.7f, 1.0f), 12346.0f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(12345.3f, 1.0f), 12345.0f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(12345.7f, 1.0f), 12346.0f);
 }
 
 // 125% DPI: 整数DIPが非整数物理ピクセルになるケース
-TEST(SnapScrollToPixelTest, SubPixelSnaps_125Percent)
+TEST(SnapToPhysicalPixelTest, SubPixelSnaps_125Percent)
 {
     float scale = 1.25f;
     // 10.0 * 1.25 = 12.5 → std::round(12.5) = 13 → 13 / 1.25 = 10.4
-    EXPECT_NEAR(SnapScrollToPixel(10.0f, scale), 10.4f, 1e-5f);
+    EXPECT_NEAR(SnapToPhysicalPixel(10.0f, scale), 10.4f, 1e-5f);
 }
 
 // スムーススクロール補間で生成される典型的な端数値
-TEST(SnapScrollToPixelTest, SmoothScrollInterpolationValues)
+TEST(SnapToPhysicalPixelTest, SmoothScrollInterpolationValues)
 {
     float scale = 1.0f;
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(25.0f, scale), 25.0f);
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(43.75f, scale), 44.0f);
-    EXPECT_FLOAT_EQ(SnapScrollToPixel(57.8125f, scale), 58.0f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(25.0f, scale), 25.0f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(43.75f, scale), 44.0f);
+    EXPECT_FLOAT_EQ(SnapToPhysicalPixel(57.8125f, scale), 58.0f);
 }
 
 // スナップ前後でスクロール差が1物理ピクセル未満であることを確認
-TEST(SnapScrollToPixelTest, SnapErrorWithinOnePixel)
+TEST(SnapToPhysicalPixelTest, SnapErrorWithinOnePixel)
 {
     float scales[] = { 1.0f, 1.25f, 1.5f, 1.75f, 2.0f };
     for (float scale : scales) {
         for (float v = 0.0f; v < 100.0f; v += 0.1f) {
-            float snapped = SnapScrollToPixel(v, scale);
+            float snapped = SnapToPhysicalPixel(v, scale);
             float error_in_pixels = std::abs((snapped - v) * scale);
             EXPECT_LE(error_in_pixels, 0.5f + 1e-5f)
                 << "scale=" << scale << " value=" << v;


### PR DESCRIPTION
## Summary
- `SetTransform(Translation(0, -scroll_y))` 経由で半径 3px の楕円を描画すると、scroll_y が大きい状態で Direct2D 内部の精度落ちにより円が bounding rect (長方形) に縮退する問題を修正。
- bullet 描画時だけ Identity transform に切り替え、ペイン座標へ CPU 側で baked して渡すことで回避。
- ついでに物理ピクセル境界へスナップし、小半径ゆえに目立っていたサブピクセル AA のばらつきも抑制。
- simplify レビュー反映: `SnapScrollToPixel` を汎用版 `SnapToPhysicalPixel` に統一、フレーム冒頭で復元 Translation matrix をキャッシュして bullet で再利用、テスト許容差を 0.5 DIP スナップに合わせて `0.51f` に調整。

## Test plan
- [x] `cmake --build build --config Release` が通ること
- [x] `build/tests/Release/mendo_tests.exe --gtest_brief=1` が 2159/2159 PASS すること
- [x] 大きめの Markdown を開いて高速スクロール後にネスト含む全 bullet が円のまま表示されることを目視確認

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)