### PR TITLE
refactor: WideViewCache に identity 検出を集約し simplify レビュー反映

### DIFF
--- a/src/app/app.h
+++ b/src/app/app.h
@@ -130,9 +130,7 @@ public:
     }
     RECT GetSearchEditRect();
 
-    // 起動時の preload が App::Init より先に完了した場合、Init 内の AttachOrApplyPreload が
-    // 同期で OnParseComplete → FinishLoadMarkdownFile を呼ぶ。復元情報は Init 呼び出し前に
-    // セットしておく必要がある。
+    // Init() より前に呼ぶこと。preload 即時完了パスは Init 内で復元情報を参照する。
     constexpr void SetPendingRestoreNode(int node, int offset) noexcept
     {
         state_.view.scroll_restore.SetNodeRestore(node, offset);

--- a/src/core/document_utils.cpp
+++ b/src/core/document_utils.cpp
@@ -46,10 +46,7 @@ constexpr CharCategory CategorizeCodePoint(uint32_t cp) noexcept
     if ((cp >= 0x30A0 && cp <= 0x30FF) || (cp >= 0x31F0 && cp <= 0x31FF) || (cp >= 0xFF65 && cp <= 0xFF9F)) {
         return CharCategory::Katakana;
     }
-    if ((cp >= 0x3400 && cp <= 0x4DBF) || (cp >= 0x4E00 && cp <= 0x9FFF) || (cp >= 0xF900 && cp <= 0xFAFF)) {
-        return CharCategory::Han;
-    }
-    if (cp >= 0x20000 && cp <= 0x2FFFF) {
+    if ((cp >= 0x3400 && cp <= 0x4DBF) || (cp >= 0x4E00 && cp <= 0x9FFF) || (cp >= 0xF900 && cp <= 0xFAFF) || (cp >= 0x20000 && cp <= 0x2FFFF)) {
         return CharCategory::Han;
     }
     if ((cp >= 0xFF10 && cp <= 0xFF19) || (cp >= 0xFF21 && cp <= 0xFF3A) || (cp >= 0xFF41 && cp <= 0xFF5A)) {

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -108,12 +108,8 @@ HitTestService::HitResult HitTestService::HitTest(const MdPaneHitContext& ctx) c
         return result;
     }
 
-    if (ctx.nodes.data() != prev_nodes_data_ || ctx.nodes.size() != prev_nodes_size_) {
-        md_wv_cache_.Reset();
-        cell_wv_cache_.Reset();
-        prev_nodes_data_ = ctx.nodes.data();
-        prev_nodes_size_ = ctx.nodes.size();
-    }
+    md_wv_cache_.ResetIfBufferChanged(ctx.nodes.data(), ctx.nodes.size());
+    cell_wv_cache_.ResetIfBufferChanged(ctx.nodes.data(), ctx.nodes.size());
 
     const uint32_t gen = ctx.cache.GetEffectsGeneration();
     if (last_md_hit_.Matches(ctx, gen)) {
@@ -129,9 +125,10 @@ HitTestService::HitResult HitTestService::HitTest(const MdPaneHitContext& ctx) c
     });
     const int candidate = (it != first) ? static_cast<int>(std::prev(it) - first) : -1;
 
-    const float candidate_text_top = (candidate >= 0)
-        ? mendo::layout::TextTopOf(ctx.cache, static_cast<size_t>(candidate), ctx.nodes[candidate], ctx.theme)
-        : 0.0f;
+    const float candidate_text_top =
+        (candidate >= 0)
+            ? mendo::layout::TextTopOf(ctx.cache, static_cast<size_t>(candidate), ctx.nodes[candidate], ctx.theme)
+            : 0.0f;
     if (candidate >= 0 && dip_y <= candidate_text_top + ctx.cache[candidate].height) {
         const auto& node = ctx.nodes[candidate];
         const auto& entry = ctx.cache[candidate];

--- a/src/input/hit_test_service.h
+++ b/src/input/hit_test_service.h
@@ -178,10 +178,8 @@ private:
 
     // HitTestPoint の UTF-16→UTF-8 逆変換を同一ノード/セル間で再利用する
     // (ドラッグ選択時の連続呼び出しで decode を抑える)。
-    // ドキュメント切替で string_view が dangling 化するため HitTest 冒頭で Reset。
-    // PMR pool がアドレスを再利用するため (data, size) の両方で同一性を判定する。
+    // HitTest 冒頭で ResetIfBufferChanged を呼び、ドキュメント切替時の string_view
+    // dangling を防ぐ。
     mutable mendo::WideViewCache md_wv_cache_;
     mutable mendo::WideViewCache cell_wv_cache_;
-    mutable const Node* prev_nodes_data_ = nullptr;
-    mutable size_t prev_nodes_size_ = 0;
 };

--- a/src/layout/doc_dwrite_bridge.h
+++ b/src/layout/doc_dwrite_bridge.h
@@ -55,8 +55,12 @@ private:
 // 直近に渡された文字列に対する WideViewForDWrite を再利用する identity ベースキャッシュ。
 // std::string_view の (data ポインタ + size) で同一性を判定し、異なる文字列が来た時のみ
 // 再構築する。連続フレームで同じノード/セルの選択や検索ハイライトを描画する典型ケースで
-// UTF-8→UTF-16 decode を 1 回に抑える。data ポインタの寿命が切れる可能性がある場合は
-// Reset() を明示的に呼んでキャッシュを破棄すること。
+// UTF-8→UTF-16 decode を 1 回に抑える。
+//
+// ドキュメント差し替え等で内部 string_view の data ポインタが dangling 化しうる場合は
+// Reset() か ResetIfBufferChanged() で明示的に無効化すること (PMR pool が解放後アドレスを
+// 再利用するため、ノード配列等の (data ポインタ + size) を別途追跡する用途で
+// ResetIfBufferChanged() を提供している)。
 class WideViewCache {
 public:
     const WideViewForDWrite& Get(std::string_view text)
@@ -79,9 +83,25 @@ public:
         text_ = {};
     }
 
+    // 任意の連続バッファ (典型的にはノード配列) の identity が前回呼び出しから
+    // 変わっていれば Reset() し、識別子を更新する。同一なら何もしない。
+    template <typename T>
+    void ResetIfBufferChanged(const T* data, size_t size) noexcept
+    {
+        const auto* p = static_cast<const void*>(data);
+        if (p == owner_data_ && size == owner_size_) {
+            return;
+        }
+        Reset();
+        owner_data_ = p;
+        owner_size_ = size;
+    }
+
 private:
     std::string_view text_;
     std::optional<WideViewForDWrite> wv_;
+    const void* owner_data_ = nullptr;
+    size_t owner_size_ = 0;
 };
 
 // IDWriteFactory::CreateTextLayout の境界ラッパー。

