### PR TITLE
fix(app): 小さい md ファイルでスクロール位置が復元できない不具合を修正 (#196)

### DIFF
--- a/src/app/app.h
+++ b/src/app/app.h
@@ -130,6 +130,9 @@ public:
     }
     RECT GetSearchEditRect();
 
+    // 起動時の preload が App::Init より先に完了した場合、Init 内の AttachOrApplyPreload が
+    // 同期で OnParseComplete → FinishLoadMarkdownFile を呼ぶ。復元情報は Init 呼び出し前に
+    // セットしておく必要がある。
     constexpr void SetPendingRestoreNode(int node, int offset) noexcept
     {
         state_.view.scroll_restore.SetNodeRestore(node, offset);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,9 @@
 #include <shellapi.h>
 #include <shellscalingapi.h>
 #include <commctrl.h>
+#include <filesystem>
 #include <memory>
+#include <system_error>
 
 namespace {
 
@@ -45,7 +47,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nC
     // 起動時のドキュメント決定フロー:
     //   引数が有効なファイル  → そのファイルを開く
     //   引数なし              → 前回ファイル復元、無ければヘルプ
-    //   引数あり かつ無効     → 前回復元せず直接ヘルプ (ユーザの指定意図を尊重)
+    //   引数あり かつ無効     → 前回復元せず直接ヘルプ
     // unique_ptr で管理することで、window.Create 失敗の早期 return でも LocalFree される。
     int argc = 0;
     const std::unique_ptr<LPWSTR, LocalFreeDeleter> argv_owner(CommandLineToArgvW(GetCommandLineW(), &argc));
@@ -54,14 +56,27 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nC
     const DWORD arg_attrs = arg_given ? GetFileAttributesW(argv[1]) : INVALID_FILE_ATTRIBUTES;
     const bool has_valid_file = arg_attrs != INVALID_FILE_ATTRIBUTES && !(arg_attrs & FILE_ATTRIBUTE_DIRECTORY);
 
+    // SessionService::LoadLastFilePath は UNC/デバイスパスや実在しないパスを除外する。
+    SessionService session{ config };
+
     std::pmr::wstring preload_path;
     bool restore_scroll = false;
     if (has_valid_file) {
         preload_path.assign(argv[1]);
+        // 引数のパスが前回終了時のファイルと一致していたら同じくスクロール位置を復元する。
+        // 大文字小文字・スラッシュ違いを吸収するため filesystem::equivalent で比較する。
+        const auto last_path = session.LoadLastFilePath();
+        if (!last_path.empty()) {
+            std::error_code ec;
+            if (std::filesystem::equivalent(
+                    std::filesystem::path(preload_path),
+                    std::filesystem::path(last_path),
+                    ec)) {
+                restore_scroll = true;
+            }
+        }
     }
     else if (!arg_given) {
-        // SessionService::LoadLastFilePath は UNC/デバイスパスや実在しないパスを除外する。
-        SessionService session{ config };
         preload_path = session.LoadLastFilePath();
         if (!preload_path.empty()) {
             restore_scroll = true;
@@ -80,6 +95,12 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nC
             window.StartPreloadAsync(std::move(preload_path));
         }
 
+        // App::Init 内の AttachOrApplyPreload が preload 完了時に同期で OnParseComplete を呼ぶ
+        // パスがあるため、Create の前に復元情報をセットしておく。
+        if (restore_scroll) {
+            window.RestoreScrollPosition();
+        }
+
         {
             MENDO_PROFILE("wWinMain - Create Window");
             if (!window.Create(hInstance, nCmdShow)) {
@@ -88,9 +109,6 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nC
             }
         }
 
-        if (restore_scroll) {
-            window.RestoreScrollPosition();
-        }
         if (!has_preload) {
             wchar_t cwd[MAX_PATH];
             if (GetCurrentDirectoryW(MAX_PATH, cwd)) {

--- a/src/window/window.h
+++ b/src/window/window.h
@@ -22,7 +22,7 @@ public:
     void ShowDirectory(std::wstring_view dir_path);
     void StartPreloadAsync(std::pmr::wstring path);
 
-    // 前回セッションのスクロール位置を復元する（LoadMarkdownFileの前に呼ぶ）
+    // App::Init が AttachOrApplyPreload で同期復元するパスに備えて、Create より前に呼ぶ。
     void RestoreScrollPosition();
 
 private:


### PR DESCRIPTION
## Summary
- `Win32Window::RestoreScrollPosition()` の呼び出しを `Create()` の **後** から **前** に移動。preload が `App::Init` より早く完了する小さいファイルでは `AttachOrApplyPreload` が `AppliedSync` を返し、Init 内で同期的に `OnParseComplete` → `FinishLoadMarkdownFile` まで走るため、Create 後の復元呼び出しでは間に合わず scroll_y が 0 にリセットされていた。
- 引数指定で開いたパスが前回終了時のファイルと一致した場合もスクロール位置を復元するように拡張 (`std::filesystem::equivalent` で大文字小文字・スラッシュ差異を吸収)。

## Why this is the fix
issue #196 のサイズ依存挙動 (小さいファイルでは復元失敗、100MB では確実に復元) は、preload 完了タイミングと `App::Init` 完了タイミングの競合で説明できる。`app_` は `Win32Window` のコンストラクタで生成済みのため、`Create()` (= `App::Init`) を呼ぶ前に `state_.view.scroll_restore.SetNodeRestore(...)` を実行しても安全 (default-constructed `AppState` への書き込みのみ)。

## Test plan
- [x] 既存テスト 2159 件パス
- [x] 小さい md ファイル (数 KB) でスクロールしてアプリ終了 → 再起動でスクロール位置が復元されること
- [x] 同じファイルをコマンドライン引数で起動した場合も同様に復元されること
- [x] 別のファイルを引数で起動した場合は復元されない (= 先頭から表示) こと
- [x] ヘルプ表示時など前回ファイルが無いケースでもクラッシュしないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)