### PR TITLE
fix: #224 — TOC末尾リンクでmdペインに空白が出る問題を修正

### DIFF
--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -55,6 +55,9 @@ void ApplyScrollTargetAndEmit(AppState& state, SideEffectList& effects, int node
 {
     state.view.viewport.SetScrollTarget(node, offset);
     state.view.viewport.ApplyScrollTarget(state.document.layout_cache);
+    // 末尾セクションへのジャンプで scroll_y > max_scroll になると、後続の DirectScrollBy で
+    // 位置が一気に飛ぶ。事前クランプ + target 無効化で範囲外への復帰を抑える。
+    state.view.viewport.ClampAndDetach();
     state.interaction.hover_throttle.Reset();
     ClearTooltip(state, effects);
     PushEffect(effects, effect::InvalidateWindow{});

--- a/src/util/viewport_manager.h
+++ b/src/util/viewport_manager.h
@@ -47,6 +47,13 @@ public:
         scroll_target_ = {};
     }
 
+    // 現在の scroll_y を [0, max_scroll] にクランプし、scroll_target を無効化する。
+    // ApplyScrollTarget 直後に「以降のレイアウト変化で範囲外へ戻らない」確定処理として使う。
+    constexpr void ClampAndDetach() noexcept
+    {
+        ScrollTo(scroll_y_);
+    }
+
     // ユーザー発のピクセルスクロール。scroll_target を無効化する。
     constexpr void DirectScrollBy(float delta) noexcept
     {

--- a/tests/test_reducer.cpp
+++ b/tests/test_reducer.cpp
@@ -1113,6 +1113,31 @@ TEST_F(ReducerTest, TocItemClicked_ValidAnchor_ScrollsAndInvalidates)
     EXPECT_TRUE(HasEffect<effect::BitmapManage>(effects));
 }
 
+// issue#224: 末尾セクションへのジャンプで scroll_y が max_scroll を超えると、
+// その後のホイールスクロールで位置が一気に補正されて「飛ぶ」体感になる。
+// ApplyScrollTargetAndEmit が事前クランプする契約を担保する。
+TEST_F(ReducerTest, TocItemClicked_TailSection_ClampsToMaxScroll)
+{
+    state.document.doc = Document::FromMarkdown(std::pmr::string("# First\n\n# Second\n\n# Tail"), L"C:\\file.md");
+
+    auto& cache = state.document.layout_cache;
+    const auto& nodes = state.document.doc.GetNodes();
+    cache.Resize(nodes.size());
+    // 末尾見出しを max_scroll (= 500) より遥か下に配置 → ペイン上端へ持ってくると要求 scroll_y > max_scroll
+    const int tail = static_cast<int>(nodes.size()) - 1;
+    cache[tail].text_top = 900.0f;
+
+    const auto anchor = nodes[tail].anchor_id();
+    if (anchor.empty()) {
+        GTEST_SKIP() << "anchor_id が空のため検証できない";
+    }
+
+    Reduce(state, TocItemClickedAction{ std::pmr::string(anchor) });
+
+    EXPECT_FLOAT_EQ(state.view.viewport.GetScrollY(), state.view.viewport.GetMaxScroll());
+    EXPECT_FALSE(state.view.viewport.HasScrollTarget());
+}
+
 // ---- 副作用順序ヘルパーの利用例 (test_helpers.h::HasEffectInOrder) ----
 // EmitScrollEffects は InvalidateWindow → BitmapManage の順で push する契約。
 // 順序が逆転すると BitmapManage 側が古い viewport で動くなどの実害があるため、


### PR DESCRIPTION
## Summary

- 目次最下部のリンクをクリックした際、mdペインのコンテンツ末尾以降の空白エリアが見えてしまい、その後少しでもスクロールすると位置が一気に補正されて「飛ぶ」体感になっていた (#224)
- 原因は `ApplyScrollTarget` が `max_scroll` でクランプしない設計のため、要求された scroll_y が範囲外のまま描画されていたこと
- `ApplyScrollTargetAndEmit` で事前クランプ + scroll_target 無効化を行い、ブラウザの `#anchor` ジャンプと同等の挙動に揃えた

## 変更内容

- `src/util/viewport_manager.h`: `ClampAndDetach()` ヘルパを追加 (現在の scroll_y を `[0, max_scroll]` にクランプし scroll_target を無効化する確定処理)
- `src/app/reducer.cpp`: `ApplyScrollTargetAndEmit` で `ApplyScrollTarget` 直後に `ClampAndDetach()` を呼ぶ
- `tests/test_reducer.cpp`: 末尾見出しへのジャンプで `scroll_y == max_scroll` に収まり scroll_target が無効化されることを検証する回帰テストを追加

## 影響範囲

`ApplyScrollTargetAndEmit` を通る全経路 — TOC クリック / `#anchor` ナビゲーション / nav 履歴復帰 — でクランプが効く。nav 履歴復帰の offset は元々ユーザーが見ていた範囲内のため通常は no-op。Mermaid 描画完了等で scroll_target が消えていても、`EnsureScrollTarget` が現在 scroll_y から target を再合成するため追従に問題なし。

## Test plan

- [x] `cmake --build build --config Release` でビルド成功
- [x] `mendo_tests.exe --gtest_brief=1` で 2202 件全 PASS (新規 1 件含む)
- [x] 実機: 長めの Markdown を開き、目次の最下部の見出しをクリック → mdペインに空白が出ず、後続のホイールスクロールで「飛び」がないことを確認
- [x] 実機: ナビゲーション履歴の戻る/進むで違和感がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)