--- a/src/layout/doc_dwrite_bridge.h
+++ b/src/layout/doc_dwrite_bridge.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "doc_text.h"
+#include <cstddef>
 #include <cstdint>
 #include <dwrite.h>
 #include <memory_resource>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,8 +95,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nC
             window.StartPreloadAsync(std::move(preload_path));
         }
 
-        // App::Init 内の AttachOrApplyPreload が preload 完了時に同期で OnParseComplete を呼ぶ
-        // パスがあるため、Create の前に復元情報をセットしておく。
+        // preload が Create 内 (App::Init) で同期完了するパスに備え、復元情報を先にセット。
         if (restore_scroll) {
             window.RestoreScrollPosition();
         }

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -117,14 +117,8 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     }
     // ドキュメント切替で string_view が dangling 化するため reset する。PMR pool が
     // 同じアドレスを再利用しうるので (data, size) の両方で同一性を判定する。
-    // selection 解除時は wide cache が抱える utf16_offsets_ メモリを早期解放する。
-    const bool doc_changed = nodes.data() != prev_nodes_data_ || nodes.size() != prev_nodes_size_;
-    if (doc_changed || !selection.active) {
-        node_wv_.Reset();
-        cell_wv_.Reset();
-    }
-    prev_nodes_data_ = nodes.data();
-    prev_nodes_size_ = nodes.size();
+    node_wv_.ResetIfBufferChanged(nodes.data(), nodes.size());
+    cell_wv_.ResetIfBufferChanged(nodes.data(), nodes.size());
 
     const int node_count = static_cast<int>(nodes.size());
     if (first_visible < 0) {

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -232,11 +232,8 @@ private:
     int prev_sel_end_node_ = -1;
 
     // 選択ハイライトの UTF-8→UTF-16 decode を、本文ノードとテーブルセルそれぞれで
-    // 連続フレーム間に渡って再利用する。GenerateMdPane 冒頭でドキュメント切り替えや
-    // selection 解除を検知して Reset() し、string_view の dangling を防ぐ。
-    // PMR pool が解放後アドレスを再利用するため (data, size) の両方で同一性を見る。
+    // 連続フレーム間に渡って再利用する。GenerateMdPane 冒頭で ResetIfBufferChanged を
+    // 呼び、ドキュメント切り替え時に string_view の dangling を防ぐ。
     mendo::WideViewCache node_wv_;
     mendo::WideViewCache cell_wv_;
-    const Node* prev_nodes_data_ = nullptr;
-    size_t prev_nodes_size_ = 0;
 };

