### PR TITLE
fix(mermaid): LaTeX が描画されない問題 (#209)

### DIFF
--- a/res/mermaid.html
+++ b/res/mermaid.html
@@ -9,27 +9,26 @@
   #container { display: block; }
 </style>
 <script>
-  let currentTheme = null;
+  let currentInitKey = null;
   let renderCount = 0;
 
   function mermaidReady() {
     return typeof mermaid !== 'undefined' && typeof mermaid.render === 'function';
   }
 
-  function ensureThemeInitialized(isDark) {
+  // 表示用 (PNG キャプチャ経由) は htmlLabels:true で LaTeX(KaTeX) を描画させる。
+  // SVG コピー用は htmlLabels:false で <foreignObject> を避け Office/Inkscape 互換にする。
+  function ensureInitialized(isDark, htmlLabels) {
     const wantTheme = isDark ? 'dark' : 'default';
-    if (currentTheme !== wantTheme) {
-      // htmlLabels:false は Mermaid v10+ のトップレベル設定で flowchart/class/state
-      // のノードラベルを <foreignObject> ではなく SVG <text> として出力させる。
-      // Office/Inkscape が <foreignObject> 内 HTML を描画しないため、SVG コピーを
-      // 互換にするには表示用とエクスポート用で共通化する必要がある。
+    const key = wantTheme + ':' + (htmlLabels ? '1' : '0');
+    if (currentInitKey !== key) {
       mermaid.initialize({
         startOnLoad: false,
         theme: wantTheme,
         securityLevel: 'strict',
-        htmlLabels: false
+        htmlLabels: htmlLabels
       });
-      currentTheme = wantTheme;
+      currentInitKey = key;
     }
   }
 
@@ -39,7 +38,7 @@
         return JSON.stringify({ ok: false, error: 'mermaid not loaded' });
       }
       document.body.className = isDark ? 'dark' : '';
-      ensureThemeInitialized(isDark);
+      ensureInitialized(isDark, true);
       const container = document.getElementById('container');
       container.innerHTML = '';
       document.body.style.width = '';
@@ -71,7 +70,7 @@
       if (!mermaidReady()) {
         return null;
       }
-      ensureThemeInitialized(isDark);
+      ensureInitialized(isDark, false);
       renderCount++;
       const { svg } = await mermaid.render('mmd-svg-' + renderCount, code);
       return svg;


### PR DESCRIPTION
## Summary
- #208 で SVG コピー互換化のため `htmlLabels:false` をトップレベルに置いた副作用で LaTeX(KaTeX) ノード内数式が描画されなくなっていた問題 (#209) を修正
- 表示用 (PNG キャプチャ経路) と SVG コピー用で `htmlLabels` を切り替える方式に変更
- 表示は WebView2 経由で `<foreignObject>` を扱えるため `htmlLabels:true`、SVG コピー先 (Office/Inkscape) は `<foreignObject>` 不可なので `htmlLabels:false` を維持

## 変更内容
- `ensureThemeInitialized(isDark)` → `ensureInitialized(isDark, htmlLabels)` に拡張
- 初期化キャッシュキーを `currentTheme` → `currentInitKey` (テーマ + htmlLabels 合成) に変更
- `renderMermaid` は `ensureInitialized(isDark, true)`、`renderMermaidSvg` は `ensureInitialized(isDark, false)` を呼ぶ

## Test plan
- [x] `cmake --build build --config Release` 成功
- [x] `mendo_tests.exe` 全 2213 テスト pass
- [x] LaTeX 数式 (\`\`\`math ブロック) が表示される (#209 の再現解消)
- [x] flowchart/class/state 図を Office/Inkscape にコピーしたときラベルが見える (#208 の修正効果維持)
- [x] LaTeX とそれ以外の図が混在する文書で両方とも正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)