### PR TITLE
feat(scroll): ブロック単位の横スクロール (#205)

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -170,12 +170,17 @@ void App::OnPaint()
 
         {
             MENDO_PROFILE("Renderer::Render");
+            const BlockHScrollContext h_scroll{
+                .scroll_x = &state_.view.block_scroll_x,
+                .hovered_block = state_.view.hovered_h_block,
+                .drag_block = state_.view.h_drag_node,
+            };
             renderer_.Render({ state_.document.doc.GetNodes(), state_.document.layout_cache,
                                state_.view.viewport.GetSelection(), layout.md_rect, sp, tb, gs, ts, sb,
                                state_.view.viewport.GetScrollY(), layout_service_->GetTotalHeight(),
                                std::to_underlying(state_.interaction.nav_hover), state_.interaction.hovered,
                                state_.view.nav_history.CanGoBack(), state_.view.nav_history.CanGoForward(),
-                               layout_service_->HasDirtyNodes() });
+                               layout_service_->HasDirtyNodes(), h_scroll });
         }
     }
 

--- a/src/app/app_events.h
+++ b/src/app/app_events.h
@@ -199,6 +199,19 @@ struct HWheelAction {
     short delta;
     uint64_t tick;
 };
+
+// ブロック単位の横スクロール (Issue #205) 関連アクション。
+struct BlockHHoverChangedAction {
+    int node_index; // -1 でホバー解除
+};
+struct BlockHScrollDragStartedAction {
+    int node_index;
+    float dip_x;
+};
+struct BlockHScrollDragMovedAction {
+    float dip_x;
+};
+struct BlockHScrollDragEndedAction {};
 struct DropFilesAction {
     std::pmr::wstring path;
 };
@@ -296,6 +309,10 @@ using AppAction = std::variant<
     NavigateAnchorAction,
     RestoreScrollAfterLoadAction,
     HWheelAction,
+    BlockHHoverChangedAction,
+    BlockHScrollDragStartedAction,
+    BlockHScrollDragMovedAction,
+    BlockHScrollDragEndedAction,
     DropFilesAction,
     UpdateTooltipAction,
     ClearTooltipAction,

--- a/src/app/app_events.h
+++ b/src/app/app_events.h
@@ -200,7 +200,7 @@ struct HWheelAction {
     uint64_t tick;
 };
 
-// ブロック単位の横スクロール (Issue #205) 関連アクション。
+// ブロック単位の横スクロール関連アクション。
 struct BlockHHoverChangedAction {
     int node_index; // -1 でホバー解除
 };

--- a/src/app/app_mouse.cpp
+++ b/src/app/app_mouse.cpp
@@ -19,7 +19,8 @@ MdPaneHitContext App::BuildMdPaneHitContext(int px, int py, const PaneLayout& pa
         state_.document.doc.GetNodes(), state_.document.layout_cache, theme,
         state_.view.viewport.GetScrollY(), pane_layout.md_rect.x,
         state_.window.cached_dpi_scale, px, py,
-        theme.ContentWidth(pane_layout.md_rect.width), pane_layout.md_rect.height
+        theme.ContentWidth(pane_layout.md_rect.width), pane_layout.md_rect.height,
+        &state_.view.block_scroll_x
     };
 }
 
