### PR TITLE
fix(layout): スクロール時のテーブルセル描画欠落を修正 (#210)

### DIFF
--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -520,6 +520,7 @@ void DWriteTextMeasurer::FinalizeTableLayout(
     entry.height = total_height;
     entry.layout_dirty = false;
     tl.last_applied_max_width = max_width;
+    tl.cells_partially_evicted = false;
 }
 
 void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float max_width) const
@@ -552,7 +553,8 @@ void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float 
     // 超高速パス: 前回と max_width がほぼ一致しキャッシュ済みレイアウトが揃っていれば、
     // セル幅・行高さ・累積位置・行オフセットすべて変化しないため、layout_dirty を倒すだけで終える。
     // 検索ハイライト矩形・effects・inline_code_bgs もテキスト位置に依存するので保持できる。
-    if (has_compatible_layouts && tl_existing->last_applied_max_width >= 0.0f && std::abs(tl_existing->last_applied_max_width - max_width) < CELL_WIDTH_EPSILON) {
+    // cells_partially_evicted 時は null セルの再生成が必要なので素通り禁止。
+    if (has_compatible_layouts && !tl_existing->cells_partially_evicted && tl_existing->last_applied_max_width >= 0.0f && std::abs(tl_existing->last_applied_max_width - max_width) < CELL_WIDTH_EPSILON) {
         entry.layout_dirty = false;
         return;
     }

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -50,6 +50,9 @@ struct TableLayoutData {
     // 圧縮を行わなかった場合の自然な総幅。横スクロールのクランプ計算用に保持する。
     // cached_table_width と一致することもあるが、圧縮分岐を通った場合は乖離する。
     float natural_total_width = 0.0f;
+    // 立っている間は MeasureTable の超高速パスをバイパスし RestoreNullCellLayouts を走らせる。
+    // FinalizeTableLayout 完了でクリア。
+    bool cells_partially_evicted = false;
     // フラットインデックスへの変換
     constexpr size_t CellIndex(size_t row, size_t col) const noexcept
     {
@@ -426,6 +429,11 @@ public:
                     EvictTableRow(tl, r);
                 }
             }
+            // EnsureVisibleLayout は layout_dirty=false の entry をスキップするため、
+            // ここで dirty 化しないと再可視化時に null セルが GenTable に渡り描画が欠落する。
+            if (tl.cells_partially_evicted) {
+                e.layout_dirty = true;
+            }
         }
     }
 
@@ -517,6 +525,7 @@ private:
         tl.last_applied_max_width = -1.0f;
         tl.cached_table_width = 0.0f;
         tl.natural_total_width = 0.0f;
+        tl.cells_partially_evicted = false;
     }
 
     static void EvictEntryLayout(NodeLayoutEntry& e) noexcept
