### PR TITLE
feat(clipboard): コードブロックのコピーボタンを CF_HTML 化 (#184)

### DIFF
--- a/src/app/app_mouse_click.cpp
+++ b/src/app/app_mouse_click.cpp
@@ -89,7 +89,8 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
     const auto hit_ctx = BuildMdPaneHitContext(px, py, pane_layout);
     const auto btn_hit = hit_test_.CodeBlockButtonsHitTest(hit_ctx);
     if (btn_hit.copy_node >= 0) {
-        clipboard_manager_.CopyCodeBlock(state_.document.doc, btn_hit.copy_node);
+        const bool dark = renderer_.GetTheme().IsDark();
+        clipboard_manager_.CopyCodeBlock(state_.document.doc, btn_hit.copy_node, dark);
         return;
     }
     if (btn_hit.svg_copy_node >= 0 || btn_hit.save_node >= 0) {

--- a/src/app/clipboard_manager.cpp
+++ b/src/app/clipboard_manager.cpp
@@ -6,6 +6,7 @@
 #include "i18n.h"
 #include "mermaid_file_cache.h"
 #include "mermaid_util.h"
+#include "selection_html.h"
 #include "string_convert.h"
 
 namespace {
@@ -31,15 +32,18 @@ void ClipboardManager::Init(HWND hwnd, MermaidFileCache* file_cache, IMermaidRen
     show_toast_ = std::move(show_toast);
 }
 
-void ClipboardManager::CopyCodeBlock(const Document& doc, int node_index) const
+void ClipboardManager::CopyCodeBlock(const Document& doc, int node_index, bool dark) const
 {
     const Node* node = NodeAt(doc, node_index);
-    if (!node) {
+    if (!node || node->type != NodeType::CodeBlock) {
         return;
     }
-    std::pmr::wstring wide;
-    string_convert::Utf8ToWide(node->GetText(), wide);
-    WriteClipboardText(hwnd_, wide);
+
+    std::pmr::wstring plain_wide;
+    string_convert::Utf8ToWide(node->GetText(), plain_wide);
+
+    const std::pmr::string html_utf8 = BuildCodeBlockHtmlFragment(*node, dark);
+    WriteClipboardHtml(hwnd_, std::string_view{ html_utf8 }, std::wstring_view{ plain_wide });
 }
 
 void ClipboardManager::SaveDiagramAsPng(const Document& doc, int node_index, float md_width, bool dark)

--- a/src/app/clipboard_manager.h
+++ b/src/app/clipboard_manager.h
@@ -25,7 +25,7 @@ public:
     void Init(HWND hwnd, MermaidFileCache* file_cache, IMermaidRenderer* mermaid_renderer,
               ToastCallback show_toast) noexcept;
 
-    void CopyCodeBlock(const Document& doc, int node_index) const;
+    void CopyCodeBlock(const Document& doc, int node_index, bool dark) const;
     void SaveDiagramAsPng(const Document& doc, int node_index, float md_width, bool dark);
     void CopyDiagramAsSvg(const Document& doc, int node_index, float md_width, bool dark);
 

--- a/src/core/selection_html.cpp
+++ b/src/core/selection_html.cpp
@@ -661,6 +661,19 @@ std::pmr::string ExtractSelectedTextAsHtml(const std::pmr::vector<Node>& nodes, 
     return out;
 }
 
+std::pmr::string BuildCodeBlockHtmlFragment(const Node& node, bool dark_mode)
+{
+    std::pmr::string out;
+    if (node.type != NodeType::CodeBlock) {
+        return out;
+    }
+    const auto& text = node.GetText();
+    const uint32_t end = static_cast<uint32_t>(text.size());
+    out.reserve(text.size() * 3 + 128);
+    AppendCodeBlockHtml(out, node, 0, end, dark_mode);
+    return out;
+}
+
 std::optional<std::pmr::string> FindLinkAtPosition(const Node& node, uint32_t text_pos)
 {
     if (node.type == NodeType::Table) {

--- a/src/core/selection_html.h
+++ b/src/core/selection_html.h
@@ -21,6 +21,11 @@ std::pmr::string ExtractSelectedTextAsHtml(
     const TextSelection& selection,
     bool dark_mode = false);
 
+// 単一の CodeBlock ノード全体をシンタックスハイライト付きの HTML フラグメント (UTF-8) に変換する。
+// コードブロック右上のコピーボタンから書式付きでクリップボードへ書き込むために使用する。
+// node が CodeBlock 以外の場合は空文字列を返す。
+std::pmr::string BuildCodeBlockHtmlFragment(const Node& node, bool dark_mode);
+
 // ノードのラン内の指定テキスト位置にあるリンクURLを検索する。
 // リンクラン内の位置であればリンクURLを返し、そうでなければnulloptを返す。
 [[nodiscard]] std::optional<std::pmr::string> FindLinkAtPosition(const Node& node, uint32_t text_pos);

--- a/src/util/clipboard_util.h
+++ b/src/util/clipboard_util.h
@@ -170,8 +170,9 @@ inline bool WriteClipboardSvg(HWND hwnd, std::wstring_view svg_text) noexcept
 }
 
 // クリップボードに CF_HTML（書式付き）と CF_UNICODETEXT（プレーンテキスト）を同時に書き込む。
-// fragment_html: <!--StartFragment--> と <!--EndFragment--> の間に入る HTML 断片。
-//                UTF-8 版は CF_HTML が要求する UTF-8 をそのまま使えるので変換コストを節約できる。
+// fragment_utf8: <!--StartFragment--> と <!--EndFragment--> の間に入る HTML 断片 (UTF-8)。
+//                CF_HTML が UTF-8 を要求するため一次経路。wide オーバーロードは UTF-8 に
+//                変換してからこの関数へ転送する。
 // plain_text:    書式付きに対応していないアプリ向けのフォールバック。
 inline void WriteClipboardHtml(HWND hwnd, std::string_view fragment_utf8, std::wstring_view plain_text) noexcept
 {
@@ -185,7 +186,7 @@ inline void WriteClipboardHtml(HWND hwnd, std::string_view fragment_utf8, std::w
 
     if (!fragment_utf8.empty()) {
         const std::string payload = BuildCfHtmlPayload(fragment_utf8);
-        const UINT cf_html = RegisterClipboardFormatW(L"HTML Format");
+        static const UINT cf_html = RegisterClipboardFormatW(L"HTML Format");
         SetClipboardZeroTerminated<char>(cf_html, payload);
     }
 

--- a/src/util/clipboard_util.h
+++ b/src/util/clipboard_util.h
@@ -170,11 +170,12 @@ inline bool WriteClipboardSvg(HWND hwnd, std::wstring_view svg_text) noexcept
 }
 
 // クリップボードに CF_HTML（書式付き）と CF_UNICODETEXT（プレーンテキスト）を同時に書き込む。
-// fragment_html: <!--StartFragment--> と <!--EndFragment--> の間に入る HTML 断片（Wide 文字列）。
+// fragment_html: <!--StartFragment--> と <!--EndFragment--> の間に入る HTML 断片。
+//                UTF-8 版は CF_HTML が要求する UTF-8 をそのまま使えるので変換コストを節約できる。
 // plain_text:    書式付きに対応していないアプリ向けのフォールバック。
-inline void WriteClipboardHtml(HWND hwnd, std::wstring_view fragment_html, std::wstring_view plain_text) noexcept
+inline void WriteClipboardHtml(HWND hwnd, std::string_view fragment_utf8, std::wstring_view plain_text) noexcept
 {
-    if (fragment_html.empty() && plain_text.empty()) {
+    if (fragment_utf8.empty() && plain_text.empty()) {
         return;
     }
     ClipboardSession session(hwnd);
@@ -182,8 +183,7 @@ inline void WriteClipboardHtml(HWND hwnd, std::wstring_view fragment_html, std::
         return;
     }
 
-    if (!fragment_html.empty()) {
-        const std::string fragment_utf8 = string_convert::WideToUtf8(fragment_html);
+    if (!fragment_utf8.empty()) {
         const std::string payload = BuildCfHtmlPayload(fragment_utf8);
         const UINT cf_html = RegisterClipboardFormatW(L"HTML Format");
         SetClipboardZeroTerminated<char>(cf_html, payload);
@@ -192,4 +192,9 @@ inline void WriteClipboardHtml(HWND hwnd, std::wstring_view fragment_html, std::
     if (!plain_text.empty()) {
         SetClipboardZeroTerminated<wchar_t>(CF_UNICODETEXT, plain_text);
     }
+}
+
+inline void WriteClipboardHtml(HWND hwnd, std::wstring_view fragment_html, std::wstring_view plain_text) noexcept
+{
+    WriteClipboardHtml(hwnd, string_convert::WideToUtf8(fragment_html), plain_text);
 }

--- a/src/util/i18n.h
+++ b/src/util/i18n.h
@@ -100,7 +100,7 @@ inline constexpr Strings kJa = {
     L"戻る (Alt+\u2190)",
     L"進む (Alt+\u2192)",
     // コピーボタン tooltip
-    L"コピー",
+    L"書式付きコピー",
     // 保存ボタン tooltip
     L"画像を保存",
     // SVG コピーボタン tooltip
@@ -157,7 +157,7 @@ inline constexpr Strings kEn = {
     L"Back (Alt+\u2190)",
     L"Forward (Alt+\u2192)",
     // コピーボタン tooltip
-    L"Copy",
+    L"Copy as HTML",
     // 保存ボタン tooltip
     L"Save Image",
     // SVG コピーボタン tooltip


### PR DESCRIPTION
## Summary

- コードブロック右上のコピーボタンを **書式付き (CF_HTML) コピー** に変更。Word/メール等にはシンタックスハイライト付きで、テキストエディタには CF_UNICODETEXT のソースが貼り付く
- 既存の選択範囲「書式付きコピー」(`ExtractSelectedTextAsHtml`) と同じ HTML 生成基盤 (`AppendCodeBlockHtml`) を `BuildCodeBlockHtmlFragment` として公開・再利用
- `WriteClipboardHtml` に UTF-8 直渡しオーバーロードを追加し、新経路の文字コード変換を 2 回 → 0 回 (HTML 部) に削減

Closes #184

## 設計判断

- **dark_mode 引数**: `SaveDiagramAsPng` / `CopyDiagramAsSvg` と揃えて `bool dark` で受け取る (Theme への依存を ClipboardManager に持ち込まない)
- **ClipboardManager 直接呼び出し維持**: コードブロックボタン経由の 3 メソッド (`CopyCodeBlock` / `CopyDiagramAsSvg` / `SaveDiagramAsPng`) は既存どおり ClipboardManager に集約。effect 化はスコープ外
- **effect 経路の utf8 化はフォローアップ**: 選択範囲コピー (`effect::ClipboardWriteHtml`) は据え置きで 2 回変換のまま。最適化は #213 で対応予定

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/core/selection_html.{h,cpp}` | `BuildCodeBlockHtmlFragment(node, dark_mode)` を公開 (既存 `AppendCodeBlockHtml` のラッパー) |
| `src/app/clipboard_manager.{h,cpp}` | `CopyCodeBlock` を CF_HTML+CF_UNICODETEXT 二重書き込みに変更、`bool dark` 引数追加 |
| `src/app/app_mouse_click.cpp` | 呼び出し元で `renderer_.GetTheme().IsDark()` を渡す |
| `src/util/clipboard_util.h` | `WriteClipboardHtml` に UTF-8 オーバーロード追加 (wide 版はラッパー化) |

## Test plan

- [x] Release ビルド成功 (`cmake --build build --config Release`)
- [x] 全 2213 テスト PASS (`mendo_tests.exe --gtest_brief=1`)
- [x] ライト/ダークそれぞれで色付き HTML が Word に貼り付けできる
- [x] 同じコピーがメモ帳には CF_UNICODETEXT のプレーンテキストとして貼り付く
- [x] Mermaid/LaTeX ブロックではコピーボタンが出ない (既存挙動維持)

🤖 Generated with [Claude Code](https://claude.com/claude-code)