@@ -75,6 +76,11 @@ void App::OnLButtonDown(int px, int py)
 
 void App::OnLButtonUp(int px, int py)
 {
+    if (state_.view.h_drag_node >= 0) {
+        Dispatch(BlockHScrollDragEndedAction{});
+        return;
+    }
+
     if (state_.search.search_bar_ctrl.IsDragging()) {
         Dispatch(SearchInputDragEndedAction{});
         return;
@@ -153,6 +159,11 @@ void App::OnMouseMove(int px, int py)
         if (layout_service_) {
             Dispatch(MdScrollbarDragMovedAction{ dip.y, layout_service_->GetTotalHeight() });
         }
+        return;
+    }
+
+    if (state_.view.h_drag_node >= 0) {
+        Dispatch(BlockHScrollDragMovedAction{ dip_x });
         return;
     }
 

--- a/src/app/app_mouse_click.cpp
+++ b/src/app/app_mouse_click.cpp
@@ -120,14 +120,13 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
             const float visible_w = theme.ContentWidth(pane_layout.md_rect.width) - indent;
             float natural_w = 0.0f;
             float bar_y_local = 0.0f;
-            if (node.type == NodeType::CodeBlock && !IsDiagramLanguage(node.code_language)) {
+            if (IsScrollableCodeBlock(node)) {
                 natural_w = entry.natural_code_width;
-                // バー描画位置と一致 (command_generator.cpp): 背景下端の padding 内。
-                bar_y_local = entry.text_top + entry.height + theme.code_block_padding - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+                bar_y_local = BlockHScrollbarBarY(entry.text_top, entry.height, theme.code_block_padding);
             }
             else if (node.type == NodeType::Table && entry.has_table_layout()) {
                 natural_w = entry.table_layout->natural_total_width;
-                bar_y_local = entry.text_top + entry.height - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+                bar_y_local = BlockHScrollbarBarY(entry.text_top, entry.height, 0.0f);
             }
             if (natural_w > visible_w) {
                 // 描画 transform は Translation(md_x, -scroll_y) で md_rect.y は加算しない。

--- a/src/app/app_mouse_click.cpp
+++ b/src/app/app_mouse_click.cpp
@@ -122,7 +122,8 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
             float bar_y_local = 0.0f;
             if (node.type == NodeType::CodeBlock && !IsDiagramLanguage(node.code_language)) {
                 natural_w = entry.natural_code_width;
-                bar_y_local = entry.text_top + entry.height - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+                // バー描画位置と一致 (command_generator.cpp): 背景下端の padding 内。
+                bar_y_local = entry.text_top + entry.height + theme.code_block_padding - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
             }
             else if (node.type == NodeType::Table && entry.has_table_layout()) {
                 natural_w = entry.table_layout->natural_total_width;

--- a/src/app/app_mouse_click.cpp
+++ b/src/app/app_mouse_click.cpp
@@ -4,6 +4,7 @@
 #include "app_mouse_helpers.h"
 #include "document_utils.h"
 #include "i18n.h"
+#include "layout_computer.h"
 #include "pane_layout.h"
 #include "string_convert.h"
 #include "ui_constants.h"
@@ -103,6 +104,44 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
     if (IsOverMdScrollbar(dip_x, dip_y, pane_layout)) {
         Dispatch(MdScrollbarDragStartedAction{ dip_y, layout_service_->GetTotalHeight() });
         return;
+    }
+
+    // Issue #205: ホバー中ブロックの水平スクロールバー上ならドラッグ開始 (テキスト選択より優先)。
+    if (state_.view.hovered_h_block >= 0) {
+        const int hover = state_.view.hovered_h_block;
+        const auto& nodes = state_.document.doc.GetNodes();
+        const auto& cache = state_.document.layout_cache;
+        if (hover < static_cast<int>(nodes.size()) && hover < static_cast<int>(cache.size())) {
+            const auto& node = nodes[hover];
+            const auto& entry = cache[hover];
+            const auto& theme = renderer_.GetTheme();
+            const float md_x = pane_layout.md_rect.x + theme.margin_left;
+            const float indent = mendo::layout::NodeIndent(node, theme);
+            const float visible_w = theme.ContentWidth(pane_layout.md_rect.width) - indent;
+            float natural_w = 0.0f;
+            float bar_y_local = 0.0f;
+            if (node.type == NodeType::CodeBlock && !IsDiagramLanguage(node.code_language)) {
+                natural_w = entry.natural_code_width;
+                bar_y_local = entry.text_top + entry.height - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+            }
+            else if (node.type == NodeType::Table && entry.has_table_layout()) {
+                natural_w = entry.table_layout->natural_total_width;
+                bar_y_local = entry.text_top + entry.height - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+            }
+            if (natural_w > visible_w) {
+                // 描画 transform は Translation(md_x, -scroll_y) で md_rect.y は加算しない。
+                // クリック判定の bar_y_screen も md_rect.y を加算してはならない (描画とズレるため)。
+                const float scroll_y = state_.view.viewport.GetScrollY();
+                const float bar_y_screen = bar_y_local - scroll_y;
+                const float block_x_screen = md_x + indent;
+                if (dip_y >= bar_y_screen - PANE_SCROLLBAR_HIT_PADDING &&
+                    dip_y <= bar_y_screen + PANE_SCROLLBAR_WIDTH + PANE_SCROLLBAR_HIT_PADDING &&
+                    dip_x >= block_x_screen && dip_x <= block_x_screen + visible_w) {
+                    Dispatch(BlockHScrollDragStartedAction{ hover, dip_x });
+                    return;
+                }
+            }
+        }
     }
 
     const auto hit = HitTest(px, py);

--- a/src/app/app_mouse_click.cpp
+++ b/src/app/app_mouse_click.cpp
@@ -2,6 +2,7 @@
 #include "app_constants.h"
 #include "app_events.h"
 #include "app_mouse_helpers.h"
+#include "block_h_scroll.h"
 #include "document_utils.h"
 #include "i18n.h"
 #include "layout_computer.h"
@@ -106,7 +107,7 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
         return;
     }
 
-    // Issue #205: ホバー中ブロックの水平スクロールバー上ならドラッグ開始 (テキスト選択より優先)。
+    // ホバー中ブロックの水平スクロールバー上ならドラッグ開始 (テキスト選択より優先)。
     if (state_.view.hovered_h_block >= 0) {
         const int hover = state_.view.hovered_h_block;
         const auto& nodes = state_.document.doc.GetNodes();
@@ -115,32 +116,14 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
             const auto& node = nodes[hover];
             const auto& entry = cache[hover];
             const auto& theme = renderer_.GetTheme();
-            const float md_x = pane_layout.md_rect.x + theme.margin_left;
-            const float indent = mendo::layout::NodeIndent(node, theme);
-            const float visible_w = theme.ContentWidth(pane_layout.md_rect.width) - indent;
-            float natural_w = 0.0f;
-            float bar_y_local = 0.0f;
-            if (IsScrollableCodeBlock(node)) {
-                natural_w = entry.natural_code_width;
-                bar_y_local = BlockHScrollbarBarY(entry.text_top, entry.height, theme.code_block_padding);
-            }
-            else if (node.type == NodeType::Table && entry.has_table_layout()) {
-                natural_w = entry.table_layout->natural_total_width;
-                bar_y_local = BlockHScrollbarBarY(entry.text_top, entry.height, 0.0f);
-            }
-            if (natural_w > visible_w) {
-                // 描画 transform は Translation(md_x, -scroll_y) で md_rect.y は加算しない。
-                // クリック判定も同じ規約に従い、bar_y_screen に md_rect.y を加算しない。
-                const float scroll_y = state_.view.viewport.GetScrollY();
-                const float bar_y_screen = bar_y_local - scroll_y;
-                const float block_x_screen = md_x + indent;
-                const D2D1_RECT_F bar_hit{
-                    block_x_screen,
-                    bar_y_screen - PANE_SCROLLBAR_HIT_PADDING,
-                    block_x_screen + visible_w,
-                    bar_y_screen + PANE_SCROLLBAR_WIDTH + PANE_SCROLLBAR_HIT_PADDING,
-                };
-                if (PointInRect(dip_x, dip_y, bar_hit)) {
+            const auto geom = GetBlockHScrollGeometry(node, entry, theme, pane_layout.md_rect.width);
+            if (geom.can_scroll()) {
+                const float pad = IsScrollableCodeBlock(node) ? theme.code_block_padding : 0.0f;
+                const float bar_y_local = BlockHScrollbarBarY(entry.text_top, entry.height, pad);
+                // 描画 transform は Translation(md_x, -scroll_y) で md_rect.y は加算しない規約。
+                const float bar_y_screen = bar_y_local - state_.view.viewport.GetScrollY();
+                const float block_x_screen = pane_layout.md_rect.x + theme.margin_left + mendo::layout::NodeIndent(node, theme);
+                if (PointInRect(dip_x, dip_y, BlockHScrollbarHitRect(block_x_screen, geom.visible_width, bar_y_screen))) {
                     Dispatch(BlockHScrollDragStartedAction{ hover, dip_x });
                     return;
                 }

--- a/src/app/app_mouse_click.cpp
+++ b/src/app/app_mouse_click.cpp
@@ -130,13 +130,17 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
             }
             if (natural_w > visible_w) {
                 // 描画 transform は Translation(md_x, -scroll_y) で md_rect.y は加算しない。
-                // クリック判定の bar_y_screen も md_rect.y を加算してはならない (描画とズレるため)。
+                // クリック判定も同じ規約に従い、bar_y_screen に md_rect.y を加算しない。
                 const float scroll_y = state_.view.viewport.GetScrollY();
                 const float bar_y_screen = bar_y_local - scroll_y;
                 const float block_x_screen = md_x + indent;
-                if (dip_y >= bar_y_screen - PANE_SCROLLBAR_HIT_PADDING &&
-                    dip_y <= bar_y_screen + PANE_SCROLLBAR_WIDTH + PANE_SCROLLBAR_HIT_PADDING &&
-                    dip_x >= block_x_screen && dip_x <= block_x_screen + visible_w) {
+                const D2D1_RECT_F bar_hit{
+                    block_x_screen,
+                    bar_y_screen - PANE_SCROLLBAR_HIT_PADDING,
+                    block_x_screen + visible_w,
+                    bar_y_screen + PANE_SCROLLBAR_WIDTH + PANE_SCROLLBAR_HIT_PADDING,
+                };
+                if (PointInRect(dip_x, dip_y, bar_hit)) {
                     Dispatch(BlockHScrollDragStartedAction{ hover, dip_x });
                     return;
                 }

--- a/src/app/app_mouse_hover.cpp
+++ b/src/app/app_mouse_hover.cpp
@@ -122,7 +122,7 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
                 const auto& entry = cache[hit.node_index];
                 const auto& theme = renderer_.GetTheme();
                 const float visible_w = theme.ContentWidth(pane_layout.md_rect.width) - mendo::layout::NodeIndent(node, theme);
-                if (node.type == NodeType::CodeBlock && !IsDiagramLanguage(node.code_language) && entry.natural_code_width > visible_w) {
+                if (IsScrollableCodeBlock(node) && entry.natural_code_width > visible_w) {
                     new_h_block = hit.node_index;
                 }
                 else if (node.type == NodeType::Table && entry.has_table_layout() && entry.table_layout->natural_total_width > visible_w) {

--- a/src/app/app_mouse_hover.cpp
+++ b/src/app/app_mouse_hover.cpp
@@ -2,6 +2,7 @@
 #include "app_constants.h"
 #include "app_events.h"
 #include "app_mouse_helpers.h"
+#include "block_h_scroll.h"
 #include "i18n.h"
 #include "layout_computer.h"
 #include "pane_layout.h"
@@ -111,27 +112,24 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
         const auto link = GetLinkAtHit(hit);
         ht.last_md_cursor_hand = link.has_value();
 
-        // Issue #205: 横スクロール対象ブロック (テーブル / コードブロック) のホバーを更新。
-        // 自然幅 > 可視幅 のときだけバーを出す。
-        int new_h_block = -1;
-        if (hit.node_index >= 0 && state_.view.h_drag_node < 0) {
-            const auto& nodes = state_.document.doc.GetNodes();
-            const auto& cache = state_.document.layout_cache;
-            if (hit.node_index < static_cast<int>(nodes.size()) && hit.node_index < static_cast<int>(cache.size())) {
-                const auto& node = nodes[hit.node_index];
-                const auto& entry = cache[hit.node_index];
-                const auto& theme = renderer_.GetTheme();
-                const float visible_w = theme.ContentWidth(pane_layout.md_rect.width) - mendo::layout::NodeIndent(node, theme);
-                if (IsScrollableCodeBlock(node) && entry.natural_code_width > visible_w) {
-                    new_h_block = hit.node_index;
-                }
-                else if (node.type == NodeType::Table && entry.has_table_layout() && entry.table_layout->natural_total_width > visible_w) {
-                    new_h_block = hit.node_index;
+        // 横スクロール対象 (Table / CodeBlock) で自然幅 > 可視幅 のときだけバーを出す。
+        // ドラッグ中は hovered を固定して、スクロールバー直下に出ても見た目が動かないようにする。
+        if (state_.view.h_drag_node < 0) {
+            int new_h_block = -1;
+            if (hit.node_index >= 0) {
+                const auto& nodes = state_.document.doc.GetNodes();
+                const auto& cache = state_.document.layout_cache;
+                if (hit.node_index < static_cast<int>(nodes.size()) && hit.node_index < static_cast<int>(cache.size())) {
+                    const auto geom = GetBlockHScrollGeometry(
+                        nodes[hit.node_index], cache[hit.node_index], renderer_.GetTheme(), pane_layout.md_rect.width);
+                    if (geom.can_scroll()) {
+                        new_h_block = hit.node_index;
+                    }
                 }
             }
-        }
-        if (state_.view.h_drag_node < 0 && new_h_block != state_.view.hovered_h_block) {
-            Dispatch(BlockHHoverChangedAction{ new_h_block });
+            if (new_h_block != state_.view.hovered_h_block) {
+                Dispatch(BlockHHoverChangedAction{ new_h_block });
+            }
         }
 
         TooltipTarget tt;

--- a/src/app/app_mouse_hover.cpp
+++ b/src/app/app_mouse_hover.cpp
@@ -3,6 +3,7 @@
 #include "app_events.h"
 #include "app_mouse_helpers.h"
 #include "i18n.h"
+#include "layout_computer.h"
 #include "pane_layout.h"
 #include "string_convert.h"
 #include "ui_constants.h"
@@ -109,6 +110,29 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
         const auto hit = HitTest(px, py);
         const auto link = GetLinkAtHit(hit);
         ht.last_md_cursor_hand = link.has_value();
+
+        // Issue #205: 横スクロール対象ブロック (テーブル / コードブロック) のホバーを更新。
+        // 自然幅 > 可視幅 のときだけバーを出す。
+        int new_h_block = -1;
+        if (hit.node_index >= 0 && state_.view.h_drag_node < 0) {
+            const auto& nodes = state_.document.doc.GetNodes();
+            const auto& cache = state_.document.layout_cache;
+            if (hit.node_index < static_cast<int>(nodes.size()) && hit.node_index < static_cast<int>(cache.size())) {
+                const auto& node = nodes[hit.node_index];
+                const auto& entry = cache[hit.node_index];
+                const auto& theme = renderer_.GetTheme();
+                const float visible_w = theme.ContentWidth(pane_layout.md_rect.width) - mendo::layout::NodeIndent(node, theme);
+                if (node.type == NodeType::CodeBlock && !IsDiagramLanguage(node.code_language) && entry.natural_code_width > visible_w) {
+                    new_h_block = hit.node_index;
+                }
+                else if (node.type == NodeType::Table && entry.has_table_layout() && entry.table_layout->natural_total_width > visible_w) {
+                    new_h_block = hit.node_index;
+                }
+            }
+        }
+        if (state_.view.h_drag_node < 0 && new_h_block != state_.view.hovered_h_block) {
+            Dispatch(BlockHHoverChangedAction{ new_h_block });
+        }
 
         TooltipTarget tt;
         if (link.has_value()) {

--- a/src/app/app_state.h
+++ b/src/app/app_state.h
@@ -34,9 +34,9 @@ struct ViewState {
     NavHistory nav_history;
     float cached_total_height = 0.0f;
 
-    // ブロック単位の横スクロール (Issue #205)。キーは LayoutCache のノードインデックス。
-    // ファイルロード/リロードでクリア (永続化しない)。スクロールバーはホバー中の対象 1 件
-    // とドラッグ中の対象 1 件のみ描画するため、map サイズはユーザー操作分に限定される。
+    // ブロック単位の横スクロール。キーは LayoutCache のノードインデックス。
+    // ファイルロード/リロードでクリア (永続化しない)。スクロールバーはホバー中とドラッグ中の
+    // 対象のみ描画するため、map サイズはユーザー操作分に限定される。
     std::pmr::unordered_map<int, float> block_scroll_x;
     int hovered_h_block = -1;
     int h_drag_node = -1;

--- a/src/app/app_state.h
+++ b/src/app/app_state.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <string_view>
 #include <memory_resource>
+#include <unordered_map>
 
 struct DocumentState {
     Document doc;
@@ -32,6 +33,21 @@ struct ViewState {
     ScrollRestoration scroll_restore;
     NavHistory nav_history;
     float cached_total_height = 0.0f;
+
+    // ブロック単位の横スクロール (Issue #205)。キーは LayoutCache のノードインデックス。
+    // ファイルロード/リロードでクリア (永続化しない)。スクロールバーはホバー中の対象 1 件
+    // とドラッグ中の対象 1 件のみ描画するため、map サイズはユーザー操作分に限定される。
+    std::pmr::unordered_map<int, float> block_scroll_x;
+    int hovered_h_block = -1;
+    int h_drag_node = -1;
+    float h_drag_start_x = 0.0f;
+    float h_drag_start_scroll = 0.0f;
+
+    float GetBlockScrollX(int node_index) const
+    {
+        const auto it = block_scroll_x.find(node_index);
+        return (it != block_scroll_x.end()) ? it->second : 0.0f;
+    }
 };
 
 struct InteractionState {

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -397,8 +397,7 @@ void ReduceHWheel(AppState& state, SideEffectList& effects, const HWheelAction& 
     if (target >= 0) {
         const auto geom = GetBlockHScrollGeometry(state, target);
         if (geom.can_scroll()) {
-            constexpr float DIP_PER_WHEEL_NOTCH = 60.0f;
-            const float dx = static_cast<float>(a.delta) / WHEEL_DELTA * DIP_PER_WHEEL_NOTCH;
+            const float dx = static_cast<float>(a.delta) / WHEEL_DELTA * HSCROLL_DIP_PER_NOTCH;
             const float cur = state.view.GetBlockScrollX(target);
             ApplyBlockHScrollDelta(state, target, cur + dx, geom.natural_width - geom.visible_width);
             PushEffect(effects, effect::InvalidateWindow{});

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -363,7 +363,7 @@ BlockHScrollGeometry GetBlockHScrollGeometry(const AppState& state, int node_ind
     if (node.type == NodeType::Table && entry.has_table_layout()) {
         g.natural_width = entry.table_layout->natural_total_width;
     }
-    else if (node.type == NodeType::CodeBlock && !IsDiagramLanguage(node.code_language)) {
+    else if (IsScrollableCodeBlock(node)) {
         g.natural_width = entry.natural_code_width;
     }
     return g;

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -1,5 +1,6 @@
 #include "reducer.h"
 #include "app_constants.h"
+#include "block_h_scroll.h"
 #include "document_utils.h"
 #include "file_io.h"
 #include "layout_computer.h"
@@ -335,42 +336,23 @@ void ReduceDpiChanged(AppState& state, SideEffectList& effects, const DpiChanged
 
 namespace {
 
-// Issue #205: 対象ブロックの自然幅と可視幅を取得する。
-struct BlockHScrollGeometry {
-    float natural_width = 0.0f;
-    float visible_width = 0.0f;
-    bool can_scroll() const noexcept { return natural_width > visible_width && visible_width > 0.0f; }
-};
-
-BlockHScrollGeometry GetBlockHScrollGeometry(const AppState& state, int node_index)
+BlockHScrollGeometry ResolveBlockHScrollGeometry(const AppState& state, int node_index) noexcept
 {
-    BlockHScrollGeometry g;
     if (node_index < 0 || !state.theme || !state.pane_layout_cache.IsValid()) {
-        return g;
+        return {};
     }
     const auto& nodes = state.document.doc.GetNodes();
     const auto& cache = state.document.layout_cache;
     if (node_index >= static_cast<int>(nodes.size()) || node_index >= static_cast<int>(cache.size())) {
-        return g;
+        return {};
     }
-    const auto& node = nodes[node_index];
-    const auto& entry = cache[node_index];
-    const float md_w = state.pane_layout_cache.Get().md_rect.width;
-    const float content_w = state.theme->ContentWidth(md_w);
-    const float indent = mendo::layout::NodeIndent(node, *state.theme);
-    g.visible_width = content_w - indent;
-
-    if (node.type == NodeType::Table && entry.has_table_layout()) {
-        g.natural_width = entry.table_layout->natural_total_width;
-    }
-    else if (IsScrollableCodeBlock(node)) {
-        g.natural_width = entry.natural_code_width;
-    }
-    return g;
+    return GetBlockHScrollGeometry(nodes[node_index], cache[node_index], *state.theme,
+                                   state.pane_layout_cache.Get().md_rect.width);
 }
 
 // scroll_x を [0, max] に詰めて map に反映する。0 になった場合はエントリを削除する。
-// scroll_x 変更で HitCache (HitTestService 内) を invalidate するため effects_generation を進める。
+// HitTestService 側のキャッシュキーには block_scroll_x が含まれないため、
+// 値が変わったタイミングで effects_generation を進めて last_md_hit_ の再計算を強制する。
 void ApplyBlockHScrollDelta(AppState& state, int node_index, float new_value, float scroll_max)
 {
     const float clamped = std::clamp(new_value, 0.0f, scroll_max);
@@ -391,15 +373,14 @@ void ApplyBlockHScrollDelta(AppState& state, int node_index, float new_value, fl
 
 void ReduceHWheel(AppState& state, SideEffectList& effects, const HWheelAction& a)
 {
-    // Issue #205: ホバー or ドラッグ中のブロックが横スクロール可能ならそこに適用し、
-    // スワイプオーバーレイには流さない (排他)。
+    // ホバー or ドラッグ中のブロックが横スクロール可能ならそこに適用し、スワイプオーバーレイには流さない。
     const int target = (state.view.h_drag_node >= 0) ? state.view.h_drag_node : state.view.hovered_h_block;
     if (target >= 0) {
-        const auto geom = GetBlockHScrollGeometry(state, target);
+        const auto geom = ResolveBlockHScrollGeometry(state, target);
         if (geom.can_scroll()) {
             const float dx = static_cast<float>(a.delta) / WHEEL_DELTA * HSCROLL_DIP_PER_NOTCH;
             const float cur = state.view.GetBlockScrollX(target);
-            ApplyBlockHScrollDelta(state, target, cur + dx, geom.natural_width - geom.visible_width);
+            ApplyBlockHScrollDelta(state, target, cur + dx, geom.scroll_max());
             PushEffect(effects, effect::InvalidateWindow{});
             return;
         }
@@ -425,7 +406,7 @@ void ReduceBlockHHoverChanged(AppState& state, SideEffectList& effects, const Bl
 
 void ReduceBlockHScrollDragStarted(AppState& state, SideEffectList& effects, const BlockHScrollDragStartedAction& a)
 {
-    const auto geom = GetBlockHScrollGeometry(state, a.node_index);
+    const auto geom = ResolveBlockHScrollGeometry(state, a.node_index);
     if (!geom.can_scroll()) {
         return;
     }
@@ -442,14 +423,18 @@ void ReduceBlockHScrollDragMoved(AppState& state, SideEffectList& effects, const
     if (target < 0) {
         return;
     }
-    const auto geom = GetBlockHScrollGeometry(state, target);
+    const auto geom = ResolveBlockHScrollGeometry(state, target);
     if (!geom.can_scroll()) {
         return;
     }
+    // dip_delta はドラッグの sum = サムが動く DIP。サムが (track - thumb_w) 動いたとき
+    // コンテンツが scroll_max 動くべきなので、scroll_delta = dip_delta * scroll_max / drag_range。
+    // thumb_w が PANE_SCROLLBAR_THUMB_MIN に張り付いた長大コンテンツでも 1:1 で対応する。
     const float dip_delta = a.dip_x - state.view.h_drag_start_x;
-    const float ratio = geom.natural_width / geom.visible_width;
-    const float scroll_max = geom.natural_width - geom.visible_width;
-    ApplyBlockHScrollDelta(state, target, state.view.h_drag_start_scroll + dip_delta * ratio, scroll_max);
+    const float thumb_w = BlockHScrollbarThumbWidth(geom.visible_width, geom.natural_width);
+    const float drag_range = std::max(1.0f, geom.visible_width - thumb_w);
+    const float scroll_max = geom.scroll_max();
+    ApplyBlockHScrollDelta(state, target, state.view.h_drag_start_scroll + dip_delta * scroll_max / drag_range, scroll_max);
     PushEffect(effects, effect::InvalidateWindow{});
 }
 
@@ -828,8 +813,7 @@ void ReduceNavigateAnchor(AppState& state, SideEffectList& effects, const Naviga
 
 void ReduceRestoreScrollAfterLoad(AppState& state, SideEffectList& /*effects*/, const RestoreScrollAfterLoadAction& a)
 {
-    // Issue #205: ファイルロード/リロード時にブロック単位の横スクロール状態をクリア。
-    // ノードインデックスはセッション内識別子で、再パース後は別ノードを指しうるため。
+    // ノードインデックスはセッション内の識別子で、再パース後は別ノードを指しうる。
     state.view.block_scroll_x.clear();
     state.view.hovered_h_block = -1;
     state.view.h_drag_node = -1;

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -2,9 +2,11 @@
 #include "app_constants.h"
 #include "document_utils.h"
 #include "file_io.h"
+#include "layout_computer.h"
 #include "overloaded.h"
 #include "ui_constants.h"
 #include "utility.h"
+#include <algorithm>
 #include <cmath>
 
 ScrollTarget SnapshotVisibleTarget(const AppState& state) noexcept
@@ -331,8 +333,79 @@ void ReduceDpiChanged(AppState& state, SideEffectList& effects, const DpiChanged
         });
 }
 
+namespace {
+
+// Issue #205: 対象ブロックの自然幅と可視幅を取得する。
+struct BlockHScrollGeometry {
+    float natural_width = 0.0f;
+    float visible_width = 0.0f;
+    bool can_scroll() const noexcept { return natural_width > visible_width && visible_width > 0.0f; }
+};
+
+BlockHScrollGeometry GetBlockHScrollGeometry(const AppState& state, int node_index)
+{
+    BlockHScrollGeometry g;
+    if (node_index < 0 || !state.theme || !state.pane_layout_cache.IsValid()) {
+        return g;
+    }
+    const auto& nodes = state.document.doc.GetNodes();
+    const auto& cache = state.document.layout_cache;
+    if (node_index >= static_cast<int>(nodes.size()) || node_index >= static_cast<int>(cache.size())) {
+        return g;
+    }
+    const auto& node = nodes[node_index];
+    const auto& entry = cache[node_index];
+    const float md_w = state.pane_layout_cache.Get().md_rect.width;
+    const float content_w = state.theme->ContentWidth(md_w);
+    const float indent = mendo::layout::NodeIndent(node, *state.theme);
+    g.visible_width = content_w - indent;
+
+    if (node.type == NodeType::Table && entry.has_table_layout()) {
+        g.natural_width = entry.table_layout->natural_total_width;
+    }
+    else if (node.type == NodeType::CodeBlock && !IsDiagramLanguage(node.code_language)) {
+        g.natural_width = entry.natural_code_width;
+    }
+    return g;
+}
+
+// scroll_x を [0, max] に詰めて map に反映する。0 になった場合はエントリを削除する。
+// scroll_x 変更で HitCache (HitTestService 内) を invalidate するため effects_generation を進める。
+void ApplyBlockHScrollDelta(AppState& state, int node_index, float new_value, float scroll_max)
+{
+    const float clamped = std::clamp(new_value, 0.0f, scroll_max);
+    const float prev = state.view.GetBlockScrollX(node_index);
+    if (std::abs(prev - clamped) < 1e-3f) {
+        return;
+    }
+    if (clamped <= 0.0f) {
+        state.view.block_scroll_x.erase(node_index);
+    }
+    else {
+        state.view.block_scroll_x[node_index] = clamped;
+    }
+    state.document.layout_cache.IncrementEffectsGeneration();
+}
+
+} // namespace
+
 void ReduceHWheel(AppState& state, SideEffectList& effects, const HWheelAction& a)
 {
+    // Issue #205: ホバー or ドラッグ中のブロックが横スクロール可能ならそこに適用し、
+    // スワイプオーバーレイには流さない (排他)。
+    const int target = (state.view.h_drag_node >= 0) ? state.view.h_drag_node : state.view.hovered_h_block;
+    if (target >= 0) {
+        const auto geom = GetBlockHScrollGeometry(state, target);
+        if (geom.can_scroll()) {
+            constexpr float DIP_PER_WHEEL_NOTCH = 60.0f;
+            const float dx = static_cast<float>(a.delta) / WHEEL_DELTA * DIP_PER_WHEEL_NOTCH;
+            const float cur = state.view.GetBlockScrollX(target);
+            ApplyBlockHScrollDelta(state, target, cur + dx, geom.natural_width - geom.visible_width);
+            PushEffect(effects, effect::InvalidateWindow{});
+            return;
+        }
+    }
+
     const bool had_overlay = state.interaction.swipe_detector.IsOverlayVisible();
     const int old_direction = state.interaction.swipe_detector.GetOverlayDirection();
     state.interaction.swipe_detector.OnHWheel(a.delta, a.tick);
@@ -340,6 +413,55 @@ void ReduceHWheel(AppState& state, SideEffectList& effects, const HWheelAction& 
     if (had_overlay != state.interaction.swipe_detector.IsOverlayVisible() || old_direction != state.interaction.swipe_detector.GetOverlayDirection()) {
         PushEffect(effects, effect::InvalidateWindow{});
     }
+}
+
+void ReduceBlockHHoverChanged(AppState& state, SideEffectList& effects, const BlockHHoverChangedAction& a)
+{
+    if (state.view.hovered_h_block == a.node_index) {
+        return;
+    }
+    state.view.hovered_h_block = a.node_index;
+    PushEffect(effects, effect::InvalidateWindow{});
+}
+
+void ReduceBlockHScrollDragStarted(AppState& state, SideEffectList& effects, const BlockHScrollDragStartedAction& a)
+{
+    const auto geom = GetBlockHScrollGeometry(state, a.node_index);
+    if (!geom.can_scroll()) {
+        return;
+    }
+    state.view.h_drag_node = a.node_index;
+    state.view.h_drag_start_x = a.dip_x;
+    state.view.h_drag_start_scroll = state.view.GetBlockScrollX(a.node_index);
+    PushEffect(effects, effect::SetCapture{});
+    PushEffect(effects, effect::InvalidateWindow{});
+}
+
+void ReduceBlockHScrollDragMoved(AppState& state, SideEffectList& effects, const BlockHScrollDragMovedAction& a)
+{
+    const int target = state.view.h_drag_node;
+    if (target < 0) {
+        return;
+    }
+    const auto geom = GetBlockHScrollGeometry(state, target);
+    if (!geom.can_scroll()) {
+        return;
+    }
+    const float dip_delta = a.dip_x - state.view.h_drag_start_x;
+    const float ratio = geom.natural_width / geom.visible_width;
+    const float scroll_max = geom.natural_width - geom.visible_width;
+    ApplyBlockHScrollDelta(state, target, state.view.h_drag_start_scroll + dip_delta * ratio, scroll_max);
+    PushEffect(effects, effect::InvalidateWindow{});
+}
+
+void ReduceBlockHScrollDragEnded(AppState& state, SideEffectList& effects, const BlockHScrollDragEndedAction&)
+{
+    if (state.view.h_drag_node < 0) {
+        return;
+    }
+    state.view.h_drag_node = -1;
+    PushEffect(effects, effect::ReleaseCapture{});
+    PushEffect(effects, effect::InvalidateWindow{});
 }
 
 void ReduceSearchStep(AppState& state, bool forward)
@@ -707,6 +829,12 @@ void ReduceNavigateAnchor(AppState& state, SideEffectList& effects, const Naviga
 
 void ReduceRestoreScrollAfterLoad(AppState& state, SideEffectList& /*effects*/, const RestoreScrollAfterLoadAction& a)
 {
+    // Issue #205: ファイルロード/リロード時にブロック単位の横スクロール状態をクリア。
+    // ノードインデックスはセッション内識別子で、再パース後は別ノードを指しうるため。
+    state.view.block_scroll_x.clear();
+    state.view.hovered_h_block = -1;
+    state.view.h_drag_node = -1;
+
     state.view.viewport.ClearScrollTarget();
     if (a.has_reload_diff) {
         state.view.viewport.SetScrollY(a.reload_diff_scroll_y);
@@ -836,6 +964,10 @@ SideEffectList Reduce(AppState& state, const AppAction& action)
         [&](const ResizeAction& a) { ReduceResize(state, effects, a); },
         [&](const DpiChangedAction& a) { ReduceDpiChanged(state, effects, a); },
         [&](const HWheelAction& a) { ReduceHWheel(state, effects, a); },
+        [&](const BlockHHoverChangedAction& a) { ReduceBlockHHoverChanged(state, effects, a); },
+        [&](const BlockHScrollDragStartedAction& a) { ReduceBlockHScrollDragStarted(state, effects, a); },
+        [&](const BlockHScrollDragMovedAction& a) { ReduceBlockHScrollDragMoved(state, effects, a); },
+        [&](const BlockHScrollDragEndedAction& a) { ReduceBlockHScrollDragEnded(state, effects, a); },
 
         // ---- 検索 ----
         [&](const OpenSearchBarAction&) { state.search.search_bar_ctrl.OnOpen(state.document.doc.GetNodes()); },

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -409,7 +409,7 @@ private:
     }
 };
 
-// CodeBlock かつ非 Diagram 言語。Issue #205 のブロック横スクロール対象判定で頻出する組合せ。
+// CodeBlock かつ非 Diagram 言語。ブロック横スクロール対象判定で頻出する組合せ。
 constexpr bool IsScrollableCodeBlock(const Node& node) noexcept
 {
     return node.type == NodeType::CodeBlock && !IsDiagramLanguage(node.code_language);

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -408,3 +408,9 @@ private:
         view_base_ = nullptr;
     }
 };
+
+// CodeBlock かつ非 Diagram 言語。Issue #205 のブロック横スクロール対象判定で頻出する組合せ。
+constexpr bool IsScrollableCodeBlock(const Node& node) noexcept
+{
+    return node.type == NodeType::CodeBlock && !IsDiagramLanguage(node.code_language);
+}

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -125,10 +125,11 @@ HitTestService::HitResult HitTestService::HitTest(const MdPaneHitContext& ctx) c
     });
     const int candidate = (it != first) ? static_cast<int>(std::prev(it) - first) : -1;
 
+    // partition_point は entry.text_top で比較しているため、局所座標 (local_y) の基準も
+    // 同じ entry.text_top を直接参照する。TextTopOf (Fenwick 経由) は等価であるべきだが、
+    // 累積誤差や部分更新中の不同期で乖離するとマウス位置と一致しないため避ける。
     const float candidate_text_top =
-        (candidate >= 0)
-            ? mendo::layout::TextTopOf(ctx.cache, static_cast<size_t>(candidate), ctx.nodes[candidate], ctx.theme)
-            : 0.0f;
+        (candidate >= 0) ? ctx.cache[candidate].text_top : 0.0f;
     if (candidate >= 0 && dip_y <= candidate_text_top + ctx.cache[candidate].height) {
         const auto& node = ctx.nodes[candidate];
         const auto& entry = ctx.cache[candidate];

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -133,15 +133,24 @@ HitTestService::HitResult HitTestService::HitTest(const MdPaneHitContext& ctx) c
         const auto& node = ctx.nodes[candidate];
         const auto& entry = ctx.cache[candidate];
 
+        // Issue #205: 横スクロール量を取得 (テーブル / コードブロックのみ非ゼロ)。
+        float h_scroll_x = 0.0f;
+        if (ctx.block_scroll_x) {
+            const auto sit = ctx.block_scroll_x->find(candidate);
+            if (sit != ctx.block_scroll_x->end()) {
+                h_scroll_x = sit->second;
+            }
+        }
+
         if (node.type == NodeType::Table) {
-            result = HitTestTable(node, entry, candidate_text_top, candidate, ctx.theme, dip_x, dip_y);
+            result = HitTestTable(node, entry, candidate_text_top, candidate, ctx.theme, dip_x, dip_y, h_scroll_x);
             last_md_hit_.Store(ctx, gen, result);
             return result;
         }
 
         if (entry.text_layout) {
             const float indent = NodeIndent(node, ctx.theme);
-            const float local_x = dip_x - ctx.theme.margin_left - indent - NodeTextXOffset(node, ctx.theme);
+            const float local_x = dip_x - ctx.theme.margin_left - indent - NodeTextXOffset(node, ctx.theme) + h_scroll_x;
             const float local_y = dip_y - candidate_text_top;
 
             BOOL is_trailing = FALSE;
@@ -176,7 +185,7 @@ HitTestService::HitResult HitTestService::HitTestTable(
     float entry_text_top,
     int node_index,
     const Theme& theme,
-    float dip_x, float dip_y) const noexcept
+    float dip_x, float dip_y, float h_scroll_x) const noexcept
 {
     HitResult result;
     result.node_index = node_index;
@@ -188,7 +197,9 @@ HitTestService::HitResult HitTestService::HitTestTable(
     const auto& tl = *entry.table_layout;
 
     const float indent = NodeIndent(node, theme);
-    const float base_x = theme.margin_left + indent;
+    // Issue #205: テーブルが scroll_x 分左にスライドして見えるので、
+    // 列の自然座標と一致させるには base_x を scroll_x 分左にずらして与える。
+    const float base_x = theme.margin_left + indent - h_scroll_x;
 
     const auto* tbl = node.table_data();
     const auto [hit_row, row_top_y] = FindTableRow(node, entry, entry_text_top, theme, dip_y);

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -130,7 +130,13 @@ HitTestService::HitResult HitTestService::HitTest(const MdPaneHitContext& ctx) c
     // 累積誤差や部分更新中の不同期で乖離するとマウス位置と一致しないため避ける。
     const float candidate_text_top =
         (candidate >= 0) ? ctx.cache[candidate].text_top : 0.0f;
-    if (candidate >= 0 && dip_y <= candidate_text_top + ctx.cache[candidate].height) {
+    // CodeBlock は背景が text 範囲の上下に padding 分はみ出る。padding 部分 (Issue #205 の
+    // 横スクロールバーを置きたい領域) もそのノードのヒットとして扱い、ホバーが切れないようにする。
+    const float bottom_extension =
+        (candidate >= 0 && ctx.nodes[candidate].type == NodeType::CodeBlock)
+            ? ctx.theme.code_block_padding
+            : 0.0f;
+    if (candidate >= 0 && dip_y <= candidate_text_top + ctx.cache[candidate].height + bottom_extension) {
         const auto& node = ctx.nodes[candidate];
         const auto& entry = ctx.cache[candidate];
 

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -130,8 +130,8 @@ HitTestService::HitResult HitTestService::HitTest(const MdPaneHitContext& ctx) c
     // 累積誤差や部分更新中の不同期で乖離するとマウス位置と一致しないため避ける。
     const float candidate_text_top =
         (candidate >= 0) ? ctx.cache[candidate].text_top : 0.0f;
-    // CodeBlock は背景が text 範囲の上下に padding 分はみ出る。padding 部分 (Issue #205 の
-    // 横スクロールバーを置きたい領域) もそのノードのヒットとして扱い、ホバーが切れないようにする。
+    // CodeBlock は背景が text 範囲の上下に padding 分はみ出る。padding 部分 (横スクロールバーを
+    // 置きたい領域) もそのノードのヒットとして扱い、ホバーが切れないようにする。
     const float bottom_extension =
         (candidate >= 0 && ctx.nodes[candidate].type == NodeType::CodeBlock)
             ? ctx.theme.code_block_padding
@@ -140,7 +140,7 @@ HitTestService::HitResult HitTestService::HitTest(const MdPaneHitContext& ctx) c
         const auto& node = ctx.nodes[candidate];
         const auto& entry = ctx.cache[candidate];
 
-        // Issue #205: 横スクロール量を取得 (テーブル / コードブロックのみ非ゼロ)。
+        // 横スクロール量 (テーブル / コードブロックのみ非ゼロ)。
         float h_scroll_x = 0.0f;
         if (ctx.block_scroll_x) {
             const auto sit = ctx.block_scroll_x->find(candidate);
@@ -204,8 +204,8 @@ HitTestService::HitResult HitTestService::HitTestTable(
     const auto& tl = *entry.table_layout;
 
     const float indent = NodeIndent(node, theme);
-    // Issue #205: テーブルが scroll_x 分左にスライドして見えるので、
-    // 列の自然座標と一致させるには base_x を scroll_x 分左にずらして与える。
+    // テーブルが scroll_x 分左にスライドして見えるため、列の自然座標と一致させるには
+    // base_x を scroll_x 分左にずらして与える。
     const float base_x = theme.margin_left + indent - h_scroll_x;
 
     const auto* tbl = node.table_data();

--- a/src/input/hit_test_service.h
+++ b/src/input/hit_test_service.h
@@ -53,7 +53,7 @@ struct MdPaneHitContext {
     // ボタンヒットテスト用（HitTestでは未使用）
     float content_width = 0.0f;
     float md_pane_height = 0.0f;
-    // Issue #205: ブロック単位の横スクロール状態。null なら全 0 扱い。
+    // ブロック単位の横スクロール状態。null なら全 0 扱い。
     const std::pmr::unordered_map<int, float>* block_scroll_x = nullptr;
 };
 
@@ -82,7 +82,7 @@ public:
 
     // テーブルセル内のヒットテスト。
     // entry_text_top はノードのテキスト上端 Y (= entry.text_top)。
-    // h_scroll_x は Issue #205 のブロック単位横スクロール量 (DIP)。
+    // h_scroll_x はブロック単位の横スクロール量 (DIP)。
     HitResult HitTestTable(const Node& node, const NodeLayoutEntry& entry,
                            float entry_text_top,
                            int node_index,

--- a/src/input/hit_test_service.h
+++ b/src/input/hit_test_service.h
@@ -9,6 +9,7 @@
 #include <concepts>
 #include <limits>
 #include <memory_resource>
+#include <unordered_map>
 
 // ボタン矩形の純粋表現。テスト側が実装の式を再構築せずに済むよう、
 // 各ボタンの矩形を返す API は本ヘッダから提供する。
@@ -52,6 +53,8 @@ struct MdPaneHitContext {
     // ボタンヒットテスト用（HitTestでは未使用）
     float content_width = 0.0f;
     float md_pane_height = 0.0f;
+    // Issue #205: ブロック単位の横スクロール状態。null なら全 0 扱い。
+    const std::pmr::unordered_map<int, float>* block_scroll_x = nullptr;
 };
 
 // 物理ピクセルをMDペインローカルのDIP座標に変換する。
@@ -79,11 +82,12 @@ public:
 
     // テーブルセル内のヒットテスト。
     // entry_text_top はノードのテキスト上端 Y (= entry.text_top)。
+    // h_scroll_x は Issue #205 のブロック単位横スクロール量 (DIP)。
     HitResult HitTestTable(const Node& node, const NodeLayoutEntry& entry,
                            float entry_text_top,
                            int node_index,
                            const Theme& theme,
-                           float dip_x, float dip_y) const noexcept;
+                           float dip_x, float dip_y, float h_scroll_x = 0.0f) const noexcept;
 
     // ナビゲーションボタンのヒットテスト
     NavButtonHover NavButtonHitTest(float dip_x, float dip_y, const PaneRect& md_rect) const noexcept;

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -510,7 +510,7 @@ void DWriteTextMeasurer::FinalizeTableLayout(Node& node, NodeLayoutEntry& entry,
     tl.cached_table_width = tl.col_cum_x.back();
 
     // 圧縮分岐に入った場合 cached_table_width は自然総幅と乖離する。
-    // 横スクロール (Issue #205) のクランプ計算は natural_total_width を基準にする。
+    // 横スクロールのクランプ計算は natural_total_width を基準にする。
     {
         float natural_total = (static_cast<float>(col_count) + 1.0f) * border_width
                               + static_cast<float>(col_count) * cell_padding * 2.0f;

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -291,6 +291,9 @@ void DWriteTextMeasurer::MeasureNode(Node& node, NodeLayoutEntry& entry, float m
             entry.height = metrics.height;
             entry.layout_dirty = false;
             CacheFirstLineHeight(entry.text_layout.Get(), entry);
+            if (node.type == NodeType::CodeBlock) {
+                entry.natural_code_width = metrics.widthIncludingTrailingWhitespace;
+            }
             // 折り返し行が変わるためエフェクト位置 / ハイライト矩形は無効化する。
             // text_layout 自体は破棄しない (フォーマット属性は保持される)。
             entry.effects_applied = false;
@@ -301,6 +304,7 @@ void DWriteTextMeasurer::MeasureNode(Node& node, NodeLayoutEntry& entry, float m
         // 失敗時はスローパスでフルに作り直す。
         entry.text_layout.Reset();
         entry.first_line_height = 0.0f;
+        entry.natural_code_width = 0.0f;
     }
 
     // 1 ノードにつき WideViewForDWrite を 1 回だけ構築し、CreateTextLayout と ApplyRunFormatting で共有する
@@ -349,6 +353,9 @@ void DWriteTextMeasurer::MeasureNode(Node& node, NodeLayoutEntry& entry, float m
     entry.height = metrics.height;
     entry.layout_dirty = false;
     entry.effects_applied = false;
+    if (node.type == NodeType::CodeBlock) {
+        entry.natural_code_width = metrics.widthIncludingTrailingWhitespace;
+    }
     entry.clear_inline_code_bgs();
     entry.invalidate_per_frame_hl_caches();
 }
@@ -501,6 +508,17 @@ void DWriteTextMeasurer::FinalizeTableLayout(Node& node, NodeLayoutEntry& entry,
 
     // col_cum_x の末尾は border_width + Σ(col_w + 2*pad + border) と一致するため再計算しない。
     tl.cached_table_width = tl.col_cum_x.back();
+
+    // 圧縮分岐に入った場合 cached_table_width は自然総幅と乖離する。
+    // 横スクロール (Issue #205) のクランプ計算は natural_total_width を基準にする。
+    {
+        float natural_total = (static_cast<float>(col_count) + 1.0f) * border_width
+                              + static_cast<float>(col_count) * cell_padding * 2.0f;
+        for (size_t c = 0; c < col_count && c < natural_widths.size(); c++) {
+            natural_total += natural_widths[c];
+        }
+        tl.natural_total_width = natural_total;
+    }
 
     entry.height = total_height;
     entry.layout_dirty = false;

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -48,6 +48,9 @@ struct TableLayoutData {
     // 列幅 + パディング + 罫線の合計。FinalizeTableLayout で確定後不変なので
     // GenTable から毎フレーム fold_left せずキャッシュを参照する。
     float cached_table_width = 0.0f;
+    // 圧縮を行わなかった場合の自然な総幅。横スクロール (Issue #205) のクランプ計算用に
+    // 保持する。cached_table_width と一致することもあるが、圧縮分岐を通った場合は乖離する。
+    float natural_total_width = 0.0f;
     // フラットインデックスへの変換
     constexpr size_t CellIndex(size_t row, size_t col) const noexcept
     {
@@ -101,6 +104,9 @@ struct NodeLayoutEntry {
     static constexpr float kUnmeasuredWidth = -1.0f;
     float cached_width = kUnmeasuredWidth;
     float cached_height = 0.0f;
+    // CodeBlock の最長行幅 (NO_WRAP で計測した自然幅)。横スクロール (Issue #205) で
+    // バーのスケール計算とクランプに使う。CodeBlock 以外では 0 のまま。
+    float natural_code_width = 0.0f;
     constexpr bool is_measured() const noexcept
     {
         return cached_width > 0.0f;
@@ -331,6 +337,7 @@ public:
             e.text_layout.Reset();
             e.effects_applied = false;
             e.first_line_height = 0.0f;
+            e.natural_code_width = 0.0f;
             e.clear_inline_code_bgs();
             e.invalidate_per_frame_hl_caches();
             if (e.table_layout) {
@@ -434,6 +441,7 @@ public:
             e.layout_dirty = true;
             e.text_layout.Reset();
             e.first_line_height = 0.0f;
+            e.natural_code_width = 0.0f;
             e.invalidate_per_frame_hl_caches();
             if (e.table_layout) {
                 ResetTableLayoutGeometry(*e.table_layout);
@@ -514,6 +522,7 @@ private:
         tl.col_count = 0;
         tl.last_applied_max_width = -1.0f;
         tl.cached_table_width = 0.0f;
+        tl.natural_total_width = 0.0f;
     }
 
     static void EvictEntryLayout(NodeLayoutEntry& e) noexcept
@@ -524,6 +533,7 @@ private:
         e.text_layout.Reset();
         e.effects_applied = false;
         e.first_line_height = 0.0f;
+        e.natural_code_width = 0.0f;
         e.clear_inline_code_bgs();
         e.table_layout.reset();
         e.layout_dirty = true;

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -48,8 +48,8 @@ struct TableLayoutData {
     // 列幅 + パディング + 罫線の合計。FinalizeTableLayout で確定後不変なので
     // GenTable から毎フレーム fold_left せずキャッシュを参照する。
     float cached_table_width = 0.0f;
-    // 圧縮を行わなかった場合の自然な総幅。横スクロール (Issue #205) のクランプ計算用に
-    // 保持する。cached_table_width と一致することもあるが、圧縮分岐を通った場合は乖離する。
+    // 圧縮を行わなかった場合の自然な総幅。横スクロールのクランプ計算用に保持する。
+    // cached_table_width と一致することもあるが、圧縮分岐を通った場合は乖離する。
     float natural_total_width = 0.0f;
     // フラットインデックスへの変換
     constexpr size_t CellIndex(size_t row, size_t col) const noexcept
@@ -104,8 +104,8 @@ struct NodeLayoutEntry {
     static constexpr float kUnmeasuredWidth = -1.0f;
     float cached_width = kUnmeasuredWidth;
     float cached_height = 0.0f;
-    // CodeBlock の最長行幅 (NO_WRAP で計測した自然幅)。横スクロール (Issue #205) で
-    // バーのスケール計算とクランプに使う。CodeBlock 以外では 0 のまま。
+    // CodeBlock の最長行幅 (NO_WRAP で計測した自然幅)。横スクロールバーのスケール計算と
+    // クランプに使う。CodeBlock 以外では 0 のまま。
     float natural_code_width = 0.0f;
     constexpr bool is_measured() const noexcept
     {

--- a/src/layout/layout_computer.cpp
+++ b/src/layout/layout_computer.cpp
@@ -73,7 +73,7 @@ void ComputeColumnWidths(std::pmr::vector<float>& out, const std::pmr::vector<fl
 
     if (total_natural > 0 && total_natural > effective_available) {
         // 比例圧縮で最も狭い列が MIN_COLUMN_WIDTH を割る場合は、無理に押し込めず
-        // 自然幅で出して横スクロール (Issue #205) に任せる方が読みやすい。
+        // 自然幅で出して横スクロールに任せる方が読みやすい。
         const auto smallest_it = std::ranges::min_element(natural_widths | std::views::take(col_count));
         const float smallest = (smallest_it != natural_widths.end()) ? *smallest_it : 0.0f;
         if (smallest * effective_available < MIN_COLUMN_WIDTH * total_natural) {

--- a/src/layout/layout_computer.cpp
+++ b/src/layout/layout_computer.cpp
@@ -67,17 +67,25 @@ float GetSpacingBelow(const Node& node, const Theme& theme) noexcept
 void ComputeColumnWidths(std::pmr::vector<float>& out, const std::pmr::vector<float>& natural_widths, float available_width, size_t col_count)
 {
     out.resize(col_count);
-    available_width = std::max(available_width, static_cast<float>(col_count) * MIN_COLUMN_WIDTH);
+    const float effective_available = std::max(available_width, static_cast<float>(col_count) * MIN_COLUMN_WIDTH);
 
     const float total_natural = std::reduce(natural_widths.begin(), natural_widths.end(), 0.0f);
 
-    if (total_natural > 0 && total_natural > available_width) {
+    if (total_natural > 0 && total_natural > effective_available) {
+        // 比例圧縮で最も狭い列が MIN_COLUMN_WIDTH を割る場合は、無理に押し込めず
+        // 自然幅で出して横スクロール (Issue #205) に任せる方が読みやすい。
+        const auto smallest_it = std::ranges::min_element(natural_widths | std::views::take(col_count));
+        const float smallest = (smallest_it != natural_widths.end()) ? *smallest_it : 0.0f;
+        if (smallest * effective_available < MIN_COLUMN_WIDTH * total_natural) {
+            std::ranges::copy(natural_widths | std::views::take(col_count), out.begin());
+            return;
+        }
         for (auto [w, nw] : std::views::zip(out, natural_widths) | std::views::take(col_count)) {
-            w = std::max(MIN_COLUMN_WIDTH, available_width * nw / total_natural);
+            w = effective_available * nw / total_natural;
         }
     }
     else {
-        const float even = available_width / static_cast<float>(col_count);
+        const float even = effective_available / static_cast<float>(col_count);
         for (auto [w, nw] : std::views::zip(out, natural_widths) | std::views::take(col_count)) {
             w = std::max(nw + COLUMN_WIDTH_PADDING, even);
         }

--- a/src/layout/layout_computer.cpp
+++ b/src/layout/layout_computer.cpp
@@ -67,6 +67,9 @@ float GetSpacingBelow(const Node& node, const Theme& theme) noexcept
 void ComputeColumnWidths(std::pmr::vector<float>& out, const std::pmr::vector<float>& natural_widths, float available_width, size_t col_count)
 {
     out.resize(col_count);
+    if (col_count == 0) {
+        return;
+    }
     const float effective_available = std::max(available_width, static_cast<float>(col_count) * MIN_COLUMN_WIDTH);
 
     const float total_natural = std::reduce(natural_widths.begin(), natural_widths.end(), 0.0f);
@@ -74,8 +77,7 @@ void ComputeColumnWidths(std::pmr::vector<float>& out, const std::pmr::vector<fl
     if (total_natural > 0 && total_natural > effective_available) {
         // 比例圧縮で最も狭い列が MIN_COLUMN_WIDTH を割る場合は、無理に押し込めず
         // 自然幅で出して横スクロールに任せる方が読みやすい。
-        const auto smallest_it = std::ranges::min_element(natural_widths | std::views::take(col_count));
-        const float smallest = (smallest_it != natural_widths.end()) ? *smallest_it : 0.0f;
+        const float smallest = *std::ranges::min_element(natural_widths | std::views::take(col_count));
         if (smallest * effective_available < MIN_COLUMN_WIDTH * total_natural) {
             std::ranges::copy(natural_widths | std::views::take(col_count), out.begin());
             return;

--- a/src/render/block_h_scroll_context.h
+++ b/src/render/block_h_scroll_context.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <memory_resource>
+#include <unordered_map>
+
+// ブロック単位の横スクロールの描画時コンテキスト。
+// AppState/ViewState から map とホバー/ドラッグ対象 node_index を切り出して描画層へ渡す。
+struct BlockHScrollContext {
+    const std::pmr::unordered_map<int, float>* scroll_x = nullptr;
+    int hovered_block = -1;
+    int drag_block = -1;
+
+    float GetScrollX(int node_index) const
+    {
+        if (!scroll_x) {
+            return 0.0f;
+        }
+        const auto it = scroll_x->find(node_index);
+        return (it != scroll_x->end()) ? it->second : 0.0f;
+    }
+};

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -42,23 +42,30 @@ static constexpr float HEADING_UNDERLINE_OFFSET_RATIO = 0.25f;
 
 namespace {
 
-// Issue #205: ブロックローカル横スクロールの clip + Translate を RAII で囲み、
-// push/pop の対称性を強制する。Table と CodeBlock の共通パターンを集約する。
+// ブロックローカル横スクロールの clip と Translate を RAII で囲み、push/pop の対称性を強制する。
+// scroll_x == 0 のときは Translate を省略し、自然幅がペイン幅以下のときは Clip も省略する。
+// 自然幅が visible_width を超えるが scroll_x == 0 の場合 (初期状態) は、依然として右端で
+// Clip しないとペイン余白に内容がはみ出るため、Clip と Translate を独立に判定する。
 class BlockHScrollScope {
 public:
     BlockHScrollScope(DrawCommandList& cmds, const D2D1_RECT_F& clip,
-                      const D2D1::Matrix3x2F& base_transform, float scroll_x, bool active)
-        : cmds_(cmds), restore_(base_transform), active_(active)
+                      const D2D1::Matrix3x2F& base_transform, float scroll_x, bool needs_clip)
+        : cmds_(cmds), restore_(base_transform),
+          push_clip_(needs_clip), translate_(needs_clip && scroll_x > 0.0f)
     {
-        if (active_) {
+        if (push_clip_) {
             cmds_.emplace_back(PushClipCmd{ clip });
+        }
+        if (translate_) {
             cmds_.emplace_back(SetTransformCmd{ base_transform * D2D1::Matrix3x2F::Translation(-scroll_x, 0) });
         }
     }
     ~BlockHScrollScope()
     {
-        if (active_) {
+        if (translate_) {
             cmds_.emplace_back(SetTransformCmd{ restore_ });
+        }
+        if (push_clip_) {
             cmds_.emplace_back(PopClipCmd{});
         }
     }
@@ -68,7 +75,8 @@ public:
 private:
     DrawCommandList& cmds_;
     D2D1::Matrix3x2F restore_;
-    bool active_;
+    bool push_clip_;
+    bool translate_;
 };
 
 } // namespace
@@ -223,20 +231,16 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
         return;
 
     case NodeType::Table: {
-        // Issue #205: 自然幅 > 可視幅 ならテーブル全体を scroll_x 分ずらしてクリップ。
         const float natural_w = entry.has_table_layout() ? entry.table_layout->natural_total_width : 0.0f;
         const bool needs_clip = natural_w > cw;
-        const float scroll_x = needs_clip
-                                   ? std::clamp(frame_h_scroll_.GetScrollX(node_index), 0.0f, natural_w - cw)
-                                   : 0.0f;
+        const float scroll_x = needs_clip ? std::clamp(frame_h_scroll_.GetScrollX(node_index), 0.0f, natural_w - cw) : 0.0f;
         {
             BlockHScrollScope guard(cmds,
                                     D2D1::RectF(x, entry_text_top, x + cw, entry_text_top + entry.height),
                                     frame_pane_transform_, scroll_x, needs_clip);
             GenTable(cmds, node, entry, node_index, x, entry_text_top, scroll_x);
         }
-        const float bar_y = BlockHScrollbarBarY(entry_text_top, entry.height, 0.0f);
-        MaybeEmitBlockHScrollbar(cmds, node_index, x, bar_y, cw, natural_w, scroll_x);
+        EmitBlockHScrollbarIfActive(cmds, node_index, x, BlockHScrollbarBarY(entry_text_top, entry.height, 0.0f), cw, natural_w, scroll_x);
         return;
     }
 
@@ -256,15 +260,11 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
             return;
         }
         GenCodeBlockBg(cmds, entry, x, cw, entry_text_top);
-        // Issue #205: 自然幅 > 可視幅 ならテキスト本体だけ scroll_x で平行移動。
-        // 背景とコピーボタンはクリップ外で固定描画する (GitHub と同じ挙動)。
-        // バーは背景下端の padding 内に置き、テキストに被らないようにする。
-        // padding 内クリックも CodeBlock ヒットとして扱うため HitTest 側でガードを緩和済み。
+        // 背景とコピーボタンはクリップ外で固定描画 (GitHub と同じ挙動)。テキスト本体だけ scroll_x 分平行移動。
         {
-            const bool needs_clip = entry.natural_code_width > cw;
-            const float scroll_x = needs_clip
-                                       ? std::clamp(frame_h_scroll_.GetScrollX(node_index), 0.0f, entry.natural_code_width - cw)
-                                       : 0.0f;
+            const float natural_w = entry.natural_code_width;
+            const bool needs_clip = natural_w > cw;
+            const float scroll_x = needs_clip ? std::clamp(frame_h_scroll_.GetScrollX(node_index), 0.0f, natural_w - cw) : 0.0f;
             const float pad = theme_->code_block_padding;
             {
                 BlockHScrollScope guard(cmds,
@@ -272,8 +272,7 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
                                         frame_pane_transform_, scroll_x, needs_clip);
                 GenNodeTextDecorations(cmds, node, entry, node_index, x, text_x, entry_text_top);
             }
-            const float bar_y = BlockHScrollbarBarY(entry_text_top, entry.height, pad);
-            MaybeEmitBlockHScrollbar(cmds, node_index, x, bar_y, cw, entry.natural_code_width, scroll_x);
+            EmitBlockHScrollbarIfActive(cmds, node_index, x, BlockHScrollbarBarY(entry_text_top, entry.height, pad), cw, natural_w, scroll_x);
         }
         GenCopyButton(cmds, entry, x, cw, node_index == frame_hovered_.copy, entry_text_top);
         return;
@@ -421,24 +420,16 @@ void CommandGenerator::GenSvgCopyButton(DrawCommandList& cmds, float bitmap_righ
     GenOverlayButton(cmds, btn, L'\uE8C8', is_hovered);
 }
 
-void CommandGenerator::MaybeEmitBlockHScrollbar(DrawCommandList& cmds, int node_index, float block_x, float bar_y, float visible_width, float natural_width, float scroll_x)
+void CommandGenerator::EmitBlockHScrollbarIfActive(DrawCommandList& cmds, int node_index, float block_x, float bar_y, float visible_width, float natural_width, float scroll_x)
 {
-    if (natural_width <= visible_width) {
+    if (natural_width <= visible_width || visible_width <= 0.0f) {
         return;
     }
     if (node_index != frame_h_scroll_.hovered_block && node_index != frame_h_scroll_.drag_block) {
         return;
     }
-    GenBlockHScrollbar(cmds, block_x, bar_y, visible_width, natural_width, scroll_x);
-}
-
-void CommandGenerator::GenBlockHScrollbar(DrawCommandList& cmds, float block_x, float bar_y, float visible_width, float natural_width, float scroll_x)
-{
-    if (natural_width <= visible_width || visible_width <= 0.0f) {
-        return;
-    }
     const float track_w = visible_width;
-    const float thumb_w = std::max(PANE_SCROLLBAR_THUMB_MIN, track_w * (visible_width / natural_width));
+    const float thumb_w = BlockHScrollbarThumbWidth(visible_width, natural_width);
     const float scroll_max = natural_width - visible_width;
     const float ratio = (scroll_max > 0.0f) ? std::clamp(scroll_x / scroll_max, 0.0f, 1.0f) : 0.0f;
     // bullet と同じく Identity transform + 物理ピクセル snap で描画する。
@@ -904,7 +895,7 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
             theme_->hr_color, border, BrushId::Hr });
 
         // 可視列のみコマンド生成、画面外は cell_text_starts で flat_offset を直接取得。
-        // 横スクロール (Issue #205) では画面に映る範囲が h_scroll_x だけ右にずれる。
+        // 横スクロール時は画面に映る範囲が h_scroll_x だけ右にずれる。
         const float cull_left = offset_x + frame_viewport_left_ + h_scroll_x;
         const float cull_right = offset_x + frame_viewport_right_ + h_scroll_x;
         float cx = offset_x + border;

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -64,8 +64,11 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     const TextSelection& selection,
     int first_visible,
     HoveredButtons hovered,
-    float dpi_scale)
+    float dpi_scale,
+    const BlockHScrollContext& block_h_scroll)
 {
+    frame_h_scroll_ = block_h_scroll;
+
     // 古いコマンドを destruct してから resource をリセットする。
     // 順序が逆だと cmds_ 内部ストレージが Reset 済みバッファを指してしまう。
     cmds_ = DrawCommandList{ frame_resource_.resource() };
@@ -186,9 +189,28 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
         }
         return;
 
-    case NodeType::Table:
-        GenTable(cmds, node, entry, node_index, x, entry_text_top);
+    case NodeType::Table: {
+        // Issue #205: 自然幅 > 可視幅 ならテーブル全体を scroll_x 分ずらしてクリップ。
+        const float natural_w = entry.has_table_layout() ? entry.table_layout->natural_total_width : 0.0f;
+        const bool needs_clip = natural_w > cw;
+        const float scroll_x = needs_clip
+                                   ? std::clamp(frame_h_scroll_.GetScrollX(node_index), 0.0f, natural_w - cw)
+                                   : 0.0f;
+        if (needs_clip) {
+            cmds.emplace_back(PushClipCmd{ D2D1::RectF(x, entry_text_top, x + cw, entry_text_top + entry.height) });
+            cmds.emplace_back(SetTransformCmd{ frame_pane_transform_ * D2D1::Matrix3x2F::Translation(-scroll_x, 0) });
+        }
+        GenTable(cmds, node, entry, node_index, x, entry_text_top, scroll_x);
+        if (needs_clip) {
+            cmds.emplace_back(SetTransformCmd{ frame_pane_transform_ });
+            cmds.emplace_back(PopClipCmd{});
+        }
+        if (needs_clip && (node_index == frame_h_scroll_.hovered_block || node_index == frame_h_scroll_.drag_block)) {
+            const float bar_y = entry_text_top + entry.height - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+            GenBlockHScrollbar(cmds, x, bar_y, cw, natural_w, scroll_x);
+        }
         return;
+    }
 
     case NodeType::CodeBlock:
         if (IsDiagramLanguage(node.code_language)) {
@@ -206,8 +228,32 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
             return;
         }
         GenCodeBlockBg(cmds, entry, x, cw, entry_text_top);
+        // Issue #205: 自然幅 > 可視幅 ならテキスト本体だけ scroll_x で平行移動。
+        // 背景とコピーボタンはクリップ外で固定描画する (GitHub と同じ挙動)。
+        {
+            const bool needs_clip = entry.natural_code_width > cw;
+            const float scroll_x = needs_clip
+                                       ? std::clamp(frame_h_scroll_.GetScrollX(node_index), 0.0f, entry.natural_code_width - cw)
+                                       : 0.0f;
+            if (needs_clip) {
+                const float pad = theme_->code_block_padding;
+                cmds.emplace_back(PushClipCmd{ D2D1::RectF(x, entry_text_top - pad, x + cw, entry_text_top + entry.height + pad) });
+                cmds.emplace_back(SetTransformCmd{ frame_pane_transform_ * D2D1::Matrix3x2F::Translation(-scroll_x, 0) });
+            }
+            GenNodeTextDecorations(cmds, node, entry, node_index, x, text_x, entry_text_top);
+            if (needs_clip) {
+                cmds.emplace_back(SetTransformCmd{ frame_pane_transform_ });
+                cmds.emplace_back(PopClipCmd{});
+            }
+            if (needs_clip && (node_index == frame_h_scroll_.hovered_block || node_index == frame_h_scroll_.drag_block)) {
+                // Issue #205: バーは text 範囲内 (最終行の上) に置く。padding 部分に置くと
+                // HitTest がそのノードを返さず、マウスがバー上に来た瞬間にホバーが解除される。
+                const float bar_y = entry_text_top + entry.height - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+                GenBlockHScrollbar(cmds, x, bar_y, cw, entry.natural_code_width, scroll_x);
+            }
+        }
         GenCopyButton(cmds, entry, x, cw, node_index == frame_hovered_.copy, entry_text_top);
-        break;
+        return;
 
     case NodeType::ListItem:
         GenListBullet(cmds, node, entry, x, entry_text_top);
@@ -350,6 +396,24 @@ void CommandGenerator::GenSvgCopyButton(DrawCommandList& cmds, float bitmap_righ
     }
     const D2D1_RECT_F btn = OverlayButtonRect(bitmap_right, bitmap_top, std::to_underlying(DiagramButtonSlot::SvgCopy));
     GenOverlayButton(cmds, btn, L'\uE8C8', is_hovered);
+}
+
+void CommandGenerator::GenBlockHScrollbar(DrawCommandList& cmds, float block_x, float bar_y, float visible_width, float natural_width, float scroll_x)
+{
+    if (natural_width <= visible_width || visible_width <= 0.0f) {
+        return;
+    }
+    const float track_w = visible_width;
+    const float thumb_w = std::max(PANE_SCROLLBAR_THUMB_MIN, track_w * (visible_width / natural_width));
+    const float scroll_max = natural_width - visible_width;
+    const float ratio = (scroll_max > 0.0f) ? std::clamp(scroll_x / scroll_max, 0.0f, 1.0f) : 0.0f;
+    const float thumb_x = block_x + ratio * (track_w - thumb_w);
+    const D2D1_RECT_F thumb_rect = D2D1::RectF(thumb_x, bar_y, thumb_x + thumb_w, bar_y + PANE_SCROLLBAR_WIDTH);
+    cmds.emplace_back(FillRoundedRectCmd{
+        thumb_rect,
+        PANE_SCROLLBAR_WIDTH / 2.0f, PANE_SCROLLBAR_WIDTH / 2.0f,
+        D2D1::ColorF(0.0f, 0.0f, 0.0f, 0.0f),
+        BrushId::ScrollbarThumb });
 }
 
 void CommandGenerator::GenOverlayButton(DrawCommandList& cmds, D2D1_RECT_F btn, wchar_t icon, bool is_hovered)
@@ -746,7 +810,7 @@ void CommandGenerator::GenTableCellContent(
 
 void CommandGenerator::GenTable(DrawCommandList& cmds,
                                 const Node& node, const NodeLayoutEntry& entry,
-                                int node_index, float offset_x, float entry_text_top)
+                                int node_index, float offset_x, float entry_text_top, float h_scroll_x)
 {
     const auto* tbl = node.table_data();
     if (!tbl || tbl->row_count == 0 || !entry.has_table_layout() || entry.table_layout->col_widths.empty()) {
@@ -798,9 +862,10 @@ void CommandGenerator::GenTable(DrawCommandList& cmds,
             D2D1::Point2F(offset_x, y), D2D1::Point2F(offset_x + table_width, y),
             theme_->hr_color, border, BrushId::Hr });
 
-        // 可視列のみコマンド生成、画面外は cell_text_starts で flat_offset を直接取得
-        const float cull_left = offset_x + frame_viewport_left_;
-        const float cull_right = offset_x + frame_viewport_right_;
+        // 可視列のみコマンド生成、画面外は cell_text_starts で flat_offset を直接取得。
+        // 横スクロール (Issue #205) では画面に映る範囲が h_scroll_x だけ右にずれる。
+        const float cull_left = offset_x + frame_viewport_left_ + h_scroll_x;
+        const float cull_right = offset_x + frame_viewport_right_ + h_scroll_x;
         float cx = offset_x + border;
         const size_t drawn_cols = std::min(col_count, tl.col_widths.size());
         for (size_t c = 0; c < drawn_cols; c++) {

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -258,8 +258,8 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
         GenCodeBlockBg(cmds, entry, x, cw, entry_text_top);
         // Issue #205: 自然幅 > 可視幅 ならテキスト本体だけ scroll_x で平行移動。
         // 背景とコピーボタンはクリップ外で固定描画する (GitHub と同じ挙動)。
-        // バーは text 範囲内 (最終行の上) に置く。padding 部分に置くと HitTest がそのノードを
-        // 返さず、マウスがバー上に来た瞬間にホバーが解除されるため。
+        // バーは背景下端の padding 内に置き、テキストに被らないようにする。
+        // padding 内クリックも CodeBlock ヒットとして扱うため HitTest 側でガードを緩和済み。
         {
             const bool needs_clip = entry.natural_code_width > cw;
             const float scroll_x = needs_clip
@@ -272,7 +272,7 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
                                         frame_pane_transform_, scroll_x, needs_clip);
                 GenNodeTextDecorations(cmds, node, entry, node_index, x, text_x, entry_text_top);
             }
-            const float bar_y = entry_text_top + entry.height - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+            const float bar_y = entry_text_top + entry.height + pad - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
             MaybeEmitBlockHScrollbar(cmds, node_index, x, bar_y, cw, entry.natural_code_width, scroll_x);
         }
         GenCopyButton(cmds, entry, x, cw, node_index == frame_hovered_.copy, entry_text_top);
@@ -441,13 +441,20 @@ void CommandGenerator::GenBlockHScrollbar(DrawCommandList& cmds, float block_x, 
     const float thumb_w = std::max(PANE_SCROLLBAR_THUMB_MIN, track_w * (visible_width / natural_width));
     const float scroll_max = natural_width - visible_width;
     const float ratio = (scroll_max > 0.0f) ? std::clamp(scroll_x / scroll_max, 0.0f, 1.0f) : 0.0f;
-    const float thumb_x = block_x + ratio * (track_w - thumb_w);
-    const D2D1_RECT_F thumb_rect = D2D1::RectF(thumb_x, bar_y, thumb_x + thumb_w, bar_y + PANE_SCROLLBAR_WIDTH);
+    // bullet と同じく Identity transform + 物理ピクセル snap で描画する。
+    // frame_pane_transform_ の md_x が非整数 (DPI 1 以外) のとき、サブピクセル位置で
+    // アンチエイリアスが上下に漏れて thumb の太さがブレる現象を防ぐ。
+    const float abs_x = SnapToPhysicalPixel(frame_md_pane_x_ + block_x + ratio * (track_w - thumb_w), frame_dpi_scale_);
+    const float abs_y = SnapToPhysicalPixel(bar_y - frame_snapped_scroll_y_, frame_dpi_scale_);
+    const float w_snapped = SnapToPhysicalPixel(thumb_w, frame_dpi_scale_);
+    const float h_snapped = SnapToPhysicalPixel(PANE_SCROLLBAR_WIDTH, frame_dpi_scale_);
+    cmds.emplace_back(SetTransformCmd{ D2D1::Matrix3x2F::Identity() });
     cmds.emplace_back(FillRoundedRectCmd{
-        thumb_rect,
-        PANE_SCROLLBAR_WIDTH / 2.0f, PANE_SCROLLBAR_WIDTH / 2.0f,
+        D2D1::RectF(abs_x, abs_y, abs_x + w_snapped, abs_y + h_snapped),
+        h_snapped / 2.0f, h_snapped / 2.0f,
         D2D1::ColorF(0.0f, 0.0f, 0.0f, 0.0f),
         BrushId::ScrollbarThumb });
+    cmds.emplace_back(SetTransformCmd{ frame_pane_transform_ });
 }
 
 void CommandGenerator::GenOverlayButton(DrawCommandList& cmds, D2D1_RECT_F btn, wchar_t icon, bool is_hovered)

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -40,6 +40,39 @@ void PublishCmdGenStats() noexcept
 // 値を小さくすると下線は見出し文字に近づき、下線と次行の間隔が広がる。
 static constexpr float HEADING_UNDERLINE_OFFSET_RATIO = 0.25f;
 
+namespace {
+
+// Issue #205: ブロックローカル横スクロールの clip + Translate を RAII で囲み、
+// push/pop の対称性を強制する。Table と CodeBlock の共通パターンを集約する。
+class BlockHScrollScope {
+public:
+    BlockHScrollScope(DrawCommandList& cmds, const D2D1_RECT_F& clip,
+                      const D2D1::Matrix3x2F& base_transform, float scroll_x, bool active)
+        : cmds_(cmds), restore_(base_transform), active_(active)
+    {
+        if (active_) {
+            cmds_.emplace_back(PushClipCmd{ clip });
+            cmds_.emplace_back(SetTransformCmd{ base_transform * D2D1::Matrix3x2F::Translation(-scroll_x, 0) });
+        }
+    }
+    ~BlockHScrollScope()
+    {
+        if (active_) {
+            cmds_.emplace_back(SetTransformCmd{ restore_ });
+            cmds_.emplace_back(PopClipCmd{});
+        }
+    }
+    BlockHScrollScope(const BlockHScrollScope&) = delete;
+    BlockHScrollScope& operator=(const BlockHScrollScope&) = delete;
+
+private:
+    DrawCommandList& cmds_;
+    D2D1::Matrix3x2F restore_;
+    bool active_;
+};
+
+} // namespace
+
 // DWRITE_HIT_TEST_METRICS を origin 加算付きの D2D1_RECT_F に変換する。
 static inline D2D1_RECT_F RectFromHitTest(const DWRITE_HIT_TEST_METRICS& m, float origin_x = 0.0f, float origin_y = 0.0f) noexcept
 {
@@ -196,19 +229,14 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
         const float scroll_x = needs_clip
                                    ? std::clamp(frame_h_scroll_.GetScrollX(node_index), 0.0f, natural_w - cw)
                                    : 0.0f;
-        if (needs_clip) {
-            cmds.emplace_back(PushClipCmd{ D2D1::RectF(x, entry_text_top, x + cw, entry_text_top + entry.height) });
-            cmds.emplace_back(SetTransformCmd{ frame_pane_transform_ * D2D1::Matrix3x2F::Translation(-scroll_x, 0) });
+        {
+            BlockHScrollScope guard(cmds,
+                                    D2D1::RectF(x, entry_text_top, x + cw, entry_text_top + entry.height),
+                                    frame_pane_transform_, scroll_x, needs_clip);
+            GenTable(cmds, node, entry, node_index, x, entry_text_top, scroll_x);
         }
-        GenTable(cmds, node, entry, node_index, x, entry_text_top, scroll_x);
-        if (needs_clip) {
-            cmds.emplace_back(SetTransformCmd{ frame_pane_transform_ });
-            cmds.emplace_back(PopClipCmd{});
-        }
-        if (needs_clip && (node_index == frame_h_scroll_.hovered_block || node_index == frame_h_scroll_.drag_block)) {
-            const float bar_y = entry_text_top + entry.height - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
-            GenBlockHScrollbar(cmds, x, bar_y, cw, natural_w, scroll_x);
-        }
+        const float bar_y = entry_text_top + entry.height - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+        MaybeEmitBlockHScrollbar(cmds, node_index, x, bar_y, cw, natural_w, scroll_x);
         return;
     }
 
@@ -230,27 +258,22 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
         GenCodeBlockBg(cmds, entry, x, cw, entry_text_top);
         // Issue #205: 自然幅 > 可視幅 ならテキスト本体だけ scroll_x で平行移動。
         // 背景とコピーボタンはクリップ外で固定描画する (GitHub と同じ挙動)。
+        // バーは text 範囲内 (最終行の上) に置く。padding 部分に置くと HitTest がそのノードを
+        // 返さず、マウスがバー上に来た瞬間にホバーが解除されるため。
         {
             const bool needs_clip = entry.natural_code_width > cw;
             const float scroll_x = needs_clip
                                        ? std::clamp(frame_h_scroll_.GetScrollX(node_index), 0.0f, entry.natural_code_width - cw)
                                        : 0.0f;
-            if (needs_clip) {
-                const float pad = theme_->code_block_padding;
-                cmds.emplace_back(PushClipCmd{ D2D1::RectF(x, entry_text_top - pad, x + cw, entry_text_top + entry.height + pad) });
-                cmds.emplace_back(SetTransformCmd{ frame_pane_transform_ * D2D1::Matrix3x2F::Translation(-scroll_x, 0) });
+            const float pad = theme_->code_block_padding;
+            {
+                BlockHScrollScope guard(cmds,
+                                        D2D1::RectF(x, entry_text_top - pad, x + cw, entry_text_top + entry.height + pad),
+                                        frame_pane_transform_, scroll_x, needs_clip);
+                GenNodeTextDecorations(cmds, node, entry, node_index, x, text_x, entry_text_top);
             }
-            GenNodeTextDecorations(cmds, node, entry, node_index, x, text_x, entry_text_top);
-            if (needs_clip) {
-                cmds.emplace_back(SetTransformCmd{ frame_pane_transform_ });
-                cmds.emplace_back(PopClipCmd{});
-            }
-            if (needs_clip && (node_index == frame_h_scroll_.hovered_block || node_index == frame_h_scroll_.drag_block)) {
-                // Issue #205: バーは text 範囲内 (最終行の上) に置く。padding 部分に置くと
-                // HitTest がそのノードを返さず、マウスがバー上に来た瞬間にホバーが解除される。
-                const float bar_y = entry_text_top + entry.height - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
-                GenBlockHScrollbar(cmds, x, bar_y, cw, entry.natural_code_width, scroll_x);
-            }
+            const float bar_y = entry_text_top + entry.height - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+            MaybeEmitBlockHScrollbar(cmds, node_index, x, bar_y, cw, entry.natural_code_width, scroll_x);
         }
         GenCopyButton(cmds, entry, x, cw, node_index == frame_hovered_.copy, entry_text_top);
         return;
@@ -396,6 +419,17 @@ void CommandGenerator::GenSvgCopyButton(DrawCommandList& cmds, float bitmap_righ
     }
     const D2D1_RECT_F btn = OverlayButtonRect(bitmap_right, bitmap_top, std::to_underlying(DiagramButtonSlot::SvgCopy));
     GenOverlayButton(cmds, btn, L'\uE8C8', is_hovered);
+}
+
+void CommandGenerator::MaybeEmitBlockHScrollbar(DrawCommandList& cmds, int node_index, float block_x, float bar_y, float visible_width, float natural_width, float scroll_x)
+{
+    if (natural_width <= visible_width) {
+        return;
+    }
+    if (node_index != frame_h_scroll_.hovered_block && node_index != frame_h_scroll_.drag_block) {
+        return;
+    }
+    GenBlockHScrollbar(cmds, block_x, bar_y, visible_width, natural_width, scroll_x);
 }
 
 void CommandGenerator::GenBlockHScrollbar(DrawCommandList& cmds, float block_x, float bar_y, float visible_width, float natural_width, float scroll_x)

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -235,7 +235,7 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
                                     frame_pane_transform_, scroll_x, needs_clip);
             GenTable(cmds, node, entry, node_index, x, entry_text_top, scroll_x);
         }
-        const float bar_y = entry_text_top + entry.height - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+        const float bar_y = BlockHScrollbarBarY(entry_text_top, entry.height, 0.0f);
         MaybeEmitBlockHScrollbar(cmds, node_index, x, bar_y, cw, natural_w, scroll_x);
         return;
     }
@@ -272,7 +272,7 @@ void CommandGenerator::GenerateNode(DrawCommandList& cmds,
                                         frame_pane_transform_, scroll_x, needs_clip);
                 GenNodeTextDecorations(cmds, node, entry, node_index, x, text_x, entry_text_top);
             }
-            const float bar_y = entry_text_top + entry.height + pad - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+            const float bar_y = BlockHScrollbarBarY(entry_text_top, entry.height, pad);
             MaybeEmitBlockHScrollbar(cmds, node_index, x, bar_y, cw, entry.natural_code_width, scroll_x);
         }
         GenCopyButton(cmds, entry, x, cw, node_index == frame_hovered_.copy, entry_text_top);

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -155,6 +155,9 @@ private:
     // ブロックローカルの水平スクロールバー (Issue #205)。
     // block_x はブロック左端、bar_y はバー上端 (ペイン内ローカル座標)。
     void GenBlockHScrollbar(DrawCommandList& cmds, float block_x, float bar_y, float visible_width, float natural_width, float scroll_x);
+    // ホバー中 / ドラッグ中の対象ブロックでのみ水平スクロールバーを emit する。
+    // Table と CodeBlock で共通の出現条件を一元化する。
+    void MaybeEmitBlockHScrollbar(DrawCommandList& cmds, int node_index, float block_x, float bar_y, float visible_width, float natural_width, float scroll_x);
     void GenListBullet(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, float x, float entry_text_top);
     void GenBlockQuoteGroupDecorations(DrawCommandList& cmds, const std::pmr::vector<Node>& nodes, const LayoutCache& cache, int node_count, int first_visible);
     void GenDiagramPlaceholder(DrawCommandList& cmds, float x, float y, float w, float h);

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -9,7 +9,26 @@
 #include "memory_resource.h"
 #include "search_state.h"
 #include <cassert>
+#include <memory_resource>
 #include <span>
+#include <unordered_map>
+
+// ブロック単位の横スクロール (Issue #205) の描画時コンテキスト。
+// AppState/ViewState から map とホバー/ドラッグ対象 node_index を切り出して渡す。
+struct BlockHScrollContext {
+    const std::pmr::unordered_map<int, float>* scroll_x = nullptr;
+    int hovered_block = -1;
+    int drag_block = -1;
+
+    float GetScrollX(int node_index) const
+    {
+        if (!scroll_x) {
+            return 0.0f;
+        }
+        const auto it = scroll_x->find(node_index);
+        return (it != scroll_x->end()) ? it->second : 0.0f;
+    }
+};
 
 // HitTestTextRange 初期バッファ容量。1 行中の inline code run が
 // 折り返される想定最大数に合わせる。描画 hot path 中の resize を避けるのが目的。
@@ -107,7 +126,8 @@ public:
         const TextSelection& selection,
         int first_visible = -1,
         HoveredButtons hovered = {},
-        float dpi_scale = 1.0f);
+        float dpi_scale = 1.0f,
+        const BlockHScrollContext& block_h_scroll = {});
 
 private:
     void GenerateNode(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, const DiagramEntry& diagram, int node_index, float entry_text_top);
@@ -124,7 +144,7 @@ private:
     NodeBaseStyle GetNodeBaseStyle(const Node& node) const noexcept;
 
     void GenHorizontalRule(DrawCommandList& cmds, const NodeLayoutEntry& entry, float x, float w, float entry_text_top);
-    void GenTable(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, int node_index, float x, float entry_text_top);
+    void GenTable(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, int node_index, float x, float entry_text_top, float h_scroll_x = 0.0f);
     void GenTableRowBg(DrawCommandList& cmds, bool is_header, bool is_even_row, float x, float y, float table_width, float row_h, float border);
     void GenTableCellContent(DrawCommandList& cmds, std::string_view cell_text, bool is_header, IDWriteTextLayout* cell_layout, float text_x, float text_y, bool has_selection, uint32_t sel_start, uint32_t sel_end, uint32_t flat_offset);
     void GenCodeBlockBg(DrawCommandList& cmds, const NodeLayoutEntry& entry, float x, float w, float entry_text_top);
@@ -132,6 +152,9 @@ private:
     void GenCopyButton(DrawCommandList& cmds, const NodeLayoutEntry& entry, float x, float w, bool is_hovered, float entry_text_top);
     void GenSaveButton(DrawCommandList& cmds, float bitmap_right, float bitmap_top, bool is_hovered);
     void GenSvgCopyButton(DrawCommandList& cmds, float bitmap_right, float bitmap_top, bool is_hovered);
+    // ブロックローカルの水平スクロールバー (Issue #205)。
+    // block_x はブロック左端、bar_y はバー上端 (ペイン内ローカル座標)。
+    void GenBlockHScrollbar(DrawCommandList& cmds, float block_x, float bar_y, float visible_width, float natural_width, float scroll_x);
     void GenListBullet(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, float x, float entry_text_top);
     void GenBlockQuoteGroupDecorations(DrawCommandList& cmds, const std::pmr::vector<Node>& nodes, const LayoutCache& cache, int node_count, int first_visible);
     void GenDiagramPlaceholder(DrawCommandList& cmds, float x, float y, float w, float h);
@@ -225,6 +248,7 @@ private:
     D2D1::Matrix3x2F frame_pane_transform_ = D2D1::Matrix3x2F::Identity();
     const TextSelection* frame_selection_ = nullptr;
     HoveredButtons frame_hovered_;
+    BlockHScrollContext frame_h_scroll_;
 
     // 前フレームの選択ノード範囲。範囲外に出たノードの selection_hl_cache を
     // 解放するために使う。-1/-1 は「前フレームは非アクティブ」を示す。

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "block_h_scroll_context.h"
 #include "doc_dwrite_bridge.h"
 #include "draw_command.h"
 #include "document_types.h"
@@ -11,24 +12,6 @@
 #include <cassert>
 #include <memory_resource>
 #include <span>
-#include <unordered_map>
-
-// ブロック単位の横スクロール (Issue #205) の描画時コンテキスト。
-// AppState/ViewState から map とホバー/ドラッグ対象 node_index を切り出して渡す。
-struct BlockHScrollContext {
-    const std::pmr::unordered_map<int, float>* scroll_x = nullptr;
-    int hovered_block = -1;
-    int drag_block = -1;
-
-    float GetScrollX(int node_index) const
-    {
-        if (!scroll_x) {
-            return 0.0f;
-        }
-        const auto it = scroll_x->find(node_index);
-        return (it != scroll_x->end()) ? it->second : 0.0f;
-    }
-};
 
 // HitTestTextRange 初期バッファ容量。1 行中の inline code run が
 // 折り返される想定最大数に合わせる。描画 hot path 中の resize を避けるのが目的。
@@ -152,12 +135,9 @@ private:
     void GenCopyButton(DrawCommandList& cmds, const NodeLayoutEntry& entry, float x, float w, bool is_hovered, float entry_text_top);
     void GenSaveButton(DrawCommandList& cmds, float bitmap_right, float bitmap_top, bool is_hovered);
     void GenSvgCopyButton(DrawCommandList& cmds, float bitmap_right, float bitmap_top, bool is_hovered);
-    // ブロックローカルの水平スクロールバー (Issue #205)。
+    // ブロックローカルの水平スクロールバー。ホバー中 / ドラッグ中の対象ブロックでのみ emit する。
     // block_x はブロック左端、bar_y はバー上端 (ペイン内ローカル座標)。
-    void GenBlockHScrollbar(DrawCommandList& cmds, float block_x, float bar_y, float visible_width, float natural_width, float scroll_x);
-    // ホバー中 / ドラッグ中の対象ブロックでのみ水平スクロールバーを emit する。
-    // Table と CodeBlock で共通の出現条件を一元化する。
-    void MaybeEmitBlockHScrollbar(DrawCommandList& cmds, int node_index, float block_x, float bar_y, float visible_width, float natural_width, float scroll_x);
+    void EmitBlockHScrollbarIfActive(DrawCommandList& cmds, int node_index, float block_x, float bar_y, float visible_width, float natural_width, float scroll_x);
     void GenListBullet(DrawCommandList& cmds, const Node& node, const NodeLayoutEntry& entry, float x, float entry_text_top);
     void GenBlockQuoteGroupDecorations(DrawCommandList& cmds, const std::pmr::vector<Node>& nodes, const LayoutCache& cache, int node_count, int first_visible);
     void GenDiagramPlaceholder(DrawCommandList& cmds, float x, float y, float w, float h);

--- a/src/render/render_params.h
+++ b/src/render/render_params.h
@@ -1,6 +1,6 @@
 #pragma once
 // Renderer::Render の引数として渡す各種描画パラメータ構造体。
-#include "command_generator.h"
+#include "block_h_scroll_context.h"
 #include "document_types.h"
 #include "layout_cache.h"
 #include "file_explorer.h"
@@ -166,6 +166,6 @@ struct RenderParams {
     bool can_go_back = false;
     bool can_go_forward = false;
     bool has_dirty_nodes = false;
-    // ブロック単位の横スクロール (Issue #205)。値で持ち、ポインタで AppState 側 map を参照する。
+    // ブロック単位の横スクロール。値で持ち、ポインタで AppState 側 map を参照する。
     BlockHScrollContext block_h_scroll;
 };

--- a/src/render/render_params.h
+++ b/src/render/render_params.h
@@ -1,5 +1,6 @@
 #pragma once
 // Renderer::Render の引数として渡す各種描画パラメータ構造体。
+#include "command_generator.h"
 #include "document_types.h"
 #include "layout_cache.h"
 #include "file_explorer.h"
@@ -165,4 +166,6 @@ struct RenderParams {
     bool can_go_back = false;
     bool can_go_forward = false;
     bool has_dirty_nodes = false;
+    // ブロック単位の横スクロール (Issue #205)。値で持ち、ポインタで AppState 側 map を参照する。
+    BlockHScrollContext block_h_scroll;
 };

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -464,7 +464,7 @@ void Renderer::Render(const RenderParams& p)
     const float dpi_scale = backend_.GetDpi() / DEFAULT_DPI;
     {
         MENDO_PROFILE("GenerateMdPane");
-        const auto& cmds = cmd_generator_.GenerateMdPane(p.nodes, p.cache, p.md_pane_rect, p.scroll_y, p.selection, first_visible, p.hovered, dpi_scale);
+        const auto& cmds = cmd_generator_.GenerateMdPane(p.nodes, p.cache, p.md_pane_rect, p.scroll_y, p.selection, first_visible, p.hovered, dpi_scale, p.block_h_scroll);
         {
             MENDO_PROFILE("CommandExecutor::Execute");
             const auto fixed = BuildFixedBrushArray();

--- a/src/util/block_h_scroll.h
+++ b/src/util/block_h_scroll.h
@@ -1,0 +1,37 @@
+#pragma once
+#include "document_types.h"
+#include "layout_cache.h"
+#include "layout_computer.h"
+#include "theme.h"
+
+// ブロック単位横スクロールの自然幅 / 可視幅 / scroll_max を一元計算する。
+// hit テスト・hover 判定・reducer・command_generator から共通利用する。
+struct BlockHScrollGeometry {
+    float natural_width = 0.0f;
+    float visible_width = 0.0f;
+
+    constexpr bool can_scroll() const noexcept
+    {
+        return natural_width > visible_width && visible_width > 0.0f;
+    }
+    constexpr float scroll_max() const noexcept
+    {
+        return natural_width > visible_width ? natural_width - visible_width : 0.0f;
+    }
+};
+
+// node が Table または非 Diagram CodeBlock のとき自然幅を埋め、それ以外は 0。
+// visible_width は md_pane_width から content_width とインデントを引いたもの。
+inline BlockHScrollGeometry GetBlockHScrollGeometry(
+    const Node& node, const NodeLayoutEntry& entry, const Theme& theme, float md_pane_width) noexcept
+{
+    BlockHScrollGeometry g;
+    g.visible_width = theme.ContentWidth(md_pane_width) - mendo::layout::NodeIndent(node, theme);
+    if (node.type == NodeType::Table && entry.has_table_layout()) {
+        g.natural_width = entry.table_layout->natural_total_width;
+    }
+    else if (IsScrollableCodeBlock(node)) {
+        g.natural_width = entry.natural_code_width;
+    }
+    return g;
+}

--- a/src/util/ui_constants.h
+++ b/src/util/ui_constants.h
@@ -42,6 +42,14 @@ inline constexpr float TABLE_STRIPE_ALPHA_LIGHT = 0.02f;
 // Shift+Wheel / WM_MOUSEHWHEEL から渡される delta (WHEEL_DELTA = 120 単位) を DIP に換算する。
 inline constexpr float HSCROLL_DIP_PER_NOTCH = 60.0f;
 
+// Issue #205: ブロック横スクロールバーの bar 上端 Y 座標 (ペインローカル document Y)。
+// extra_padding は CodeBlock の背景下端 padding 内に置く場合に渡す (Table は 0)。
+// 描画 (command_generator.cpp) と hit 判定 (app_mouse_click.cpp) で同じ式を使う。
+inline constexpr float BlockHScrollbarBarY(float entry_text_top, float entry_height, float extra_padding) noexcept
+{
+    return entry_text_top + entry_height + extra_padding - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+}
+
 // ナビゲーションオーバーレイボタンの定数（DIP単位）。
 // レンダラー（描画）とhit_test_service（クリック検出）の間で共有される。
 inline constexpr float NAV_BTN_SIZE = 32.0f;

--- a/src/util/ui_constants.h
+++ b/src/util/ui_constants.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "ui_types.h"
 #include <d2d1.h>
+#include <algorithm>
 #include <cmath>
 #include <numbers>
 
@@ -38,16 +39,36 @@ inline constexpr float MIN_DIAGRAM_PLACEHOLDER_HEIGHT = 60.0f;
 inline constexpr float TABLE_STRIPE_ALPHA_DARK = 0.05f;
 inline constexpr float TABLE_STRIPE_ALPHA_LIGHT = 0.02f;
 
-// 横ホイール 1 ノッチあたりの DIP スクロール量。Issue #205 のブロック単位横スクロールで
-// Shift+Wheel / WM_MOUSEHWHEEL から渡される delta (WHEEL_DELTA = 120 単位) を DIP に換算する。
+// 横ホイール 1 ノッチあたりの DIP スクロール量。
+// Shift+Wheel / WM_MOUSEHWHEEL の delta (WHEEL_DELTA = 120 単位) を DIP に換算する。
 inline constexpr float HSCROLL_DIP_PER_NOTCH = 60.0f;
 
-// Issue #205: ブロック横スクロールバーの bar 上端 Y 座標 (ペインローカル document Y)。
+// ブロック横スクロールバーの bar 上端 Y 座標 (ペインローカル document Y)。
 // extra_padding は CodeBlock の背景下端 padding 内に置く場合に渡す (Table は 0)。
-// 描画 (command_generator.cpp) と hit 判定 (app_mouse_click.cpp) で同じ式を使う。
 inline constexpr float BlockHScrollbarBarY(float entry_text_top, float entry_height, float extra_padding) noexcept
 {
     return entry_text_top + entry_height + extra_padding - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+}
+
+// thumb の幅 (DIP)。track の縦と異なり最小幅張り付き時もドラッグ範囲を可動域に揃える必要があるので、
+// 描画とドラッグの ratio 計算で同じ式を共有する。
+inline float BlockHScrollbarThumbWidth(float visible_width, float natural_width) noexcept
+{
+    if (natural_width <= 0.0f) {
+        return 0.0f;
+    }
+    const float raw = visible_width * (visible_width / natural_width);
+    return std::clamp(raw, PANE_SCROLLBAR_THUMB_MIN, visible_width);
+}
+
+// バーのヒット矩形 (スクリーン座標系)。クリック判定 / 描画位置の式を一元化する。
+inline D2D1_RECT_F BlockHScrollbarHitRect(float block_x_screen, float visible_width, float bar_y_screen) noexcept
+{
+    return D2D1::RectF(
+        block_x_screen,
+        bar_y_screen - PANE_SCROLLBAR_HIT_PADDING,
+        block_x_screen + visible_width,
+        bar_y_screen + PANE_SCROLLBAR_WIDTH + PANE_SCROLLBAR_HIT_PADDING);
 }
 
 // ナビゲーションオーバーレイボタンの定数（DIP単位）。

--- a/src/util/ui_constants.h
+++ b/src/util/ui_constants.h
@@ -38,6 +38,10 @@ inline constexpr float MIN_DIAGRAM_PLACEHOLDER_HEIGHT = 60.0f;
 inline constexpr float TABLE_STRIPE_ALPHA_DARK = 0.05f;
 inline constexpr float TABLE_STRIPE_ALPHA_LIGHT = 0.02f;
 
+// 横ホイール 1 ノッチあたりの DIP スクロール量。Issue #205 のブロック単位横スクロールで
+// Shift+Wheel / WM_MOUSEHWHEEL から渡される delta (WHEEL_DELTA = 120 単位) を DIP に換算する。
+inline constexpr float HSCROLL_DIP_PER_NOTCH = 60.0f;
+
 // ナビゲーションオーバーレイボタンの定数（DIP単位）。
 // レンダラー（描画）とhit_test_service（クリック検出）の間で共有される。
 inline constexpr float NAV_BTN_SIZE = 32.0f;

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -365,9 +365,7 @@ LRESULT Win32Window::HandleMouseMessage(UINT msg, WPARAM wParam, LPARAM lParam)
             app_->OnMouseWheel(0, 0, wheel_delta, true);
         }
         else if (shift) {
-            // Issue #205: Shift+Wheel は横スクロール扱い。
-            // Wheel-down (delta < 0) を右スクロール (delta > 0 in HWheel) に変換し、
-            // Web ブラウザの慣習に揃える。
+            // Shift+Wheel は横スクロール扱い。Web ブラウザの慣習に合わせ wheel-down を右スクロールに反転する。
             app_->OnMouseHWheel(static_cast<short>(-wheel_delta));
         }
         else {

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -359,9 +359,16 @@ LRESULT Win32Window::HandleMouseMessage(UINT msg, WPARAM wParam, LPARAM lParam)
     case WM_MOUSEWHEEL: {
         const short wheel_delta = GET_WHEEL_DELTA_WPARAM(wParam);
         const bool ctrl = (LOWORD(wParam) & MK_CONTROL) != 0;
+        const bool shift = (LOWORD(wParam) & MK_SHIFT) != 0;
 
         if (ctrl) {
             app_->OnMouseWheel(0, 0, wheel_delta, true);
+        }
+        else if (shift) {
+            // Issue #205: Shift+Wheel は横スクロール扱い。
+            // Wheel-down (delta < 0) を右スクロール (delta > 0 in HWheel) に変換し、
+            // Web ブラウザの慣習に揃える。
+            app_->OnMouseHWheel(static_cast<short>(-wheel_delta));
         }
         else {
             POINT pt;

--- a/tests/test_hit_test_service_dwrite.cpp
+++ b/tests/test_hit_test_service_dwrite.cpp
@@ -130,3 +130,59 @@ TEST_F(HitTestDWriteTest, CodeBlockButtonsHitTest_RepeatCallReturnsSameResult)
     EXPECT_EQ(a.save_node, b.save_node);
     EXPECT_EQ(a.svg_copy_node, b.svg_copy_node);
 }
+
+// 回帰テスト: HitTest は partition_point と local_y 計算で同じ entry.text_top を
+// 基準にすべき。Fenwick (block_heights) と entry.text_top が乖離すると、 修正前は
+// candidate_text_top に Fenwick 経由の TextTopOf を使っていたため local_y がズレ、
+// 縦スクロール量に比例してテキスト選択位置が大きく上にズレる現象が発生していた。
+// (修正コミット: hit_test_service.cpp で TextTopOf → cache[candidate].text_top)
+TEST_F(HitTestDWriteTest, HitTestRobustToFenwickDesync)
+{
+    auto pl = ParseAndLayout(
+        "First paragraph here.\n\nSecond paragraph with more words.\n\n"
+        "Third paragraph in the middle of document.\n\nFourth and last paragraph.");
+
+    // 3 つ目以上の Paragraph ノードを target にする (上の方ほど誤差が小さく差が出にくい)。
+    int target = -1;
+    int para_count = 0;
+    for (size_t i = 0; i < pl.nodes.size(); ++i) {
+        if (pl.nodes[i].type == NodeType::Paragraph) {
+            ++para_count;
+            if (para_count == 3) {
+                target = static_cast<int>(i);
+                break;
+            }
+        }
+    }
+    ASSERT_GE(target, 0) << "テスト前提: 3 つ目以降の Paragraph ノードが必要";
+
+    // Fenwick の block_heights を意図的に小さい値で潰す。entry.text_top はそのまま。
+    // これで TextTopOf(i) = margin_top + PrefixSum(i) + sa[i] は本来より遥かに小さくなり、
+    // 一方 partition_point の比較対象 entry.text_top は元の正しい累積位置のまま。
+    for (size_t i = 0; i < pl.nodes.size(); ++i) {
+        pl.cache.SetBlockHeight(i, 1.0f);
+    }
+
+    const auto& entry = pl.cache[target];
+    const int sx = static_cast<int>(theme_.margin_left + 20.0f);
+    // テキスト第 1 行の中央付近を狙う (entry.text_top + line_height * 0.5 程度)。
+    const int sy = static_cast<int>(entry.text_top + 4.0f);
+
+    const float content_width = ContentWidth(800.0f);
+    const MdPaneHitContext ctx{
+        pl.nodes, pl.cache, theme_, 0.0f, 0.0f, 1.0f,
+        sx, sy, content_width, 600.0f
+    };
+    const auto r = hit_.HitTest(ctx);
+
+    EXPECT_EQ(r.node_index, target)
+        << "Fenwick が乖離しても partition_point は entry.text_top で比較するため正しい候補が選ばれる";
+
+    // 修正前 (TextTopOf 使用) は local_y が巨大値になり HitTestPoint がテキスト末尾に
+    // クランプして r.text_pos == text.size() になる。修正後 (entry.text_top 使用) は
+    // 第 1 行内の早い位置を返すため text.size() より十分小さい。
+    const auto target_text_size = pl.nodes[target].GetText().size();
+    ASSERT_GT(target_text_size, 5u);
+    EXPECT_LT(r.text_pos, target_text_size)
+        << "local_y が entry.text_top 基準で計算されれば、 末尾クランプではなく行内位置が返る";
+}

--- a/tests/test_reducer.cpp
+++ b/tests/test_reducer.cpp
@@ -245,6 +245,50 @@ TEST_F(ReducerTest, ImageLoadedAction_EmitsNotifyImageLoaded)
     EXPECT_TRUE(HasEffect<effect::NotifyImageLoaded>(effects));
 }
 
+// ---- Issue #205: ブロック単位の横スクロール ----
+
+TEST_F(ReducerTest, BlockHHoverChanged_UpdatesAndInvalidates)
+{
+    auto effects = Reduce(state, BlockHHoverChangedAction{ 5 });
+    EXPECT_EQ(state.view.hovered_h_block, 5);
+    EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
+}
+
+TEST_F(ReducerTest, BlockHHoverChanged_SameValue_NoEffect)
+{
+    state.view.hovered_h_block = 5;
+    auto effects = Reduce(state, BlockHHoverChangedAction{ 5 });
+    EXPECT_TRUE(effects.empty());
+}
+
+TEST_F(ReducerTest, RestoreScrollAfterLoad_ClearsBlockHScroll)
+{
+    state.view.block_scroll_x[3] = 100.0f;
+    state.view.block_scroll_x[7] = 250.0f;
+    state.view.hovered_h_block = 3;
+    state.view.h_drag_node = 7;
+
+    Reduce(state, RestoreScrollAfterLoadAction{ false, 0.0f });
+
+    EXPECT_TRUE(state.view.block_scroll_x.empty());
+    EXPECT_EQ(state.view.hovered_h_block, -1);
+    EXPECT_EQ(state.view.h_drag_node, -1);
+}
+
+TEST_F(ReducerTest, BlockHScrollDragEnded_ReleasesCapture)
+{
+    state.view.h_drag_node = 4;
+    auto effects = Reduce(state, BlockHScrollDragEndedAction{});
+    EXPECT_EQ(state.view.h_drag_node, -1);
+    EXPECT_TRUE(HasEffect<effect::ReleaseCapture>(effects));
+}
+
+TEST_F(ReducerTest, BlockHScrollDragEnded_NotDragging_NoEffect)
+{
+    auto effects = Reduce(state, BlockHScrollDragEndedAction{});
+    EXPECT_TRUE(effects.empty());
+}
+
 // ---- ナビゲーションテスト ----
 
 TEST_F(ReducerTest, NavigateBack_NoHistory_NoEffects)

--- a/tests/test_reducer.cpp
+++ b/tests/test_reducer.cpp
@@ -245,7 +245,7 @@ TEST_F(ReducerTest, ImageLoadedAction_EmitsNotifyImageLoaded)
     EXPECT_TRUE(HasEffect<effect::NotifyImageLoaded>(effects));
 }
 
-// ---- Issue #205: ブロック単位の横スクロール ----
+// ---- ブロック単位の横スクロール ----
 
 TEST_F(ReducerTest, BlockHHoverChanged_UpdatesAndInvalidates)
 {


### PR DESCRIPTION
## Summary

- Issue #205「画面幅より広いテーブル等を横スクロールしたい」を、本文段落・見出しの折り返しは維持したまま **テーブルとコードブロックだけブロック内で横スクロールする** GitHub 風の挙動で実装
- ホバー時のみバーを下端に表示。Shift+Wheel / 横ホイール / バーのドラッグの 3 系統で操作可能。ファイル切替/リロードでスクロール位置はリセット
- 実装中に発見した **既存バグ「縦スクロール時のテキスト選択 Y 座標ズレ」** (HitTest の partition_point と TextTopOf の不整合) も同梱で修正
- 回帰テスト追加 (HitTestRobustToFenwickDesync) でバグの再発を防止

## コミット構成

5 コミットで関心事を分離:
- `f09b618 feat(scroll)`: 横スクロール本体 (18 ファイル / +460)
- `1b8a49b fix(hit_test)`: 縦スクロール選択ズレ修正 + 回帰テスト
- `b181e07 refactor(scroll)`: simplify 1 回目 (PointInRect 利用、BlockHScrollScope RAII 等)
- `fc16adc fix(scroll)`: ユーザーフィードバック反映 (バー位置をテキストと被らない padding 内へ、太さブレを Identity+snap で修正)
- `314f759 refactor(scroll)`: simplify 2 回目 (BlockHScrollbarBarY / IsScrollableCodeBlock ヘルパで重複集約)

## Test plan

- [x] 全 2213 件のユニットテスト PASS (新規 6 件含む)
- [x] DPI 100% / 150% で太さが安定
- [x] 横長テーブル/コードブロックで:
  - [x] ホバーで下端にバー出現、外れると消える
  - [x] Shift+Wheel / 横ホイールでスクロール、両端でクランプ
  - [x] バーをドラッグで連続スクロール
  - [x] スクロール後のセルクリック / コード選択で位置ズレなし
- [x] F5 リロード / 別ファイル切替で scroll_x が 0 に戻る
- [x] 縦スクロール後のテキスト選択でズレが発生しない
- [x] コピーボタン / コードブロック背景は scroll_x によらず固定

🤖 Generated with [Claude Code](https://claude.com/claude-code)