### PR TITLE
fix(render): 大規模ファイルの行間ばらつきを修正 (#216)

### DIFF
--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -131,12 +131,20 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     const float snapped_y = SnapToPhysicalPixel(scroll_y, dpi_scale);
     frame_md_pane_x_ = md_pane_rect.x;
     frame_snapped_scroll_y_ = snapped_y;
-    frame_pane_transform_ = D2D1::Matrix3x2F::Translation(md_pane_rect.x, -snapped_y);
+    // SetTransform から Y 平行移動を撤廃。100MB ファイル末尾で text_top と scroll_y が
+    // 共に 10^7 DIP オーダーになると、Direct2D 内部の float32 行列演算で
+    // catastrophic cancellation が起き、各行の Y がサブピクセルでばらつく (#216)。
+    // 対策: CPU 側で text_top - snapped_y を先に引いて、Direct2D には viewport 内
+    // (~数千 DIP) の小さな相対 Y のみを渡す。
+    frame_pane_transform_ = D2D1::Matrix3x2F::Translation(md_pane_rect.x, 0.0f);
     cmds.emplace_back(SetTransformCmd{ frame_pane_transform_ });
 
     frame_offset_x_ = theme_->margin_left;
-    frame_viewport_top_ = scroll_y;
-    frame_viewport_bottom_ = scroll_y + md_pane_rect.height;
+    // viewport bounds をローカル Y 系 (0 〜 pane_height) に統一。
+    // 以下、frame_viewport_top_/bottom_ と GenerateNode 引数 entry_text_top はすべて
+    // ローカル Y。ドキュメント Y が必要な箇所は scroll_y / cache[i].text_top を直接使う。
+    frame_viewport_top_ = 0.0f;
+    frame_viewport_bottom_ = md_pane_rect.height;
     // 水平カリング範囲: ペイン内ローカル座標で margin_left を起点とした相対値
     frame_viewport_left_ = -theme_->margin_left;
     frame_viewport_right_ = md_pane_rect.width - theme_->margin_left;
@@ -167,8 +175,10 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     cell_wv_.ResetIfBufferChanged(nodes.data(), nodes.size());
 
     const int node_count = static_cast<int>(nodes.size());
+    // FindFirstVisibleNodeIndex は cache[i].text_top (ドキュメント Y) で二分探索するため
+    // scroll_y (ドキュメント Y) を渡す必要がある。
     if (first_visible < 0) {
-        first_visible = FindFirstVisibleNodeIndex(cache, nodes.size(), frame_viewport_top_);
+        first_visible = FindFirstVisibleNodeIndex(cache, nodes.size(), scroll_y);
     }
 
     // 同一 blockquote_group のノードをまとめてバー/背景を描画する。
@@ -176,11 +186,13 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     GenBlockQuoteGroupDecorations(cmds, nodes, cache, node_count, first_visible);
 
     int visible_count = 0;
+    const float doc_viewport_bottom = scroll_y + md_pane_rect.height;
     for (int i = first_visible; i < node_count; i++) {
-        if (cache[i].text_top > frame_viewport_bottom_) {
+        if (cache[i].text_top > doc_viewport_bottom) {
             break;
         }
-        GenerateNode(cmds, nodes[i], cache[i], cache.GetDiagram(i), i, cache[i].text_top);
+        const float local_text_top = cache[i].text_top - snapped_y;
+        GenerateNode(cmds, nodes[i], cache[i], cache.GetDiagram(i), i, local_text_top);
         ++visible_count;
     }
 
@@ -437,7 +449,10 @@ void CommandGenerator::EmitBlockHScrollbarIfActive(DrawCommandList& cmds, int no
     // frame_pane_transform_ の md_x が非整数 (DPI 1 以外) のとき、サブピクセル位置で
     // アンチエイリアスが上下に漏れて thumb の太さがブレる現象を防ぐ。
     const float abs_x = SnapToPhysicalPixel(frame_md_pane_x_ + block_x + ratio * (track_w - thumb_w), frame_dpi_scale_);
-    const float abs_y = SnapToPhysicalPixel(bar_y - frame_snapped_scroll_y_, frame_dpi_scale_);
+    // bar_y は呼び出し元で BlockHScrollbarBarY(entry_text_top, ...) から算出され、
+    // entry_text_top はローカル Y (= doc_y - snapped_scroll_y) なので bar_y もローカル Y。
+    // 余分な scroll_y 減算は不要 (二重相対化を避ける)。
+    const float abs_y = SnapToPhysicalPixel(bar_y, frame_dpi_scale_);
     const float w_snapped = SnapToPhysicalPixel(thumb_w, frame_dpi_scale_);
     const float h_snapped = SnapToPhysicalPixel(PANE_SCROLLBAR_WIDTH, frame_dpi_scale_);
     cmds.emplace_back(SetTransformCmd{ D2D1::Matrix3x2F::Identity() });
@@ -482,7 +497,9 @@ void CommandGenerator::GenListBullet(DrawCommandList& cmds, const Node& node, co
         // baked 座標で描画する。
         const float first_line_h = GetFirstLineHeight(entry, theme_->font_size_body);
         const float bullet_x = SnapToPhysicalPixel(frame_md_pane_x_ + x - theme_->list_bullet_offset * LIST_BULLET_X_FACTOR, frame_dpi_scale_);
-        const float bullet_y = SnapToPhysicalPixel(entry_text_top + first_line_h * 0.5f - frame_snapped_scroll_y_, frame_dpi_scale_);
+        // entry_text_top はローカル Y。Identity transform で描画するので X は frame_md_pane_x_ を加算するが、
+        // Y は scroll 相殺済 (二重相対化を避ける)。
+        const float bullet_y = SnapToPhysicalPixel(entry_text_top + first_line_h * 0.5f, frame_dpi_scale_);
         const float r = LIST_BULLET_RADIUS;
         cmds.emplace_back(SetTransformCmd{ D2D1::Matrix3x2F::Identity() });
         if (node.indent_level <= 1) {
@@ -499,7 +516,9 @@ void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds, cons
 {
     const float offset_x = frame_offset_x_;
     const float content_width = frame_content_width_;
-    const float viewport_bottom = frame_viewport_bottom_;
+    // viewport カリングは cache[i].text_top (ドキュメント Y) と比較するため
+    // frame_viewport_bottom_ (ローカル Y) からドキュメント Y へ戻して使う。
+    const float doc_viewport_bottom = frame_snapped_scroll_y_ + frame_viewport_bottom_;
     static constexpr float BAR_EXTEND = 2.0f;
     static constexpr float ALERT_BG_PAD = 4.0f;
     static constexpr float ALERT_BG_CORNER = 4.0f;
@@ -519,7 +538,7 @@ void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds, cons
             i++;
             continue;
         }
-        if (cache[i].text_top > viewport_bottom) {
+        if (cache[i].text_top > doc_viewport_bottom) {
             break;
         }
 
@@ -542,7 +561,7 @@ void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds, cons
             // ビューポート外に大きく超えたグループ末尾は j を進めるだけにする。
             // バー/背景はクリップで切られるため、可視外で max_depth を更新しても
             // 描画コマンド数は変わらず CPU を浪費するだけ。
-            if (group_bottom > viewport_bottom) {
+            if (group_bottom > doc_viewport_bottom) {
                 while (j < node_count && nodes[j].blockquote_group == group) {
                     j++;
                 }
@@ -561,7 +580,9 @@ void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds, cons
             const auto idx = AlertColorIndex(alert_type);
             if (idx < ALERT_TYPE_COUNT) {
                 const float cw = content_width - outer_x_indent;
-                const D2D1_RECT_F bg_rect = D2D1::RectF(outer_x - ALERT_BG_PAD, group_top - ALERT_BG_PAD, outer_x + cw, group_bottom + ALERT_BG_PAD);
+                const float local_top = group_top - frame_snapped_scroll_y_;
+                const float local_bottom = group_bottom - frame_snapped_scroll_y_;
+                const D2D1_RECT_F bg_rect = D2D1::RectF(outer_x - ALERT_BG_PAD, local_top - ALERT_BG_PAD, outer_x + cw, local_bottom + ALERT_BG_PAD);
                 cmds.emplace_back(FillRoundedRectCmd{ bg_rect, ALERT_BG_CORNER, ALERT_BG_CORNER, theme_->alert_bg_color[idx] });
             }
         }
@@ -580,9 +601,11 @@ void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds, cons
                     : BrushId::BlockquoteBar;
 
             const auto emit_bar = [&](float top, float bottom) {
+                const float local_top = top - frame_snapped_scroll_y_;
+                const float local_bottom = bottom - frame_snapped_scroll_y_;
                 cmds.emplace_back(DrawLineCmd{
-                    D2D1::Point2F(bar_x, top - BAR_EXTEND),
-                    D2D1::Point2F(bar_x, bottom + BAR_EXTEND),
+                    D2D1::Point2F(bar_x, local_top - BAR_EXTEND),
+                    D2D1::Point2F(bar_x, local_bottom + BAR_EXTEND),
                     bar_color, theme_->blockquote_bar_width, bar_brush });
             };
 

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -131,18 +131,13 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     const float snapped_y = SnapToPhysicalPixel(scroll_y, dpi_scale);
     frame_md_pane_x_ = md_pane_rect.x;
     frame_snapped_scroll_y_ = snapped_y;
-    // SetTransform から Y 平行移動を撤廃。100MB ファイル末尾で text_top と scroll_y が
-    // 共に 10^7 DIP オーダーになると、Direct2D 内部の float32 行列演算で
-    // catastrophic cancellation が起き、各行の Y がサブピクセルでばらつく (#216)。
-    // 対策: CPU 側で text_top - snapped_y を先に引いて、Direct2D には viewport 内
-    // (~数千 DIP) の小さな相対 Y のみを渡す。
+    // Y 平行移動は Transform に乗せず CPU 側で entry ごとに加算する。
+    // 大規模ファイルで text_top/scroll_y が 10^7 DIP オーダーになると、D2D 内部の
+    // float32 行列演算で catastrophic cancellation が起きるため (詳細は header)。
     frame_pane_transform_ = D2D1::Matrix3x2F::Translation(md_pane_rect.x, 0.0f);
     cmds.emplace_back(SetTransformCmd{ frame_pane_transform_ });
 
     frame_offset_x_ = theme_->margin_left;
-    // viewport bounds をローカル Y 系 (0 〜 pane_height) に統一。
-    // 以下、frame_viewport_top_/bottom_ と GenerateNode 引数 entry_text_top はすべて
-    // ローカル Y。ドキュメント Y が必要な箇所は scroll_y / cache[i].text_top を直接使う。
     frame_viewport_top_ = 0.0f;
     frame_viewport_bottom_ = md_pane_rect.height;
     // 水平カリング範囲: ペイン内ローカル座標で margin_left を起点とした相対値
@@ -175,9 +170,8 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     cell_wv_.ResetIfBufferChanged(nodes.data(), nodes.size());
 
     const int node_count = static_cast<int>(nodes.size());
-    // FindFirstVisibleNodeIndex は cache[i].text_top (ドキュメント Y) で二分探索するため
-    // scroll_y (ドキュメント Y) を渡す必要がある。
     if (first_visible < 0) {
+        // 二分探索キーはドキュメント Y。
         first_visible = FindFirstVisibleNodeIndex(cache, nodes.size(), scroll_y);
     }
 
@@ -186,12 +180,11 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
     GenBlockQuoteGroupDecorations(cmds, nodes, cache, node_count, first_visible);
 
     int visible_count = 0;
-    const float doc_viewport_bottom = scroll_y + md_pane_rect.height;
     for (int i = first_visible; i < node_count; i++) {
-        if (cache[i].text_top > doc_viewport_bottom) {
+        const float local_text_top = cache[i].text_top - snapped_y;
+        if (local_text_top > frame_viewport_bottom_) {
             break;
         }
-        const float local_text_top = cache[i].text_top - snapped_y;
         GenerateNode(cmds, nodes[i], cache[i], cache.GetDiagram(i), i, local_text_top);
         ++visible_count;
     }
@@ -449,9 +442,7 @@ void CommandGenerator::EmitBlockHScrollbarIfActive(DrawCommandList& cmds, int no
     // frame_pane_transform_ の md_x が非整数 (DPI 1 以外) のとき、サブピクセル位置で
     // アンチエイリアスが上下に漏れて thumb の太さがブレる現象を防ぐ。
     const float abs_x = SnapToPhysicalPixel(frame_md_pane_x_ + block_x + ratio * (track_w - thumb_w), frame_dpi_scale_);
-    // bar_y は呼び出し元で BlockHScrollbarBarY(entry_text_top, ...) から算出され、
-    // entry_text_top はローカル Y (= doc_y - snapped_scroll_y) なので bar_y もローカル Y。
-    // 余分な scroll_y 減算は不要 (二重相対化を避ける)。
+    // bar_y は entry_text_top から算出されたローカル Y。Identity transform でも追加減算は不要。
     const float abs_y = SnapToPhysicalPixel(bar_y, frame_dpi_scale_);
     const float w_snapped = SnapToPhysicalPixel(thumb_w, frame_dpi_scale_);
     const float h_snapped = SnapToPhysicalPixel(PANE_SCROLLBAR_WIDTH, frame_dpi_scale_);
@@ -496,9 +487,8 @@ void CommandGenerator::GenListBullet(DrawCommandList& cmds, const Node& node, co
         // の楕円を bounding rect (長方形) に縮退させるため、bullet だけ Identity transform +
         // baked 座標で描画する。
         const float first_line_h = GetFirstLineHeight(entry, theme_->font_size_body);
+        // X は Identity 化に伴い frame_md_pane_x_ を手動で加算。Y は entry_text_top が既にローカル Y。
         const float bullet_x = SnapToPhysicalPixel(frame_md_pane_x_ + x - theme_->list_bullet_offset * LIST_BULLET_X_FACTOR, frame_dpi_scale_);
-        // entry_text_top はローカル Y。Identity transform で描画するので X は frame_md_pane_x_ を加算するが、
-        // Y は scroll 相殺済 (二重相対化を避ける)。
         const float bullet_y = SnapToPhysicalPixel(entry_text_top + first_line_h * 0.5f, frame_dpi_scale_);
         const float r = LIST_BULLET_RADIUS;
         cmds.emplace_back(SetTransformCmd{ D2D1::Matrix3x2F::Identity() });
@@ -516,9 +506,8 @@ void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds, cons
 {
     const float offset_x = frame_offset_x_;
     const float content_width = frame_content_width_;
-    // viewport カリングは cache[i].text_top (ドキュメント Y) と比較するため
-    // frame_viewport_bottom_ (ローカル Y) からドキュメント Y へ戻して使う。
-    const float doc_viewport_bottom = frame_snapped_scroll_y_ + frame_viewport_bottom_;
+    const float snap = frame_snapped_scroll_y_;
+    const float local_viewport_bottom = frame_viewport_bottom_;
     static constexpr float BAR_EXTEND = 2.0f;
     static constexpr float ALERT_BG_PAD = 4.0f;
     static constexpr float ALERT_BG_CORNER = 4.0f;
@@ -538,19 +527,19 @@ void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds, cons
             i++;
             continue;
         }
-        if (cache[i].text_top > doc_viewport_bottom) {
+        const float group_top = cache[i].text_top - snap;
+        if (group_top > local_viewport_bottom) {
             break;
         }
 
-        const float group_top = cache[i].text_top;
-        float group_bottom = cache[i].text_top + cache[i].height;
+        float group_bottom = group_top + cache[i].height;
         const AlertType alert_type = nodes[i].alert_type;
         const int outer_indent = nodes[i].quote_outer_indent;
         int max_depth = nodes[i].quote_depth;
 
         int j = i + 1;
         while (j < node_count && nodes[j].blockquote_group == group) {
-            const float bottom = cache[j].text_top + cache[j].height;
+            const float bottom = cache[j].text_top - snap + cache[j].height;
             if (bottom > group_bottom) {
                 group_bottom = bottom;
             }
@@ -561,7 +550,7 @@ void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds, cons
             // ビューポート外に大きく超えたグループ末尾は j を進めるだけにする。
             // バー/背景はクリップで切られるため、可視外で max_depth を更新しても
             // 描画コマンド数は変わらず CPU を浪費するだけ。
-            if (group_bottom > doc_viewport_bottom) {
+            if (group_bottom > local_viewport_bottom) {
                 while (j < node_count && nodes[j].blockquote_group == group) {
                     j++;
                 }
@@ -580,9 +569,7 @@ void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds, cons
             const auto idx = AlertColorIndex(alert_type);
             if (idx < ALERT_TYPE_COUNT) {
                 const float cw = content_width - outer_x_indent;
-                const float local_top = group_top - frame_snapped_scroll_y_;
-                const float local_bottom = group_bottom - frame_snapped_scroll_y_;
-                const D2D1_RECT_F bg_rect = D2D1::RectF(outer_x - ALERT_BG_PAD, local_top - ALERT_BG_PAD, outer_x + cw, local_bottom + ALERT_BG_PAD);
+                const D2D1_RECT_F bg_rect = D2D1::RectF(outer_x - ALERT_BG_PAD, group_top - ALERT_BG_PAD, outer_x + cw, group_bottom + ALERT_BG_PAD);
                 cmds.emplace_back(FillRoundedRectCmd{ bg_rect, ALERT_BG_CORNER, ALERT_BG_CORNER, theme_->alert_bg_color[idx] });
             }
         }
@@ -601,11 +588,9 @@ void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds, cons
                     : BrushId::BlockquoteBar;
 
             const auto emit_bar = [&](float top, float bottom) {
-                const float local_top = top - frame_snapped_scroll_y_;
-                const float local_bottom = bottom - frame_snapped_scroll_y_;
                 cmds.emplace_back(DrawLineCmd{
-                    D2D1::Point2F(bar_x, local_top - BAR_EXTEND),
-                    D2D1::Point2F(bar_x, local_bottom + BAR_EXTEND),
+                    D2D1::Point2F(bar_x, top - BAR_EXTEND),
+                    D2D1::Point2F(bar_x, bottom + BAR_EXTEND),
                     bar_color, theme_->blockquote_bar_width, bar_brush });
             };
 
@@ -613,12 +598,13 @@ void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds, cons
             float region_top = 0.0f;
             float region_bottom = 0.0f;
             for (int k = i; k < j; ++k) {
+                const float local_top_k = cache[k].text_top - snap;
                 if (nodes[k].quote_depth >= level) {
                     if (!in_region) {
                         in_region = true;
-                        region_top = cache[k].text_top;
+                        region_top = local_top_k;
                     }
-                    region_bottom = cache[k].text_top + cache[k].height;
+                    region_bottom = local_top_k + cache[k].height;
                 }
                 else if (in_region) {
                     emit_bar(region_top, region_bottom);

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -126,8 +126,8 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
         md_pane_rect.x + md_pane_rect.width, md_pane_rect.y + md_pane_rect.height);
     cmds.emplace_back(PushClipCmd{ md_clip });
     // スクロール位置を物理ピクセル境界にスナップし、ClearTypeヒンティングの
-    // フレーム間変動によるテキストのガタつきを防止する。
-    // viewport bounds にはスナップ前の scroll_y を使い、ヒットテストとの座標一致を保つ。
+    // フレーム間変動によるテキストのガタつきを防止する。スナップは描画 Y のみに
+    // 適用し、二分探索 (FindFirstVisibleNodeIndex) には未スナップ scroll_y を渡す。
     const float snapped_y = SnapToPhysicalPixel(scroll_y, dpi_scale);
     frame_md_pane_x_ = md_pane_rect.x;
     frame_snapped_scroll_y_ = snapped_y;
@@ -171,7 +171,7 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
 
     const int node_count = static_cast<int>(nodes.size());
     if (first_visible < 0) {
-        // 二分探索キーはドキュメント Y。
+        // 二分探索キーは未スナップのドキュメント Y (cache[i].text_top と同じ系)。
         first_visible = FindFirstVisibleNodeIndex(cache, nodes.size(), scroll_y);
     }
 

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -217,6 +217,11 @@ private:
     // GenerateMdPane のスコープ内で不変のフレーム単位コンテキスト。
     // GenerateNode 等の private 関数から参照される。
     float frame_offset_x_ = 0.0f;
+    // ビューポート Y 範囲は **ペインローカル Y** (= 0 〜 pane_height)。GenerateNode に
+    // 渡す entry_text_top も同じローカル Y 系。100MB ファイルでドキュメント Y が 10^7
+    // オーダーに達すると float32 の桁落ちで描画位置が ±1px ばらつく問題 (#216) の対策。
+    // ドキュメント Y で比較したい箇所 (cache[i].text_top との直接比較) では
+    // frame_snapped_scroll_y_ を足し戻して使う。
     float frame_viewport_top_ = 0.0f;
     float frame_viewport_bottom_ = 0.0f;
     // フレーム座標系でのビューポート左右端。各セル x を frame_offset_x_ と

--- a/tests/test_command_generator_frame.cpp
+++ b/tests/test_command_generator_frame.cpp
@@ -31,10 +31,7 @@ TEST_F(CmdGenFrameTest, PushClipMatchesPaneRect)
 
 TEST_F(CmdGenFrameTest, TransformTranslatesByPaneOriginOnly)
 {
-    // 100MB ファイル末尾で text_top と scroll_y が 10^7 DIP オーダーになると、
-    // SetTransform 経由で D2D に渡すと float32 の catastrophic cancellation で
-    // 各行の Y がサブピクセルでばらつく (#216)。そのため Y 平行移動は Transform から
-    // 撤廃し、CPU 側で各描画コマンドの Y に直接合算する設計にした。
+    // Transform の Y は常に 0、スクロール量は描画コマンドの Y に直接合算される。
     Parse("---");
     constexpr float origin_x = 120.0f;
     constexpr float scroll_y = 40.0f;

--- a/tests/test_command_generator_frame.cpp
+++ b/tests/test_command_generator_frame.cpp
@@ -29,9 +29,13 @@ TEST_F(CmdGenFrameTest, PushClipMatchesPaneRect)
     EXPECT_FLOAT_EQ(clip->rect.bottom, 450.0f);
 }
 
-TEST_F(CmdGenFrameTest, TransformTranslatesByPaneOriginAndScroll)
+TEST_F(CmdGenFrameTest, TransformTranslatesByPaneOriginOnly)
 {
-    Parse("Hello");
+    // 100MB ファイル末尾で text_top と scroll_y が 10^7 DIP オーダーになると、
+    // SetTransform 経由で D2D に渡すと float32 の catastrophic cancellation で
+    // 各行の Y がサブピクセルでばらつく (#216)。そのため Y 平行移動は Transform から
+    // 撤廃し、CPU 側で各描画コマンドの Y に直接合算する設計にした。
+    Parse("---");
     constexpr float origin_x = 120.0f;
     constexpr float scroll_y = 40.0f;
     const PaneRect pane{ origin_x, 0.0f, 600.0f, 400.0f };
@@ -40,13 +44,20 @@ TEST_F(CmdGenFrameTest, TransformTranslatesByPaneOriginAndScroll)
     const auto* first_xform = FindFirst<SetTransformCmd>(cmds);
     ASSERT_NE(first_xform, nullptr);
     EXPECT_FLOAT_EQ(first_xform->transform._31, origin_x);
-    EXPECT_FLOAT_EQ(first_xform->transform._32, -scroll_y);
+    EXPECT_FLOAT_EQ(first_xform->transform._32, 0.0f);
+
+    // スクロール量は HR の Y 座標に CPU 側で直接合算される。
+    const auto* line = FindFirst<DrawLineCmd>(cmds);
+    ASSERT_NE(line, nullptr);
+    const float expected_y = cache_[0].text_top - scroll_y + theme_.paragraph_spacing * 0.5f;
+    EXPECT_FLOAT_EQ(line->p0.y, expected_y);
 }
 
-TEST_F(CmdGenFrameTest, TransformSnapsScrollToPixelWithDpi)
+TEST_F(CmdGenFrameTest, ScrollSnapsToPixelWithDpi)
 {
-    // DPI=2.0 → round(scroll_y * 2) / 2 で 0.5px 境界にスナップ
-    Parse("Hello");
+    // DPI=2.0 → round(scroll_y * 2) / 2 で 0.5px 境界にスナップ。
+    // スナップは Transform でなく描画コマンドの Y 計算に反映される。
+    Parse("---");
     const PaneRect pane{ 0.0f, 0.0f, 800.0f, 400.0f };
     const float scroll_y = 0.3f;
     const float dpi = 2.0f;
@@ -54,7 +65,13 @@ TEST_F(CmdGenFrameTest, TransformSnapsScrollToPixelWithDpi)
 
     const auto* xform = FindFirst<SetTransformCmd>(cmds);
     ASSERT_NE(xform, nullptr);
-    EXPECT_FLOAT_EQ(xform->transform._32, -0.5f);
+    EXPECT_FLOAT_EQ(xform->transform._32, 0.0f);
+
+    const auto* line = FindFirst<DrawLineCmd>(cmds);
+    ASSERT_NE(line, nullptr);
+    const float snapped_scroll = 0.5f; // round(0.3 * 2) / 2
+    const float expected_y = cache_[0].text_top - snapped_scroll + theme_.paragraph_spacing * 0.5f;
+    EXPECT_FLOAT_EQ(line->p0.y, expected_y);
 }
 
 // ═══════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- 100MB クラスのファイル末尾で text_top/scroll_y が 10^7 DIP オーダーになると、`SetTransform(0, -snapped_y)` 経由で D2D に渡すと float32 行列演算の catastrophic cancellation で各行 Y がサブピクセルにばらついて行間が乱れる問題 (#216) を修正
- 対策として Y 平行移動を Transform から外し、CPU 側で `entry_text_top = cache[i].text_top - snapped_y` を計算してから描画コマンドに直接合算する設計に変更
- `frame_viewport_top_/bottom_` および `GenerateNode(entry_text_top)` をペインローカル Y 系に統一
- blockquote グループ装飾のリファクタで `cache[k].text_top - snap` を読み取り時 1 回に集約し、`emit_bar`/alert 背景の per-bar 減算を撤廃

## Test plan
- [x] `mendo_tests.exe` 全 2218 ケース通過
- [x] `command_generator.cpp` の Y 系統一を直接検証する 2 ケース (`TransformTranslatesByPaneOriginOnly` / `ScrollSnapsToPixelWithDpi`) を追加
- [x] 100MB Markdown を実機で開いて末尾までスクロール、行間が均一なことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)