@@ -550,6 +559,7 @@ private:
             const size_t ci = base + c;
             if (tl.cell_layouts[ci]) {
                 tl.cell_layouts[ci].Reset();
+                tl.cells_partially_evicted = true;
             }
             if (ci < tl.cell_heights.size()) {
                 tl.cell_heights[ci] = 0.0f;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(mendo_tests
     test_copy_button.cpp
     test_hit_test_service.cpp
     test_hit_test_service_dwrite.cpp
+    test_table_eviction_dwrite.cpp
     test_swipe_detector.cpp
     test_titlebar.cpp
     test_ui_constants.cpp

--- a/tests/test_table_eviction_dwrite.cpp
+++ b/tests/test_table_eviction_dwrite.cpp
@@ -1,0 +1,122 @@
+// issue#210: スクロールでテーブルセル描画が欠落する不具合の再発防止テスト。
+// EvictInvisibleTableRows で行単位 evict された entry が dirty 化され、
+// 再可視化時の MeasureTable で null セルが復元される一連のフローを検証する。
+#include <gtest/gtest.h>
+#include "dwrite_test_base.h"
+#include <string>
+
+namespace {
+
+class TableEvictionDWriteTest : public DWriteTestBase {
+protected:
+    static std::string MakeBigTableMd(size_t row_count)
+    {
+        std::string md = "| A | B | C |\n|---|---|---|\n";
+        for (size_t i = 0; i < row_count; ++i) {
+            md += "| r" + std::to_string(i) + "c0 ";
+            md += "| r" + std::to_string(i) + "c1 ";
+            md += "| r" + std::to_string(i) + "c2 |\n";
+        }
+        return md;
+    }
+
+    static int FindTableNode(const std::pmr::vector<Node>& nodes)
+    {
+        for (size_t i = 0; i < nodes.size(); ++i) {
+            if (nodes[i].type == NodeType::Table) {
+                return static_cast<int>(i);
+            }
+        }
+        return -1;
+    }
+
+    static size_t CountNonNullCells(const TableLayoutData& tl)
+    {
+        size_t n = 0;
+        for (const auto& cl : tl.cell_layouts) {
+            if (cl) {
+                ++n;
+            }
+        }
+        return n;
+    }
+};
+
+} // namespace
+
+// 範囲外行を evict すると entry が dirty 化されフラグが立ち、null セルが発生する。
+TEST_F(TableEvictionDWriteTest, EvictInvisibleRowsMarksDirtyAndCreatesNullCells)
+{
+    auto pl = ParseAndLayout(MakeBigTableMd(40));
+    const int idx = FindTableNode(pl.nodes);
+    ASSERT_GE(idx, 0);
+    auto& entry = pl.cache[idx];
+    ASSERT_TRUE(entry.has_table_layout());
+    auto& tl = *entry.table_layout;
+
+    const size_t total_cells = tl.cell_layouts.size();
+    ASSERT_GT(total_cells, 0u);
+    ASSERT_EQ(CountNonNullCells(tl), total_cells);
+    entry.layout_dirty = false;
+    tl.cells_partially_evicted = false;
+
+    // entry は text_top=margin_top あたりから始まるので、
+    // [text_top, text_top + viewport_height] を可視範囲としても
+    // テーブル後半は範囲外になる。buffer は 0 にして外行を確実に evict する。
+    const float vp_top = entry.text_top;
+    const float vp_bottom = entry.text_top + 80.0f;
+    pl.cache.EvictInvisibleTableRows(vp_top, vp_bottom, 0.0f);
+
+    EXPECT_TRUE(tl.cells_partially_evicted);
+    EXPECT_TRUE(entry.layout_dirty);
+    EXPECT_LT(CountNonNullCells(tl), total_cells)
+        << "範囲外行のセルが Reset されているはず";
+}
+
+// 全行が viewport 内なら evict は発生せず dirty 化もしない。
+TEST_F(TableEvictionDWriteTest, EvictInvisibleRowsNoOpWhenAllVisible)
+{
+    auto pl = ParseAndLayout(MakeBigTableMd(5));
+    const int idx = FindTableNode(pl.nodes);
+    ASSERT_GE(idx, 0);
+    auto& entry = pl.cache[idx];
+    ASSERT_TRUE(entry.has_table_layout());
+    auto& tl = *entry.table_layout;
+
+    const size_t total_cells = tl.cell_layouts.size();
+    entry.layout_dirty = false;
+    tl.cells_partially_evicted = false;
+
+    pl.cache.EvictInvisibleTableRows(entry.text_top - 100.0f, entry.text_top + entry.height + 100.0f, 50.0f);
+
+    EXPECT_FALSE(tl.cells_partially_evicted);
+    EXPECT_FALSE(entry.layout_dirty);
+    EXPECT_EQ(CountNonNullCells(tl), total_cells);
+}
+
+// evict 後の再 measure で null セルが復元されフラグがクリアされる。
+TEST_F(TableEvictionDWriteTest, MeasureAfterEvictionRestoresNullCells)
+{
+    auto pl = ParseAndLayout(MakeBigTableMd(40));
+    const int idx = FindTableNode(pl.nodes);
+    ASSERT_GE(idx, 0);
+    auto& entry = pl.cache[idx];
+    ASSERT_TRUE(entry.has_table_layout());
+    auto& tl = *entry.table_layout;
+
+    const size_t total_cells = tl.cell_layouts.size();
+    ASSERT_GT(total_cells, 0u);
+
+    pl.cache.EvictInvisibleTableRows(entry.text_top, entry.text_top + 80.0f, 0.0f);
+    ASSERT_TRUE(tl.cells_partially_evicted);
+    ASSERT_LT(CountNonNullCells(tl), total_cells);
+
+    // EnsureVisibleLayout に相当する経路: dirty な entry に対して再 measure する。
+    const float content_width = theme_.ContentWidth(800.0f);
+    measurer_.MeasureNode(pl.nodes[idx], entry, content_width);
+
+    EXPECT_FALSE(tl.cells_partially_evicted);
+    EXPECT_FALSE(entry.layout_dirty);
+    EXPECT_EQ(CountNonNullCells(tl), total_cells)
+        << "RestoreNullCellLayouts で evict されたセルが復元されているはず";
+}


### PR DESCRIPTION
## Summary
- スクロールで大きなテーブルの中身が描画されなくなる不具合を修正 (closes #210)
- `EvictInvisibleTableRows` が cell_layouts を Reset しても `entry.layout_dirty` を立てなかったため、`EnsureVisibleLayout` が当該テーブルの `MeasureTable` をスキップ。さらに `MeasureTable` の超高速パスが `last_applied_max_width` 一致だけで早期 return し、null セルが復元されないまま `GenTable` に渡って描画が欠落していた
- `TableLayoutData::cells_partially_evicted` フラグを導入し、Evict → dirty 化 → 超高速パスバイパス → `RestoreNullCellLayouts` → `FinalizeTableLayout` でフラグクリア、という単方向フローに整理

## 変更点
- `src/layout/layout_cache.h`
  - `TableLayoutData` に `cells_partially_evicted` を追加 (`ResetTableLayoutGeometry` でも初期化)
  - `EvictTableRow` がセルを Reset した際にフラグを立てる
  - `EvictInvisibleTableRows` のループ後にフラグを見て `e.layout_dirty = true`
- `src/layout/dwrite_measurer.cpp`
  - `MeasureTable` の超高速パス条件に `!cells_partially_evicted` を追加
  - `FinalizeTableLayout` 完了時にフラグをクリア

## なぜ「ウィンドウリサイズで直る」のか
リサイズ時は `width_changed=true` 経路 (`layout.cpp:69`) で `layout_dirty` を見ずに全ノードを `MeasureNode` にかけ、`MeasureTable` 内では `last_applied_max_width != max_width` のため超高速パスを抜けて `RestoreNullCellLayouts` で null セルが再生成される。スクロールではこの強制再計測が走らないため症状が顕在化していた。

## なぜ「大きいテーブル」で起きやすいのか
`EvictInvisibleTableRows` はテーブル単位ではなく行単位で破棄する仕組み。小さいテーブルはノード単位 evict (`EvictTextLayouts`) で `e.table_layout.reset()` まで落ちて自然に dirty になるが、行単位 evict は dirty を立てなかったため、1ノード内で部分的に evict される巨大テーブルでのみ発症していた。

## Test plan
- [x] `cmake --build build --config Release` でビルド成功
- [x] `mendo_tests.exe --gtest_brief=1` で 2213 件すべて pass
- [x] 実機で大きなテーブルを含む Markdown を開き、スクロール往復してセルが常に描画されることを確認
- [x] 同じ条件で従来通りウィンドウリサイズでも描画が直ることを確認 (回帰なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)