### PR TITLE
feat(core): ダブルクリック選択を CJK 文字種カテゴリへ拡張 (#194)

### DIFF
--- a/src/app/app_clipboard.cpp
+++ b/src/app/app_clipboard.cpp
@@ -32,7 +32,12 @@ void App::OnLButtonDblClk(int px, int py)
     if (hit.node_index < 0) {
         return;
     }
-    const auto& text = state_.document.doc.GetNodes()[hit.node_index].GetText();
+    const auto& node = state_.document.doc.GetNodes()[hit.node_index];
+    // テーブルノードは owned_text_ が空で、HitTestTable が concat_text 内のグローバル
+    // offset を text_pos として返す。Node::GetText() ではなく concat_text を見る。
+    const std::string_view text = (node.type == NodeType::Table && node.table_data() != nullptr)
+        ? std::string_view{ node.table_data()->concat_text }
+        : node.GetText();
     if (text.empty()) {
         return;
     }

--- a/src/core/document_utils.cpp
+++ b/src/core/document_utils.cpp
@@ -112,7 +112,11 @@ constexpr DecodedCp DecodeAt(std::string_view text, uint32_t pos) noexcept
         return { 0xFFFD, 1 };
     }
     for (uint32_t i = 1; i < len; ++i) {
-        cp = (cp << 6) | (static_cast<unsigned char>(text[pos + i]) & 0x3F);
+        const auto b = static_cast<unsigned char>(text[pos + i]);
+        if ((b & 0xC0) != 0x80) {
+            return { 0xFFFD, 1 };
+        }
+        cp = (cp << 6) | (b & 0x3F);
     }
     return { cp, len };
 }

