### PR TITLE
refactor: refactoring_todo.md 見送り項目の追対応 + simplify クリーンアップ

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ add_library(mendo_core STATIC
     src/io/file_dialog_service.cpp
     src/io/file_explorer.cpp
     src/io/file_load_service.cpp
+    src/io/async_load_coordinator.cpp
     src/io/preloader.cpp
     src/io/config_service.cpp
     src/io/image_loader.cpp

--- a/src/app/app_constants.h
+++ b/src/app/app_constants.h
@@ -58,9 +58,6 @@ inline constexpr UINT END = WM_APP + 7;
 
 namespace app_param {
 
-// SEARCH_FOCUS / SEARCH_UNFOCUS は IWin32Host::SearchFocus / SearchUnfocus からのみ生成される。
-// reducer / app_init などのアプリ層は型安全な effect::SearchFocus / SearchUnfocus を使い、
-// 本 namespace は Win32Host (発行側) と window.cpp (受信側) の間のワイヤフォーマットに留まる。
 inline constexpr WPARAM SEARCH_FOCUS_SELECT_ALL = 0;
 inline constexpr WPARAM SEARCH_FOCUS_SET_CARET = 1;          // lParam = caret (int)
 inline constexpr WPARAM SEARCH_FOCUS_SET_SELECTION = 2;      // lParam = SearchSelectionPayload* (heap, 受信側で delete)
@@ -68,8 +65,8 @@ inline constexpr WPARAM SEARCH_UNFOCUS_CLOSE = 0;
 inline constexpr WPARAM SEARCH_UNFOCUS_FILE_SWITCH = 1;
 
 // SEARCH_FOCUS_SET_SELECTION の lParam で運ぶペイロード。
-// 所有権: Win32Host::SearchFocus が `new` (MakeSearchSelectionLParam)、
-// 受信側 (SEARCH_FOCUS ハンドラまたは PostMessage 失敗時の Win32Host) で `delete`。
+// 所有権: 発行側 (Win32Host::SearchFocus) で `new`、受信側 (SEARCH_FOCUS ハンドラ
+// または PostMessage 失敗時の発行側) で `delete`。
 struct SearchSelectionPayload {
     int anchor;
     int caret;

--- a/src/app/app_constants.h
+++ b/src/app/app_constants.h
@@ -58,6 +58,9 @@ inline constexpr UINT END = WM_APP + 7;
 
 namespace app_param {
 
+// SEARCH_FOCUS / SEARCH_UNFOCUS は IWin32Host::SearchFocus / SearchUnfocus からのみ生成される。
+// reducer / app_init などのアプリ層は型安全な effect::SearchFocus / SearchUnfocus を使い、
+// 本 namespace は Win32Host (発行側) と window.cpp (受信側) の間のワイヤフォーマットに留まる。
 inline constexpr WPARAM SEARCH_FOCUS_SELECT_ALL = 0;
 inline constexpr WPARAM SEARCH_FOCUS_SET_CARET = 1;          // lParam = caret (int)
 inline constexpr WPARAM SEARCH_FOCUS_SET_SELECTION = 2;      // lParam = SearchSelectionPayload* (heap, 受信側で delete)
@@ -65,7 +68,8 @@ inline constexpr WPARAM SEARCH_UNFOCUS_CLOSE = 0;
 inline constexpr WPARAM SEARCH_UNFOCUS_FILE_SWITCH = 1;
 
 // SEARCH_FOCUS_SET_SELECTION の lParam で運ぶペイロード。
-// 所有権: 発行側で `new` (MakeSearchSelectionLParam)、SEARCH_FOCUS ハンドラで `delete`。
+// 所有権: Win32Host::SearchFocus が `new` (MakeSearchSelectionLParam)、
+// 受信側 (SEARCH_FOCUS ハンドラまたは PostMessage 失敗時の Win32Host) で `delete`。
 struct SearchSelectionPayload {
     int anchor;
     int caret;

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -198,7 +198,7 @@ void App::OnParseComplete()
         const std::string_view new_view(result->doc.GetRawText());
         const auto decision = AnalyzeReloadDiff(old_view, new_view);
 
-        MENDO_TRACEF("OnParseComplete: reload node_count=%zu diff_pos=%zu old_size=%zu new_size=%zu op=%d",
+        MENDO_TRACEF("OnParseComplete: reload node_count={} diff_pos={} old_size={} new_size={} op={}",
                      result->doc.GetNodes().size(), decision.diff_pos, old_view.size(), new_view.size(),
                      std::to_underlying(decision.op));
 
@@ -228,7 +228,7 @@ void App::FinishLoadMarkdownFile(bool heights_estimated)
 {
     ResetViewForNewDocument();
     state_.search.search_bar_ctrl.Reset();
-    EmitEffect(effect::PostWindowMessage{ app_msg::SEARCH_UNFOCUS, app_param::SEARCH_UNFOCUS_FILE_SWITCH, 0 });
+    EmitEffect(effect::SearchUnfocus{ /*clear_text=*/true });
     state_.active_toc_index = -1;
 
     const std::pmr::wstring dir = state_.document.doc.GetDirectory();
@@ -246,14 +246,14 @@ void App::FinishLoadMarkdownFile(bool heights_estimated)
     const bool has_reload_diff = (state_.reload_diff_pos != std::string_view::npos);
 
     if (state_.view.scroll_restore.HasNodeRestore()) {
-        MENDO_TRACEF("FinishLoad: has_reload_diff=%d node=%d offset=%d heights_estimated=%d",
+        MENDO_TRACEF("FinishLoad: has_reload_diff={} node={} offset={} heights_estimated={}",
                      has_reload_diff ? 1 : 0,
                      state_.view.scroll_restore.pending_restore_node,
                      state_.view.scroll_restore.pending_restore_offset,
                      heights_estimated ? 1 : 0);
     }
     else {
-        MENDO_TRACEF("FinishLoad: has_reload_diff=%d (no node restore) heights_estimated=%d",
+        MENDO_TRACEF("FinishLoad: has_reload_diff={} (no node restore) heights_estimated={}",
                      has_reload_diff ? 1 : 0,
                      heights_estimated ? 1 : 0);
     }
@@ -286,7 +286,7 @@ void App::FinishLoadMarkdownFile(bool heights_estimated)
 
     FinalizeLayout(md_height);
 
-    MENDO_TRACEF("FinishLoad: scroll_y=%.1f max_scroll=%.1f reload_diff_scroll_y=%.1f",
+    MENDO_TRACEF("FinishLoad: scroll_y={:.1f} max_scroll={:.1f} reload_diff_scroll_y={:.1f}",
                  state_.view.viewport.GetScrollY(),
                  state_.view.viewport.GetMaxScroll(),
                  reload_diff_scroll_y);
@@ -352,7 +352,7 @@ void App::DoReloadCurrentFile()
     const std::string_view new_view(new_text);
     const auto decision = AnalyzeReloadDiff(old_view, new_view);
 
-    MENDO_TRACEF("DoReload: diff_pos=%zu old_size=%zu new_size=%zu op=%d",
+    MENDO_TRACEF("DoReload: diff_pos={} old_size={} new_size={} op={}",
                  decision.diff_pos, old_view.size(), new_view.size(),
                  std::to_underlying(decision.op));
 
@@ -385,7 +385,7 @@ void App::FinishReload(size_t diff_pos)
         std::string_view{ state_.document.doc.GetRawText() },
         diff_pos, md_height, state_.view.viewport.GetScrollY());
 
-    MENDO_TRACEF("FinishReload: desired_scroll=%.1f diff_pos=%zu",
+    MENDO_TRACEF("FinishReload: desired_scroll={:.1f} diff_pos={}",
                  desired_scroll, diff_pos);
 
     // スクロール位置を先に設定してから ViewportLayout を呼ぶことで、変更箇所周辺の
@@ -401,7 +401,7 @@ void App::FinishReload(size_t diff_pos)
 
     FinalizeLayout(md_height);
 
-    MENDO_TRACEF("FinishReload: after-finalize scroll_y=%.1f max_scroll=%.1f",
+    MENDO_TRACEF("FinishReload: after-finalize scroll_y={:.1f} max_scroll={:.1f}",
                  state_.view.viewport.GetScrollY(),
                  state_.view.viewport.GetMaxScroll());
 

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -272,16 +272,16 @@ SearchBarController::Callbacks App::BuildSearchBarCallbacks()
             KillTimer(hwnd_, id);
         },
         .focus_select_all = [this]() {
-            EmitEffect(effect::PostWindowMessage{ app_msg::SEARCH_FOCUS, app_param::SEARCH_FOCUS_SELECT_ALL, 0 });
+            EmitEffect(effect::SearchFocus{});
         },
         .focus_set_caret = [this](int pos) {
-            EmitEffect(effect::PostWindowMessage{ app_msg::SEARCH_FOCUS, app_param::SEARCH_FOCUS_SET_CARET, static_cast<LPARAM>(pos) });
+            EmitEffect(effect::SearchFocus{ effect::SearchFocus::Mode::SetCaret, 0, pos });
         },
         .focus_set_selection = [this](int anchor, int caret) {
-            EmitEffect(effect::PostWindowMessage{ app_msg::SEARCH_FOCUS, app_param::SEARCH_FOCUS_SET_SELECTION, app_param::MakeSearchSelectionLParam(anchor, caret) });
+            EmitEffect(effect::SearchFocus{ effect::SearchFocus::Mode::SetSelection, anchor, caret });
         },
         .unfocus = [this]() {
-            EmitEffect(effect::PostWindowMessage{ app_msg::SEARCH_UNFOCUS, 0, 0 });
+            EmitEffect(effect::SearchUnfocus{});
         },
         .get_md_pane_height = [this]() -> float {
             return GetPaneLayout().md_rect.height;

--- a/src/app/app_mouse_click.cpp
+++ b/src/app/app_mouse_click.cpp
@@ -21,7 +21,7 @@ bool App::HandleSearchBarClick(float dip_x, float dip_y, const PaneLayout& pane_
     switch (HitTestSearchBar(sbl, dip_x, dip_y)) {
     case SearchBarHitZone::None:
         if (!is_double_click) {
-            EmitEffect(effect::PostWindowMessage{ app_msg::SEARCH_FOCUS, app_param::SEARCH_FOCUS_SELECT_ALL, 0 });
+            EmitEffect(effect::SearchFocus{});
         }
         break;
     case SearchBarHitZone::Up:
@@ -50,10 +50,11 @@ bool App::HandleSearchBarClick(float dip_x, float dip_y, const PaneLayout& pane_
             // 自前で単語境界を計算して EM_SETSEL を発行する。
             const auto wb = FindWordBoundaries(std::wstring_view{ query_wide }, static_cast<uint32_t>(pos));
             if (wb.found) {
-                EmitEffect(effect::PostWindowMessage{
-                    app_msg::SEARCH_FOCUS,
-                    app_param::SEARCH_FOCUS_SET_SELECTION,
-                    app_param::MakeSearchSelectionLParam(static_cast<int>(wb.start), static_cast<int>(wb.end)) });
+                EmitEffect(effect::SearchFocus{
+                    effect::SearchFocus::Mode::SetSelection,
+                    static_cast<int>(wb.start),
+                    static_cast<int>(wb.end),
+                });
             }
         }
         else {

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -433,11 +433,7 @@ void ReduceSearchInputDragStarted(AppState& state, SideEffectList& effects, cons
     PushEffect(effects, effect::SetCapture{});
     PushEffect(
         effects,
-        effect::PostWindowMessage{
-            app_msg::SEARCH_FOCUS,
-            app_param::SEARCH_FOCUS_SET_CARET,
-            static_cast<LPARAM>(a.caret_pos),
-        });
+        effect::SearchFocus{ effect::SearchFocus::Mode::SetCaret, 0, a.caret_pos });
 }
 
 void ReduceSearchInputDragMoved(AppState& state, SideEffectList& effects, const SearchInputDragMovedAction& a)
@@ -451,10 +447,10 @@ void ReduceSearchInputDragMoved(AppState& state, SideEffectList& effects, const 
     }
     PushEffect(
         effects,
-        effect::PostWindowMessage{
-            app_msg::SEARCH_FOCUS,
-            app_param::SEARCH_FOCUS_SET_SELECTION,
-            app_param::MakeSearchSelectionLParam(ctrl.GetDragAnchor(), a.caret_pos),
+        effect::SearchFocus{
+            effect::SearchFocus::Mode::SetSelection,
+            ctrl.GetDragAnchor(),
+            a.caret_pos,
         });
 }
 

--- a/src/app/side_effect.h
+++ b/src/app/side_effect.h
@@ -59,8 +59,6 @@ struct PostWindowMessage {
     WPARAM wp;
     LPARAM lp;
 };
-// 検索バーの focus 操作を型安全に運ぶ effect。内部実装は IWin32Host が
-// PostMessage 経由で window.cpp のハンドラに引き継ぐ (heap payload は host 側に閉じる)。
 struct SearchFocus {
     enum class Mode : uint8_t {
         SelectAll,    // 既存テキスト全選択

--- a/src/app/side_effect.h
+++ b/src/app/side_effect.h
@@ -59,6 +59,21 @@ struct PostWindowMessage {
     WPARAM wp;
     LPARAM lp;
 };
+// 検索バーの focus 操作を型安全に運ぶ effect。内部実装は IWin32Host が
+// PostMessage 経由で window.cpp のハンドラに引き継ぐ (heap payload は host 側に閉じる)。
+struct SearchFocus {
+    enum class Mode : uint8_t {
+        SelectAll,    // 既存テキスト全選択
+        SetCaret,     // caret に位置決め
+        SetSelection, // [anchor, caret) を選択
+    };
+    Mode mode = Mode::SelectAll;
+    int anchor = 0; // SetSelection でのみ参照
+    int caret = 0;  // SetCaret/SetSelection で参照
+};
+struct SearchUnfocus {
+    bool clear_text = false; // ファイル切替時に true。検索ボックスのテキストを消去する。
+};
 struct SetWindowTitle {
     std::pmr::wstring title;
 };
@@ -162,6 +177,8 @@ using UiEffect = std::variant<
 using WindowEffect = std::variant<
     effect::ShowWindowCmd,
     effect::PostWindowMessage,
+    effect::SearchFocus,
+    effect::SearchUnfocus,
     effect::SetWindowTitle,
     effect::SetWindowPosition,
     effect::ApplyDarkMode,

--- a/src/app/side_effect_executor.cpp
+++ b/src/app/side_effect_executor.cpp
@@ -128,13 +128,15 @@ void SideEffectExecutor::ExecuteWindow(const WindowEffect& e)
             host_->ShowWindowCmd(ev.cmd);
         },
         [this](const effect::PostWindowMessage& ev) {
-            const bool ok = host_->PostWindowMessage(ev.msg, ev.wp, ev.lp);
-            // SEARCH_FOCUS_SET_SELECTION の lParam は発行側で new した heap payload。
-            // PostMessageW 失敗時は受信側 (window.cpp の SEARCH_FOCUS ハンドラ) が走らないため、
-            // 発行側で delete して所有権を回収しないとリークする。
-            if (!ok && ev.msg == app_msg::SEARCH_FOCUS && ev.wp == app_param::SEARCH_FOCUS_SET_SELECTION) {
-                delete reinterpret_cast<app_param::SearchSelectionPayload*>(ev.lp);
-            }
+            // 残存 callsite (WM_CLOSE 等) 用の汎用 PostMessage。新規の検索 focus 系は
+            // SearchFocus / SearchUnfocus で発行されるため、ここでは heap payload の特殊扱いは不要。
+            host_->PostWindowMessage(ev.msg, ev.wp, ev.lp);
+        },
+        [this](const effect::SearchFocus& ev) {
+            host_->SearchFocus(ev);
+        },
+        [this](const effect::SearchUnfocus& ev) {
+            host_->SearchUnfocus(ev);
         },
         [this](const effect::SetWindowTitle& ev) {
             host_->SetWindowTitle(ev.title);

--- a/src/app/side_effect_executor.cpp
+++ b/src/app/side_effect_executor.cpp
@@ -128,8 +128,6 @@ void SideEffectExecutor::ExecuteWindow(const WindowEffect& e)
             host_->ShowWindowCmd(ev.cmd);
         },
         [this](const effect::PostWindowMessage& ev) {
-            // 残存 callsite (WM_CLOSE 等) 用の汎用 PostMessage。新規の検索 focus 系は
-            // SearchFocus / SearchUnfocus で発行されるため、ここでは heap payload の特殊扱いは不要。
             host_->PostWindowMessage(ev.msg, ev.wp, ev.lp);
         },
         [this](const effect::SearchFocus& ev) {

--- a/src/app/win32_host.h
+++ b/src/app/win32_host.h
@@ -34,13 +34,7 @@ public:
     // wstring_view 経由の null 終端コピーを 1 回省略できる。
     virtual void ShellOpen(const std::pmr::wstring& url) = 0;
     virtual void ShowWindowCmd(int cmd) = 0;
-    // 失敗 (PostMessageW が FALSE) を呼び出し側に伝えるため bool 戻り値。
-    // 旧経路: SEARCH_FOCUS_SET_SELECTION のように lParam で heap payload を運ぶ際、
-    // 失敗時に発行側が delete して所有権を回収する必要があった。新規 callsite では
-    // SearchFocus / SearchUnfocus を使い heap allocation の所有権を本 IF 内に閉じる。
-    virtual bool PostWindowMessage(UINT msg, WPARAM wp, LPARAM lp) = 0;
-    // 検索バー focus 系の型安全 IF。PostMessage ベースのメッセージング機構は維持するが、
-    // anchor/caret の運搬・heap allocation の所有権は host 内部で完結する。
+    virtual void PostWindowMessage(UINT msg, WPARAM wp, LPARAM lp) = 0;
     virtual void SearchFocus(effect::SearchFocus action) = 0;
     virtual void SearchUnfocus(effect::SearchUnfocus action) = 0;
     virtual void SetWindowTitle(const std::pmr::wstring& title) = 0;

--- a/src/app/win32_host.h
+++ b/src/app/win32_host.h
@@ -35,9 +35,14 @@ public:
     virtual void ShellOpen(const std::pmr::wstring& url) = 0;
     virtual void ShowWindowCmd(int cmd) = 0;
     // 失敗 (PostMessageW が FALSE) を呼び出し側に伝えるため bool 戻り値。
-    // SEARCH_FOCUS_SET_SELECTION のように lParam で heap payload を運ぶ経路では、
-    // 失敗時に発行側が delete して所有権を回収する必要がある。
+    // 旧経路: SEARCH_FOCUS_SET_SELECTION のように lParam で heap payload を運ぶ際、
+    // 失敗時に発行側が delete して所有権を回収する必要があった。新規 callsite では
+    // SearchFocus / SearchUnfocus を使い heap allocation の所有権を本 IF 内に閉じる。
     virtual bool PostWindowMessage(UINT msg, WPARAM wp, LPARAM lp) = 0;
+    // 検索バー focus 系の型安全 IF。PostMessage ベースのメッセージング機構は維持するが、
+    // anchor/caret の運搬・heap allocation の所有権は host 内部で完結する。
+    virtual void SearchFocus(effect::SearchFocus action) = 0;
+    virtual void SearchUnfocus(effect::SearchUnfocus action) = 0;
     virtual void SetWindowTitle(const std::pmr::wstring& title) = 0;
     virtual void SetWindowPosition(int x, int y, int cx, int cy) = 0;
     virtual POINT ClientToScreen(POINT client_pt) = 0;

--- a/src/app/win32_host_impl.cpp
+++ b/src/app/win32_host_impl.cpp
@@ -1,4 +1,5 @@
 #include "win32_host_impl.h"
+#include "app_constants.h"
 #include "clipboard_util.h"
 #include "cursor_manager.h"
 #include "darkmode_util.h"
@@ -95,6 +96,36 @@ void Win32Host::ShowWindowCmd(int cmd)
 bool Win32Host::PostWindowMessage(UINT msg, WPARAM wp, LPARAM lp)
 {
     return PostMessageW(hwnd_, msg, wp, lp) != 0;
+}
+
+void Win32Host::SearchFocus(effect::SearchFocus action)
+{
+    using Mode = effect::SearchFocus::Mode;
+    switch (action.mode) {
+    case Mode::SelectAll:
+        PostMessageW(hwnd_, app_msg::SEARCH_FOCUS, app_param::SEARCH_FOCUS_SELECT_ALL, 0);
+        break;
+    case Mode::SetCaret:
+        PostMessageW(hwnd_, app_msg::SEARCH_FOCUS, app_param::SEARCH_FOCUS_SET_CARET,
+                     static_cast<LPARAM>(action.caret));
+        break;
+    case Mode::SetSelection: {
+        // 失敗時は所有権を回収して leak を防ぐ。
+        const LPARAM lp = app_param::MakeSearchSelectionLParam(action.anchor, action.caret);
+        if (!PostMessageW(hwnd_, app_msg::SEARCH_FOCUS, app_param::SEARCH_FOCUS_SET_SELECTION, lp)) {
+            delete reinterpret_cast<app_param::SearchSelectionPayload*>(lp);
+        }
+        break;
+    }
+    }
+}
+
+void Win32Host::SearchUnfocus(effect::SearchUnfocus action)
+{
+    const WPARAM wp = action.clear_text
+        ? app_param::SEARCH_UNFOCUS_FILE_SWITCH
+        : app_param::SEARCH_UNFOCUS_CLOSE;
+    PostMessageW(hwnd_, app_msg::SEARCH_UNFOCUS, wp, 0);
 }
 
 void Win32Host::SetWindowTitle(const std::pmr::wstring& title)

--- a/src/app/win32_host_impl.cpp
+++ b/src/app/win32_host_impl.cpp
@@ -93,9 +93,9 @@ void Win32Host::ShowWindowCmd(int cmd)
     ShowWindow(hwnd_, cmd);
 }
 
-bool Win32Host::PostWindowMessage(UINT msg, WPARAM wp, LPARAM lp)
+void Win32Host::PostWindowMessage(UINT msg, WPARAM wp, LPARAM lp)
 {
-    return PostMessageW(hwnd_, msg, wp, lp) != 0;
+    PostMessageW(hwnd_, msg, wp, lp);
 }
 
 void Win32Host::SearchFocus(effect::SearchFocus action)

--- a/src/app/win32_host_impl.h
+++ b/src/app/win32_host_impl.h
@@ -21,6 +21,8 @@ public:
     void ShellOpen(const std::pmr::wstring& url) override;
     void ShowWindowCmd(int cmd) override;
     bool PostWindowMessage(UINT msg, WPARAM wp, LPARAM lp) override;
+    void SearchFocus(effect::SearchFocus action) override;
+    void SearchUnfocus(effect::SearchUnfocus action) override;
     void SetWindowTitle(const std::pmr::wstring& title) override;
     void SetWindowPosition(int x, int y, int cx, int cy) override;
     POINT ClientToScreen(POINT client_pt) override;

--- a/src/app/win32_host_impl.h
+++ b/src/app/win32_host_impl.h
@@ -20,7 +20,7 @@ public:
     void WriteClipboardHtml(std::wstring_view html, std::wstring_view plain) override;
     void ShellOpen(const std::pmr::wstring& url) override;
     void ShowWindowCmd(int cmd) override;
-    bool PostWindowMessage(UINT msg, WPARAM wp, LPARAM lp) override;
+    void PostWindowMessage(UINT msg, WPARAM wp, LPARAM lp) override;
     void SearchFocus(effect::SearchFocus action) override;
     void SearchUnfocus(effect::SearchUnfocus action) override;
     void SetWindowTitle(const std::pmr::wstring& title) override;

--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -35,7 +35,7 @@ void NormalizeNewlines(std::pmr::string& s)
 
     char* first_cr = FindDocCr(data, n);
     if (!first_cr) {
-        MENDO_STATF("NormalizeNewlines: in=%zu out=%zu shrunk=0 (fast LF-only)", n, n);
+        MENDO_STATF("NormalizeNewlines: in={} out={} shrunk=0 (fast LF-only)", n, n);
         return;
     }
 
@@ -59,7 +59,7 @@ void NormalizeNewlines(std::pmr::string& s)
     } while (src < end);
 
     s.resize(static_cast<size_t>(dst - data));
-    MENDO_STATF("NormalizeNewlines: in=%zu out=%zu shrunk=%zu", n, s.size(), n - s.size());
+    MENDO_STATF("NormalizeNewlines: in={} out={} shrunk={}", n, s.size(), n - s.size());
 }
 
 } // namespace

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -855,35 +855,43 @@ int OnText(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, void* userdata)
 ParseResult ParseMarkdown(std::string_view markdown_text)
 {
     MENDO_PROFILE("ParseMarkdown");
-    // 入力 1 byte あたりの予約容量ヒント。実測 (100MB 入力 = 30k ノード相当)
-    // を基準に、初期確保サイズと再確保回数のバランスで決めている。
-    // 各除数の意味:
-    //   /20: 入力の 5% を初期 arena に。new_delete 直結回数を削減。
-    //   /8:  ノード当たりの平均テキスト長を ~8B として scratch 初期確保。
-    //   /48: ノード平均サイズの逆数 (1 ノード ~48 入力 byte)。realloc 14 回→4 回相当。
-    //   /4096: 1MB あたり 256 個の見出し相当。実測数十〜数百に収まる。
-    //   /512:  画像/blockquote の頻度 (~0.2%)
-    //   /1024: ダイアグラムの頻度 (~0.1%)
+    // 各種予約サイズのヒント定数。実測 (100MB 入力 = 30k ノード相当) を基準に、
+    // 初期確保サイズと再確保回数のバランスで決めている。値は「入力 N byte あたり 1 個」を表す:
+    //   - kArenaInputBytesPerByte=20  → 入力の 5% を初期 arena に。new_delete 直結回数を削減。
+    //   - kScratchInputBytesPerByte=8 → ノード当たりの平均テキスト長 ~8B 想定の scratch。
+    //   - kInputBytesPerNode=48       → 1 ノードあたり ~48 入力 byte (realloc 14 回→4 回相当)。
+    //   - kInputBytesPerHeading=4096  → 1MB あたり 256 個の見出し相当。実測数十〜数百に収まる。
+    //   - kInputBytesPerImage=512     → 画像頻度 ~0.2%。
+    //   - kInputBytesPerBlockquote=512 → blockquote 頻度 (image と同程度)。
+    //   - kInputBytesPerDiagram=1024  → ダイアグラム頻度 ~0.1%。
+    constexpr size_t kArenaInputBytesPerByte = 20;
+    constexpr size_t kScratchInputBytesPerByte = 8;
+    constexpr size_t kInputBytesPerNode = 48;
+    constexpr size_t kInputBytesPerHeading = 4096;
+    constexpr size_t kInputBytesPerImage = 512;
+    constexpr size_t kInputBytesPerBlockquote = 512;
+    constexpr size_t kInputBytesPerDiagram = 1024;
     constexpr size_t kArenaMin = 128 * 1024;
     constexpr size_t kArenaMax = 5 * 1024 * 1024;
-    const size_t arena_bytes = std::clamp(markdown_text.size() / 20, kArenaMin, kArenaMax);
-    MENDO_STATF("parse_resource arena: input=%zu arena=%zu", markdown_text.size(), arena_bytes);
+    const size_t input_size = markdown_text.size();
+    const size_t arena_bytes = std::clamp(input_size / kArenaInputBytesPerByte, kArenaMin, kArenaMax);
+    MENDO_STATF("parse_resource arena: input={} arena={}", input_size, arena_bytes);
     ParseContext ctx{ arena_bytes };
     ctx.markdown_base = markdown_text.data();
-    ctx.markdown_size = markdown_text.size();
-    ctx.current_text.reserve(std::clamp(markdown_text.size() / 8, SCRATCH_RESERVE_MIN, SCRATCH_RESERVE_MAX));
+    ctx.markdown_size = input_size;
+    ctx.current_text.reserve(std::clamp(input_size / kScratchInputBytesPerByte, SCRATCH_RESERVE_MIN, SCRATCH_RESERVE_MAX));
     // 上限 256K: 100MB / 48 ≈ 2.18M ノード期待だが Node sizeof × 256K = ~20MB に抑える。
-    const size_t nodes_reserve = std::clamp(markdown_text.size() / 48, size_t{ 64 }, size_t{ 262144 });
+    const size_t nodes_reserve = std::clamp(input_size / kInputBytesPerNode, size_t{ 64 }, size_t{ 262144 });
     ctx.nodes.reserve(nodes_reserve);
     ctx.list_counter.reserve(8);
-    MENDO_STATF("nodes.reserve: input=%zu reserve=%zu", markdown_text.size(), nodes_reserve);
+    MENDO_STATF("nodes.reserve: input={} reserve={}", input_size, nodes_reserve);
     // heading_indices と anchor_counts は 1 見出し 1 エントリで対になるので同じヒントを使う。
-    const size_t heading_hint = std::clamp(markdown_text.size() / 4096, size_t{ 8 }, size_t{ 256 });
+    const size_t heading_hint = std::clamp(input_size / kInputBytesPerHeading, size_t{ 8 }, size_t{ 256 });
     ctx.heading_indices.reserve(heading_hint);
     ctx.anchor_counts.reserve(heading_hint);
-    ctx.image_indices.reserve(std::clamp(markdown_text.size() / 512, size_t{ 4 }, size_t{ 256 }));
-    ctx.diagram_indices.reserve(std::clamp(markdown_text.size() / 1024, size_t{ 4 }, size_t{ 128 }));
-    ctx.blockquote_indices.reserve(std::clamp(markdown_text.size() / 512, size_t{ 4 }, size_t{ 256 }));
+    ctx.image_indices.reserve(std::clamp(input_size / kInputBytesPerImage, size_t{ 4 }, size_t{ 256 }));
+    ctx.diagram_indices.reserve(std::clamp(input_size / kInputBytesPerDiagram, size_t{ 4 }, size_t{ 128 }));
+    ctx.blockquote_indices.reserve(std::clamp(input_size / kInputBytesPerBlockquote, size_t{ 4 }, size_t{ 256 }));
 
     MD_PARSER parser{};
     parser.abi_version = 0;

--- a/src/io/async_load_coordinator.cpp
+++ b/src/io/async_load_coordinator.cpp
@@ -1,0 +1,73 @@
+#include "async_load_coordinator.h"
+#include "document.h"
+#include "layout.h"
+#include "layout_cache.h"
+
+void AsyncLoadCoordinator::ResetSinks()
+{
+    const std::lock_guard lock(mutex_);
+    result_.reset();
+    error_.reset();
+}
+
+void AsyncLoadCoordinator::Start(TaskScheduler& scheduler, std::pmr::wstring path, HWND hwnd, UINT msg_id, const Theme& theme)
+{
+    ResetSinks();
+    in_flight_ = true;
+    const uint32_t gen = gen_.fetch_add(1, std::memory_order_relaxed) + 1;
+
+    scheduler.Post([this, path = std::move(path), hwnd, msg_id, gen, theme] {
+        if (gen_.load(std::memory_order_relaxed) != gen) {
+            return;
+        }
+
+        auto load_result = FileLoader::LoadFile(path);
+        if (!load_result) {
+            if (gen_.load(std::memory_order_relaxed) == gen) {
+                {
+                    const std::lock_guard lock(mutex_);
+                    error_ = load_result.error();
+                }
+                ::PostMessageW(hwnd, msg_id, 0, 0);
+            }
+            return;
+        }
+
+        if (gen_.load(std::memory_order_relaxed) != gen) {
+            return;
+        }
+
+        Document doc = Document::FromMarkdown(std::move(load_result->text), load_result->byte_size, path);
+
+        if (gen_.load(std::memory_order_relaxed) != gen) {
+            return;
+        }
+
+        LayoutCache cache;
+        cache.Reset(doc.GetNodes().size(), /* shrink = */ false);
+        EstimateNodeHeights(doc.GetNodes(), cache, theme);
+
+        {
+            const std::lock_guard lock(mutex_);
+            result_.emplace(AsyncLoadResult{ std::move(doc), std::move(cache), /* heights_estimated = */ true });
+        }
+
+        ::PostMessageW(hwnd, msg_id, 0, 0);
+    });
+}
+
+std::optional<AsyncLoadResult> AsyncLoadCoordinator::TakeResult()
+{
+    const std::lock_guard lock(mutex_);
+    auto result = std::move(result_);
+    result_.reset();
+    return result;
+}
+
+std::optional<FileLoadError> AsyncLoadCoordinator::TakeError() noexcept
+{
+    const std::lock_guard lock(mutex_);
+    auto err = error_;
+    error_.reset();
+    return err;
+}

--- a/src/io/async_load_coordinator.cpp
+++ b/src/io/async_load_coordinator.cpp
@@ -59,15 +59,25 @@ void AsyncLoadCoordinator::Start(TaskScheduler& scheduler, std::pmr::wstring pat
 std::optional<AsyncLoadResult> AsyncLoadCoordinator::TakeResult()
 {
     const std::lock_guard lock(mutex_);
+    if (!result_) {
+        return std::nullopt;
+    }
     auto result = std::move(result_);
     result_.reset();
+    // 取り出し成功 = 非同期ロードの完結。これ以降 IsActive() は false を返す。
+    // 同期 ExecuteLoad など別経路から in_flight を触ると race になるため、coordinator の責務に閉じる。
+    in_flight_ = false;
     return result;
 }
 
 std::optional<FileLoadError> AsyncLoadCoordinator::TakeError() noexcept
 {
     const std::lock_guard lock(mutex_);
+    if (!error_) {
+        return std::nullopt;
+    }
     auto err = error_;
     error_.reset();
+    in_flight_ = false;
     return err;
 }

--- a/src/io/async_load_coordinator.cpp
+++ b/src/io/async_load_coordinator.cpp
@@ -3,11 +3,16 @@
 #include "layout.h"
 #include "layout_cache.h"
 
-void AsyncLoadCoordinator::ResetSinks()
+void AsyncLoadCoordinator::ResetSinks() noexcept
 {
-    const std::lock_guard lock(mutex_);
-    result_.reset();
-    error_.reset();
+    std::optional<AsyncLoadResult> stale_result;
+    std::optional<FileLoadError> stale_error;
+    {
+        const std::lock_guard lock(mutex_);
+        stale_result.swap(result_);
+        stale_error.swap(error_);
+    }
+    // stale_result / stale_error はここで lock 外で破棄される。
 }
 
 void AsyncLoadCoordinator::Start(TaskScheduler& scheduler, std::pmr::wstring path, HWND hwnd, UINT msg_id, const Theme& theme)
@@ -17,25 +22,29 @@ void AsyncLoadCoordinator::Start(TaskScheduler& scheduler, std::pmr::wstring pat
     const uint32_t gen = gen_.fetch_add(1, std::memory_order_relaxed) + 1;
 
     scheduler.Post([this, path = std::move(path), hwnd, msg_id, gen, theme] {
-        // 重い処理 (I/O / Parse / Estimate) の手前で stale gen を short-circuit する。
-        // sink への書き込みは Cancel との直列化のため lock 内で gen を再確認してから行う。
-        if (gen_.load(std::memory_order_relaxed) != gen) {
-            return;
-        }
-
-        auto load_result = FileLoader::LoadFile(path);
-        if (!load_result) {
+        // sink 書き込みは Cancel との直列化のため lock 内で gen を再確認してから行う。
+        // I/O / Parse / Estimate の前段の gen check は重い処理を skip するための short-circuit。
+        auto try_publish = [this, hwnd, msg_id, gen](auto&& assign_sink) {
             bool published = false;
             {
                 const std::lock_guard lock(mutex_);
                 if (gen_.load(std::memory_order_relaxed) == gen) {
-                    error_ = load_result.error();
+                    assign_sink();
                     published = true;
                 }
             }
             if (published) {
                 ::PostMessageW(hwnd, msg_id, 0, 0);
             }
+        };
+
+        if (gen_.load(std::memory_order_relaxed) != gen) {
+            return;
+        }
+
+        auto load_result = FileLoader::LoadFile(path);
+        if (!load_result) {
+            try_publish([&] { error_ = load_result.error(); });
             return;
         }
 
@@ -53,17 +62,9 @@ void AsyncLoadCoordinator::Start(TaskScheduler& scheduler, std::pmr::wstring pat
         cache.Reset(doc.GetNodes().size(), /* shrink = */ false);
         EstimateNodeHeights(doc.GetNodes(), cache, theme);
 
-        bool published = false;
-        {
-            const std::lock_guard lock(mutex_);
-            if (gen_.load(std::memory_order_relaxed) == gen) {
-                result_.emplace(AsyncLoadResult{ std::move(doc), std::move(cache), /* heights_estimated = */ true });
-                published = true;
-            }
-        }
-        if (published) {
-            ::PostMessageW(hwnd, msg_id, 0, 0);
-        }
+        try_publish([&] {
+            result_.emplace(AsyncLoadResult{ std::move(doc), std::move(cache), /* heights_estimated = */ true });
+        });
     });
 }
 

--- a/src/io/async_load_coordinator.cpp
+++ b/src/io/async_load_coordinator.cpp
@@ -17,17 +17,23 @@ void AsyncLoadCoordinator::Start(TaskScheduler& scheduler, std::pmr::wstring pat
     const uint32_t gen = gen_.fetch_add(1, std::memory_order_relaxed) + 1;
 
     scheduler.Post([this, path = std::move(path), hwnd, msg_id, gen, theme] {
+        // 重い処理 (I/O / Parse / Estimate) の手前で stale gen を short-circuit する。
+        // sink への書き込みは Cancel との直列化のため lock 内で gen を再確認してから行う。
         if (gen_.load(std::memory_order_relaxed) != gen) {
             return;
         }
 
         auto load_result = FileLoader::LoadFile(path);
         if (!load_result) {
-            if (gen_.load(std::memory_order_relaxed) == gen) {
-                {
-                    const std::lock_guard lock(mutex_);
+            bool published = false;
+            {
+                const std::lock_guard lock(mutex_);
+                if (gen_.load(std::memory_order_relaxed) == gen) {
                     error_ = load_result.error();
+                    published = true;
                 }
+            }
+            if (published) {
                 ::PostMessageW(hwnd, msg_id, 0, 0);
             }
             return;
@@ -47,12 +53,17 @@ void AsyncLoadCoordinator::Start(TaskScheduler& scheduler, std::pmr::wstring pat
         cache.Reset(doc.GetNodes().size(), /* shrink = */ false);
         EstimateNodeHeights(doc.GetNodes(), cache, theme);
 
+        bool published = false;
         {
             const std::lock_guard lock(mutex_);
-            result_.emplace(AsyncLoadResult{ std::move(doc), std::move(cache), /* heights_estimated = */ true });
+            if (gen_.load(std::memory_order_relaxed) == gen) {
+                result_.emplace(AsyncLoadResult{ std::move(doc), std::move(cache), /* heights_estimated = */ true });
+                published = true;
+            }
         }
-
-        ::PostMessageW(hwnd, msg_id, 0, 0);
+        if (published) {
+            ::PostMessageW(hwnd, msg_id, 0, 0);
+        }
     });
 }
 

--- a/src/io/async_load_coordinator.h
+++ b/src/io/async_load_coordinator.h
@@ -40,12 +40,6 @@ public:
         in_flight_ = false;
     }
 
-    // ExecuteLoad (同期経路) で消費した場合等、外部から in_flight_ を畳むためのフック。
-    void Finish() noexcept
-    {
-        in_flight_ = false;
-    }
-
 private:
     void ResetSinks();
 

--- a/src/io/async_load_coordinator.h
+++ b/src/io/async_load_coordinator.h
@@ -1,0 +1,57 @@
+#pragma once
+#include "async_load_result.h"
+#include "file_loader.h"
+#include "task_scheduler.h"
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <windows.h>
+
+struct Theme;
+
+// StartAsyncLoad 専用の状態管理を Preloader と対称に分離したもの。
+// gen による cancellation, mutex 保護の result/error sink, in_flight フラグを 1 クラスに閉じる。
+// FileLoadService からは合成だけ受け持ち、preloader_ と並べて TakeResult/TakeError を順に確認する。
+class AsyncLoadCoordinator {
+public:
+    AsyncLoadCoordinator() = default;
+    AsyncLoadCoordinator(const AsyncLoadCoordinator&) = delete;
+    AsyncLoadCoordinator& operator=(const AsyncLoadCoordinator&) = delete;
+
+    bool IsActive() const noexcept
+    {
+        return in_flight_;
+    }
+
+    // path は worker capture コピーで安全に持ち回す。theme も値コピー: UI スレッドの SetTheme が
+    // std::wstring メンバを非アトミックに書き換えるため、参照キャプチャだと EstimateNodeHeights と race。
+    void Start(TaskScheduler& scheduler, std::pmr::wstring path, HWND hwnd, UINT msg_id, const Theme& theme);
+
+    // ロード結果の取り出し。fired から TakeResult までの間に Cancel が走った場合 sink は破棄済み。
+    std::optional<AsyncLoadResult> TakeResult();
+    std::optional<FileLoadError> TakeError() noexcept;
+
+    // 既存リクエストを破棄。worker は次の gen チェックで早期 return する (PostMessage は飛ばない)。
+    void Cancel() noexcept
+    {
+        gen_.fetch_add(1, std::memory_order_relaxed);
+        in_flight_ = false;
+    }
+
+    // ExecuteLoad (同期経路) で消費した場合等、外部から in_flight_ を畳むためのフック。
+    void Finish() noexcept
+    {
+        in_flight_ = false;
+    }
+
+private:
+    void ResetSinks();
+
+    bool in_flight_ = false;
+    std::atomic<uint32_t> gen_{ 0 };
+    std::mutex mutex_;
+    std::optional<AsyncLoadResult> result_;
+    std::optional<FileLoadError> error_;
+};

--- a/src/io/async_load_coordinator.h
+++ b/src/io/async_load_coordinator.h
@@ -34,21 +34,20 @@ public:
     std::optional<AsyncLoadResult> TakeResult();
     std::optional<FileLoadError> TakeError() noexcept;
 
-    // 既存リクエストを破棄。gen を進めて worker の次回 gen チェックで早期 return させ、
-    // 同時に mutex 下で result_/error_ もクリアする。worker が最終 gen check を通過した
-    // 直後に Cancel が割り込んだ場合でも、sink への emplace と Cancel の reset は同じ
-    // mutex 上で直列化される (worker は emplace 前に lock 内で gen 再チェック)。
+    // gen を進めて worker の以後の publish を弾き、result_/error_ も即時クリア。
+    // worker 側 emplace と Cancel reset は同一 mutex 上で直列化される (worker は
+    // sink 書き込み前に lock 内で gen を再確認)。
     void Cancel() noexcept
     {
         gen_.fetch_add(1, std::memory_order_relaxed);
         in_flight_ = false;
-        const std::lock_guard lock(mutex_);
-        result_.reset();
-        error_.reset();
+        ResetSinks();
     }
 
 private:
-    void ResetSinks();
+    // sink を swap-out して lock 解放後に破棄する。100MB 級の Document/LayoutCache の
+    // destruction を mutex 保持時間に乗せないため。
+    void ResetSinks() noexcept;
 
     bool in_flight_ = false;
     std::atomic<uint32_t> gen_{ 0 };

--- a/src/io/async_load_coordinator.h
+++ b/src/io/async_load_coordinator.h
@@ -4,6 +4,7 @@
 #include "task_scheduler.h"
 #include <atomic>
 #include <cstdint>
+#include <memory_resource>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -33,11 +34,17 @@ public:
     std::optional<AsyncLoadResult> TakeResult();
     std::optional<FileLoadError> TakeError() noexcept;
 
-    // 既存リクエストを破棄。worker は次の gen チェックで早期 return する (PostMessage は飛ばない)。
+    // 既存リクエストを破棄。gen を進めて worker の次回 gen チェックで早期 return させ、
+    // 同時に mutex 下で result_/error_ もクリアする。worker が最終 gen check を通過した
+    // 直後に Cancel が割り込んだ場合でも、sink への emplace と Cancel の reset は同じ
+    // mutex 上で直列化される (worker は emplace 前に lock 内で gen 再チェック)。
     void Cancel() noexcept
     {
         gen_.fetch_add(1, std::memory_order_relaxed);
         in_flight_ = false;
+        const std::lock_guard lock(mutex_);
+        result_.reset();
+        error_.reset();
     }
 
 private:

--- a/src/io/async_load_coordinator.h
+++ b/src/io/async_load_coordinator.h
@@ -11,9 +11,9 @@
 
 struct Theme;
 
-// StartAsyncLoad 専用の状態管理を Preloader と対称に分離したもの。
-// gen による cancellation, mutex 保護の result/error sink, in_flight フラグを 1 クラスに閉じる。
-// FileLoadService からは合成だけ受け持ち、preloader_ と並べて TakeResult/TakeError を順に確認する。
+// gen による cancellation、mutex 保護の result/error sink、in_flight フラグを 1 クラスに閉じる。
+// 全 public API は UI スレッドからのみ呼ぶ前提 (in_flight_ は非 atomic)。
+// worker は gen_ (atomic) のチェックと、mutex 経由の result_/error_ sink への書き込みのみ行う。
 class AsyncLoadCoordinator {
 public:
     AsyncLoadCoordinator() = default;

--- a/src/io/config_service.cpp
+++ b/src/io/config_service.cpp
@@ -17,21 +17,28 @@ void ConfigService::SetConfigDirOverride(const std::filesystem::path& dir)
     config_dir_override_ = dir;
 }
 
+const std::filesystem::path& ConfigService::DefaultConfigDir()
+{
+    // magic static: SHGetKnownFolderPath はプロセス全体で 1 回のみ呼び出される。
+    // 失敗時は空 path のままキャッシュされ、callsite (GetConfigPath/Load/Flush) で空チェックされる。
+    static const std::filesystem::path kDir = []() noexcept {
+        wchar_t* appdata = nullptr;
+        std::filesystem::path result;
+        if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &appdata))) {
+            result = std::filesystem::path(appdata) / L"mendo";
+            CoTaskMemFree(appdata);
+        }
+        return result;
+    }();
+    return kDir;
+}
+
 std::filesystem::path ConfigService::GetConfigDir() const
 {
     if (!config_dir_override_.empty()) {
         return config_dir_override_;
     }
-    // 単一スレッド前提の lazy 初期化 (header の Why コメント参照)。
-    if (!default_dir_resolved_) {
-        wchar_t* appdata = nullptr;
-        if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &appdata))) {
-            cached_default_dir_ = std::filesystem::path(appdata) / L"mendo";
-            CoTaskMemFree(appdata);
-        }
-        default_dir_resolved_ = true;
-    }
-    return cached_default_dir_;
+    return DefaultConfigDir();
 }
 
 std::filesystem::path ConfigService::GetConfigPath(std::wstring_view filename) const

--- a/src/io/config_service.h
+++ b/src/io/config_service.h
@@ -42,13 +42,12 @@ public:
 private:
     [[nodiscard]] const std::string* FindValue(std::string_view section, std::string_view key) const;
 
+    // SHGetKnownFolderPath の結果をプロセス全体で 1 回だけ resolve する。
+    // 関数ローカル static (magic static) は C++11 以降 thread-safe な lazy init を保証するため、
+    // 別スレッド (並列計測 worker 等) から GetConfigDir() を呼んでも安全。
+    static const std::filesystem::path& DefaultConfigDir();
+
     std::filesystem::path config_dir_override_;
-    // SHGetKnownFolderPath の結果キャッシュ。override 未設定時の問い合わせを 1 回に抑える。
-    // 単一 UI スレッドからの呼び出しのみ前提 (本クラスは ConfigService 自体が UI スレッド常駐)。
-    // 並列計測スレッド等から GetConfigDir() を呼ばないこと。並列利用が必要になったら
-    // call_once + ConfigService をコピー禁止に切り替える必要がある。
-    mutable std::filesystem::path cached_default_dir_;
-    mutable bool default_dir_resolved_ = false;
     ini::IniData data_;
 };
 

--- a/src/io/file_load_service.cpp
+++ b/src/io/file_load_service.cpp
@@ -13,8 +13,9 @@ void FileLoadService::StartLoading(std::pmr::wstring path)
 
 void FileLoadService::StopLoading() noexcept
 {
+    // animation のみ停止。coordinator の in_flight 管理は coordinator 自身に閉じる
+    // (Cancel / TakeResult / TakeError で完結) ので同期 ExecuteLoad 経路から触らない。
     animation_.End();
-    coordinator_.Finish();
 }
 
 std::expected<void, FileLoadError> FileLoadService::ExecuteLoad(Document& doc, LayoutCache& cache)

--- a/src/io/file_load_service.cpp
+++ b/src/io/file_load_service.cpp
@@ -7,14 +7,10 @@ void FileLoadService::StartLoading(std::pmr::wstring path)
 {
     loading_path_ = std::move(path);
     animation_.Begin();
-    // coordinator_ の in_flight は StartAsyncLoad 経由で立てる。同期 ExecuteLoad 経路では
-    // animation_ と loading_path_ のみで進行を表現する。
 }
 
 void FileLoadService::StopLoading() noexcept
 {
-    // animation のみ停止。coordinator の in_flight 管理は coordinator 自身に閉じる
-    // (Cancel / TakeResult / TakeError で完結) ので同期 ExecuteLoad 経路から触らない。
     animation_.End();
 }
 
@@ -55,8 +51,6 @@ std::optional<FileLoadError> FileLoadService::TakeAsyncError() noexcept
 
 void FileLoadService::StartPreloadAsync(std::pmr::wstring path)
 {
-    // coordinator_ の in_flight は触らない: preload 中の状態管理は preloader_ に閉じる
-    // (IsAsyncLoading() が両者を OR で見る)。
     loading_path_ = path;
     preloader_.Start(std::move(path));
 }

--- a/src/io/file_load_service.cpp
+++ b/src/io/file_load_service.cpp
@@ -7,13 +7,14 @@ void FileLoadService::StartLoading(std::pmr::wstring path)
 {
     loading_path_ = std::move(path);
     animation_.Begin();
-    async_in_flight_ = true;
+    // coordinator_ の in_flight は StartAsyncLoad 経由で立てる。同期 ExecuteLoad 経路では
+    // animation_ と loading_path_ のみで進行を表現する。
 }
 
 void FileLoadService::StopLoading() noexcept
 {
     animation_.End();
-    async_in_flight_ = false;
+    coordinator_.Finish();
 }
 
 std::expected<void, FileLoadError> FileLoadService::ExecuteLoad(Document& doc, LayoutCache& cache)
@@ -29,61 +30,9 @@ std::expected<void, FileLoadError> FileLoadService::ExecuteLoad(Document& doc, L
     return {};
 }
 
-void FileLoadService::ResetAsyncState()
-{
-    const std::lock_guard lock(async_mutex_);
-    async_result_.reset();
-    async_error_.reset();
-}
-
 void FileLoadService::StartAsyncLoad(TaskScheduler& scheduler, HWND hwnd, UINT msg_id, const Theme& theme)
 {
-    ResetAsyncState();
-    async_in_flight_ = true;
-    const uint32_t gen = async_gen_.fetch_add(1, std::memory_order_relaxed) + 1;
-
-    // ワーカースレッドは loading_path_ に触らないため、capture コピーで安全。
-    // theme も値コピー: UI スレッドの SetTheme は std::wstring メンバ (font_family など) を
-    // 非アトミックに書き換えるので、参照キャプチャだと worker の EstimateNodeHeights が
-    // 文字列リードと同時にレースする。
-    scheduler.Post([this, path = loading_path_, hwnd, msg_id, gen, theme] {
-        if (async_gen_.load(std::memory_order_relaxed) != gen) {
-            return;
-        }
-
-        auto load_result = FileLoader::LoadFile(path);
-        if (!load_result) {
-            if (async_gen_.load(std::memory_order_relaxed) == gen) {
-                {
-                    const std::lock_guard lock(async_mutex_);
-                    async_error_ = load_result.error();
-                }
-                ::PostMessageW(hwnd, msg_id, 0, 0);
-            }
-            return;
-        }
-
-        if (async_gen_.load(std::memory_order_relaxed) != gen) {
-            return;
-        }
-
-        Document doc = Document::FromMarkdown(std::move(load_result->text), load_result->byte_size, path);
-
-        if (async_gen_.load(std::memory_order_relaxed) != gen) {
-            return;
-        }
-
-        LayoutCache cache;
-        cache.Reset(doc.GetNodes().size(), /* shrink = */ false);
-        EstimateNodeHeights(doc.GetNodes(), cache, theme);
-
-        {
-            const std::lock_guard lock(async_mutex_);
-            async_result_.emplace(AsyncLoadResult{ std::move(doc), std::move(cache), /* heights_estimated = */ true });
-        }
-
-        ::PostMessageW(hwnd, msg_id, 0, 0);
-    });
+    coordinator_.Start(scheduler, loading_path_, hwnd, msg_id, theme);
 }
 
 std::optional<AsyncLoadResult> FileLoadService::TakeAsyncResult()
@@ -92,10 +41,7 @@ std::optional<AsyncLoadResult> FileLoadService::TakeAsyncResult()
     if (auto r = preloader_.TakeResult()) {
         return r;
     }
-    const std::lock_guard lock(async_mutex_);
-    auto result = std::move(async_result_);
-    async_result_.reset();
-    return result;
+    return coordinator_.TakeResult();
 }
 
 std::optional<FileLoadError> FileLoadService::TakeAsyncError() noexcept
@@ -103,15 +49,12 @@ std::optional<FileLoadError> FileLoadService::TakeAsyncError() noexcept
     if (auto e = preloader_.TakeError()) {
         return e;
     }
-    const std::lock_guard lock(async_mutex_);
-    auto err = async_error_;
-    async_error_.reset();
-    return err;
+    return coordinator_.TakeError();
 }
 
 void FileLoadService::StartPreloadAsync(std::pmr::wstring path)
 {
-    // async_in_flight_ は触らない: preload 中の状態管理は preloader_ に閉じる
+    // coordinator_ の in_flight は触らない: preload 中の状態管理は preloader_ に閉じる
     // (IsAsyncLoading() が両者を OR で見る)。
     loading_path_ = path;
     preloader_.Start(std::move(path));

--- a/src/io/file_load_service.h
+++ b/src/io/file_load_service.h
@@ -99,9 +99,6 @@ private:
     DocumentService& doc_service_;
     LoadingAnimation animation_;
     std::pmr::wstring loading_path_;
-
-    // 非同期ロード coordinator: StartAsyncLoad 専用の状態管理を完全に分離。
     AsyncLoadCoordinator coordinator_;
-    // 起動時 preload: jthread + cv で hwnd 解禁を待つ独立経路。
     Preloader preloader_;
 };

--- a/src/io/file_load_service.h
+++ b/src/io/file_load_service.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "async_load_coordinator.h"
 #include "async_load_result.h"
 #include "document_service.h"
 #include "document.h"
@@ -10,14 +11,11 @@
 #include <string>
 #include <optional>
 #include <expected>
-#include <mutex>
-#include <atomic>
-#include <memory>
 
 struct Theme;
 
 // ファイル読み込みのオーケストレーション。
-// 内部に LoadingAnimation / Preloader / 非同期ロード coordinator を持ち、
+// 内部に LoadingAnimation / Preloader / AsyncLoadCoordinator を持ち、
 // UI から見える API はそれらを束ねた薄い facade。preload と StartAsyncLoad の
 // 結果ストレージは互いに独立で、TakeAsyncResult/TakeAsyncError が両者を順に確認する。
 class FileLoadService {
@@ -35,7 +33,7 @@ public:
     // 重複スケジューリングを抑制するためのフラグ。preload 経路は preloader_ が状態を持つ。
     bool IsAsyncLoading() const noexcept
     {
-        return async_in_flight_ || preloader_.IsActive();
+        return coordinator_.IsActive() || preloader_.IsActive();
     }
     constexpr float GetLoadingAngle() const noexcept
     {
@@ -68,8 +66,7 @@ public:
     std::optional<FileLoadError> TakeAsyncError() noexcept;
     void CancelAsyncLoad() noexcept
     {
-        async_gen_.fetch_add(1, std::memory_order_relaxed);
-        async_in_flight_ = false;
+        coordinator_.Cancel();
     }
 
     // ---- 起動時 preload (App::Init 前から走らせる経路) ----
@@ -99,20 +96,12 @@ public:
     }
 
 private:
-    void ResetAsyncState();
-
     DocumentService& doc_service_;
     LoadingAnimation animation_;
     std::pmr::wstring loading_path_;
 
-    // ---- 非同期ロード coordinator (StartAsyncLoad 専用) ----
-    // worker thread は async_gen_ (atomic) と async_result_/async_error_ (mutex 保護) のみ触る。
-    bool async_in_flight_ = false;
-    std::atomic<uint32_t> async_gen_{ 0 };
-    std::mutex async_mutex_;
-    std::optional<AsyncLoadResult> async_result_;
-    std::optional<FileLoadError> async_error_;
-
-    // ---- 起動時 preload (jthread + cv で hwnd 解禁を待つ) ----
+    // 非同期ロード coordinator: StartAsyncLoad 専用の状態管理を完全に分離。
+    AsyncLoadCoordinator coordinator_;
+    // 起動時 preload: jthread + cv で hwnd 解禁を待つ独立経路。
     Preloader preloader_;
 };

--- a/src/layout/dirty_scheduler.cpp
+++ b/src/layout/dirty_scheduler.cpp
@@ -11,7 +11,7 @@ DirtyBatchResult DirtyScheduler::RunSerial(std::pmr::vector<Node>& nodes,
                                            const Theme& theme,
                                            const IMeasureBackend& backend,
                                            ViewportClip clip,
-                                           DirtyBudget budget) const
+                                           SerialBudget budget) const
 {
     MENDO_PROFILE("DirtyScheduler::RunSerial");
     DirtyBatchResult result;

--- a/src/layout/dirty_scheduler.h
+++ b/src/layout/dirty_scheduler.h
@@ -44,9 +44,16 @@ struct ViewportClip {
 };
 
 // 1 回の RunSerial で消費可能な予算。0 = 無制限。
-struct DirtyBudget {
+struct SerialBudget {
     int max_nodes = 0;
     int time_us = 0;
+};
+
+// 1 回の RunParallel で消費可能な予算。並列版は time_budget を持たない:
+// Plan/Dispatch/Wait の各 phase に checkpoint を入れる枠組みが無く、worker 側 polling コストが
+// 利得を上回るため。time 制御が必要なら呼び出し側で RunSerial にフォールバックすること。
+struct ParallelBudget {
+    int max_nodes = 0;
 };
 
 enum class StopReason : uint8_t {
@@ -78,7 +85,7 @@ public:
                                const Theme& theme,
                                const IMeasureBackend& backend,
                                ViewportClip clip,
-                               DirtyBudget budget) const;
+                               SerialBudget budget) const;
 };
 
 } // namespace mendo::layout

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -43,6 +43,24 @@ void LayoutEngine::ComputeLayout(std::pmr::vector<Node>& nodes, LayoutCache& cac
     }
 
     const float content_width = theme_->ContentWidth(viewport_width);
+
+    if (partial) {
+        ComputeLayoutPartial(nodes, cache, content_width, width_changed, viewport_top, viewport_bottom);
+    }
+    else {
+        ComputeLayoutFull(nodes, cache, content_width, width_changed);
+    }
+
+    MENDO_PLOT("layout.compute.partial", static_cast<int64_t>(partial));
+    MENDO_PLOT("layout.compute.width_changed", static_cast<int64_t>(width_changed));
+    MENDO_PLOT("layout.compute.node_count", static_cast<int64_t>(node_count));
+}
+
+void LayoutEngine::ComputeLayoutPartial(std::pmr::vector<Node>& nodes, LayoutCache& cache,
+                                        float content_width, bool width_changed,
+                                        float viewport_top, float viewport_bottom)
+{
+    const auto node_count = nodes.size();
     float y = theme_->margin_top;
     bool any_dirty = false;
     bool any_height_changed = false;
@@ -59,36 +77,26 @@ void LayoutEngine::ComputeLayout(std::pmr::vector<Node>& nodes, LayoutCache& cac
         const float indent = NodeIndent(node, *theme_);
         const float node_width = content_width - indent;
 
-        const bool needs_layout = width_changed || entry.layout_dirty;
-
-        if (needs_layout) {
-            if (partial) {
-                const float node_bottom = y + entry.height; // 古い高さを使って推定
-                const bool visible = (node_bottom >= viewport_top && y <= viewport_bottom);
-                if (visible) {
-                    const float old_height = entry.height;
-                    backend_->MeasureNode(node, entry, node_width);
-                    any_measured = true;
-                    entry.cached_width = node_width;
-                    entry.cached_height = entry.height;
-                    if (entry.height != old_height) {
-                        any_height_changed = true;
-                    }
-                }
-                else {
-                    // 不可視ノードは保守的な推定値だけ更新し、厳密値は後続の
-                    // ProcessDirtyBatch / EnsureVisibleLayout に委ねる。
-                    if (EstimateInvisibleNodeHeight(node, entry, *theme_, node_width)) {
-                        any_height_changed = true;
-                    }
-                    entry.layout_dirty = true;
-                }
-            }
-            else {
+        if (width_changed || entry.layout_dirty) {
+            const float node_bottom = y + entry.height; // 古い高さを使って推定
+            const bool visible = (node_bottom >= viewport_top && y <= viewport_bottom);
+            if (visible) {
+                const float old_height = entry.height;
                 backend_->MeasureNode(node, entry, node_width);
                 any_measured = true;
                 entry.cached_width = node_width;
                 entry.cached_height = entry.height;
+                if (entry.height != old_height) {
+                    any_height_changed = true;
+                }
+            }
+            else {
+                // 不可視ノードは保守的な推定値だけ更新し、厳密値は後続の
+                // ProcessDirtyBatch / EnsureVisibleLayout に委ねる。
+                if (EstimateInvisibleNodeHeight(node, entry, *theme_, node_width)) {
+                    any_height_changed = true;
+                }
+                entry.layout_dirty = true;
             }
         }
 
@@ -106,9 +114,9 @@ void LayoutEngine::ComputeLayout(std::pmr::vector<Node>& nodes, LayoutCache& cac
 
         block_heights.push_back(sa + entry.height + sb);
 
-        // 部分モードで幅の変更がなく、ビューポートを超えた後に
-        // 高さの変更もなければ、残りの Y 位置は変わらないので早期終了する。
-        if (partial && !width_changed && !any_height_changed && y > viewport_bottom) {
+        // 幅の変更がなく、ビューポートを超えた後に高さの変更もなければ、
+        // 残りの Y 位置は変わらないので早期終了する。
+        if (!width_changed && !any_height_changed && y > viewport_bottom) {
             // 中断地点より先にダーティノードが存在する可能性を保守的に仮定する。
             // ProcessDirtyBatch が存在しない場合は速やかに確認・クリアする。
             any_dirty = true;
@@ -119,15 +127,58 @@ void LayoutEngine::ComputeLayout(std::pmr::vector<Node>& nodes, LayoutCache& cac
 
     ApplyComputeLayoutBlockHeights(cache, block_heights, broke_early, y);
     has_dirty_nodes_ = any_dirty;
-
     if (any_measured) {
         cache.IncrementEffectsGeneration();
     }
-
-    MENDO_PLOT("layout.compute.partial", static_cast<int64_t>(partial));
-    MENDO_PLOT("layout.compute.width_changed", static_cast<int64_t>(width_changed));
-    MENDO_PLOT("layout.compute.node_count", static_cast<int64_t>(node_count));
     MENDO_PLOT("layout.compute.broke_early", static_cast<int64_t>(broke_early));
+}
+
+void LayoutEngine::ComputeLayoutFull(std::pmr::vector<Node>& nodes, LayoutCache& cache,
+                                     float content_width, bool width_changed)
+{
+    const auto node_count = nodes.size();
+    float y = theme_->margin_top;
+    bool any_dirty = false;
+    bool any_measured = false;
+
+    StackArena<4096> arena;
+    std::pmr::vector<float> block_heights(arena.resource());
+    block_heights.reserve(node_count);
+
+    for (size_t i = 0; i < node_count; i++) {
+        auto& node = nodes[i];
+        auto& entry = cache[i];
+        const float indent = NodeIndent(node, *theme_);
+        const float node_width = content_width - indent;
+
+        if (width_changed || entry.layout_dirty) {
+            backend_->MeasureNode(node, entry, node_width);
+            any_measured = true;
+            entry.cached_width = node_width;
+            entry.cached_height = entry.height;
+        }
+
+        if (entry.layout_dirty) {
+            any_dirty = true;
+        }
+
+        const float sa = GetSpacingAbove(node, *theme_);
+        const float sb = GetSpacingBelow(node, *theme_);
+
+        y += sa;
+        entry.text_top = y;
+        y += entry.height;
+        y += sb;
+
+        block_heights.push_back(sa + entry.height + sb);
+    }
+
+    ApplyComputeLayoutBlockHeights(cache, block_heights, /*broke_early=*/false, y);
+    has_dirty_nodes_ = any_dirty;
+    if (any_measured) {
+        cache.IncrementEffectsGeneration();
+    }
+    MENDO_PLOT("layout.compute.broke_early", 0LL);
 }
 
 void LayoutEngine::ApplyComputeLayoutBlockHeights(LayoutCache& cache, const std::pmr::vector<float>& block_heights,
@@ -193,13 +244,15 @@ bool LayoutEngine::ProcessDirtyBatch(std::pmr::vector<Node>& nodes, LayoutCache&
     const float content_width = theme_->ContentWidth(viewport_width);
 
     const mendo::layout::ViewportClip clip{ viewport_top, viewport_height, buffer_screens };
-    const mendo::layout::DirtyBudget budget{ batch_size, time_budget_us };
 
-    // RunParallel は time_budget_us を無視するが、batch_size は Phase 1 で適用するので
-    // スクロール時バッチも上限以下に収まる。小規模 dirty は内部で inline 直列に倒れる。
+    // 並列版は ParallelBudget (max_nodes のみ) を取り、time_budget は型レベルで遮断される。
+    // batch_size は Phase 1 で適用するのでスクロール時バッチも上限以下に収まる。
+    // 小規模 dirty は RunParallel 内部で inline 直列に倒れる。
     const auto result = layout_scheduler_
-        ? mendo::layout::RunParallel(nodes, cache, content_width, *theme_, *backend_, clip, budget, *layout_scheduler_)
-        : scheduler_.RunSerial(nodes, cache, content_width, *theme_, *backend_, clip, budget);
+        ? mendo::layout::RunParallel(nodes, cache, content_width, *theme_, *backend_, clip,
+                                     mendo::layout::ParallelBudget{ batch_size }, *layout_scheduler_)
+        : scheduler_.RunSerial(nodes, cache, content_width, *theme_, *backend_, clip,
+                               mendo::layout::SerialBudget{ batch_size, time_budget_us });
 
     if (result.processed == 0) {
         has_dirty_nodes_ = false;

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -6,6 +6,7 @@
 #include "task_scheduler.h"
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <memory_resource>
 
 bool LayoutEngine::Init(ITextMeasurer* measurer, const Theme& theme)
@@ -42,25 +43,13 @@ void LayoutEngine::ComputeLayout(std::pmr::vector<Node>& nodes, LayoutCache& cac
         last_viewport_width_ = viewport_width;
     }
 
+    // partial=false 時は ±∞ で full レイアウトを再現する
+    // (visible が常に true、不可視推定経路と early break が発火しない)。
+    constexpr float kInf = std::numeric_limits<float>::infinity();
+    const float vp_top = partial ? viewport_top : -kInf;
+    const float vp_bottom = partial ? viewport_bottom : kInf;
     const float content_width = theme_->ContentWidth(viewport_width);
 
-    if (partial) {
-        ComputeLayoutPartial(nodes, cache, content_width, width_changed, viewport_top, viewport_bottom);
-    }
-    else {
-        ComputeLayoutFull(nodes, cache, content_width, width_changed);
-    }
-
-    MENDO_PLOT("layout.compute.partial", static_cast<int64_t>(partial));
-    MENDO_PLOT("layout.compute.width_changed", static_cast<int64_t>(width_changed));
-    MENDO_PLOT("layout.compute.node_count", static_cast<int64_t>(node_count));
-}
-
-void LayoutEngine::ComputeLayoutPartial(std::pmr::vector<Node>& nodes, LayoutCache& cache,
-                                        float content_width, bool width_changed,
-                                        float viewport_top, float viewport_bottom)
-{
-    const auto node_count = nodes.size();
     float y = theme_->margin_top;
     bool any_dirty = false;
     bool any_height_changed = false;
@@ -79,7 +68,7 @@ void LayoutEngine::ComputeLayoutPartial(std::pmr::vector<Node>& nodes, LayoutCac
 
         if (width_changed || entry.layout_dirty) {
             const float node_bottom = y + entry.height; // 古い高さを使って推定
-            const bool visible = (node_bottom >= viewport_top && y <= viewport_bottom);
+            const bool visible = (node_bottom >= vp_top && y <= vp_bottom);
             if (visible) {
                 const float old_height = entry.height;
                 backend_->MeasureNode(node, entry, node_width);
@@ -116,7 +105,7 @@ void LayoutEngine::ComputeLayoutPartial(std::pmr::vector<Node>& nodes, LayoutCac
 
         // 幅の変更がなく、ビューポートを超えた後に高さの変更もなければ、
         // 残りの Y 位置は変わらないので早期終了する。
-        if (!width_changed && !any_height_changed && y > viewport_bottom) {
+        if (!width_changed && !any_height_changed && y > vp_bottom) {
             // 中断地点より先にダーティノードが存在する可能性を保守的に仮定する。
             // ProcessDirtyBatch が存在しない場合は速やかに確認・クリアする。
             any_dirty = true;
@@ -130,55 +119,11 @@ void LayoutEngine::ComputeLayoutPartial(std::pmr::vector<Node>& nodes, LayoutCac
     if (any_measured) {
         cache.IncrementEffectsGeneration();
     }
+
+    MENDO_PLOT("layout.compute.partial", static_cast<int64_t>(partial));
+    MENDO_PLOT("layout.compute.width_changed", static_cast<int64_t>(width_changed));
+    MENDO_PLOT("layout.compute.node_count", static_cast<int64_t>(node_count));
     MENDO_PLOT("layout.compute.broke_early", static_cast<int64_t>(broke_early));
-}
-
-void LayoutEngine::ComputeLayoutFull(std::pmr::vector<Node>& nodes, LayoutCache& cache,
-                                     float content_width, bool width_changed)
-{
-    const auto node_count = nodes.size();
-    float y = theme_->margin_top;
-    bool any_dirty = false;
-    bool any_measured = false;
-
-    StackArena<4096> arena;
-    std::pmr::vector<float> block_heights(arena.resource());
-    block_heights.reserve(node_count);
-
-    for (size_t i = 0; i < node_count; i++) {
-        auto& node = nodes[i];
-        auto& entry = cache[i];
-        const float indent = NodeIndent(node, *theme_);
-        const float node_width = content_width - indent;
-
-        if (width_changed || entry.layout_dirty) {
-            backend_->MeasureNode(node, entry, node_width);
-            any_measured = true;
-            entry.cached_width = node_width;
-            entry.cached_height = entry.height;
-        }
-
-        if (entry.layout_dirty) {
-            any_dirty = true;
-        }
-
-        const float sa = GetSpacingAbove(node, *theme_);
-        const float sb = GetSpacingBelow(node, *theme_);
-
-        y += sa;
-        entry.text_top = y;
-        y += entry.height;
-        y += sb;
-
-        block_heights.push_back(sa + entry.height + sb);
-    }
-
-    ApplyComputeLayoutBlockHeights(cache, block_heights, /*broke_early=*/false, y);
-    has_dirty_nodes_ = any_dirty;
-    if (any_measured) {
-        cache.IncrementEffectsGeneration();
-    }
-    MENDO_PLOT("layout.compute.broke_early", 0LL);
 }
 
 void LayoutEngine::ApplyComputeLayoutBlockHeights(LayoutCache& cache, const std::pmr::vector<float>& block_heights,

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -69,6 +69,14 @@ private:
     void ApplyComputeLayoutBlockHeights(LayoutCache& cache, const std::pmr::vector<float>& block_heights,
                                         bool broke_early, float final_y) noexcept;
 
+    // partial: 可視範囲のみ厳密計測、不可視は推定値、早期終了あり。
+    // full:    全ノード計測。一致する経路は ComputeLayout が dispatch する。
+    void ComputeLayoutPartial(std::pmr::vector<Node>& nodes, LayoutCache& cache,
+                              float content_width, bool width_changed,
+                              float viewport_top, float viewport_bottom);
+    void ComputeLayoutFull(std::pmr::vector<Node>& nodes, LayoutCache& cache,
+                           float content_width, bool width_changed);
+
     // 同一の ITextMeasurer 派生から得た 2 つの IF view。lifecycle 系 (Init/RecreateFormats/UpdateTheme)
     // は UI スレッドからのみ呼び、backend (MeasureNode/MeasureTable) は const 経由で
     // 将来 worker pool から並列呼び出し可能にする設計。

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -69,14 +69,6 @@ private:
     void ApplyComputeLayoutBlockHeights(LayoutCache& cache, const std::pmr::vector<float>& block_heights,
                                         bool broke_early, float final_y) noexcept;
 
-    // partial: 可視範囲のみ厳密計測、不可視は推定値、早期終了あり。
-    // full:    全ノード計測。一致する経路は ComputeLayout が dispatch する。
-    void ComputeLayoutPartial(std::pmr::vector<Node>& nodes, LayoutCache& cache,
-                              float content_width, bool width_changed,
-                              float viewport_top, float viewport_bottom);
-    void ComputeLayoutFull(std::pmr::vector<Node>& nodes, LayoutCache& cache,
-                           float content_width, bool width_changed);
-
     // 同一の ITextMeasurer 派生から得た 2 つの IF view。lifecycle 系 (Init/RecreateFormats/UpdateTheme)
     // は UI スレッドからのみ呼び、backend (MeasureNode/MeasureTable) は const 経由で
     // 将来 worker pool から並列呼び出し可能にする設計。

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -95,9 +95,16 @@ struct NodeLayoutEntry {
     // MeasureNode で text_layout 確定時に同時に求める。
     float first_line_height = 0.0f;
     // 直近 MeasureNode の幅と実測 height。同じ幅へ戻った際に EstimateNodeHeight の上書きを避ける。
-    // cached_width < 0 が「未計測」のセンチネル (per-node で密に並ぶため optional<> を避けたい)。
-    float cached_width = -1.0f;
+    // 「未計測」のセンチネルは kUnmeasuredWidth (= 負値)。MeasureNode 入力 (node_width) は
+    // 常に正なので負値は初期化/invalidate 経路でしか出現しない。per-node で密に並ぶ hot field の
+    // ため optional<float> 化はサイズ膨張を招き避けている (is_measured() で判定統一)。
+    static constexpr float kUnmeasuredWidth = -1.0f;
+    float cached_width = kUnmeasuredWidth;
     float cached_height = 0.0f;
+    constexpr bool is_measured() const noexcept
+    {
+        return cached_width > 0.0f;
+    }
     Microsoft::WRL::ComPtr<IDWriteTextLayout> text_layout;
     bool layout_dirty = true;
     bool effects_applied = false;

--- a/src/layout/layout_computer.cpp
+++ b/src/layout/layout_computer.cpp
@@ -159,7 +159,7 @@ bool EstimateInvisibleNodeHeight(const Node& node, NodeLayoutEntry& entry, const
     }
     // 同じ幅での実測キャッシュがあればそれを使い、無ければ推定値で成長させる。
     constexpr float kCachedWidthEpsilon = 0.5f;
-    const bool cache_hit = entry.cached_width > 0.0f &&
+    const bool cache_hit = entry.is_measured() &&
                            std::abs(entry.cached_width - node_width) < kCachedWidthEpsilon &&
                            entry.cached_height > 0.0f;
     const float fallback = cache_hit ? entry.cached_height : EstimateNodeHeight(node, theme);

--- a/src/layout/parallel_measure.cpp
+++ b/src/layout/parallel_measure.cpp
@@ -43,7 +43,7 @@ DirtyBatchResult RunParallel(std::pmr::vector<Node>& nodes,
                              const Theme& theme,
                              const IMeasureBackend& backend,
                              ViewportClip clip,
-                             DirtyBudget budget,
+                             ParallelBudget budget,
                              TaskScheduler& scheduler)
 {
     MENDO_PROFILE("DirtyScheduler::RunParallel");
@@ -53,7 +53,8 @@ DirtyBatchResult RunParallel(std::pmr::vector<Node>& nodes,
     const bool has_viewport_limit = clip.active();
     const float limit_top = has_viewport_limit ? clip.limit_top() : 0.0f;
     const float limit_bottom = has_viewport_limit ? clip.limit_bottom() : 0.0f;
-    // time_us 無視: worker 側に polling checkpoint が無いので RunSerial と非対称。
+    // ParallelBudget には time_us が無い (シグネチャで明示)。
+    // worker 側に polling checkpoint が無いため、time-based 制御は RunSerial 専用。
     const bool has_batch_limit = (budget.max_nodes > 0);
 
     std::pmr::vector<size_t> indices(std::pmr::get_default_resource());

--- a/src/layout/parallel_measure.h
+++ b/src/layout/parallel_measure.h
@@ -6,16 +6,17 @@ class TaskScheduler;
 namespace mendo::layout {
 
 // per-node 並列レイアウト計測。MeasureNode を TaskScheduler に分散実行する。
-// time_budget は並列モードでは無視。CodeBlock の Tokenize 結果は UI スレッドで
-// node_index 昇順に集約後 Node に書き戻す (Node 副作用の race を回避)。
+// CodeBlock の Tokenize 結果は UI スレッドで node_index 昇順に集約後 Node に書き戻す
+// (Node 副作用の race を回避)。
 // 小規模 dirty (< kMinDirtyForParallel) は dispatch コストを避けて inline 直列化。
+// budget が ParallelBudget 型なのは「time_budget は並列版では機能しない」を型レベルで明示するため。
 DirtyBatchResult RunParallel(std::pmr::vector<Node>& nodes,
                              LayoutCache& cache,
                              float content_width,
                              const Theme& theme,
                              const IMeasureBackend& backend,
                              ViewportClip clip,
-                             DirtyBudget budget,
+                             ParallelBudget budget,
                              TaskScheduler& scheduler);
 
 } // namespace mendo::layout

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -104,8 +104,10 @@ void Renderer::UpdateLayoutTheme()
     layout_.RecreateFormats();
 }
 
-// ノード描画ロジックは CommandGenerator に抽出済み。
-// D2D ブラシが必要な ApplyNodeEffects のみ描画前パスとしてここに残る。
+// ノード描画ロジックは CommandGenerator に抽出済み。ApplyNodeEffects は
+// IDWriteTextLayout の mutable state (SetDrawingEffect/SetUnderline) を書き換える性質上、
+// 値型 DrawCommand には乗せられず、描画前パスとしてここに残る。
+// effects_applied フラグで初回のみ走り、以降のフレームでは no-op。
 
 void Renderer::PrepareVisibleEffects(std::pmr::vector<Node>& nodes, LayoutCache& cache, float scroll_y, float md_pane_height)
 {

--- a/src/ui/context_menu.cpp
+++ b/src/ui/context_menu.cpp
@@ -42,40 +42,34 @@ LRESULT CALLBACK ContextMenu::Impl::WndProc(HWND hwnd, UINT msg, WPARAM wParam, 
     return DefWindowProcW(hwnd, msg, wParam, lParam);
 }
 
-int ContextMenu::Show(HWND owner_hwnd, const ContextMenuParams& params)
+void ContextMenu::Impl::PrepareContent(const ContextMenuParams& params)
 {
-    auto& s = *impl_;
-    if (!s.d2d_factory || !s.dwrite_factory || !params.theme || params.dpi_scale <= 0.0f) {
-        return 0;
+    BuildItems(params);
+    CreateTextFormats(*theme);
+    ComputeLayout();
+}
+
+bool ContextMenu::Impl::CreatePopupWindow(int screen_x, int screen_y)
+{
+    if (!RegisterWindowClass()) {
+        return false;
     }
-
-    s.owner = owner_hwnd;
-    s.theme = params.theme;
-    s.dpi_scale = params.dpi_scale;
-
-    s.BuildItems(params);
-    s.CreateTextFormats(*s.theme);
-    s.ComputeLayout();
-
-    if (!Impl::RegisterWindowClass()) {
-        return 0;
+    if (hwnd) {
+        DestroyWindow(hwnd);
+        hwnd = nullptr;
     }
-    if (s.hwnd) {
-        DestroyWindow(s.hwnd);
-        s.hwnd = nullptr;
-    }
-    s.rt.Reset();
+    rt.Reset();
 
-    const int pixel_w = static_cast<int>(std::ceil(s.menu_width * s.dpi_scale));
-    const int pixel_h = static_cast<int>(std::ceil(s.menu_height * s.dpi_scale));
+    const int pixel_w = static_cast<int>(std::ceil(menu_width * dpi_scale));
+    const int pixel_h = static_cast<int>(std::ceil(menu_height * dpi_scale));
 
     // 画面外にはみ出さないよう調整
-    const HMONITOR monitor = MonitorFromPoint({ params.screen_x, params.screen_y }, MONITOR_DEFAULTTONEAREST);
+    const HMONITOR monitor = MonitorFromPoint({ screen_x, screen_y }, MONITOR_DEFAULTTONEAREST);
     MONITORINFO mi = { sizeof(mi) };
     GetMonitorInfoW(monitor, &mi);
 
-    int x = params.screen_x;
-    int y = params.screen_y;
+    int x = screen_x;
+    int y = screen_y;
     if (x + pixel_w > mi.rcWork.right) {
         x = mi.rcWork.right - pixel_w;
     }
@@ -89,55 +83,78 @@ int ContextMenu::Show(HWND owner_hwnd, const ContextMenuParams& params)
         y = mi.rcWork.top;
     }
 
-    s.hwnd = CreateWindowExW(
+    hwnd = CreateWindowExW(
         WS_EX_TOOLWINDOW | WS_EX_TOPMOST,
         L"mendoContextMenu", nullptr,
         WS_POPUP,
         x, y, pixel_w, pixel_h,
-        s.owner, nullptr, GetModuleHandleW(nullptr), &s);
+        owner, nullptr, GetModuleHandleW(nullptr), this);
 
-    if (!s.hwnd) {
-        return 0;
+    if (!hwnd) {
+        return false;
     }
 
-    const float dpi = s.dpi_scale * 96.0f;
-    if (!s.EnsureRenderTarget(dpi)) {
-        DestroyWindow(s.hwnd);
-        s.hwnd = nullptr;
-        return 0;
+    const float dpi = dpi_scale * 96.0f;
+    if (!EnsureRenderTarget(dpi)) {
+        DestroyWindow(hwnd);
+        hwnd = nullptr;
+        return false;
     }
-    s.CreateBrushes();
+    CreateBrushes();
 
     // 角丸クリッピング用リージョン
-    const int corner_px = static_cast<int>(MENU_CORNER * s.dpi_scale);
+    const int corner_px = static_cast<int>(MENU_CORNER * dpi_scale);
     const HRGN rgn = CreateRoundRectRgn(0, 0, pixel_w + 1, pixel_h + 1, corner_px, corner_px);
-    SetWindowRgn(s.hwnd, rgn, FALSE);
+    SetWindowRgn(hwnd, rgn, FALSE);
 
-    s.selected_id = 0;
-    s.done = false;
-    s.hovered_id = 0;
-    s.hovered_nav = 0;
+    selected_id = 0;
+    done = false;
+    hovered_id = 0;
+    hovered_nav = 0;
 
-    ShowWindow(s.hwnd, SW_SHOW);
-    SetForegroundWindow(s.hwnd);
-    SetCapture(s.hwnd);
+    ShowWindow(hwnd, SW_SHOW);
+    SetForegroundWindow(hwnd);
+    SetCapture(hwnd);
+    return true;
+}
 
+void ContextMenu::Impl::RunModalLoop()
+{
     MSG msg{};
-    while (!s.done) {
+    while (!done) {
         // WM_APP+* (TaskScheduler 完了通知など) を parent_hwnd 宛のままキューに残し、メインループで処理させる。
         // メニュー表示中に App 状態を書き換えると race になるため。
         if (PeekMessageW(&msg, nullptr, WM_QUIT, WM_QUIT, PM_NOREMOVE)) {
             PostQuitMessage(static_cast<int>(msg.wParam));
-            s.done = true;
+            done = true;
             break;
         }
-        if (!PeekMessageW(&msg, s.hwnd, 0, 0, PM_REMOVE)) {
+        if (!PeekMessageW(&msg, hwnd, 0, 0, PM_REMOVE)) {
             WaitMessage();
             continue;
         }
         TranslateMessage(&msg);
         DispatchMessageW(&msg);
     }
+}
+
+int ContextMenu::Show(HWND owner_hwnd, const ContextMenuParams& params)
+{
+    auto& s = *impl_;
+    if (!s.d2d_factory || !s.dwrite_factory || !params.theme || params.dpi_scale <= 0.0f) {
+        return 0;
+    }
+
+    s.owner = owner_hwnd;
+    s.theme = params.theme;
+    s.dpi_scale = params.dpi_scale;
+
+    s.PrepareContent(params);
+    if (!s.CreatePopupWindow(params.screen_x, params.screen_y)) {
+        s.theme = nullptr;
+        return 0;
+    }
+    s.RunModalLoop();
 
     if (s.hwnd) {
         ReleaseCapture();

--- a/src/ui/context_menu_impl.h
+++ b/src/ui/context_menu_impl.h
@@ -35,7 +35,7 @@ struct ContextMenu::Impl {
     static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
     LRESULT HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam);
 
-    // Show() の 3 段階。各段階の失敗で false を返したら呼び出し側は早期 return する。
+    // Show() の 3 段階。CreatePopupWindow が false を返したら Show() は早期 return する。
     void PrepareContent(const ContextMenuParams& params);
     bool CreatePopupWindow(int screen_x, int screen_y);
     void RunModalLoop();

--- a/src/ui/context_menu_impl.h
+++ b/src/ui/context_menu_impl.h
@@ -35,6 +35,11 @@ struct ContextMenu::Impl {
     static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
     LRESULT HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam);
 
+    // Show() の 3 段階。各段階の失敗で false を返したら呼び出し側は早期 return する。
+    void PrepareContent(const ContextMenuParams& params);
+    bool CreatePopupWindow(int screen_x, int screen_y);
+    void RunModalLoop();
+
     void BuildItems(const ContextMenuParams& params);
     void ComputeLayout();
     bool EnsureRenderTarget(float dpi);

--- a/src/ui/pane_controller.h
+++ b/src/ui/pane_controller.h
@@ -156,7 +156,6 @@ public:
 
     static constexpr float PANE_DEFAULT_WIDTH = 220.0f;
     static constexpr float PANE_MIN_WIDTH = 100.0f;
-    static constexpr float MD_PANE_MIN_WIDTH = ::MD_PANE_MIN_WIDTH;
 
 private:
     float file_width_ = PANE_DEFAULT_WIDTH;

--- a/src/util/profiler.h
+++ b/src/util/profiler.h
@@ -52,7 +52,8 @@
 #define MENDO_IF_TRACY(...) __VA_ARGS__
 
 // 256 バイト固定はトレース用途として十分 (callsite が短いメッセージのみ生成)。
-// バッファ超過は format_to_n が out iterator で打ち切るため切り詰め検知不要。
+// 切り詰め時は format_to_n の out iterator がバッファ末尾で停止し、`out - buf` が
+// 実書き込みバイト数 (= min(必要量, sizeof(buf))) を表す。
 #define MENDO_LOGF(prefix, fmt_str, ...)                                                  \
     do {                                                                                  \
         char _mendo_buf[256];                                                             \

--- a/src/util/profiler.h
+++ b/src/util/profiler.h
@@ -33,8 +33,8 @@
 #ifdef MENDO_USE_TRACY
 
 #include <tracy/Tracy.hpp>
-#include <cstdio>
-#include <cstring>
+#include <format>
+#include <string_view>
 
 // Tracy の ZoneScopedN は固定変数名 `___tracy_scoped_zone` を生成するため、
 // 同一スコープに 2 個書くと再定義エラーになる。__LINE__ で固有名を作る
@@ -51,26 +51,23 @@
 #define MENDO_COUNT_SET(counter, value) ((counter) = (value))
 #define MENDO_IF_TRACY(...) __VA_ARGS__
 
-// _snprintf_s は _TRUNCATE 指定時、収まれば書き込んだ文字数を返し、切り詰めが
-// 起きると -1 を返す（バッファ自体は NUL 終端される）。-1 を 0 と同様に
-// 捨てると長メッセージが silently drop されるため、切り詰め時は実長を取り直す。
-#define MENDO_LOGF(prefix, fmt, ...)                                            \
-    do {                                                                        \
-        char _mendo_buf[256];                                                   \
-        const int _mendo_n = _snprintf_s(_mendo_buf, sizeof(_mendo_buf),        \
-                                         _TRUNCATE, prefix fmt, __VA_ARGS__);   \
-        const size_t _mendo_len = (_mendo_n >= 0)                               \
-            ? static_cast<size_t>(_mendo_n)                                     \
-            : strnlen(_mendo_buf, sizeof(_mendo_buf) - 1);                      \
-        if (_mendo_len > 0) {                                                   \
-            TracyMessage(_mendo_buf, _mendo_len);                               \
-        }                                                                       \
+// 256 バイト固定はトレース用途として十分 (callsite が短いメッセージのみ生成)。
+// バッファ超過は format_to_n が out iterator で打ち切るため切り詰め検知不要。
+#define MENDO_LOGF(prefix, fmt_str, ...)                                                  \
+    do {                                                                                  \
+        char _mendo_buf[256];                                                             \
+        const auto _mendo_r = std::format_to_n(                                           \
+            _mendo_buf, sizeof(_mendo_buf), prefix fmt_str __VA_OPT__(, ) __VA_ARGS__);   \
+        const size_t _mendo_len = static_cast<size_t>(_mendo_r.out - _mendo_buf);         \
+        if (_mendo_len > 0) {                                                             \
+            TracyMessage(_mendo_buf, _mendo_len);                                         \
+        }                                                                                 \
     } while (0)
 
 // TracyMessageL はリテラル前提（NULL 終端の文字列をそのまま参照保持する）。
 #define MENDO_TRACE(msg) TracyMessageL("[mendo-reload] " msg)
-#define MENDO_TRACEF(fmt, ...) MENDO_LOGF("[mendo-reload] ", fmt, __VA_ARGS__)
-#define MENDO_STATF(fmt, ...) MENDO_LOGF("[mendo-stat] ", fmt, __VA_ARGS__)
+#define MENDO_TRACEF(fmt_str, ...) MENDO_LOGF("[mendo-reload] ", fmt_str __VA_OPT__(, ) __VA_ARGS__)
+#define MENDO_STATF(fmt_str, ...) MENDO_LOGF("[mendo-stat] ", fmt_str __VA_OPT__(, ) __VA_ARGS__)
 
 #else
 

--- a/src/util/profiler.h
+++ b/src/util/profiler.h
@@ -20,9 +20,11 @@
 //   MENDO_COUNT_SET(counter, value)  : 累積でない直近値の代入。Tracy OFF で no-op。
 //   MENDO_IF_TRACY(...)              : Tracy ON のときだけ展開する任意コード。
 //   MENDO_TRACE(msg)                 : リテラルメッセージ（reload 系トレース）。
-//   MENDO_TRACEF(fmt, ...)           : printf 形式トレース。
-//   MENDO_STATF(fmt, ...)            : printf 形式の統計値ログ。
-//   MENDO_LOGF(prefix, fmt, ...)     : 任意プレフィックスでログ出力。
+//   MENDO_TRACEF(fmt, ...)           : std::format 形式トレース ("{}", "{:.1f}" 等)。
+//   MENDO_STATF(fmt, ...)            : std::format 形式の統計値ログ。
+//   MENDO_LOGF(prefix, fmt, ...)     : prefix + fmt の隣接リテラル連結でログ出力。
+//                                      fmt は std::format のコンパイル時チェック対象のため
+//                                      文字列リテラル必須 (std::format_to_n に渡される)。
 
 // __LINE__ ベースで一意な識別子を生成するための内部マクロ。
 // MENDO_PROFILE の展開で参照されるため #undef で隠せないが、`_MENDO_DETAIL_` prefix で

--- a/src/util/string_convert.h
+++ b/src/util/string_convert.h
@@ -25,7 +25,7 @@ inline void Utf8ToWide(std::string_view utf8, std::pmr::wstring& out)
         const int n = MultiByteToWideChar(CP_UTF8, 0, utf8.data(), static_cast<int>(utf8.size()), buf, static_cast<int>(count));
         return n > 0 ? static_cast<size_t>(n) : 0;
     });
-    MENDO_STATF("Utf8ToWide(utf8): utf8=%zu wide.size=%zu wide.cap=%zu", utf8.size(), out.size(), out.capacity());
+    MENDO_STATF("Utf8ToWide(utf8): utf8={} wide.size={} wide.cap={}", utf8.size(), out.size(), out.capacity());
 }
 
 inline std::pmr::wstring Utf8ToWide(std::string_view utf8)

--- a/tests/test_dirty_scheduler.cpp
+++ b/tests/test_dirty_scheduler.cpp
@@ -7,7 +7,7 @@
 #include "theme.h"
 
 using mendo::layout::DirtyBatchResult;
-using mendo::layout::DirtyBudget;
+using mendo::layout::SerialBudget;
 using mendo::layout::DirtyScheduler;
 using mendo::layout::StopReason;
 using mendo::layout::ViewportClip;
@@ -63,7 +63,7 @@ TEST_F(DirtySchedulerTest, NoneDirtyReturnsNoneDirty)
 {
     DirtyFixture f;
     f.Build(5, {});
-    const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_, ViewportClip{}, DirtyBudget{});
+    const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_, ViewportClip{}, SerialBudget{});
     EXPECT_EQ(r.processed, 0);
     EXPECT_EQ(r.reason, StopReason::NoneDirty);
     EXPECT_FALSE(r.any_nearby_skipped);
@@ -73,7 +73,7 @@ TEST_F(DirtySchedulerTest, AllDirtyProcessedReturnsDone)
 {
     DirtyFixture f;
     f.Build(5, { 0, 1, 2, 3, 4 });
-    const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_, ViewportClip{}, DirtyBudget{});
+    const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_, ViewportClip{}, SerialBudget{});
     EXPECT_EQ(r.processed, 5);
     EXPECT_EQ(r.reason, StopReason::Done);
     EXPECT_FALSE(r.any_nearby_skipped);
@@ -85,7 +85,7 @@ TEST_F(DirtySchedulerTest, BatchLimitStopsAtMaxNodes)
 {
     DirtyFixture f;
     f.Build(10, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
-    const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_, ViewportClip{}, DirtyBudget{ 3, 0 });
+    const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_, ViewportClip{}, SerialBudget{ 3, 0 });
     EXPECT_EQ(r.processed, 3);
     EXPECT_EQ(r.reason, StopReason::BatchLimit);
     EXPECT_TRUE(r.any_nearby_skipped);
@@ -98,7 +98,7 @@ TEST_F(DirtySchedulerTest, TimeBudgetGuaranteesProgressOfAtLeastOneNode)
     // time_us=1 (実質ゼロ) でも進行保証で 1 ノードは処理されること
     DirtyFixture f;
     f.Build(10, { 0, 1, 2, 3, 4 });
-    const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_, ViewportClip{}, DirtyBudget{ 0, 1 });
+    const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_, ViewportClip{}, SerialBudget{ 0, 1 });
     EXPECT_GE(r.processed, 1);
     // 処理が 1 件で打ち切られた場合: TimeBudget。全件入った場合: Done。
     if (r.processed < 5) {
@@ -119,7 +119,7 @@ TEST_F(DirtySchedulerTest, ViewportClipSkipsOffscreenDirty)
     DirtyFixture f;
     f.Build(10, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
     const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_,
-                                        ViewportClip{ 150.0f, 200.0f, 0.0f }, DirtyBudget{});
+                                        ViewportClip{ 150.0f, 200.0f, 0.0f }, SerialBudget{});
     EXPECT_EQ(r.processed, 3);
     EXPECT_EQ(r.reason, StopReason::Done);
     EXPECT_FALSE(r.any_nearby_skipped);
@@ -137,7 +137,7 @@ TEST_F(DirtySchedulerTest, ViewportClipWithBufferIncludesNearbyDirty)
     DirtyFixture f;
     f.Build(10, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
     const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_,
-                                        ViewportClip{ 300.0f, 100.0f, 1.0f }, DirtyBudget{});
+                                        ViewportClip{ 300.0f, 100.0f, 1.0f }, SerialBudget{});
     EXPECT_GE(r.processed, 3);
     EXPECT_LE(r.processed, 4);
     EXPECT_EQ(r.reason, StopReason::Done);
@@ -147,7 +147,7 @@ TEST_F(DirtySchedulerTest, FirstLastProcessedTracking)
 {
     DirtyFixture f;
     f.Build(7, { 3, 4, 5 });
-    const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_, ViewportClip{}, DirtyBudget{});
+    const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_, ViewportClip{}, SerialBudget{});
     EXPECT_EQ(r.processed, 3);
     EXPECT_EQ(r.first_processed, 3u);
     EXPECT_EQ(r.last_processed, 5u);
@@ -161,7 +161,7 @@ TEST_F(DirtySchedulerTest, BudgetZeroIsUnlimited)
     for (int i = 0; i < 50; ++i) {
         f.cache[i].layout_dirty = true;
     }
-    const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_, ViewportClip{}, DirtyBudget{ 0, 0 });
+    const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_, ViewportClip{}, SerialBudget{ 0, 0 });
     EXPECT_EQ(r.processed, 50);
     EXPECT_EQ(r.reason, StopReason::Done);
     EXPECT_FALSE(r.any_nearby_skipped);
@@ -173,7 +173,7 @@ TEST_F(DirtySchedulerTest, MeasureNodeIsCalledOnEachProcessed)
     // 計測 callback がインスタンスごとに 1 回ずつ呼ばれたことを検証する。
     DirtyFixture f;
     f.Build(5, { 0, 1, 2, 3, 4 });
-    const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_, ViewportClip{}, DirtyBudget{});
+    const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_, ViewportClip{}, SerialBudget{});
     EXPECT_EQ(r.processed, 5);
     for (int i = 0; i < 5; ++i) {
         EXPECT_FALSE(f.cache[i].layout_dirty) << "node " << i << " should be cleaned";
@@ -187,7 +187,7 @@ TEST_F(DirtySchedulerTest, NoClipProcessesAllDirtyEvenIfYUnreachable)
     f.Build(5, { 0, 4 });
     f.cache[0].text_top = -1000.0f; // 大きく外れた値
     f.cache[4].text_top = 999999.0f;
-    const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_, ViewportClip{}, DirtyBudget{});
+    const auto r = scheduler_.RunSerial(f.nodes, f.cache, 800.0f, theme_, mock_, ViewportClip{}, SerialBudget{});
     EXPECT_EQ(r.processed, 2);
     EXPECT_EQ(r.first_processed, 0u);
     EXPECT_EQ(r.last_processed, 4u);

--- a/tests/test_pane_controller.cpp
+++ b/tests/test_pane_controller.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "pane_controller.h"
+#include "ui_constants.h"
 
 class PaneControllerTest : public ::testing::Test {
 protected:
@@ -165,7 +166,7 @@ TEST_F(PaneControllerTest, DragSplitter1RespectsMinMdWidth)
     // MDペインに残るのは12のみ(< 200)なので、制約されるべき
     panes_.DragSplitter1To(960.0f, 1200.0f, 4.0f);
     float remaining = 1200.0f - panes_.GetFilePaneWidth() - 4.0f - 220.0f - 4.0f;
-    EXPECT_GE(remaining, PaneController::MD_PANE_MIN_WIDTH);
+    EXPECT_GE(remaining, ::MD_PANE_MIN_WIDTH);
 }
 
 TEST_F(PaneControllerTest, DragSplitter2RespectsMinWidth)
@@ -181,7 +182,7 @@ TEST_F(PaneControllerTest, DragSplitter2RespectsMinMdWidth)
     panes_.DragSplitter2To(1190.0f, 1200.0f, 4.0f);
     float layout_width = panes_.GetFilePaneWidth() + 4.0f + panes_.GetTocPaneWidth() + 4.0f;
     float md_width = 1200.0f - layout_width;
-    EXPECT_GE(md_width, PaneController::MD_PANE_MIN_WIDTH);
+    EXPECT_GE(md_width, ::MD_PANE_MIN_WIDTH);
 }
 
 // ═══════════════════════════════════════════════

--- a/tests/test_parallel_measure.cpp
+++ b/tests/test_parallel_measure.cpp
@@ -11,7 +11,8 @@
 #include "theme.h"
 
 using mendo::layout::DirtyBatchResult;
-using mendo::layout::DirtyBudget;
+using mendo::layout::ParallelBudget;
+using mendo::layout::SerialBudget;
 using mendo::layout::DirtyScheduler;
 using mendo::layout::RunParallel;
 using mendo::layout::StopReason;
@@ -69,7 +70,7 @@ TEST_F(ParallelMeasureTest, EmptyDirtyReturnsNoneDirty)
     ParallelFixture f;
     f.Build(10, false);
     const auto r = RunParallel(f.nodes, f.cache, 800.0f, theme_, mock_,
-                               ViewportClip{}, DirtyBudget{}, task_scheduler_);
+                               ViewportClip{}, ParallelBudget{}, task_scheduler_);
     EXPECT_EQ(r.processed, 0);
     EXPECT_EQ(r.reason, StopReason::NoneDirty);
 }
@@ -85,9 +86,9 @@ TEST_F(ParallelMeasureTest, MatchesSerialOutputOnSmallFixture)
     f_parallel.Build(N, true);
 
     const auto r_serial = scheduler_.RunSerial(f_serial.nodes, f_serial.cache, 800.0f, theme_, mock_,
-                                               ViewportClip{}, DirtyBudget{});
+                                               ViewportClip{}, SerialBudget{});
     const auto r_parallel = RunParallel(f_parallel.nodes, f_parallel.cache, 800.0f, theme_, mock_,
-                                        ViewportClip{}, DirtyBudget{}, task_scheduler_);
+                                        ViewportClip{}, ParallelBudget{}, task_scheduler_);
 
     EXPECT_EQ(r_serial.processed, r_parallel.processed);
     EXPECT_EQ(r_serial.first_processed, r_parallel.first_processed);
@@ -109,7 +110,7 @@ TEST_F(ParallelMeasureTest, ChunkBoundary)
         ParallelFixture f;
         f.Build(N, true);
         const auto r = RunParallel(f.nodes, f.cache, 800.0f, theme_, mock_,
-                                   ViewportClip{}, DirtyBudget{}, task_scheduler_);
+                                   ViewportClip{}, ParallelBudget{}, task_scheduler_);
         EXPECT_EQ(r.processed, static_cast<int>(N)) << "N=" << N;
         for (size_t i = 0; i < N; ++i) {
             EXPECT_FALSE(f.cache[i].layout_dirty) << "i=" << i << " N=" << N;
@@ -126,7 +127,7 @@ TEST_F(ParallelMeasureTest, ViewportClipSkipsOffscreen)
     f.Build(100, true);
     ViewportClip clip{ 200.0f, 400.0f, 1.0f };
     const auto r = RunParallel(f.nodes, f.cache, 800.0f, theme_, mock_,
-                               clip, DirtyBudget{}, task_scheduler_);
+                               clip, ParallelBudget{}, task_scheduler_);
     // y_position[i] = i*100, height=80。clip [-200, 1000] に重なるのは i=0..10
     EXPECT_GT(r.processed, 0);
     EXPECT_LE(r.processed, 11);
@@ -139,7 +140,7 @@ TEST_F(ParallelMeasureTest, BatchLimitClampsProcessed)
     ParallelFixture f;
     f.Build(100, true);
     const auto r = RunParallel(f.nodes, f.cache, 800.0f, theme_, mock_,
-                               ViewportClip{}, DirtyBudget{ 10, 0 }, task_scheduler_);
+                               ViewportClip{}, ParallelBudget{ 10 }, task_scheduler_);
     EXPECT_EQ(r.processed, 10);
     EXPECT_EQ(r.reason, StopReason::BatchLimit);
     EXPECT_TRUE(r.any_nearby_skipped);
@@ -152,7 +153,7 @@ TEST_F(ParallelMeasureTest, AllDirtyClearedAfterRun)
     ParallelFixture f;
     f.Build(N, true);
     const auto r = RunParallel(f.nodes, f.cache, 800.0f, theme_, mock_,
-                               ViewportClip{}, DirtyBudget{}, task_scheduler_);
+                               ViewportClip{}, ParallelBudget{}, task_scheduler_);
     EXPECT_EQ(r.processed, static_cast<int>(N));
     for (size_t i = 0; i < N; ++i) {
         EXPECT_FALSE(f.cache[i].layout_dirty) << "i=" << i;

--- a/tests/test_parallel_measure_stress.cpp
+++ b/tests/test_parallel_measure_stress.cpp
@@ -16,7 +16,8 @@
 #include "theme.h"
 
 using mendo::layout::DirtyBatchResult;
-using mendo::layout::DirtyBudget;
+using mendo::layout::ParallelBudget;
+using mendo::layout::SerialBudget;
 using mendo::layout::DirtyScheduler;
 using mendo::layout::RunParallel;
 using mendo::layout::StopReason;
@@ -203,9 +204,9 @@ TEST_F(ParallelMeasureStressTest, MatchesSerialOutputOnLargeMixedFixture)
     p.Build(N, /*include_code_block=*/false, /*all_dirty=*/true);
 
     const auto rs = scheduler_.RunSerial(s.nodes, s.cache, 800.0f, theme_, mock_,
-                                         ViewportClip{}, DirtyBudget{});
+                                         ViewportClip{}, SerialBudget{});
     const auto rp = RunParallel(p.nodes, p.cache, 800.0f, theme_, mock_,
-                                ViewportClip{}, DirtyBudget{}, task_scheduler_);
+                                ViewportClip{}, ParallelBudget{}, task_scheduler_);
 
     EXPECT_EQ(rp.processed, static_cast<int>(N));
     ExpectBitExactEqual(s, p, rs, rp);
@@ -222,9 +223,9 @@ TEST_F(ParallelMeasureStressTest, CodeBlockSyntaxTokensAggregatedInOrder)
     p.Build(N, /*include_code_block=*/true, /*all_dirty=*/true);
 
     const auto rs = scheduler_.RunSerial(s.nodes, s.cache, 800.0f, theme_, mock_,
-                                         ViewportClip{}, DirtyBudget{});
+                                         ViewportClip{}, SerialBudget{});
     const auto rp = RunParallel(p.nodes, p.cache, 800.0f, theme_, mock_,
-                                ViewportClip{}, DirtyBudget{}, task_scheduler_);
+                                ViewportClip{}, ParallelBudget{}, task_scheduler_);
 
     EXPECT_EQ(rp.processed, static_cast<int>(N));
     ExpectBitExactEqual(s, p, rs, rp);
@@ -274,9 +275,9 @@ TEST_P(ParallelWorkerCountTest, BitExactAcrossWorkerCount)
     p.Build(N, /*include_code_block=*/true, /*all_dirty=*/true);
 
     const auto rs = scheduler_.RunSerial(s.nodes, s.cache, 800.0f, theme_, mock_,
-                                         ViewportClip{}, DirtyBudget{});
+                                         ViewportClip{}, SerialBudget{});
     const auto rp = RunParallel(p.nodes, p.cache, 800.0f, theme_, mock_,
-                                ViewportClip{}, DirtyBudget{}, ts);
+                                ViewportClip{}, ParallelBudget{}, ts);
 
     EXPECT_EQ(rp.processed, static_cast<int>(N));
     ExpectBitExactEqual(s, p, rs, rp);
@@ -314,7 +315,7 @@ TEST(ParallelMeasurePostFailure, AllChunksFallbackOnSaturatedQueue)
     MockTextMeasurerWithTokens mock;
     Theme theme = GetLightTheme();
     const auto r = RunParallel(f.nodes, f.cache, 800.0f, theme, mock,
-                               ViewportClip{}, DirtyBudget{}, ts);
+                               ViewportClip{}, ParallelBudget{}, ts);
 
     EXPECT_EQ(r.processed, static_cast<int>(N));
     EXPECT_EQ(r.reason, StopReason::Done);
@@ -380,11 +381,11 @@ TEST(ParallelMeasureBench, DISABLED_ChunkSizeSweep)
 
         const double us_serial = MeasureUs([&] {
             scheduler.RunSerial(sf.nodes, sf.cache, 800.0f, theme, mock,
-                                ViewportClip{}, DirtyBudget{});
+                                ViewportClip{}, SerialBudget{});
         });
         const double us_parallel = MeasureUs([&] {
             RunParallel(pf.nodes, pf.cache, 800.0f, theme, mock,
-                        ViewportClip{}, DirtyBudget{}, ts);
+                        ViewportClip{}, ParallelBudget{}, ts);
         });
         std::cout << N << ",serial," << us_serial << "\n";
         std::cout << N << ",parallel," << us_parallel << "\n";

--- a/tests/test_reducer.cpp
+++ b/tests/test_reducer.cpp
@@ -587,7 +587,7 @@ TEST_F(ReducerTest, SearchInputDragStarted_BeginsDragAndCaptures)
     EXPECT_TRUE(state.search.search_bar_ctrl.IsDragging());
     EXPECT_EQ(state.search.search_bar_ctrl.GetDragAnchor(), 5);
     EXPECT_TRUE(HasEffect<effect::SetCapture>(effects));
-    EXPECT_TRUE(HasEffect<effect::PostWindowMessage>(effects));
+    EXPECT_TRUE(HasEffect<effect::SearchFocus>(effects));
 }
 
 TEST_F(ReducerTest, SearchInputDragMoved_NotDragging_NoOp)
@@ -596,11 +596,11 @@ TEST_F(ReducerTest, SearchInputDragMoved_NotDragging_NoOp)
     EXPECT_TRUE(effects.empty());
 }
 
-TEST_F(ReducerTest, SearchInputDragMoved_DraggingAndChanged_EmitsPostWindowMessage)
+TEST_F(ReducerTest, SearchInputDragMoved_DraggingAndChanged_EmitsSearchFocus)
 {
     state.search.search_bar_ctrl.StartDrag(3);
     auto effects = Reduce(state, SearchInputDragMovedAction{ 7 });
-    EXPECT_TRUE(HasEffect<effect::PostWindowMessage>(effects));
+    EXPECT_TRUE(HasEffect<effect::SearchFocus>(effects));
 }
 
 TEST_F(ReducerTest, SearchInputDragMoved_Unchanged_NoEffect)

--- a/tests/test_side_effect_executor.cpp
+++ b/tests/test_side_effect_executor.cpp
@@ -87,6 +87,16 @@ public:
         return post_window_message_result;
     }
     bool post_window_message_result = true;
+    std::vector<effect::SearchFocus> search_focus_calls;
+    std::vector<effect::SearchUnfocus> search_unfocus_calls;
+    void SearchFocus(effect::SearchFocus action) override
+    {
+        search_focus_calls.push_back(action);
+    }
+    void SearchUnfocus(effect::SearchUnfocus action) override
+    {
+        search_unfocus_calls.push_back(action);
+    }
     void SetWindowTitle(const std::pmr::wstring& title) override
     {
         set_window_title_calls.emplace_back(std::wstring_view{ title });
@@ -445,18 +455,6 @@ TEST_F(SideEffectExecutorTest, PostWindowMessageForwardsToHost)
     EXPECT_EQ(std::get<0>(host_.post_message_calls[0]), UINT{ WM_USER + 1 });
     EXPECT_EQ(std::get<1>(host_.post_message_calls[0]), WPARAM{ 7 });
     EXPECT_EQ(std::get<2>(host_.post_message_calls[0]), LPARAM{ 13 });
-}
-
-// PostMessageW 失敗時に SEARCH_FOCUS_SET_SELECTION の heap payload が確実に
-// 解放されることを確認する。AddressSanitizer/CRT debug heap 配下では未解放だと検知される。
-TEST_F(SideEffectExecutorTest, PostWindowMessageReclaimsSearchSelectionPayloadOnFailure)
-{
-    host_.post_window_message_result = false;
-    exec_.ExecuteOne(effect::PostWindowMessage{
-        app_msg::SEARCH_FOCUS,
-        app_param::SEARCH_FOCUS_SET_SELECTION,
-        app_param::MakeSearchSelectionLParam(3, 7) });
-    ASSERT_EQ(host_.post_message_calls.size(), 1u);
 }
 
 TEST_F(SideEffectExecutorTest, SetWindowTitleForwardsToHost)

--- a/tests/test_side_effect_executor.cpp
+++ b/tests/test_side_effect_executor.cpp
@@ -455,6 +455,25 @@ TEST_F(SideEffectExecutorTest, PostWindowMessageForwardsToHost)
     EXPECT_EQ(std::get<2>(host_.post_message_calls[0]), LPARAM{ 13 });
 }
 
+TEST_F(SideEffectExecutorTest, SearchFocusForwardsToHost)
+{
+    exec_.ExecuteOne(effect::SearchFocus{
+        effect::SearchFocus::Mode::SetSelection, 3, 7 });
+    ASSERT_EQ(host_.search_focus_calls.size(), 1u);
+    EXPECT_EQ(host_.search_focus_calls[0].mode, effect::SearchFocus::Mode::SetSelection);
+    EXPECT_EQ(host_.search_focus_calls[0].anchor, 3);
+    EXPECT_EQ(host_.search_focus_calls[0].caret, 7);
+    EXPECT_TRUE(host_.post_message_calls.empty());
+}
+
+TEST_F(SideEffectExecutorTest, SearchUnfocusForwardsToHost)
+{
+    exec_.ExecuteOne(effect::SearchUnfocus{ /*clear_text=*/true });
+    ASSERT_EQ(host_.search_unfocus_calls.size(), 1u);
+    EXPECT_TRUE(host_.search_unfocus_calls[0].clear_text);
+    EXPECT_TRUE(host_.post_message_calls.empty());
+}
+
 TEST_F(SideEffectExecutorTest, SetWindowTitleForwardsToHost)
 {
     exec_.ExecuteOne(effect::SetWindowTitle{ std::pmr::wstring(L"mendo — doc.md") });

--- a/tests/test_side_effect_executor.cpp
+++ b/tests/test_side_effect_executor.cpp
@@ -81,12 +81,10 @@ public:
     {
         show_window_cmd_calls.push_back(cmd);
     }
-    bool PostWindowMessage(UINT msg, WPARAM wp, LPARAM lp) override
+    void PostWindowMessage(UINT msg, WPARAM wp, LPARAM lp) override
     {
         post_message_calls.emplace_back(msg, wp, lp);
-        return post_window_message_result;
     }
-    bool post_window_message_result = true;
     std::vector<effect::SearchFocus> search_focus_calls;
     std::vector<effect::SearchUnfocus> search_unfocus_calls;
     void SearchFocus(effect::SearchFocus action) override


### PR DESCRIPTION
## Summary

- `refactoring_todo.md` で「見送り」「コメント補強のみ」と記録していた派生タスクを再点検し、利得が見込める 10 件を実装 (致命的 2/3/6、中 17/26/34、軽微 46/48/51/57)
- `AsyncLoadCoordinator::Finish()` を撤去し in_flight 管理を coordinator に完全に閉じる (sync と async の状態が独立)
- 上記を simplify レビュー (再利用 / 品質 / 効率) にかけ、指摘 5 件を反映:
  - `ComputeLayoutPartial` / `ComputeLayoutFull` を 1 関数に再統合 (partial=false 時は viewport を ±∞ に拡張して full を再現)
  - `IWin32Host::PostWindowMessage` を `bool` → `void` 化 (戻り値が全 callsite で捨てられていたため)
  - `MENDO_LOGF` のコメントを実装と整合 (`out - buf` が実書き込み長)
  - 過剰な narrative / 変更経緯コメントを削除
  - `AsyncLoadCoordinator` のヘッダコメントを運用上の制約 (UI スレッドからのみ) に書き換え

主要な構造変更:
- `src/io/async_load_coordinator.{h,cpp}` 新設、`FileLoadService` から async ロード状態 (in_flight / gen / result / error / mutex) を分離
- `effect::SearchFocus` / `effect::SearchUnfocus` を新設し PostMessage 経路の API を型安全化、`SearchSelectionPayload` の heap allocation を `Win32Host` 内に閉じる
- `ContextMenu::Show()` を `PrepareContent` / `CreatePopupWindow` / `RunModalLoop` の 3 メソッドに分割
- `DirtyBudget` を `SerialBudget` / `ParallelBudget` に分離 (time_budget が並列版で機能しないことを型レベルで明示)
- `cached_width = -1.0f` を `kUnmeasuredWidth` 定数 + `is_measured()` ヘルパに統一
- `ParseMarkdown` 予約サイズの 6 つのマジックナンバーを named constexpr 化
- `MENDO_LOGF` を `_snprintf_s` から `std::format_to_n` に移行
- `ConfigService::cached_default_dir_` を magic-static 関数に置換

## Test plan
- [x] `cmake --build build --config Release` 成功
- [x] `mendo_tests.exe --gtest_brief=1` で 2203 件全パス
- [x] 100MB ファイルの実機ロードでリグレッションが無いことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)