--- a/src/util/utf8_codec.h
+++ b/src/util/utf8_codec.h
@@ -74,8 +74,19 @@ constexpr DecodedCp DecodeAt(std::string_view text, uint32_t pos) noexcept
     // 非スカラー値の排除:
     //   overlong (より短い符号化が可能な値)、UTF-16 サロゲート領域、Unicode 範囲外。
     //   これらをそのまま返すと UTF-16 化で孤立サロゲートを生むなど後続処理で破綻する。
-    constexpr uint32_t min_cp_for_len[] = { 0x80u, 0x800u, 0x10000u }; // len = 2/3/4
-    if (cp < min_cp_for_len[len - 2] || cp > 0x10FFFFu || (cp >= 0xD800u && cp <= 0xDFFFu)) {
+    uint32_t min_cp = 0;
+    switch (len) {
+    case 2:
+        min_cp = 0x80u;
+        break;
+    case 3:
+        min_cp = 0x800u;
+        break;
+    case 4:
+        min_cp = 0x10000u;
+        break;
+    }
+    if (cp < min_cp || cp > 0x10FFFFu || (cp >= 0xD800u && cp <= 0xDFFFu)) {
         return { kReplacement, 1 };
     }
     return { cp, len };


### PR DESCRIPTION
## Summary

- \`WideViewCache::ResetIfBufferChanged(data, size)\` を追加し、\`command_generator\` / \`hit_test_service\` で重複していた \`prev_nodes_data_/prev_nodes_size_\` 比較ロジックを 1 行に集約。両クラスの追跡用メンバーを削除。
- \`command_generator\` の選択ハイライトキャッシュ破棄から \`!selection.active\` 条件を削除。非選択フレームで cache を捨てなくなり、選択 → 非選択 → 再選択の往復で UTF-8→UTF-16 の再 decode が発生しなくなった。
- \`utf8_codec.h\` の \`min_cp_for_len[len-2]\` の暗黙オフセットを \`switch (len)\` に置換。
- \`CategorizeCodePoint\` の Han 範囲を 1 つの \`if\` に統合。
- \`app.h\` / \`main.cpp\` の冗長な「呼び出し先実装」言及コメントを縮約。

\`/simplify\` レビュー (3 エージェント並列) で挙がった共通指摘から、影響度の高いものを反映。

## 補足

レビューで挙がったが本 PR では保留した項目:

- \`HitTestService\` の 2 スロット固定キャッシュ → LRU 化は設計変更が大きいため別途。
- \`SearchState\` への \`WideViewCache\` 配置 → ノード境界で必ずミスする 1 スロット型では効果薄。多スロットキャッシュの設計判断が必要なため別途。
- \`parser.cpp\` の手書き UTF-8 encoder の \`utf8_codec.h\` 集約 → 当 PR の差分範囲外のため #201 で別 PR 化。

## Test plan

- [x] \`cmake --build build --config Release\` 成功
- [x] \`build/tests/Release/mendo_tests.exe --gtest_brief=1\` で 2194 tests 全パス
- [x] 起動して Markdown ファイルを開き、選択ハイライト・テーブルセル選択・ドラッグ選択が正常動作することを確認
- [x] ダブルクリック単語選択 (CJK 含む) が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)