--- a/src/core/document_utils.cpp
+++ b/src/core/document_utils.cpp
@@ -22,43 +22,35 @@ namespace {
 
 // ダブルクリック選択時の文字種カテゴリ。同じカテゴリが連続する code point を 1 単語として扱う。
 enum class CharCategory : uint8_t {
-    AsciiWord,      // [A-Za-z0-9_]
-    Hiragana,       // U+3041–U+309F (繰り返し記号 ゝゞ 含む)
-    Katakana,       // U+30A0–U+30FF (長音 ー 含む) + U+31F0–U+31FF + 半角ｶﾅ U+FF65–U+FF9F
-    Han,            // CJK 統合漢字 + 互換漢字 + 拡張 + 「々〆〇」
-    FullwidthAlnum, // 全角英数 (FF10–FF19, FF21–FF3A, FF41–FF5A)
-    Other,          // 上記以外。ダブルクリックでは選択しない。
+    AsciiWord,
+    Hiragana,
+    Katakana,
+    Han,
+    FullwidthAlnum,
+    Other,
 };
 
 constexpr CharCategory CategorizeCodePoint(uint32_t cp) noexcept
 {
     if (cp < 0x80) {
-        if ((cp >= 'a' && cp <= 'z') || (cp >= 'A' && cp <= 'Z') || (cp >= '0' && cp <= '9') || cp == '_') {
-            return CharCategory::AsciiWord;
-        }
-        return CharCategory::Other;
+        return ascii_util::IsAsciiWordChar(static_cast<char>(cp)) ? CharCategory::AsciiWord : CharCategory::Other;
     }
-    // CJK 漢字繰り返し記号 (々〆〇)。ひらがな/カタカナより先に判定。
+    // 漢字繰り返し記号 (々〆〇) はひらがな/カタカナ範囲より先に判定。
     if (cp == 0x3005 || cp == 0x3006 || cp == 0x3007) {
         return CharCategory::Han;
     }
-    // ひらがな (U+3041–U+309F)
     if (cp >= 0x3041 && cp <= 0x309F) {
         return CharCategory::Hiragana;
     }
-    // カタカナ + カタカナ拡張 + 半角ｶﾅ
     if ((cp >= 0x30A0 && cp <= 0x30FF) || (cp >= 0x31F0 && cp <= 0x31FF) || (cp >= 0xFF65 && cp <= 0xFF9F)) {
         return CharCategory::Katakana;
     }
-    // CJK 統合漢字 + 拡張 A + 互換漢字
     if ((cp >= 0x3400 && cp <= 0x4DBF) || (cp >= 0x4E00 && cp <= 0x9FFF) || (cp >= 0xF900 && cp <= 0xFAFF)) {
         return CharCategory::Han;
     }
-    // CJK 拡張 B–F (BMP 外、サロゲートペアで表現)
     if (cp >= 0x20000 && cp <= 0x2FFFF) {
         return CharCategory::Han;
     }
-    // 全角英数
     if ((cp >= 0xFF10 && cp <= 0xFF19) || (cp >= 0xFF21 && cp <= 0xFF3A) || (cp >= 0xFF41 && cp <= 0xFF5A)) {
         return CharCategory::FullwidthAlnum;
     }

--- a/src/core/document_utils.cpp
+++ b/src/core/document_utils.cpp
@@ -19,6 +19,150 @@ std::pmr::string ToLowerAscii(std::string_view text)
 }
 
 namespace {
+
+// ダブルクリック選択時の文字種カテゴリ。同じカテゴリが連続する code point を 1 単語として扱う。
+enum class CharCategory : uint8_t {
+    AsciiWord,      // [A-Za-z0-9_]
+    Hiragana,       // U+3041–U+309F (繰り返し記号 ゝゞ 含む)
+    Katakana,       // U+30A0–U+30FF (長音 ー 含む) + U+31F0–U+31FF + 半角ｶﾅ U+FF65–U+FF9F
+    Han,            // CJK 統合漢字 + 互換漢字 + 拡張 + 「々〆〇」
+    FullwidthAlnum, // 全角英数 (FF10–FF19, FF21–FF3A, FF41–FF5A)
+    Other,          // 上記以外。ダブルクリックでは選択しない。
+};
+
+constexpr CharCategory CategorizeCodePoint(uint32_t cp) noexcept
+{
+    if (cp < 0x80) {
+        if ((cp >= 'a' && cp <= 'z') || (cp >= 'A' && cp <= 'Z') || (cp >= '0' && cp <= '9') || cp == '_') {
+            return CharCategory::AsciiWord;
+        }
+        return CharCategory::Other;
+    }
+    // CJK 漢字繰り返し記号 (々〆〇)。ひらがな/カタカナより先に判定。
+    if (cp == 0x3005 || cp == 0x3006 || cp == 0x3007) {
+        return CharCategory::Han;
+    }
+    // ひらがな (U+3041–U+309F)
+    if (cp >= 0x3041 && cp <= 0x309F) {
+        return CharCategory::Hiragana;
+    }
+    // カタカナ + カタカナ拡張 + 半角ｶﾅ
+    if ((cp >= 0x30A0 && cp <= 0x30FF) || (cp >= 0x31F0 && cp <= 0x31FF) || (cp >= 0xFF65 && cp <= 0xFF9F)) {
+        return CharCategory::Katakana;
+    }
+    // CJK 統合漢字 + 拡張 A + 互換漢字
+    if ((cp >= 0x3400 && cp <= 0x4DBF) || (cp >= 0x4E00 && cp <= 0x9FFF) || (cp >= 0xF900 && cp <= 0xFAFF)) {
+        return CharCategory::Han;
+    }
+    // CJK 拡張 B–F (BMP 外、サロゲートペアで表現)
+    if (cp >= 0x20000 && cp <= 0x2FFFF) {
+        return CharCategory::Han;
+    }
+    // 全角英数
+    if ((cp >= 0xFF10 && cp <= 0xFF19) || (cp >= 0xFF21 && cp <= 0xFF3A) || (cp >= 0xFF41 && cp <= 0xFF5A)) {
+        return CharCategory::FullwidthAlnum;
+    }
+    return CharCategory::Other;
+}
+
+struct DecodedCp {
+    uint32_t cp;
+    uint32_t len;
+};
+
+// UTF-8: pos がマルチバイト継続バイトを指したら先頭バイトまで戻す。
+constexpr uint32_t SnapToCpStart(std::string_view text, uint32_t pos) noexcept
+{
+    while (pos > 0 && (static_cast<unsigned char>(text[pos]) & 0xC0) == 0x80) {
+        --pos;
+    }
+    return pos;
+}
+
+// UTF-16: pos が low surrogate を指したら直前の high surrogate まで戻す。
+constexpr uint32_t SnapToCpStart(std::wstring_view text, uint32_t pos) noexcept
+{
+    if (pos > 0) {
+        const auto c = static_cast<uint16_t>(text[pos]);
+        const auto p = static_cast<uint16_t>(text[pos - 1]);
+        if (c >= 0xDC00 && c <= 0xDFFF && p >= 0xD800 && p <= 0xDBFF) {
+            return pos - 1;
+        }
+    }
+    return pos;
+}
+
+// UTF-8 を pos から 1 code point decode。不正バイトは U+FFFD として 1 byte 進める。
+constexpr DecodedCp DecodeAt(std::string_view text, uint32_t pos) noexcept
+{
+    const auto first = static_cast<unsigned char>(text[pos]);
+    if (first < 0x80) {
+        return { first, 1 };
+    }
+    uint32_t cp = 0;
+    uint32_t len = 0;
+    if ((first & 0xE0) == 0xC0) {
+        cp = first & 0x1F;
+        len = 2;
+    }
+    else if ((first & 0xF0) == 0xE0) {
+        cp = first & 0x0F;
+        len = 3;
+    }
+    else if ((first & 0xF8) == 0xF0) {
+        cp = first & 0x07;
+        len = 4;
+    }
+    else {
+        return { 0xFFFD, 1 };
+    }
+    if (static_cast<size_t>(pos) + len > text.size()) {
+        return { 0xFFFD, 1 };
+    }
+    for (uint32_t i = 1; i < len; ++i) {
+        cp = (cp << 6) | (static_cast<unsigned char>(text[pos + i]) & 0x3F);
+    }
+    return { cp, len };
+}
+
+// UTF-16 を pos から 1 code point decode。サロゲートペアを考慮。
+constexpr DecodedCp DecodeAt(std::wstring_view text, uint32_t pos) noexcept
+{
+    const auto c = static_cast<uint16_t>(text[pos]);
+    if (c >= 0xD800 && c <= 0xDBFF && static_cast<size_t>(pos) + 1 < text.size()) {
+        const auto c2 = static_cast<uint16_t>(text[pos + 1]);
+        if (c2 >= 0xDC00 && c2 <= 0xDFFF) {
+            const uint32_t cp = 0x10000u + ((static_cast<uint32_t>(c) - 0xD800u) << 10) + (static_cast<uint32_t>(c2) - 0xDC00u);
+            return { cp, 2 };
+        }
+    }
+    return { c, 1 };
+}
+
+// UTF-8: pos の直前の code point を decode。pos > 0 が前提。
+constexpr DecodedCp DecodePrev(std::string_view text, uint32_t pos) noexcept
+{
+    uint32_t start = pos - 1;
+    while (start > 0 && (static_cast<unsigned char>(text[start]) & 0xC0) == 0x80) {
+        --start;
+    }
+    return DecodeAt(text, start);
+}
+
+// UTF-16: pos の直前の code point を decode。pos > 0 が前提。
+constexpr DecodedCp DecodePrev(std::wstring_view text, uint32_t pos) noexcept
+{
+    uint32_t start = pos - 1;
+    if (start > 0) {
+        const auto c = static_cast<uint16_t>(text[start]);
+        const auto p = static_cast<uint16_t>(text[start - 1]);
+        if (c >= 0xDC00 && c <= 0xDFFF && p >= 0xD800 && p <= 0xDBFF) {
+            --start;
+        }
+    }
+    return DecodeAt(text, start);
+}
+
 template <typename SV>
 WordBoundary FindWordBoundariesImpl(SV text, uint32_t pos) noexcept
 {
@@ -29,25 +173,38 @@ WordBoundary FindWordBoundariesImpl(SV text, uint32_t pos) noexcept
     if (pos >= text.size()) {
         pos = static_cast<uint32_t>(text.size()) - 1;
     }
-    if (!ascii_util::IsAsciiWordChar(text[pos])) {
+    pos = SnapToCpStart(text, pos);
+
+    const auto here = DecodeAt(text, pos);
+    const auto cat = CategorizeCodePoint(here.cp);
+    if (cat == CharCategory::Other) {
         return result;
     }
 
-    uint32_t word_start = pos;
-    while (word_start > 0 && ascii_util::IsAsciiWordChar(text[word_start - 1])) {
-        word_start--;
+    uint32_t start = pos;
+    while (start > 0) {
+        const auto prev = DecodePrev(text, start);
+        if (CategorizeCodePoint(prev.cp) != cat) {
+            break;
+        }
+        start -= prev.len;
     }
 
-    uint32_t word_end = pos + 1;
-    while (word_end < text.size() && ascii_util::IsAsciiWordChar(text[word_end])) {
-        word_end++;
+    uint32_t end = pos + here.len;
+    while (end < text.size()) {
+        const auto next = DecodeAt(text, end);
+        if (CategorizeCodePoint(next.cp) != cat) {
+            break;
+        }
+        end += next.len;
     }
 
-    result.start = word_start;
-    result.end = word_end;
+    result.start = start;
+    result.end = end;
     result.found = true;
     return result;
 }
+
 } // namespace
 
 WordBoundary FindWordBoundaries(std::string_view text, uint32_t pos) noexcept

--- a/src/core/document_utils.cpp
+++ b/src/core/document_utils.cpp
@@ -135,28 +135,11 @@ constexpr DecodedCp DecodeAt(std::wstring_view text, uint32_t pos) noexcept
     return { c, 1 };
 }
 
-// UTF-8: pos の直前の code point を decode。pos > 0 が前提。
-constexpr DecodedCp DecodePrev(std::string_view text, uint32_t pos) noexcept
+// pos の直前の code point を decode。pos > 0 が前提。
+template <typename SV>
+constexpr DecodedCp DecodePrev(SV text, uint32_t pos) noexcept
 {
-    uint32_t start = pos - 1;
-    while (start > 0 && (static_cast<unsigned char>(text[start]) & 0xC0) == 0x80) {
-        --start;
-    }
-    return DecodeAt(text, start);
-}
-
-// UTF-16: pos の直前の code point を decode。pos > 0 が前提。
-constexpr DecodedCp DecodePrev(std::wstring_view text, uint32_t pos) noexcept
-{
-    uint32_t start = pos - 1;
-    if (start > 0) {
-        const auto c = static_cast<uint16_t>(text[start]);
-        const auto p = static_cast<uint16_t>(text[start - 1]);
-        if (c >= 0xDC00 && c <= 0xDFFF && p >= 0xD800 && p <= 0xDBFF) {
-            --start;
-        }
-    }
-    return DecodeAt(text, start);
+    return DecodeAt(text, SnapToCpStart(text, pos - 1));
 }
 
 template <typename SV>

--- a/src/core/document_utils.h
+++ b/src/core/document_utils.h
@@ -14,9 +14,12 @@ struct WordBoundary {
     bool found = false;
 };
 
-// テキスト内の指定位置周辺の単語境界を検索する。
-// 「単語文字」は英数字またはアンダースコア。
-// 位置が単語文字上にあれば {start, end, true} を返し、そうでなければ {0, 0, false} を返す。
+// テキスト内の指定位置周辺の「同一文字種カテゴリの連続区間」を検索する。
+// カテゴリ: ASCII単語(英数+_) / ひらがな / カタカナ / 漢字 / 全角英数 / その他。
+// 「その他」(空白・記号など) のときは {0, 0, false} を返す。
+// 単語単位の形態素解析は行わない (UAX#29 簡易版)。
+// pos の単位は UTF-8 版がバイト、UTF-16 版がコードユニット。
+// pos がマルチバイト/サロゲートの途中を指した場合はその code point の先頭へスナップする。
 WordBoundary FindWordBoundaries(std::string_view text, uint32_t pos) noexcept;
 WordBoundary FindWordBoundaries(std::wstring_view text, uint32_t pos) noexcept;
 

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -662,12 +662,13 @@ TEST(FindWordBoundaries, PositionBeyondEnd)
     EXPECT_EQ(result.end, 5u);
 }
 
-TEST(FindWordBoundaries, NonAlphanumericAtPosition)
+TEST(FindWordBoundaries, KatakanaSequence)
 {
-    // CJK文字はIsCharAlphaNumericWで単語文字として扱われないため
-    // ダブルクリックでは選択されないべき
+    // カタカナ連続区間は同一カテゴリで一塊に選択される (UTF-8 で各 3 byte)。
     auto result = FindWordBoundaries("テスト test", 0);
-    EXPECT_FALSE(result.found);
+    ASSERT_TRUE(result.found);
+    EXPECT_EQ(result.start, 0u);
+    EXPECT_EQ(result.end, 9u);
 }
 
 TEST(FindWordBoundaries, AsciiWordAfterCjk)
@@ -703,10 +704,13 @@ TEST(FindWordBoundariesW, AsciiWordAfterCjk)
     EXPECT_EQ(result.end, 8u);
 }
 
-TEST(FindWordBoundariesW, CjkNotSelected)
+TEST(FindWordBoundariesW, KatakanaSequence)
 {
+    // UTF-16 のカタカナ連続区間 (各 1 wchar_t)。
     auto result = FindWordBoundaries(std::wstring_view{ L"テスト" }, 0);
-    EXPECT_FALSE(result.found);
+    ASSERT_TRUE(result.found);
+    EXPECT_EQ(result.start, 0u);
+    EXPECT_EQ(result.end, 3u);
 }
 
 // ============================================================
@@ -1080,6 +1084,98 @@ TEST(FindWordBoundaries, MixedPunctuationAndWords)
     ASSERT_TRUE(result.found);
     EXPECT_EQ(result.start, 1u);
     EXPECT_EQ(result.end, 6u);
+}
+
+// ---- FindWordBoundaries 文字種カテゴリ (UTF-8) ----
+
+TEST(FindWordBoundaries, HiraganaSequence)
+{
+    // 「これはテスト」で「これは」(ひらがな) の最初の文字をクリック
+    // ひらがな = 各 3 byte。「これは」= 9 byte、「テスト」は別カテゴリで止まる。
+    auto result = FindWordBoundaries("これはテスト", 0);
+    ASSERT_TRUE(result.found);
+    EXPECT_EQ(result.start, 0u);
+    EXPECT_EQ(result.end, 9u);
+}
+
+TEST(FindWordBoundaries, HanSequence)
+{
+    // 「日本語」(漢字 3 文字, 各 3 byte = 9 byte)
+    auto result = FindWordBoundaries("日本語です", 3);
+    ASSERT_TRUE(result.found);
+    EXPECT_EQ(result.start, 0u);
+    EXPECT_EQ(result.end, 9u);
+}
+
+TEST(FindWordBoundaries, HiraganaAfterHan)
+{
+    // 「日本語です」の「で」(offset 9) をクリック → 「です」(6 byte) が選択
+    auto result = FindWordBoundaries("日本語です", 9);
+    ASSERT_TRUE(result.found);
+    EXPECT_EQ(result.start, 9u);
+    EXPECT_EQ(result.end, 15u);
+}
+
+TEST(FindWordBoundaries, KatakanaWithLongVowel)
+{
+    // 「コーヒー」: 長音「ー」(U+30FC) はカタカナと同カテゴリ。各 3 byte = 12 byte。
+    auto result = FindWordBoundaries("コーヒー", 3);
+    ASSERT_TRUE(result.found);
+    EXPECT_EQ(result.start, 0u);
+    EXPECT_EQ(result.end, 12u);
+}
+
+TEST(FindWordBoundaries, FullwidthAlnumSequence)
+{
+    // 全角「ＡＢＣ１２３」: U+FF21 U+FF22 U+FF23 U+FF11 U+FF12 U+FF13 (各 3 byte = 18 byte)
+    auto result = FindWordBoundaries("ＡＢＣ１２３", 6);
+    ASSERT_TRUE(result.found);
+    EXPECT_EQ(result.start, 0u);
+    EXPECT_EQ(result.end, 18u);
+}
+
+TEST(FindWordBoundaries, PosOnUtf8ContinuationByte)
+{
+    // 「テスト」の中間バイト (例: 1) を指しても先頭バイトにスナップして同じ結果
+    auto result = FindWordBoundaries("テスト", 1);
+    ASSERT_TRUE(result.found);
+    EXPECT_EQ(result.start, 0u);
+    EXPECT_EQ(result.end, 9u);
+}
+
+TEST(FindWordBoundaries, FullwidthSymbolNotSelected)
+{
+    // 全角句読点「、」(U+3001) は Other → 選択されない
+    auto result = FindWordBoundaries("、", 0);
+    EXPECT_FALSE(result.found);
+}
+
+TEST(FindWordBoundaries, HanRepetitionMark)
+{
+    // 「人々」: 「々」(U+3005) は Han として「人」(U+4EBA) と連続して選択される
+    auto result = FindWordBoundaries("人々", 0);
+    ASSERT_TRUE(result.found);
+    EXPECT_EQ(result.start, 0u);
+    EXPECT_EQ(result.end, 6u);
+}
+
+// ---- FindWordBoundaries 文字種カテゴリ (UTF-16) ----
+
+TEST(FindWordBoundariesW, HiraganaSequence)
+{
+    auto result = FindWordBoundaries(std::wstring_view{ L"これはテスト" }, 0);
+    ASSERT_TRUE(result.found);
+    EXPECT_EQ(result.start, 0u);
+    EXPECT_EQ(result.end, 3u);
+}
+
+TEST(FindWordBoundariesW, HanAndHiraganaBoundary)
+{
+    // 「日本語です」 (UTF-16) で 「で」(offset 3) をクリック → 「です」が選択
+    auto result = FindWordBoundaries(std::wstring_view{ L"日本語です" }, 3);
+    ASSERT_TRUE(result.found);
+    EXPECT_EQ(result.start, 3u);
+    EXPECT_EQ(result.end, 5u);
 }
 
 // ---- ExtractFilename 追加テスト ----

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -1178,6 +1178,45 @@ TEST(FindWordBoundariesW, HanAndHiraganaBoundary)
     EXPECT_EQ(result.end, 5u);
 }
 
