### PR TITLE
perf(layout): テーブルセル復元を viewport 範囲に絞る (#218)

### DIFF
--- a/src/layout/dirty_scheduler.cpp
+++ b/src/layout/dirty_scheduler.cpp
@@ -46,7 +46,10 @@ DirtyBatchResult DirtyScheduler::RunSerial(
             result.first_processed = i;
         }
         const float indent = NodeIndent(nodes[i], theme);
-        backend.MeasureNode(nodes[i], entry, content_width - indent);
+        const MeasureViewportRange vp = has_viewport_limit
+            ? MeasureViewportRange{ limit_top, limit_bottom }
+            : MeasureViewportRange{};
+        backend.MeasureNode(nodes[i], entry, content_width - indent, nullptr, vp);
         result.last_processed = i;
         ++result.processed;
 

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -216,7 +216,8 @@ void DWriteTextMeasurer::ApplyRunFormatting(IDWriteTextLayout* layout, std::span
 
 void DWriteTextMeasurer::MeasureNode(
     Node& node, NodeLayoutEntry& entry, float max_width,
-    std::pmr::vector<SyntaxToken>* tokens_out) const
+    std::pmr::vector<SyntaxToken>* tokens_out,
+    MeasureViewportRange viewport) const
 {
     MENDO_PROFILE("MeasureNode");
     if (!dwrite_ || !theme_) {
@@ -230,7 +231,7 @@ void DWriteTextMeasurer::MeasureNode(
     }
 
     if (node.type == NodeType::Table) {
-        MeasureTable(node, entry, max_width);
+        MeasureTable(node, entry, max_width, viewport);
         return;
     }
 
@@ -396,9 +397,10 @@ void DWriteTextMeasurer::MeasureTableCells(Node& node, NodeLayoutEntry& entry, s
     }
 }
 
-void DWriteTextMeasurer::RestoreNullCellLayouts(Node& node, NodeLayoutEntry& entry) const
+void DWriteTextMeasurer::RestoreNullCellLayouts(Node& node, NodeLayoutEntry& entry, MeasureViewportRange viewport) const
 {
     // EvictInvisibleTableRows で Reset された null セルを再生成する。
+    // viewport が部分範囲なら、その範囲外の行はスキップして CreateTextLayout を回避する。
     MENDO_PROFILE("RestoreNullCellLayouts");
     IDWriteTextFormat* const fmt = fmt_body_.Get();
     IDWriteTextFormat* const fmt_bold = fmt_h_[3].Get();
@@ -407,7 +409,18 @@ void DWriteTextMeasurer::RestoreNullCellLayouts(Node& node, NodeLayoutEntry& ent
     const auto row_count = tbl->row_count;
     const auto col_count = tbl->col_count;
 
+    const bool has_row_geometry = !tl.row_cum_y.empty() && tl.row_cum_y.size() >= row_count + 1;
+    const bool clip_rows = has_row_geometry && !viewport.is_full();
+    const float entry_top = entry.text_top;
+
     for (size_t r = 0; r < row_count; r++) {
+        if (clip_rows) {
+            const float row_top = entry_top + tl.row_cum_y[r];
+            const float row_bottom = entry_top + tl.row_cum_y[r + 1];
+            if (row_bottom < viewport.top || row_top > viewport.bottom) {
+                continue;
+            }
+        }
         const bool is_header = tbl->IsHeaderRow(r);
         IDWriteTextFormat* const row_fmt = is_header ? fmt_bold : fmt;
         for (size_t c = 0; c < col_count; c++) {
@@ -455,8 +468,10 @@ void DWriteTextMeasurer::FinalizeTableLayout(
     float total_height = border_width;
     const auto* tbl = node.table_data();
     const auto row_count = tbl->row_count;
+    bool any_row_unrestored = false;
     for (size_t r = 0; r < row_count; r++) {
         float row_height = theme_->font_size_body * 1.4f;
+        bool row_has_null_cell = false;
         for (size_t c = 0; c < col_count; c++) {
             const float cw = (c < tl.col_widths.size()) ? tl.col_widths[c] : DEFAULT_COLUMN_WIDTH;
             const auto align = tbl->ColAlign(c);
@@ -479,9 +494,20 @@ void DWriteTextMeasurer::FinalizeTableLayout(
                 }
                 row_height = std::max(row_height, tl.cell_heights[ci] + cell_padding * 2.0f);
             }
+            else if (!tbl->GetCellText(r, c).empty()) {
+                row_has_null_cell = true;
+            }
         }
-        tl.row_heights[r] = row_height;
-        total_height += row_height + border_width;
+        // 部分復元時は null セルがある行 = 範囲外 evict 行。再計算で行高さを既定値に戻すと
+        // 累積位置がずれるため、既存の row_heights[r] を保持する。
+        if (row_has_null_cell && r < tl.row_heights.size() && tl.row_heights[r] > 0.0f) {
+            any_row_unrestored = true;
+            total_height += tl.row_heights[r] + border_width;
+        }
+        else {
+            tl.row_heights[r] = row_height;
+            total_height += row_height + border_width;
+        }
     }
 
     // ヒットテスト高速化用に行Y累積と列X累積を事前計算
@@ -518,12 +544,21 @@ void DWriteTextMeasurer::FinalizeTableLayout(
     }
 
     entry.height = total_height;
-    entry.layout_dirty = false;
     tl.last_applied_max_width = max_width;
-    tl.cells_partially_evicted = false;
+    // 部分復元で null セルが残っている場合は dirty を維持して、次回スクロール時の
+    // EnsureVisibleLayout で新しい viewport を渡して残り行を埋められるようにする。
+    // 完全復元時のみフラグと dirty をクリア。
+    if (any_row_unrestored) {
+        entry.layout_dirty = true;
+    }
+    else {
+        entry.layout_dirty = false;
+        tl.cells_partially_evicted = false;
+    }
 }
 
-void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float max_width) const
+void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float max_width,
+                                       MeasureViewportRange viewport) const
 {
     MENDO_PROFILE("MeasureTable");
     if (!dwrite_ || !theme_) {
@@ -573,7 +608,7 @@ void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float 
     // 第1パス（テキストレイアウト作成）をスキップして列幅再計算だけ行う。
     const bool has_existing_layouts = has_compatible_layouts;
     if (has_existing_layouts) {
-        RestoreNullCellLayouts(node, entry);
+        RestoreNullCellLayouts(node, entry, viewport);
         if (tl.natural_col_widths.size() == col_count) {
             // キャッシュ済み自然幅を使用し、DirectWrite呼び出しを回避
             FinalizeTableLayout(node, entry, max_width, col_count, tl.natural_col_widths);
@@ -600,7 +635,8 @@ void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float 
         tl.col_count = col_count;
         tl.cell_layouts.assign(row_count * col_count, {});
 
-        // 第1パス: テキストレイアウトを作成し、自然な幅を計測
+        // 第1パス: テキストレイアウトを作成し、自然な幅を計測。
+        // 初回構築は常に全行を作る (列幅判定に全行の自然幅が必要なため)。
         std::pmr::vector<float> natural_widths(col_count, 0.0f);
         MeasureTableCells(node, entry, natural_widths);
 

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -635,7 +635,6 @@ void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float 
         tl.col_count = col_count;
         tl.cell_layouts.assign(row_count * col_count, {});
 
-        // 第1パス: テキストレイアウトを作成し、自然な幅を計測。
         // 初回構築は常に全行を作る (列幅判定に全行の自然幅が必要なため)。
         std::pmr::vector<float> natural_widths(col_count, 0.0f);
         MeasureTableCells(node, entry, natural_widths);

--- a/src/layout/dwrite_measurer.h
+++ b/src/layout/dwrite_measurer.h
@@ -21,8 +21,11 @@ public:
         theme_ = &theme;
     }
 
-    void MeasureNode(Node& node, NodeLayoutEntry& entry, float max_width, std::pmr::vector<SyntaxToken>* tokens_out = nullptr) const override;
-    void MeasureTable(Node& node, NodeLayoutEntry& entry, float max_width) const override;
+    void MeasureNode(Node& node, NodeLayoutEntry& entry, float max_width,
+                     std::pmr::vector<SyntaxToken>* tokens_out = nullptr,
+                     MeasureViewportRange viewport = {}) const override;
+    void MeasureTable(Node& node, NodeLayoutEntry& entry, float max_width,
+                      MeasureViewportRange viewport = {}) const override;
 
     // 外部のIDWriteFactoryで初期化する（Initの前に呼び出す必要がある）。
     void SetFactory(IDWriteFactory* factory) noexcept
@@ -35,7 +38,7 @@ private:
     IDWriteTextFormat* GetTextFormat(const Node& node) const noexcept;
     void ApplyRunFormatting(IDWriteTextLayout* layout, std::span<const TextRun> runs, const mendo::WideViewForDWrite& view, std::optional<NodeType> node_type) const;
     void MeasureTableCells(Node& node, NodeLayoutEntry& entry, std::pmr::vector<float>& natural_widths) const;
-    void RestoreNullCellLayouts(Node& node, NodeLayoutEntry& entry) const;
+    void RestoreNullCellLayouts(Node& node, NodeLayoutEntry& entry, MeasureViewportRange viewport) const;
     void FinalizeTableLayout(Node& node, NodeLayoutEntry& entry, float max_width, size_t col_count, std::pmr::vector<float>& natural_widths) const;
 
     IDWriteFactory* dwrite_ = nullptr;

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -71,7 +71,10 @@ void LayoutEngine::ComputeLayout(std::pmr::vector<Node>& nodes, LayoutCache& cac
             const bool visible = (node_bottom >= vp_top && y <= vp_bottom);
             if (visible) {
                 const float old_height = entry.height;
-                backend_->MeasureNode(node, entry, node_width);
+                // 部分レイアウトでは可視範囲を渡してテーブル内行を絞り込む。
+                // partial=false (フルレイアウト) では vp_top/bottom が ±inf なので全範囲扱い。
+                const MeasureViewportRange vp{ vp_top, vp_bottom };
+                backend_->MeasureNode(node, entry, node_width, nullptr, vp);
                 any_measured = true;
                 entry.cached_width = node_width;
                 entry.cached_height = entry.height;
@@ -166,7 +169,8 @@ bool LayoutEngine::EnsureVisibleLayout(std::pmr::vector<Node>& nodes, LayoutCach
             continue;
         }
         const float indent = NodeIndent(nodes[i], *theme_);
-        backend_->MeasureNode(nodes[i], entry, content_width - indent);
+        const MeasureViewportRange vp{ viewport_top, viewport_bottom };
+        backend_->MeasureNode(nodes[i], entry, content_width - indent, nullptr, vp);
         any_updated = true;
         last_measured = i;
     }

--- a/src/layout/measure_backend.h
+++ b/src/layout/measure_backend.h
@@ -7,14 +7,14 @@
 #include <memory_resource>
 
 // テーブルセル復元の対象範囲を絞るための viewport クリップ。
-// MeasureTable の RestoreNullCellLayouts と FinalizeTableLayout で参照する。
 // デフォルト (±inf) は全範囲扱いで、部分復元しない従来挙動と一致する。
 struct MeasureViewportRange {
-    float top = -std::numeric_limits<float>::infinity();
-    float bottom = std::numeric_limits<float>::infinity();
+    static constexpr float kInf = std::numeric_limits<float>::infinity();
+    float top = -kInf;
+    float bottom = kInf;
     constexpr bool is_full() const noexcept
     {
-        return top == -std::numeric_limits<float>::infinity() && bottom == std::numeric_limits<float>::infinity();
+        return top == -kInf && bottom == kInf;
     }
 };
 

--- a/src/layout/measure_backend.h
+++ b/src/layout/measure_backend.h
@@ -3,7 +3,20 @@
 #include "layout_cache.h"
 #include "syntax.h"
 #include "theme.h"
+#include <limits>
 #include <memory_resource>
+
+// テーブルセル復元の対象範囲を絞るための viewport クリップ。
+// MeasureTable の RestoreNullCellLayouts と FinalizeTableLayout で参照する。
+// デフォルト (±inf) は全範囲扱いで、部分復元しない従来挙動と一致する。
+struct MeasureViewportRange {
+    float top = -std::numeric_limits<float>::infinity();
+    float bottom = std::numeric_limits<float>::infinity();
+    constexpr bool is_full() const noexcept
+    {
+        return top == -std::numeric_limits<float>::infinity() && bottom == std::numeric_limits<float>::infinity();
+    }
+};
 
 // per-node 計測専用 IF。const 仮想で thread-safe な API のみを露出する。
 // IDWriteFactory はスレッドセーフで IDWriteTextLayout は per-call 生成のため、
@@ -19,10 +32,13 @@ public:
     // 触らない (UI スレッドで集約後に書き戻す責務は呼び出し側にある)。
     // tokens_out == nullptr (default) のシリアル経路では従来通り
     // node.syntax_tokens_mut() に直接書き込む。
+    // viewport は MeasureTable 配下で行単位の部分復元判定に用いる。
     virtual void MeasureNode(
         Node& node, NodeLayoutEntry& entry, float max_width,
-        std::pmr::vector<SyntaxToken>* tokens_out = nullptr) const = 0;
-    virtual void MeasureTable(Node& node, NodeLayoutEntry& entry, float max_width) const = 0;
+        std::pmr::vector<SyntaxToken>* tokens_out = nullptr,
+        MeasureViewportRange viewport = {}) const = 0;
+    virtual void MeasureTable(Node& node, NodeLayoutEntry& entry, float max_width,
+                              MeasureViewportRange viewport = {}) const = 0;
 };
 
 // セットアップ系 IF。UI スレッドからのみ呼び、並列計測中は呼ばない契約。

--- a/src/layout/parallel_measure.cpp
+++ b/src/layout/parallel_measure.cpp
@@ -27,12 +27,13 @@ void MeasureChunk(
     const Theme& theme,
     const IMeasureBackend& backend,
     std::span<const size_t> chunk_indices,
-    std::span<std::pmr::vector<SyntaxToken>> chunk_slot_tokens)
+    std::span<std::pmr::vector<SyntaxToken>> chunk_slot_tokens,
+    MeasureViewportRange viewport)
 {
     for (size_t k = 0; k < chunk_indices.size(); ++k) {
         const size_t i = chunk_indices[k];
         const float indent = NodeIndent(nodes[i], theme);
-        backend.MeasureNode(nodes[i], cache[i], content_width - indent, &chunk_slot_tokens[k]);
+        backend.MeasureNode(nodes[i], cache[i], content_width - indent, &chunk_slot_tokens[k], viewport);
     }
 }
 
@@ -55,6 +56,9 @@ DirtyBatchResult RunParallel(
     const bool has_viewport_limit = clip.active();
     const float limit_top = has_viewport_limit ? clip.limit_top() : 0.0f;
     const float limit_bottom = has_viewport_limit ? clip.limit_bottom() : 0.0f;
+    const MeasureViewportRange measure_vp = has_viewport_limit
+        ? MeasureViewportRange{ limit_top, limit_bottom }
+        : MeasureViewportRange{};
     // ParallelBudget には time_us が無い (シグネチャで明示)。
     // worker 側に polling checkpoint が無いため、time-based 制御は RunSerial 専用。
     const bool has_batch_limit = (budget.max_nodes > 0);
@@ -98,7 +102,7 @@ DirtyBatchResult RunParallel(
 
     if (indices.size() < kMinDirtyForParallel) {
         MENDO_PROFILE("RunParallel.Inline");
-        MeasureChunk(nodes, cache, content_width, theme, backend, indices, { slot_tokens.data(), slot_tokens.size() });
+        MeasureChunk(nodes, cache, content_width, theme, backend, indices, { slot_tokens.data(), slot_tokens.size() }, measure_vp);
     }
     else {
         const size_t worker_count = std::max<size_t>(scheduler.WorkerCount(), 1);
@@ -112,7 +116,7 @@ DirtyBatchResult RunParallel(
         // 例外が latch.count_down() の前で抜けると wait() が永久ブロックするので必ず try/catch で覆う。
         auto run_chunk = [&](std::span<const size_t> ci, std::span<std::pmr::vector<SyntaxToken>> co) {
             try {
-                MeasureChunk(nodes, cache, content_width, theme, backend, ci, co);
+                MeasureChunk(nodes, cache, content_width, theme, backend, ci, co, measure_vp);
             } catch (...) {
                 failed_node_count.fetch_add(static_cast<int>(ci.size()), std::memory_order_relaxed);
                 OutputDebugStringW(L"[mendo] RunParallel chunk threw exception\n");

--- a/tests/mock_text_measurer.h
+++ b/tests/mock_text_measurer.h
@@ -19,7 +19,8 @@ public:
     void UpdateTheme(const Theme&) noexcept override {}
 
     void MeasureNode(Node& node, NodeLayoutEntry& entry, float max_width,
-                     std::pmr::vector<SyntaxToken>* /*tokens_out*/ = nullptr) const override
+                     std::pmr::vector<SyntaxToken>* /*tokens_out*/ = nullptr,
+                     MeasureViewportRange viewport = {}) const override
     {
         if (node.type == NodeType::HorizontalRule) {
             entry.height = 10.0f;
@@ -27,7 +28,7 @@ public:
             return;
         }
         if (node.type == NodeType::Table) {
-            MeasureTable(node, entry, max_width);
+            MeasureTable(node, entry, max_width, viewport);
             return;
         }
 
@@ -80,7 +81,8 @@ public:
         entry.effects_applied = false;
     }
 
-    void MeasureTable(Node& node, NodeLayoutEntry& entry, float max_width) const override
+    void MeasureTable(Node& node, NodeLayoutEntry& entry, float max_width,
+                      MeasureViewportRange /*viewport*/ = {}) const override
     {
         const auto* tbl = node.table_data();
         if (!tbl || tbl->row_count == 0) {

--- a/tests/test_parallel_measure_stress.cpp
+++ b/tests/test_parallel_measure_stress.cpp
@@ -117,9 +117,10 @@ struct StressFixture {
 class MockTextMeasurerWithTokens : public MockTextMeasurer {
 public:
     void MeasureNode(Node& node, NodeLayoutEntry& entry, float max_width,
-                     std::pmr::vector<SyntaxToken>* tokens_out = nullptr) const override
+                     std::pmr::vector<SyntaxToken>* tokens_out = nullptr,
+                     MeasureViewportRange viewport = {}) const override
     {
-        MockTextMeasurer::MeasureNode(node, entry, max_width, tokens_out);
+        MockTextMeasurer::MeasureNode(node, entry, max_width, tokens_out, viewport);
 
         if (node.type != NodeType::CodeBlock || IsDiagramLanguage(node.code_language)) {
             return;
@@ -338,7 +339,8 @@ public:
     int spin_us = 100;
 
     void MeasureNode(Node& node, NodeLayoutEntry& entry, float max_width,
-                     std::pmr::vector<SyntaxToken>* tokens_out = nullptr) const override
+                     std::pmr::vector<SyntaxToken>* tokens_out = nullptr,
+                     MeasureViewportRange viewport = {}) const override
     {
         const auto start = std::chrono::steady_clock::now();
         const auto deadline = start + std::chrono::microseconds(spin_us);
@@ -346,7 +348,7 @@ public:
         while (std::chrono::steady_clock::now() < deadline) {
             // no-op
         }
-        MockTextMeasurer::MeasureNode(node, entry, max_width, tokens_out);
+        MockTextMeasurer::MeasureNode(node, entry, max_width, tokens_out, viewport);
     }
 };
 

--- a/tests/test_table_eviction_dwrite.cpp
+++ b/tests/test_table_eviction_dwrite.cpp
@@ -94,7 +94,8 @@ TEST_F(TableEvictionDWriteTest, EvictInvisibleRowsNoOpWhenAllVisible)
     EXPECT_EQ(CountNonNullCells(tl), total_cells);
 }
 
-// evict 後の再 measure で null セルが復元されフラグがクリアされる。
+// evict 後にデフォルト引数 (viewport 全範囲) で再 measure すると、null セル全てが
+// 復元されフラグがクリアされる (リサイズ等の全範囲計測ケース)。
 TEST_F(TableEvictionDWriteTest, MeasureAfterEvictionRestoresNullCells)
 {
     auto pl = ParseAndLayout(MakeBigTableMd(40));
@@ -111,7 +112,6 @@ TEST_F(TableEvictionDWriteTest, MeasureAfterEvictionRestoresNullCells)
     ASSERT_TRUE(tl.cells_partially_evicted);
     ASSERT_LT(CountNonNullCells(tl), total_cells);
 
-    // EnsureVisibleLayout に相当する経路: dirty な entry に対して再 measure する。
     const float content_width = theme_.ContentWidth(800.0f);
     measurer_.MeasureNode(pl.nodes[idx], entry, content_width);
 
@@ -119,4 +119,70 @@ TEST_F(TableEvictionDWriteTest, MeasureAfterEvictionRestoresNullCells)
     EXPECT_FALSE(entry.layout_dirty);
     EXPECT_EQ(CountNonNullCells(tl), total_cells)
         << "RestoreNullCellLayouts で evict されたセルが復元されているはず";
+}
+
+// viewport 範囲を指定した MeasureNode は範囲内の行だけ復元し、範囲外は null のまま残す。
+// dirty / cells_partially_evicted は維持され、次回スクロール時の追加復元を促す。
+TEST_F(TableEvictionDWriteTest, MeasureWithViewportRestoresOnlyVisibleRows)
+{
+    auto pl = ParseAndLayout(MakeBigTableMd(60));
+    const int idx = FindTableNode(pl.nodes);
+    ASSERT_GE(idx, 0);
+    auto& entry = pl.cache[idx];
+    ASSERT_TRUE(entry.has_table_layout());
+    auto& tl = *entry.table_layout;
+
+    const size_t total_cells = tl.cell_layouts.size();
+    ASSERT_GT(total_cells, 0u);
+
+    // テーブル全体を一旦 evict (viewport より遠い範囲) → ほぼ全セルが null になる。
+    pl.cache.EvictInvisibleTableRows(entry.text_top - 10000.0f, entry.text_top - 9000.0f, 0.0f);
+    const size_t after_evict = CountNonNullCells(tl);
+    ASSERT_LT(after_evict, total_cells);
+    ASSERT_TRUE(tl.cells_partially_evicted);
+
+    // テーブル先頭 80px だけを viewport として measure。範囲内行のみ復元される。
+    const float content_width = theme_.ContentWidth(800.0f);
+    const MeasureViewportRange vp{ entry.text_top, entry.text_top + 80.0f };
+    measurer_.MeasureNode(pl.nodes[idx], entry, content_width, nullptr, vp);
+
+    const size_t after_measure = CountNonNullCells(tl);
+    EXPECT_GT(after_measure, after_evict)
+        << "viewport 範囲内のセルは復元されているはず";
+    EXPECT_LT(after_measure, total_cells)
+        << "viewport 範囲外のセルは null のまま残っているはず";
+    EXPECT_TRUE(tl.cells_partially_evicted)
+        << "復元未完了なのでフラグは維持される";
+    EXPECT_TRUE(entry.layout_dirty)
+        << "次回スクロール時に再 measure させるため dirty を維持";
+}
+
+// 部分復元 → 別 viewport で追加復元 → 最終的に全セルが揃いフラグがクリアされる。
+TEST_F(TableEvictionDWriteTest, ProgressivelyRestoresAcrossScrolls)
+{
+    auto pl = ParseAndLayout(MakeBigTableMd(60));
+    const int idx = FindTableNode(pl.nodes);
+    ASSERT_GE(idx, 0);
+    auto& entry = pl.cache[idx];
+    ASSERT_TRUE(entry.has_table_layout());
+    auto& tl = *entry.table_layout;
+
+    const size_t total_cells = tl.cell_layouts.size();
+    pl.cache.EvictInvisibleTableRows(entry.text_top - 10000.0f, entry.text_top - 9000.0f, 0.0f);
+    ASSERT_LT(CountNonNullCells(tl), total_cells);
+
+    const float content_width = theme_.ContentWidth(800.0f);
+    // 1 回目: テーブル上半分を viewport にして measure
+    const MeasureViewportRange vp1{ entry.text_top, entry.text_top + entry.height * 0.5f };
+    measurer_.MeasureNode(pl.nodes[idx], entry, content_width, nullptr, vp1);
+    EXPECT_TRUE(tl.cells_partially_evicted);
+
+    // 2 回目: テーブル全体を覆う viewport で再 measure
+    const MeasureViewportRange vp2{ entry.text_top, entry.text_top + entry.height };
+    measurer_.MeasureNode(pl.nodes[idx], entry, content_width, nullptr, vp2);
+
+    EXPECT_EQ(CountNonNullCells(tl), total_cells)
+        << "全範囲を覆う viewport で全セル復元されるはず";
+    EXPECT_FALSE(tl.cells_partially_evicted);
+    EXPECT_FALSE(entry.layout_dirty);
 }


### PR DESCRIPTION
## Summary
- closes #218
- `EvictInvisibleTableRows` 直後の `MeasureTable` → `RestoreNullCellLayouts` がテーブル全行を走査して null セルを復元してしまい、行単位 eviction で削減したメモリが即座に CPU/COM churn と相殺される問題を修正
- `MeasureNode` / `MeasureTable` に `MeasureViewportRange` を追加し、`RestoreNullCellLayouts` が viewport 範囲外の行をスキップするよう変更
- 部分復元時は `entry.layout_dirty` と `cells_partially_evicted` を維持し、次回スクロールで残り行を段階的に埋める

## 設計判断
issue #218 の 3 案のうち **案1 (行範囲付き RestoreNullCellLayouts)** を採用:
- 案2 (lazy 復元 / GenTable 内で on-demand 生成) は `CommandGenerator` から DirectWrite ファクトリへのアクセスや tl の mutable 化が必要で、描画パスでの動的セル生成は描画コストが不安定
- 案3 (行単位 dirty bitset) は新たなビット管理層が必要で複雑度が高い
- 案1 は `IMeasureBackend` のシグネチャをオプショナル引数で拡張でき、既存呼び出しを壊さず影響範囲が局所的

## 変更点

### コア
- `src/layout/measure_backend.h`: `MeasureViewportRange` 構造体と `MeasureNode/MeasureTable` の viewport 引数を追加
- `src/layout/dwrite_measurer.{h,cpp}`:
  - `RestoreNullCellLayouts` が `tl.row_cum_y` + `entry.text_top` で行ごとに範囲判定し、外の行は CreateTextLayout をスキップ
  - `FinalizeTableLayout` で null セルがある行は既存の `row_heights[r]` を保持し、累積位置の整合性を確保
  - 部分復元完了後は `layout_dirty=true` と `cells_partially_evicted=true` を維持
- `src/layout/layout.cpp` / `src/layout/dirty_scheduler.cpp`: 各 `MeasureNode` 呼び出しで viewport を伝搬

### テスト
- `tests/mock_text_measurer.h` / `tests/test_parallel_measure_stress.cpp`: シグネチャ追従
- `tests/test_table_eviction_dwrite.cpp` に 2 ケース追加:
  - `MeasureWithViewportRestoresOnlyVisibleRows`: 範囲指定 measure で範囲内のみ復元、フラグ維持
  - `ProgressivelyRestoresAcrossScrolls`: 部分復元 → 全体復元で最終的に全セル揃ってフラグクリア

## 効果
- `EvictInvisibleTableRows` で範囲外の行をメモリ解放後、150ms 後の `BITMAP_MANAGE` タイマーで MeasureTable が走っても、可視範囲外のセルは CreateTextLayout されない
- スクロール直後の MeasureTable コストが evict されたセル数ではなく可視行のセル数に比例するようになる
- ユーザーが新しいエリアにスクロールすると、その時点の viewport で再 measure されて段階的に復元される (描画欠落なし)

## Test plan
- [x] `cmake --build build --config Release` でビルド成功
- [x] `mendo_tests.exe --gtest_brief=1` で 2218 件すべて pass (新規 2 ケース含む)
- [x] 既存の #210 再発防止テストが引き続き pass (`MeasureAfterEvictionRestoresNullCells` は viewport デフォルト = 全範囲なので従来動作で pass)
- [x] 実機: 100MB クラスのテーブルを上下スクロールしてメモリが安定し、描画欠落も再発しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)