+// ---- BMP 外文字 (4byte UTF-8 / サロゲートペア) ----
+
+TEST(FindWordBoundaries, HanInSupplementaryPlane)
+{
+    // 「𠮷田」: 𠮷 = U+20BB7 (UTF-8 4byte = F0 A0 AE B7), 田 = U+7530 (3byte)。
+    // 両方 Han カテゴリで連続して選択されるはず。
+    auto result = FindWordBoundaries("𠮷田", 0);
+    ASSERT_TRUE(result.found);
+    EXPECT_EQ(result.start, 0u);
+    EXPECT_EQ(result.end, 7u);
+}
+
+TEST(FindWordBoundaries, PosOnUtf8FourByteContinuation)
+{
+    // 「𠮷田」の 4byte シーケンス内側 (pos=2) を指しても先頭にスナップ。
+    auto result = FindWordBoundaries("𠮷田", 2);
+    ASSERT_TRUE(result.found);
+    EXPECT_EQ(result.start, 0u);
+    EXPECT_EQ(result.end, 7u);
+}
+
+TEST(FindWordBoundariesW, HanSurrogatePair)
+{
+    // L"𠮷田" = { 0xD842, 0xDFB7, 0x7530 }、長さ 3。
+    auto result = FindWordBoundaries(std::wstring_view{ L"𠮷田" }, 0);
+    ASSERT_TRUE(result.found);
+    EXPECT_EQ(result.start, 0u);
+    EXPECT_EQ(result.end, 3u);
+}
+
+TEST(FindWordBoundariesW, PosOnLowSurrogate)
+{
+    // pos=1 (low surrogate) を指しても high surrogate にスナップして同じ結果。
+    auto result = FindWordBoundaries(std::wstring_view{ L"𠮷田" }, 1);
+    ASSERT_TRUE(result.found);
+    EXPECT_EQ(result.start, 0u);
+    EXPECT_EQ(result.end, 3u);
+}
+
 // ---- ExtractFilename 追加テスト ----
 
 TEST(ExtractFilename, UncPath)


### PR DESCRIPTION
## Summary

- ダブルクリック単語選択の判定を ASCII 英数 + `_` のみから「同一文字種カテゴリの連続区間」へ拡張し、CJK でも一塊が選択されるようにする (Closes #194)
- カテゴリは **ASCII 単語 / ひらがな / カタカナ (長音含む) / 漢字 (々〆〇含む) / 全角英数 / その他** の 6 種類。「その他」(空白・記号) のときは従来通り選択しない (UAX #29 簡易版、形態素解析は行わない)
- UTF-8 (md ペイン) はマルチバイト境界、UTF-16 (検索入力欄) はサロゲートペアを考慮し、`pos` が code point の中間を指した場合は先頭にスナップ

## 挙動の変化

| 入力 | クリック位置 | 選択範囲 |
|---|---|---|
| `テスト test` | `テ` | `テスト` (旧: 何もしない) |
| `日本語です` | `本` | `日本語` |
| `日本語です` | `で` | `です` |
| `コーヒー` | `ー` | `コーヒー` (長音はカタカナ扱い) |
| `ＡＢＣ１２３` | 任意 | `ＡＢＣ１２３` |
| `(hello)` | `l` | `hello` (従来通り) |
| `   ` (空白) | 任意 | 選択なし (従来通り) |

## Test plan

- [x] `mendo_tests.exe --gtest_filter=FindWordBoundaries*:FindWordBoundariesW*` が全 28 件パス
- [x] 全テスト `mendo_tests.exe` が 2169 件パス
- [ ] 実機で md ペイン上の日本語をダブルクリック → 連続するひらがな・カタカナ・漢字が選択される
- [ ] 検索入力欄 (Ctrl+F) で日本語をダブルクリック → 同様に選択される

🤖 Generated with [Claude Code](https://claude.com/claude-code)