### PR TITLE
perf: Node 構造体を 216B→144B に圧縮 (-33%)

### DIFF
--- a/src/app/clipboard_manager.cpp
+++ b/src/app/clipboard_manager.cpp
@@ -50,7 +50,7 @@ void ClipboardManager::CopyCodeBlock(const Document& doc, int node_index, bool d
 void ClipboardManager::SaveDiagramAsPng(const Document& doc, int node_index, float md_width, bool dark)
 {
     const Node* node_ptr = ValidateCodeBlockNode(doc, node_index);
-    if (!node_ptr || !IsDiagramLanguage(node_ptr->code_language)) {
+    if (!node_ptr || !IsDiagramLanguage(node_ptr->code_language())) {
         return;
     }
     const auto& node = *node_ptr;
@@ -83,7 +83,7 @@ void ClipboardManager::SaveDiagramAsPng(const Document& doc, int node_index, flo
 void ClipboardManager::CopyDiagramAsSvg(const Document& doc, int node_index, float md_width, bool dark)
 {
     const Node* node_ptr = ValidateCodeBlockNode(doc, node_index);
-    if (!node_ptr || !IsSvgExportable(node_ptr->code_language)) {
+    if (!node_ptr || !IsSvgExportable(node_ptr->code_language())) {
         return;
     }
     const auto& node = *node_ptr;

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -17,10 +17,12 @@
 #include "text_types.h"
 #include "utility.h"
 
-// Node::runs / TableCell::runs の型エイリアス。SBO=4 で大半のノード (run < 4 が中央値)
-// で動的確保ゼロ。SBO を超えた場合のみ操作 new_delete に確保する (synchronized_pool を
-// 経由しないため、parse 時のロック取得を Node 数だけ削減できる)。
-using TextRunList = mendo::small_vector<TextRun, 4>;
+// Node::runs / TableCell::runs の型エイリアス。SBO=2 で size=1 (実測中央値) のノード 65%
+// を完全 inline 保持しつつ、Node 直下の 8B 削減と Paragraph/BlockQuote (中央値 4) の
+// heap fallback を許容する設計。example/test.md 実測ヒット率 75.8% (テキスト系のみ)。
+// SBO を超えた場合のみ operator new_delete に確保する (synchronized_pool を経由しないため、
+// parse 時のロック取得を Node 数だけ削減できる)。
+using TextRunList = mendo::small_vector<TextRun, 2>;
 
 enum class NodeType : uint8_t {
     Heading,
@@ -139,19 +141,41 @@ struct NodeTableData {
     }
 };
 
+// Heading 固有データ。anchor_id は外部 heap 持ちで variant alternative サイズを 16B に抑える。
+// 持たない alternative (Paragraph 等) では確保しないため、Heading 以外でのオーバーヘッドは無い。
 struct NodeHeadingData {
-    std::pmr::string anchor_id; // 内部リンク向けGitHubスタイルのスラグ
+    mendo::pmr_unique_ptr<std::pmr::string> anchor_id;
+    int8_t heading_level = 0;
 };
 
+// CodeBlock 固有データ。tokens は外部 heap 持ちで variant alternative サイズを 16B に抑える。
 struct NodeCodeData {
-    std::pmr::vector<SyntaxToken> syntax_tokens;
+    mendo::pmr_unique_ptr<std::pmr::vector<SyntaxToken>> tokens;
+    SyntaxLanguage code_language = SyntaxLanguage::None;
 };
+
+// ListItem / TaskListItem 固有データ。
+struct NodeListData {
+    int32_t list_number = 0;   // 0 = 順序なし, >0 = 順序付きリスト番号
+    bool task_checked = false; // TaskListItem のときのみ意味を持つ
+};
+
+// BlockQuote 本体の alert 情報。alert_type は同一 blockquote_group の後続ノードにも
+// 伝播するため Node 直下に置く (parser.cpp:DetectAlertAt 参照)。
+// alert_label_length は BlockQuote 本体だけが持つラベル長で variant 内に閉じ込められる。
+struct NodeAlertData {
+    uint32_t alert_label_length = 0;
+};
+
+// Tableノードのみが確保。pmr_unique_ptr の単独 alternative として variant に乗せる。
+using NodeTablePtr = mendo::pmr_unique_ptr<NodeTableData>;
 
 struct NodeImageData {
     std::pmr::string src; // 画像ソースパス（Markdown内の記述）
     float width = 0.0f;   // 元画像の幅（ピクセル）
     float height = 0.0f;  // 元画像の高さ（ピクセル）
 };
+using NodeImagePtr = mendo::pmr_unique_ptr<NodeImageData>;
 
 // Node::source_offset が未設定であることを示すセンチネル値。
 // HorizontalRule のようなテキストを持たないノードはオフセットを記録しない。
@@ -160,25 +184,26 @@ inline constexpr uint32_t kUnsetSourceOffset = std::numeric_limits<uint32_t>::ma
 struct Node {
     TextRunList runs;
 
-    // Table と Image のデータは Node 全体の少数派 (画像/表のあるノードのみ) なので、
-    // variant に詰め込むと最大 alternative である NodeImageData が全 Node の sizeof を支配する。
-    // pmr_unique_ptr で外出しすると variant 上限が下がり、持たないノードは null pointer の
-    // オーバーヘッドだけで済む。PmrDefaultDeleter (ステートレス) が pmr default_resource に
-    // 自動返却するため Node 自身は copy/move/dtor の手書き不要 (= スマートポインタメンバの
-    // 存在で Node は move-only になる)。
-    // Parser invariant: type == NodeType::Table のとき table_ != nullptr。MeasureTable や
-    // HitTestTable は type 判定だけで table_data() を参照するため、parser はテーブル開始時に
-    // 必ず ensure_table() を呼ぶこと。
-    mendo::pmr_unique_ptr<NodeTableData> table_;
-    mendo::pmr_unique_ptr<NodeImageData> image_;
-
     // リンク URL の集合。リンクを含むノードでのみ確保される。
     // Why: `Node::runs` が link_url_index で参照する URL テーブル。リンクを持つノードは
     // 全体の少数派 (見出し/段落の一部) なので、空時は 8B ポインタ 1 本に抑える。
     mendo::pmr_unique_ptr<std::pmr::vector<std::pmr::string>> link_urls_;
 
-    // ノード種別ごとの拡張データ。Heading/Code のみ variant に格納 (上限 24B + tag 8B = 32B)。
-    using Extra = std::variant<std::monostate, NodeHeadingData, NodeCodeData>;
+    // ノード種別ごとの拡張データ。variant alternative ごとに 16B 以下に抑えてあり、
+    // 上限 16B + tag 8B = 24B で Node 全体のサイズを支配しない。
+    //   - 重データ (anchor_id / tokens / table / image) は pmr_unique_ptr で外出し
+    //   - 小スカラ (heading_level / code_language / list_number / alert_label_length / task_checked)
+    //     は NodeType に対応した alternative 内にまとめる
+    // Parser invariant: 1 つのノードは 1 つの alternative しか持たない (ensure_* は他を破壊する)。
+    using Extra = std::variant<
+        std::monostate,    // Paragraph / HorizontalRule など固有データ無し
+        NodeHeadingData,   // Heading
+        NodeCodeData,      // CodeBlock
+        NodeListData,      // ListItem / TaskListItem
+        NodeAlertData,     // BlockQuote 本体の alert ラベル
+        NodeTablePtr,      // Table
+        NodeImagePtr       // Image
+    >;
     Extra extra;
 
     // 表示テキストの owned バッファ。テキスト加工 (Alert / HTML entity / SOFTBR/BR / display math 昇格 / 表セル等)
@@ -192,8 +217,6 @@ struct Node {
     const char* view_base_ = nullptr;
 
     // --- 4 バイトアライメント ---
-    int32_t list_number = 0;                     // 0 = 順序なし, >0 = 順序付きリスト番号
-    uint32_t alert_label_length = 0;             // ラベル部分の UTF-8 byte 長（描画エフェクト適用範囲）
     uint32_t source_offset = kUnsetSourceOffset; // ソーステキスト内の UTF-8 byte オフセット (view モード時は view 開始位置)
     int32_t blockquote_group = -1;               // 最外側 blockquote 単位のグループID（ネストしてもgroupは共有）
     int32_t line_count = 0;                      // テキスト内の改行数（パース時にカウント済み）
@@ -201,12 +224,9 @@ struct Node {
 
     // --- 1 バイトアライメント ---
     NodeType type = NodeType::Paragraph;
-    bool task_checked = false;
-    AlertType alert_type = AlertType::None;
-    SyntaxLanguage code_language = SyntaxLanguage::None;
+    AlertType alert_type = AlertType::None;        // 同一 blockquote_group 内で伝播するため直下に残す
     int8_t quote_depth = 0;        // 現在の blockquote ネスト深さ（0 = 引用外, 1.. = ネストレベル）
     int8_t quote_outer_indent = 0; // 最外側 blockquote が居る indent_level（バー位置の起点）
-    int8_t heading_level = 0;      // 1〜6（0 = 見出しでない）
     int8_t indent_level = 0;       // リスト/引用のネスト深さ（int8_t の最大値で飽和）
 
     constexpr bool IsViewMode() const noexcept
@@ -231,13 +251,15 @@ struct Node {
         return owned_text_;
     }
 
-    // テーブルは owned_text_ が空で線形化テキストを table_->concat_text に保持する。
+    // テーブルは owned_text_ が空で線形化テキストを table->concat_text に保持する。
     // HitTestTable / OnLButtonDblClk が返す text_pos も concat_text 内のグローバル offset
     // 体系で揃っているため、選択範囲を前提とする抽出側はこちらを使う。
     constexpr std::string_view LinearizedText() const noexcept
     {
-        if (type == NodeType::Table && table_) {
-            return table_->concat_text;
+        if (type == NodeType::Table) {
+            if (const auto* tbl = table_data()) {
+                return tbl->concat_text;
+            }
         }
         return GetText();
     }
@@ -290,14 +312,6 @@ struct Node {
 
     // get_if 風に *_data() でポインタを返す。所持していなければ nullptr。
     // C++23 deducing this で const/非 const を 1 つに集約。
-    constexpr auto* table_data(this auto& self) noexcept
-    {
-        return self.table_.get();
-    }
-    constexpr auto* image_data(this auto& self) noexcept
-    {
-        return self.image_.get();
-    }
     constexpr auto* heading_data(this auto& self) noexcept
     {
         return std::get_if<NodeHeadingData>(&self.extra);
@@ -306,15 +320,38 @@ struct Node {
     {
         return std::get_if<NodeCodeData>(&self.extra);
     }
+    constexpr auto* list_data(this auto& self) noexcept
+    {
+        return std::get_if<NodeListData>(&self.extra);
+    }
+    constexpr auto* alert_data(this auto& self) noexcept
+    {
+        return std::get_if<NodeAlertData>(&self.extra);
+    }
 
-    constexpr bool has_table() const noexcept
+    // table / image は variant に NodePtr (pmr_unique_ptr) を格納する形なので、
+    // alternative の存在 → 内部 unique_ptr の中身、と 2 段で取り出す。
+    constexpr NodeTableData* table_data() noexcept
     {
-        return static_cast<bool>(table_);
+        auto* p = std::get_if<NodeTablePtr>(&extra);
+        return p ? p->get() : nullptr;
     }
-    constexpr bool has_image() const noexcept
+    constexpr const NodeTableData* table_data() const noexcept
     {
-        return static_cast<bool>(image_);
+        const auto* p = std::get_if<NodeTablePtr>(&extra);
+        return p ? p->get() : nullptr;
     }
+    constexpr NodeImageData* image_data() noexcept
+    {
+        auto* p = std::get_if<NodeImagePtr>(&extra);
+        return p ? p->get() : nullptr;
+    }
+    constexpr const NodeImageData* image_data() const noexcept
+    {
+        const auto* p = std::get_if<NodeImagePtr>(&extra);
+        return p ? p->get() : nullptr;
+    }
+
     constexpr bool has_heading() const noexcept
     {
         return std::holds_alternative<NodeHeadingData>(extra);
@@ -323,41 +360,116 @@ struct Node {
     {
         return std::holds_alternative<NodeCodeData>(extra);
     }
+    constexpr bool has_list() const noexcept
+    {
+        return std::holds_alternative<NodeListData>(extra);
+    }
+    constexpr bool has_alert() const noexcept
+    {
+        return std::holds_alternative<NodeAlertData>(extra);
+    }
+    constexpr bool has_table() const noexcept
+    {
+        return std::holds_alternative<NodeTablePtr>(extra);
+    }
+    constexpr bool has_image() const noexcept
+    {
+        return std::holds_alternative<NodeImagePtr>(extra);
+    }
 
     // ensure_*: 既に存在すれば内部参照、無ければ新規確保して返す。
-    constexpr NodeTableData* ensure_table()
-    {
-        if (!table_) {
-            table_ = mendo::MakePmrUnique<NodeTableData>();
-        }
-        return table_.get();
-    }
-    constexpr NodeImageData* ensure_image()
-    {
-        if (!image_) {
-            image_ = mendo::MakePmrUnique<NodeImageData>();
-        }
-        return image_.get();
-    }
-    constexpr NodeHeadingData* ensure_heading()
+    // 既存 alternative がある状態で別種の ensure_* を呼ぶと、それは破棄される (variant の emplace 動作)。
+    // parser は BeginNode 直後に 1 種類だけ ensure する規約。
+    NodeHeadingData* ensure_heading()
     {
         if (!has_heading()) {
             return &extra.emplace<NodeHeadingData>();
         }
         return std::get_if<NodeHeadingData>(&extra);
     }
-    constexpr NodeCodeData* ensure_code()
+    NodeCodeData* ensure_code()
     {
         if (!has_code()) {
             return &extra.emplace<NodeCodeData>();
         }
         return std::get_if<NodeCodeData>(&extra);
     }
+    NodeListData* ensure_list()
+    {
+        if (!has_list()) {
+            return &extra.emplace<NodeListData>();
+        }
+        return std::get_if<NodeListData>(&extra);
+    }
+    NodeAlertData* ensure_alert()
+    {
+        if (!has_alert()) {
+            return &extra.emplace<NodeAlertData>();
+        }
+        return std::get_if<NodeAlertData>(&extra);
+    }
+    NodeTableData* ensure_table()
+    {
+        if (!has_table()) {
+            extra.emplace<NodeTablePtr>(mendo::MakePmrUnique<NodeTableData>());
+        }
+        return std::get_if<NodeTablePtr>(&extra)->get();
+    }
+    NodeImageData* ensure_image()
+    {
+        if (!has_image()) {
+            extra.emplace<NodeImagePtr>(mendo::MakePmrUnique<NodeImageData>());
+        }
+        return std::get_if<NodeImagePtr>(&extra)->get();
+    }
+
+    // 互換 inline getter: 旧メンバ直アクセスのコールサイトを 1 文字差分で置換可能にする。
+    // 該当 alternative を持たないノードではデフォルト値 (0 / None / false) を返す。
+    constexpr int8_t heading_level() const noexcept
+    {
+        const auto* hd = heading_data();
+        return hd ? hd->heading_level : static_cast<int8_t>(0);
+    }
+    constexpr SyntaxLanguage code_language() const noexcept
+    {
+        const auto* cd = code_data();
+        return cd ? cd->code_language : SyntaxLanguage::None;
+    }
+    constexpr int32_t list_number() const noexcept
+    {
+        const auto* ld = list_data();
+        return ld ? ld->list_number : 0;
+    }
+    constexpr bool task_checked() const noexcept
+    {
+        const auto* ld = list_data();
+        return ld && ld->task_checked;
+    }
+    constexpr uint32_t alert_label_length() const noexcept
+    {
+        const auto* ad = alert_data();
+        return ad ? ad->alert_label_length : 0u;
+    }
 
     constexpr std::string_view anchor_id() const noexcept
     {
         const auto* hd = heading_data();
-        return hd ? std::string_view{ hd->anchor_id } : std::string_view{};
+        if (hd && hd->anchor_id) {
+            return std::string_view{ *hd->anchor_id };
+        }
+        return std::string_view{};
+    }
+
+    // anchor_id は pmr_unique_ptr<pmr::string> で外出しされているため、書き込み時は
+    // ensure_heading() → pmr_unique_ptr の lazy 確保 → 内側 string の操作と 3 段になる。
+    // ホットパスではないが parser と test で 3 回繰り返したくないため helper に集約する。
+    std::pmr::string& ensure_anchor_id_mut()
+    {
+        auto* hd = ensure_heading();
+        if (!hd->anchor_id) {
+            hd->anchor_id = mendo::MakePmrUnique<std::pmr::string>();
+        }
+        return *hd->anchor_id;
     }
 
     constexpr std::pmr::vector<std::pmr::string>& ensure_link_urls()
@@ -374,15 +486,19 @@ struct Node {
 
     const std::pmr::vector<SyntaxToken>& syntax_tokens() const noexcept
     {
-        if (const auto* cd = code_data()) {
-            return cd->syntax_tokens;
+        if (const auto* cd = code_data(); cd && cd->tokens) {
+            return *cd->tokens;
         }
         static const std::pmr::vector<SyntaxToken> empty;
         return empty;
     }
-    constexpr std::pmr::vector<SyntaxToken>& syntax_tokens_mut() noexcept
+    std::pmr::vector<SyntaxToken>& syntax_tokens_mut() noexcept
     {
-        return ensure_code()->syntax_tokens;
+        auto* cd = ensure_code();
+        if (!cd->tokens) {
+            cd->tokens = mendo::MakePmrUnique<std::pmr::vector<SyntaxToken>>();
+        }
+        return *cd->tokens;
     }
 
 private:
@@ -394,8 +510,12 @@ private:
     }
 };
 
+// 将来の小フィールド追加用に 8B の余裕を持たせた上限。超過時は variant alternative の
+// サイズ再分配または TextRunList の SBO 値を再検討する。
+static_assert(sizeof(Node) <= 152, "Node size regression: exceeded 152 bytes");
+
 // CodeBlock かつ非 Diagram 言語。ブロック横スクロール対象判定で頻出する組合せ。
 constexpr bool IsScrollableCodeBlock(const Node& node) noexcept
 {
-    return node.type == NodeType::CodeBlock && !IsDiagramLanguage(node.code_language);
+    return node.type == NodeType::CodeBlock && !IsDiagramLanguage(node.code_language());
 }

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cassert>
 #include <string>
 #include <string_view>
 #include <span>
@@ -381,7 +382,11 @@ struct Node {
     NodeImageData* ensure_image() { return EnsurePtrAlt<NodeImagePtr>(); }
 
     // 該当 alternative を持たないノードでは黙ってデフォルト値 (0 / None / false) を返す。
-    // 呼び出し側は必要に応じて type を先に判定すること (Heading 以外で heading_level() が 0 を返すなど)。
+    //
+    // 規約: ホットパス (全 Node ループ等) では `node.type == NodeType::X && node.foo()` の順で短絡評価し、
+    //       variant タグ比較を skip すること。例: `node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language())`、
+    //       `node.alert_type != AlertType::None && node.alert_label_length() > 0`。
+    //       新規アクセサを追加する場合もこの規約に倣い、type で先にゲートできる呼び出し側を維持する。
     constexpr int8_t heading_level() const noexcept
     {
         const auto* hd = heading_data();
@@ -465,12 +470,17 @@ private:
         view_base_ = nullptr;
     }
 
+    // parser 契約: BeginNode 直後の Node は monostate で、対応する 1 種類だけが ensure される。
+    // 異種 alternative を保持した状態で別種を ensure すると元データはサイレントに破棄されるため、
+    // Debug ビルドでは契約違反を assert で捕捉する (Release では noop)。
     template <class T>
     T* EnsureAlt()
     {
         if (auto* p = std::get_if<T>(&extra)) {
             return p;
         }
+        assert(std::holds_alternative<std::monostate>(extra) &&
+               "ensure_*<T>: Node already holds a different alternative — parser contract violation");
         return &extra.emplace<T>();
     }
 
@@ -480,14 +490,20 @@ private:
         using T = typename Ptr::element_type;
         auto* p = std::get_if<Ptr>(&extra);
         if (!p) {
+            assert(std::holds_alternative<std::monostate>(extra) &&
+                   "ensure_*<Ptr>: Node already holds a different alternative — parser contract violation");
             p = &extra.emplace<Ptr>(mendo::MakePmrUnique<T>());
         }
         return p->get();
     }
 };
 
-// 超過時は variant alternative のサイズ再分配または TextRunList の SBO 値を再検討する。
-static_assert(sizeof(Node) <= 144, "Node size regression: exceeded 144 bytes");
+// 超過時の対処: (1) `sizeof(Node)` の実際の値を確認 (例: /d1reportSingleClassLayoutNode)、
+// (2) variant alternative のうち最大のものを pmr_unique_ptr 経由で外出し、または
+// (3) TextRunList の SBO 値を再検討。閾値変更は ViewStats.RunsSizeHistogram* の実測も併せて確認。
+// 注意: variant の discriminator パディングは std lib 実装依存なので、ツールチェーン切替時にも踏む可能性あり。
+static_assert(sizeof(Node) <= 144,
+              "Node size regression: exceeded 144 bytes — see comment above for remediation steps");
 
 // CodeBlock かつ非 Diagram 言語。ブロック横スクロール対象判定で頻出する組合せ。
 constexpr bool IsScrollableCodeBlock(const Node& node) noexcept

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -190,14 +190,13 @@ struct Node {
     // 外出しすることで variant alternative の最大サイズを 16B に抑える。
     // Parser invariant: 1 つのノードは 1 つの alternative しか持たない (ensure_* は他を破壊する)。
     using Extra = std::variant<
-        std::monostate,    // Paragraph / HorizontalRule など固有データ無し
-        NodeHeadingData,   // Heading
-        NodeCodeData,      // CodeBlock
-        NodeListData,      // ListItem / TaskListItem
-        NodeAlertData,     // BlockQuote 本体の alert ラベル
-        NodeTablePtr,      // Table
-        NodeImagePtr       // Image
-    >;
+        std::monostate,  // Paragraph / HorizontalRule など固有データ無し
+        NodeHeadingData, // Heading
+        NodeCodeData,    // CodeBlock
+        NodeListData,    // ListItem / TaskListItem
+        NodeAlertData,   // BlockQuote 本体の alert ラベル
+        NodeTablePtr,    // Table
+        NodeImagePtr>;   // Image
     Extra extra;
 
     // 表示テキストの owned バッファ。テキスト加工 (Alert / HTML entity / SOFTBR/BR / display math 昇格 / 表セル等)
@@ -218,10 +217,10 @@ struct Node {
 
     // --- 1 バイトアライメント ---
     NodeType type = NodeType::Paragraph;
-    AlertType alert_type = AlertType::None;        // 同一 blockquote_group 内で伝播するため直下に残す
-    int8_t quote_depth = 0;        // 現在の blockquote ネスト深さ（0 = 引用外, 1.. = ネストレベル）
-    int8_t quote_outer_indent = 0; // 最外側 blockquote が居る indent_level（バー位置の起点）
-    int8_t indent_level = 0;       // リスト/引用のネスト深さ（int8_t の最大値で飽和）
+    AlertType alert_type = AlertType::None; // 同一 blockquote_group 内で伝播するため直下に残す
+    int8_t quote_depth = 0;                 // 現在の blockquote ネスト深さ（0 = 引用外, 1.. = ネストレベル）
+    int8_t quote_outer_indent = 0;          // 最外側 blockquote が居る indent_level（バー位置の起点）
+    int8_t indent_level = 0;                // リスト/引用のネスト深さ（int8_t の最大値で飽和）
 
     constexpr bool IsViewMode() const noexcept
     {
@@ -374,12 +373,30 @@ struct Node {
     // ensure_*: 既に存在すれば内部参照、無ければ新規確保して返す。
     // 既存 alternative がある状態で別種の ensure_* を呼ぶと、それは破棄される (variant の emplace 動作)。
     // parser は BeginNode 直後に 1 種類だけ ensure する規約。
-    NodeHeadingData* ensure_heading() { return EnsureAlt<NodeHeadingData>(); }
-    NodeCodeData* ensure_code() { return EnsureAlt<NodeCodeData>(); }
-    NodeListData* ensure_list() { return EnsureAlt<NodeListData>(); }
-    NodeAlertData* ensure_alert() { return EnsureAlt<NodeAlertData>(); }
-    NodeTableData* ensure_table() { return EnsurePtrAlt<NodeTablePtr>(); }
-    NodeImageData* ensure_image() { return EnsurePtrAlt<NodeImagePtr>(); }
+    NodeHeadingData* ensure_heading()
+    {
+        return EnsureAlt<NodeHeadingData>();
+    }
+    NodeCodeData* ensure_code()
+    {
+        return EnsureAlt<NodeCodeData>();
+    }
+    NodeListData* ensure_list()
+    {
+        return EnsureAlt<NodeListData>();
+    }
+    NodeAlertData* ensure_alert()
+    {
+        return EnsureAlt<NodeAlertData>();
+    }
+    NodeTableData* ensure_table()
+    {
+        return EnsurePtrAlt<NodeTablePtr>();
+    }
+    NodeImageData* ensure_image()
+    {
+        return EnsurePtrAlt<NodeImagePtr>();
+    }
 
     // 該当 alternative を持たないノードでは黙ってデフォルト値 (0 / None / false) を返す。
     //

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -141,33 +141,29 @@ struct NodeTableData {
     }
 };
 
-// Heading 固有データ。anchor_id は外部 heap 持ちで variant alternative サイズを 16B に抑える。
-// 持たない alternative (Paragraph 等) では確保しないため、Heading 以外でのオーバーヘッドは無い。
+// Heading 固有データ。anchor_id は外部 heap 持ちにすることで variant alternative を 16B に抑える。
 struct NodeHeadingData {
     mendo::pmr_unique_ptr<std::pmr::string> anchor_id;
     int8_t heading_level = 0;
 };
 
-// CodeBlock 固有データ。tokens は外部 heap 持ちで variant alternative サイズを 16B に抑える。
+// CodeBlock 固有データ。tokens は外部 heap 持ちにすることで variant alternative を 16B に抑える。
 struct NodeCodeData {
     mendo::pmr_unique_ptr<std::pmr::vector<SyntaxToken>> tokens;
     SyntaxLanguage code_language = SyntaxLanguage::None;
 };
 
-// ListItem / TaskListItem 固有データ。
 struct NodeListData {
     int32_t list_number = 0;   // 0 = 順序なし, >0 = 順序付きリスト番号
     bool task_checked = false; // TaskListItem のときのみ意味を持つ
 };
 
-// BlockQuote 本体の alert 情報。alert_type は同一 blockquote_group の後続ノードにも
-// 伝播するため Node 直下に置く (parser.cpp:DetectAlertAt 参照)。
-// alert_label_length は BlockQuote 本体だけが持つラベル長で variant 内に閉じ込められる。
+// alert_type は同一 blockquote_group の後続ノードにも伝播するため Node 直下に置く
+// (parser.cpp:DetectAlertAt 参照)。alert_label_length は BlockQuote 本体専用なので variant 内。
 struct NodeAlertData {
     uint32_t alert_label_length = 0;
 };
 
-// Tableノードのみが確保。pmr_unique_ptr の単独 alternative として variant に乗せる。
 using NodeTablePtr = mendo::pmr_unique_ptr<NodeTableData>;
 
 struct NodeImageData {
@@ -189,11 +185,8 @@ struct Node {
     // 全体の少数派 (見出し/段落の一部) なので、空時は 8B ポインタ 1 本に抑える。
     mendo::pmr_unique_ptr<std::pmr::vector<std::pmr::string>> link_urls_;
 
-    // ノード種別ごとの拡張データ。variant alternative ごとに 16B 以下に抑えてあり、
-    // 上限 16B + tag 8B = 24B で Node 全体のサイズを支配しない。
-    //   - 重データ (anchor_id / tokens / table / image) は pmr_unique_ptr で外出し
-    //   - 小スカラ (heading_level / code_language / list_number / alert_label_length / task_checked)
-    //     は NodeType に対応した alternative 内にまとめる
+    // ノード種別ごとの拡張データ。重データ (anchor_id / tokens / table / image) は pmr_unique_ptr で
+    // 外出しすることで variant alternative の最大サイズを 16B に抑える。
     // Parser invariant: 1 つのノードは 1 つの alternative しか持たない (ensure_* は他を破壊する)。
     using Extra = std::variant<
         std::monostate,    // Paragraph / HorizontalRule など固有データ無し
@@ -380,51 +373,15 @@ struct Node {
     // ensure_*: 既に存在すれば内部参照、無ければ新規確保して返す。
     // 既存 alternative がある状態で別種の ensure_* を呼ぶと、それは破棄される (variant の emplace 動作)。
     // parser は BeginNode 直後に 1 種類だけ ensure する規約。
-    NodeHeadingData* ensure_heading()
-    {
-        if (!has_heading()) {
-            return &extra.emplace<NodeHeadingData>();
-        }
-        return std::get_if<NodeHeadingData>(&extra);
-    }
-    NodeCodeData* ensure_code()
-    {
-        if (!has_code()) {
-            return &extra.emplace<NodeCodeData>();
-        }
-        return std::get_if<NodeCodeData>(&extra);
-    }
-    NodeListData* ensure_list()
-    {
-        if (!has_list()) {
-            return &extra.emplace<NodeListData>();
-        }
-        return std::get_if<NodeListData>(&extra);
-    }
-    NodeAlertData* ensure_alert()
-    {
-        if (!has_alert()) {
-            return &extra.emplace<NodeAlertData>();
-        }
-        return std::get_if<NodeAlertData>(&extra);
-    }
-    NodeTableData* ensure_table()
-    {
-        if (!has_table()) {
-            extra.emplace<NodeTablePtr>(mendo::MakePmrUnique<NodeTableData>());
-        }
-        return std::get_if<NodeTablePtr>(&extra)->get();
-    }
-    NodeImageData* ensure_image()
-    {
-        if (!has_image()) {
-            extra.emplace<NodeImagePtr>(mendo::MakePmrUnique<NodeImageData>());
-        }
-        return std::get_if<NodeImagePtr>(&extra)->get();
-    }
+    NodeHeadingData* ensure_heading() { return EnsureAlt<NodeHeadingData>(); }
+    NodeCodeData* ensure_code() { return EnsureAlt<NodeCodeData>(); }
+    NodeListData* ensure_list() { return EnsureAlt<NodeListData>(); }
+    NodeAlertData* ensure_alert() { return EnsureAlt<NodeAlertData>(); }
+    NodeTableData* ensure_table() { return EnsurePtrAlt<NodeTablePtr>(); }
+    NodeImageData* ensure_image() { return EnsurePtrAlt<NodeImagePtr>(); }
 
-    // 互換 inline getter: 旧メンバ直アクセスのコールサイトを 1 文字差分で置換可能にする。
-    // 該当 alternative を持たないノードではデフォルト値 (0 / None / false) を返す。
+    // 該当 alternative を持たないノードでは黙ってデフォルト値 (0 / None / false) を返す。
+    // 呼び出し側は必要に応じて type を先に判定すること (Heading 以外で heading_level() が 0 を返すなど)。
     constexpr int8_t heading_level() const noexcept
     {
         const auto* hd = heading_data();
@@ -460,9 +417,8 @@ struct Node {
         return std::string_view{};
     }
 
-    // anchor_id は pmr_unique_ptr<pmr::string> で外出しされているため、書き込み時は
-    // ensure_heading() → pmr_unique_ptr の lazy 確保 → 内側 string の操作と 3 段になる。
-    // ホットパスではないが parser と test で 3 回繰り返したくないため helper に集約する。
+    // anchor_id は pmr_unique_ptr<pmr::string> で外出しされているため書き込みが 3 段になる。
+    // parser と test での重複を避けるため helper に集約する。
     std::pmr::string& ensure_anchor_id_mut()
     {
         auto* hd = ensure_heading();
@@ -508,11 +464,30 @@ private:
         view_length = 0;
         view_base_ = nullptr;
     }
+
+    template <class T>
+    T* EnsureAlt()
+    {
+        if (auto* p = std::get_if<T>(&extra)) {
+            return p;
+        }
+        return &extra.emplace<T>();
+    }
+
+    template <class Ptr>
+    auto* EnsurePtrAlt()
+    {
+        using T = typename Ptr::element_type;
+        auto* p = std::get_if<Ptr>(&extra);
+        if (!p) {
+            p = &extra.emplace<Ptr>(mendo::MakePmrUnique<T>());
+        }
+        return p->get();
+    }
 };
 
-// 将来の小フィールド追加用に 8B の余裕を持たせた上限。超過時は variant alternative の
-// サイズ再分配または TextRunList の SBO 値を再検討する。
-static_assert(sizeof(Node) <= 152, "Node size regression: exceeded 152 bytes");
+// 超過時は variant alternative のサイズ再分配または TextRunList の SBO 値を再検討する。
+static_assert(sizeof(Node) <= 144, "Node size regression: exceeded 144 bytes");
 
 // CodeBlock かつ非 Diagram 言語。ブロック横スクロール対象判定で頻出する組合せ。
 constexpr bool IsScrollableCodeBlock(const Node& node) noexcept

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -394,17 +394,18 @@ int OnEnterBlock(MD_BLOCKTYPE type, void* detail, void* userdata)
 
     case MD_BLOCK_LI: {
         auto* const li = static_cast<MD_BLOCK_LI_DETAIL*>(detail);
-        if (li->is_task) {
-            ctx->BeginNode(NodeType::TaskListItem);
-            ctx->current_node->ensure_list()->task_checked = (li->task_mark == 'x' || li->task_mark == 'X');
-        }
-        else {
-            ctx->BeginNode(NodeType::ListItem);
-        }
-        if (!ctx->list_counter.empty()) {
-            const int counter = ctx->list_counter.back();
-            ctx->current_node->ensure_list()->list_number = counter;
+        const bool is_task = li->is_task;
+        ctx->BeginNode(is_task ? NodeType::TaskListItem : NodeType::ListItem);
+        // counter==0 (unordered list) かつ非 task のときは NodeListData を確保しない
+        // (デフォルト値 list_number=0 / task_checked=false が getter で返るため)。
+        const int counter = ctx->list_counter.empty() ? 0 : ctx->list_counter.back();
+        if (is_task || counter > 0) {
+            auto* ld = ctx->current_node->ensure_list();
+            if (is_task) {
+                ld->task_checked = (li->task_mark == 'x' || li->task_mark == 'X');
+            }
             if (counter > 0) {
+                ld->list_number = counter;
                 ctx->list_counter.back()++;
             }
         }

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -202,7 +202,7 @@ struct ParseContext {
             current_node->quote_depth = static_cast<int8_t>(std::min(blockquote_depth, kInt8Max));
             current_node->quote_outer_indent = static_cast<int8_t>(std::min(outermost_quote_indent, kInt8Max));
         }
-        // runs は SBO=4 で初期確保ゼロを狙う。reserve すると SBO の利点が消えるので呼ばない。
+        // runs は SBO 内で初期確保ゼロを狙う。reserve すると SBO の利点が消えるので呼ばない。
         node_source_offset_set = false;
         current_node_owned_only = false;
     }
@@ -323,7 +323,7 @@ constexpr bool TryPromoteParagraphToDisplayMath(ParseContext* ctx)
         return false;
     }
     node->type = NodeType::CodeBlock;
-    node->code_language = SyntaxLanguage::LatexMath;
+    node->ensure_code()->code_language = SyntaxLanguage::LatexMath;
     node->runs.clear();
     // current_text 経由で渡すと FinalizeCurrentNode で 2 回目のコピーが走るため、Node::text_ へ直接書く。
     node->SetTextWithLineCount(ctx->display_math_buf, ctx->display_math_newlines);
@@ -342,7 +342,7 @@ int OnEnterBlock(MD_BLOCKTYPE type, void* detail, void* userdata)
     case MD_BLOCK_H: {
         auto* const h = static_cast<MD_BLOCK_H_DETAIL*>(detail);
         ctx->BeginNode(NodeType::Heading);
-        ctx->current_node->heading_level = static_cast<int8_t>(h->level);
+        ctx->current_node->ensure_heading()->heading_level = static_cast<int8_t>(h->level);
         break;
     }
 
@@ -366,7 +366,7 @@ int OnEnterBlock(MD_BLOCKTYPE type, void* detail, void* userdata)
         ctx->BeginNode(NodeType::CodeBlock);
         auto* const code_detail = static_cast<MD_BLOCK_CODE_DETAIL*>(detail);
         if (code_detail && code_detail->lang.text && code_detail->lang.size > 0) {
-            ctx->current_node->code_language = DetectLanguage(std::string_view{ code_detail->lang.text, static_cast<size_t>(code_detail->lang.size) });
+            ctx->current_node->ensure_code()->code_language = DetectLanguage(std::string_view{ code_detail->lang.text, static_cast<size_t>(code_detail->lang.size) });
         }
         break;
     }
@@ -396,14 +396,14 @@ int OnEnterBlock(MD_BLOCKTYPE type, void* detail, void* userdata)
         auto* const li = static_cast<MD_BLOCK_LI_DETAIL*>(detail);
         if (li->is_task) {
             ctx->BeginNode(NodeType::TaskListItem);
-            ctx->current_node->task_checked = (li->task_mark == 'x' || li->task_mark == 'X');
+            ctx->current_node->ensure_list()->task_checked = (li->task_mark == 'x' || li->task_mark == 'X');
         }
         else {
             ctx->BeginNode(NodeType::ListItem);
         }
         if (!ctx->list_counter.empty()) {
             const int counter = ctx->list_counter.back();
-            ctx->current_node->list_number = counter;
+            ctx->current_node->ensure_list()->list_number = counter;
             if (counter > 0) {
                 ctx->list_counter.back()++;
             }
@@ -514,7 +514,7 @@ int OnLeaveBlock(MD_BLOCKTYPE type, void* /*detail*/, void* userdata)
                 }
             }
         }
-        if (cn && cn->code_language == SyntaxLanguage::Mermaid) {
+        if (cn && cn->code_language() == SyntaxLanguage::Mermaid) {
             ctx->diagram_indices.emplace_back(ctx->current_node_index);
         }
         break;
@@ -591,10 +591,10 @@ int OnLeaveBlock(MD_BLOCKTYPE type, void* /*detail*/, void* userdata)
             GenerateAnchorIdInto(cn->GetText(), base_id);
             auto [it, inserted] = ctx->anchor_counts.try_emplace(std::move(base_id), 0);
             const int count = it->second++;
-            auto* hd = cn->ensure_heading();
-            hd->anchor_id.assign(it->first.data(), it->first.size());
+            auto& aid = cn->ensure_anchor_id_mut();
+            aid.assign(it->first.data(), it->first.size());
             if (count > 0) {
-                std::format_to(std::back_inserter(hd->anchor_id), "-{}", count);
+                std::format_to(std::back_inserter(aid), "-{}", count);
             }
             ctx->heading_indices.emplace_back(ctx->current_node_index);
         }
@@ -1068,7 +1068,7 @@ void TransformAlertNode(Node& node, AlertType type, size_t marker_end)
     node.SetTextWithLineCount(std::move(new_text), new_line_count);
     node.runs = std::move(new_runs);
     node.alert_type = type;
-    node.alert_label_length = static_cast<uint32_t>(full_label_len);
+    node.ensure_alert()->alert_label_length = static_cast<uint32_t>(full_label_len);
 }
 
 // 単一の BlockQuote ノードに対して Alert マーカーを検出・適用し、

--- a/src/core/selection_html.cpp
+++ b/src/core/selection_html.cpp
@@ -499,7 +499,7 @@ constexpr bool IsListNode(const Node& n) noexcept
 
 constexpr bool IsOrderedList(const Node& n) noexcept
 {
-    return IsListNode(n) && n.list_number > 0;
+    return IsListNode(n) && n.list_number() > 0;
 }
 
 std::optional<std::pmr::string> FindLinkInRuns(std::span<const TextRun> runs, std::span<const std::pmr::string> link_urls, uint32_t pos)
@@ -605,7 +605,7 @@ std::pmr::string ExtractSelectedTextAsHtml(const std::pmr::vector<Node>& nodes, 
 
         switch (node.type) {
         case NodeType::Heading: {
-            const int level = std::clamp(static_cast<int>(node.heading_level), 1, 6);
+            const int level = std::clamp(static_cast<int>(node.heading_level()), 1, 6);
             AppendHeadingOpenTag(out, level);
             AppendNodeInlineHtml(out, node, start, end);
             AppendHeadingCloseTag(out, level);
@@ -630,7 +630,7 @@ std::pmr::string ExtractSelectedTextAsHtml(const std::pmr::vector<Node>& nodes, 
             out.append("</li>");
             break;
         case NodeType::TaskListItem:
-            out.append(node.task_checked ? "<li><input type=\"checkbox\" checked disabled> " : "<li><input type=\"checkbox\" disabled> ");
+            out.append(node.task_checked() ? "<li><input type=\"checkbox\" checked disabled> " : "<li><input type=\"checkbox\" disabled> ");
             AppendNodeInlineHtml(out, node, start, end);
             out.append("</li>");
             break;

--- a/src/core/toc.cpp
+++ b/src/core/toc.cpp
@@ -3,7 +3,7 @@
 
 void TableOfContents::AddEntry(const Node& node, int node_index)
 {
-    entries_.emplace_back(node_index, node.heading_level);
+    entries_.emplace_back(node_index, node.heading_level());
 }
 
 int TableOfContents::HitTest(float local_y, float item_height) const noexcept

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -288,7 +288,7 @@ HitTestService::CodeBlockButtonHit HitTestService::CodeBlockButtonsHitTest(const
         const float x = ctx.theme.margin_left + indent;
         const float w = ctx.content_width - indent;
         const float pad = ctx.theme.code_block_padding;
-        if (IsDiagramLanguage(node.code_language)) {
+        if (IsDiagramLanguage(node.code_language())) {
             const auto& diagram = ctx.cache.GetDiagram(i);
             if (diagram.bitmap) {
                 const auto bmp = MermaidBitmapRect(diagram.width, diagram.height, x, w, entry_text_top);
@@ -298,7 +298,7 @@ HitTestService::CodeBlockButtonHit HitTestService::CodeBlockButtonsHitTest(const
                         out.save_node = i;
                     }
                 }
-                if (out.svg_copy_node < 0 && IsSvgExportable(node.code_language)) {
+                if (out.svg_copy_node < 0 && IsSvgExportable(node.code_language())) {
                     const D2D1_RECT_F btn2 = OverlayButtonRect(bmp.right, bmp.top, std::to_underlying(DiagramButtonSlot::SvgCopy));
                     if (PointInRectInclusive(dip_x, dip_y, btn2)) {
                         out.svg_copy_node = i;

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -337,10 +337,8 @@ void DWriteTextMeasurer::MeasureNode(
     // コードブロックのシンタックストークン化をレイアウトパスで事前実行する。
     // 描画パス（ApplyNodeEffects）での遅延トークン化を排除し、フレーム落ちを防止する。
     if (node.type == NodeType::CodeBlock) {
-        const auto* cd = node.code_data();
-        const auto lang = cd ? cd->code_language : SyntaxLanguage::None;
-        const bool tokens_empty = !cd || !cd->tokens || cd->tokens->empty();
-        if (tokens_empty && lang != SyntaxLanguage::None && !IsDiagramLanguage(lang)) {
+        const auto lang = node.code_language();
+        if (lang != SyntaxLanguage::None && !IsDiagramLanguage(lang) && node.syntax_tokens().empty()) {
             if (tokens_out != nullptr) {
                 *tokens_out = Tokenize(text, lang);
             }

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -106,8 +106,9 @@ IDWriteTextFormat* DWriteTextMeasurer::GetTextFormat(const Node& node) const noe
         return fmt_code_.Get();
     }
     if (node.type == NodeType::Heading) {
-        if (node.heading_level >= 1 && node.heading_level <= 6) {
-            return fmt_h_[node.heading_level - 1].Get();
+        const int8_t lv = node.heading_level();
+        if (lv >= 1 && lv <= 6) {
+            return fmt_h_[lv - 1].Get();
         }
     }
     return fmt_body_.Get();
@@ -163,7 +164,6 @@ void DWriteTextMeasurer::ApplyRunFormatting(IDWriteTextLayout* layout, std::span
     if (runs.empty()) {
         return;
     }
-    MENDO_PROFILE("ApplyRunFormatting");
     const bool apply_code = (!node_type || *node_type != NodeType::CodeBlock);
     const bool apply_code_size = apply_code && (!node_type || *node_type != NodeType::Heading);
     const bool apply_link = !node_type;
@@ -236,7 +236,7 @@ void DWriteTextMeasurer::MeasureNode(
     }
 
     // ダイアグラム系コードブロック: ビットマップがレンダリングされるまでのプレースホルダー高さ
-    if (node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language)) {
+    if (node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language())) {
         if (entry.height <= 0) {
             entry.height = std::max(MIN_DIAGRAM_PLACEHOLDER_HEIGHT, theme_->font_size_body * 3.0f);
         }
@@ -315,7 +315,6 @@ void DWriteTextMeasurer::MeasureNode(
 
     ComPtr<IDWriteTextLayout> layout;
     const HRESULT hr = [&] {
-        MENDO_PROFILE("CreateTextLayout");
         return mendo::CreateDocTextLayout(dwrite_, wv, fmt, layout_width, dynamic_max_height, &layout);
     }();
     if (FAILED(hr)) {
@@ -327,7 +326,7 @@ void DWriteTextMeasurer::MeasureNode(
     // Alert ノードのアイコン文字のフォントウェイトを設定。
     // 6 種類のアイコンは UTF-16 で 1 code unit (BMP) または 2 code unit (Tip 💡 = U+1F4A1 サロゲートペア) と
     // コンパイル時に確定するため、対応表で済ませて WideViewForDWrite の構築を回避する。
-    if (node.type == NodeType::BlockQuote && node.alert_type != AlertType::None && node.alert_label_length > 0) {
+    if (node.type == NodeType::BlockQuote && node.alert_type != AlertType::None && node.alert_label_length() > 0) {
         const DWRITE_TEXT_RANGE icon_range{ 0, WideUnitCountForAlertIcon(node.alert_type) };
         layout->SetFontWeight(DWRITE_FONT_WEIGHT_NORMAL, icon_range);
     }
@@ -337,15 +336,17 @@ void DWriteTextMeasurer::MeasureNode(
 
     // コードブロックのシンタックストークン化をレイアウトパスで事前実行する。
     // 描画パス（ApplyNodeEffects）での遅延トークン化を排除し、フレーム落ちを防止する。
-    if (node.type == NodeType::CodeBlock && node.syntax_tokens().empty() &&
-        node.code_language != SyntaxLanguage::None &&
-        !IsDiagramLanguage(node.code_language)) {
-        MENDO_PROFILE("Tokenize");
-        if (tokens_out != nullptr) {
-            *tokens_out = Tokenize(text, node.code_language);
-        }
-        else {
-            node.syntax_tokens_mut() = Tokenize(text, node.code_language);
+    if (node.type == NodeType::CodeBlock) {
+        const auto* cd = node.code_data();
+        const auto lang = cd ? cd->code_language : SyntaxLanguage::None;
+        const bool tokens_empty = !cd || !cd->tokens || cd->tokens->empty();
+        if (tokens_empty && lang != SyntaxLanguage::None && !IsDiagramLanguage(lang)) {
+            if (tokens_out != nullptr) {
+                *tokens_out = Tokenize(text, lang);
+            }
+            else {
+                node.syntax_tokens_mut() = Tokenize(text, lang);
+            }
         }
     }
 
@@ -382,10 +383,7 @@ void DWriteTextMeasurer::MeasureTableCells(Node& node, NodeLayoutEntry& entry, s
             }
             const size_t ci = tl.CellIndex(r, c);
             const mendo::WideViewForDWrite wv{ text };
-            {
-                MENDO_PROFILE("CreateTextLayout.cell");
-                mendo::CreateDocTextLayout(dwrite_, wv, row_fmt, LAYOUT_INFINITY, LAYOUT_INFINITY, &tl.cell_layouts[ci]);
-            }
+            mendo::CreateDocTextLayout(dwrite_, wv, row_fmt, LAYOUT_INFINITY, LAYOUT_INFINITY, &tl.cell_layouts[ci]);
 
             if (tl.cell_layouts[ci]) {
                 ApplyRunFormatting(tl.cell_layouts[ci].Get(), tbl->GetCellRuns(r, c), wv, std::nullopt);
@@ -433,10 +431,7 @@ void DWriteTextMeasurer::RestoreNullCellLayouts(Node& node, NodeLayoutEntry& ent
                 continue;
             }
             const mendo::WideViewForDWrite wv{ text };
-            {
-                MENDO_PROFILE("CreateTextLayout.cell.restore");
-                mendo::CreateDocTextLayout(dwrite_, wv, row_fmt, LAYOUT_INFINITY, LAYOUT_INFINITY, &tl.cell_layouts[ci]);
-            }
+            mendo::CreateDocTextLayout(dwrite_, wv, row_fmt, LAYOUT_INFINITY, LAYOUT_INFINITY, &tl.cell_layouts[ci]);
             if (tl.cell_layouts[ci]) {
                 ApplyRunFormatting(tl.cell_layouts[ci].Get(), tbl->GetCellRuns(r, c), wv, std::nullopt);
             }
@@ -558,7 +553,7 @@ void DWriteTextMeasurer::FinalizeTableLayout(
 }
 
 void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float max_width,
-                                       MeasureViewportRange viewport) const
+                                      MeasureViewportRange viewport) const
 {
     MENDO_PROFILE("MeasureTable");
     if (!dwrite_ || !theme_) {

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -375,7 +375,7 @@ public:
     {
         const auto count = std::min(nodes.size(), diagrams_.size());
         for (const auto& [idx, node] : nodes | std::views::take(count) | std::views::enumerate) {
-            if (IsDiagramLanguage(node.code_language)) {
+            if (IsDiagramLanguage(node.code_language())) {
                 diagrams_[static_cast<size_t>(idx)].bitmap.Reset();
             }
         }

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -375,6 +375,11 @@ public:
     {
         const auto count = std::min(nodes.size(), diagrams_.size());
         for (const auto& [idx, node] : nodes | std::views::take(count) | std::views::enumerate) {
+            // 非 CodeBlock ノードに対する variant 検索 (code_language()) を避けるため
+            // type 比較で先にフィルタする。
+            if (node.type != NodeType::CodeBlock) {
+                continue;
+            }
             if (IsDiagramLanguage(node.code_language())) {
                 diagrams_[static_cast<size_t>(idx)].bitmap.Reset();
             }

--- a/src/layout/layout_computer.cpp
+++ b/src/layout/layout_computer.cpp
@@ -47,7 +47,7 @@ float GetSpacingBelow(const Node& node, const Theme& theme) noexcept
     switch (node.type) {
     case NodeType::Heading:
         // h1/h2 は下線を描くため、下線と次行の余白を確保すべく大きめの値を返す。
-        return (node.heading_level <= 2) ? theme.heading_spacing_below_h1h2 : theme.heading_spacing_below;
+        return (node.heading_level() <= 2) ? theme.heading_spacing_below_h1h2 : theme.heading_spacing_below;
     case NodeType::CodeBlock:
     case NodeType::Image:
         return theme.paragraph_spacing + theme.code_block_spacing_above;
@@ -99,7 +99,7 @@ float EstimateNodeHeight(const Node& node, const Theme& theme) noexcept
     const float line_height = theme.font_size_body * 1.5f;
     switch (node.type) {
     case NodeType::Heading: {
-        const int level = std::clamp(static_cast<int>(node.heading_level), 1, 6) - 1;
+        const int level = std::clamp(static_cast<int>(node.heading_level()), 1, 6) - 1;
         return theme.font_size_h[level] * 1.5f;
     }
     case NodeType::CodeBlock: {
@@ -163,7 +163,7 @@ bool EstimateInvisibleNodeHeight(const Node& node, NodeLayoutEntry& entry, const
     // ダイアグラム系コードブロックの高さは描画完了時にビットマップ実寸で確定する。
     // テキスト基準の EstimateNodeHeight で上書きすると描画時に bitmap が後続ノードへ
     // はみ出すため既存値を維持する。
-    if (node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language)) {
+    if (node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language())) {
         return false;
     }
     // 同じ幅での実測キャッシュがあればそれを使い、無ければ推定値で成長させる。

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -412,7 +412,7 @@ void MermaidRenderer::RequestRender(
     float max_width, bool dark_mode,
     Callback on_complete)
 {
-    if (!IsDiagramLanguage(node.code_language)) {
+    if (!IsDiagramLanguage(node.code_language())) {
         return;
     }
 
@@ -578,7 +578,7 @@ void MermaidRenderer::RenderInWorker(Worker& worker)
     std::pmr::wstring src_text_wide;
     string_convert::Utf8ToWide(src_node.GetText(), src_text_wide);
     const std::wstring_view src_text = src_text_wide;
-    if (src_node.code_language == SyntaxLanguage::LatexMath) {
+    if (src_node.code_language() == SyntaxLanguage::LatexMath) {
         code_storage = mermaid_util::BuildLatexFlowchartCode(src_text);
         code_view = code_storage;
     }

--- a/src/mermaid/mermaid_util.cpp
+++ b/src/mermaid/mermaid_util.cpp
@@ -248,7 +248,7 @@ uint64_t mermaid_util::NodeDiagramHash(const Node& node, float max_width, bool d
     // LatexMath を Mermaid とキャッシュ衝突させないためのソルト（任意の定数）。
     constexpr uint64_t LATEX_MATH_HASH_SALT = 0xA1B2C3D4E5F60718ULL;
     uint64_t h = HashCode(node.GetText(), max_width, dark_mode);
-    if (node.code_language == SyntaxLanguage::LatexMath) {
+    if (node.code_language() == SyntaxLanguage::LatexMath) {
         h ^= LATEX_MATH_HASH_SALT;
     }
     return h;
@@ -256,5 +256,5 @@ uint64_t mermaid_util::NodeDiagramHash(const Node& node, float max_width, bool d
 
 bool mermaid_lifecycle::ShouldTriggerInitForNode(const Node& node) noexcept
 {
-    return node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language);
+    return node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language());
 }

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -210,8 +210,11 @@ void CommandGenerator::GenerateNode(
 {
     // h1/h2は見出し下線がentry.heightの外に描画されるため、カリング境界を拡張する。
     float node_bottom = entry_text_top + entry.height;
-    if (node.type == NodeType::Heading && node.heading_level <= 2) {
-        node_bottom += theme_->heading_spacing_below_h1h2 * HEADING_UNDERLINE_OFFSET_RATIO + theme_->GetHeadingUnderlineThickness(node.heading_level);
+    if (node.type == NodeType::Heading) {
+        const int8_t lv = node.heading_level();
+        if (lv <= 2) {
+            node_bottom += theme_->heading_spacing_below_h1h2 * HEADING_UNDERLINE_OFFSET_RATIO + theme_->GetHeadingUnderlineThickness(lv);
+        }
     }
     if (node_bottom < fc.viewport_top || entry_text_top > fc.viewport_bottom) {
         return;
@@ -254,13 +257,14 @@ void CommandGenerator::GenerateNode(
         return;
     }
 
-    case NodeType::CodeBlock:
-        if (IsDiagramLanguage(node.code_language)) {
+    case NodeType::CodeBlock: {
+        const auto lang = node.code_language();
+        if (IsDiagramLanguage(lang)) {
             if (diagram.bitmap) {
                 const auto bmp = MermaidBitmapRect(diagram.width, diagram.height, x, cw, entry_text_top);
                 cmds.emplace_back(DrawBitmapCmd{ diagram.bitmap.Get(), bmp });
                 GenSaveButton(cmds, bmp.right, bmp.top, node_index == fc.hovered.save);
-                if (IsSvgExportable(node.code_language)) {
+                if (IsSvgExportable(lang)) {
                     GenSvgCopyButton(cmds, bmp.right, bmp.top, node_index == fc.hovered.svg_copy);
                 }
             }
@@ -287,6 +291,7 @@ void CommandGenerator::GenerateNode(
         }
         GenCopyButton(cmds, entry, x, cw, node_index == fc.hovered.copy, entry_text_top);
         return;
+    }
 
     case NodeType::ListItem:
         GenListBullet(cmds, fc, node, entry, x, entry_text_top);
@@ -299,14 +304,16 @@ void CommandGenerator::GenerateNode(
         // バーと背景はグループ単位で GenBlockQuoteGroupDecorations から描画済み
         break;
 
-    case NodeType::Heading:
-        if (node.heading_level <= 2) {
+    case NodeType::Heading: {
+        const int8_t lv = node.heading_level();
+        if (lv <= 2) {
             const float line_y = entry_text_top + entry.height + theme_->heading_spacing_below_h1h2 * HEADING_UNDERLINE_OFFSET_RATIO;
             cmds.emplace_back(DrawLineCmd{
                 D2D1::Point2F(x, line_y), D2D1::Point2F(x + cw, line_y),
-                theme_->hr_color, theme_->GetHeadingUnderlineThickness(node.heading_level), BrushId::Hr });
+                theme_->hr_color, theme_->GetHeadingUnderlineThickness(lv), BrushId::Hr });
         }
         break;
+    }
 
     case NodeType::Paragraph:
         break;
@@ -371,7 +378,7 @@ void CommandGenerator::GenNodeTextDecorations(DrawCommandList& cmds, const Frame
     cmds.emplace_back(DrawTextLayoutCmd{ D2D1::Point2F(text_x, entry_text_top), entry.text_layout.Get(), base_color, base_brush });
 
     if (node.type == NodeType::TaskListItem && formats_.icon_font) {
-        const wchar_t icon = node.task_checked ? L'\u2611' : L'\u2610'; // ☑ / ☐
+        const wchar_t icon = node.task_checked() ? L'\u2611' : L'\u2610'; // ☑ / ☐
         const float icon_size = theme_->font_size_body;
         const float cb_x = x - theme_->list_bullet_offset;
         cmds.emplace_back(MakeTextCmd(
@@ -471,11 +478,11 @@ void CommandGenerator::GenOverlayButton(DrawCommandList& cmds, D2D1_RECT_F btn, 
 
 void CommandGenerator::GenListBullet(DrawCommandList& cmds, const FrameContext& fc, const Node& node, const NodeLayoutEntry& entry, float x, float entry_text_top)
 {
-    if (node.list_number > 0) {
+    if (const int32_t num = node.list_number(); num > 0) {
         if (formats_.list_number) {
             const float first_line_h = GetFirstLineHeight(entry, theme_->font_size_body);
             wchar_t num_buf[16];
-            const auto fmt_result = std::format_to_n(num_buf, std::size(num_buf), L"{}.", node.list_number);
+            const auto fmt_result = std::format_to_n(num_buf, std::size(num_buf), L"{}.", num);
             const size_t num_len = std::min(static_cast<size_t>(fmt_result.size), std::size(num_buf));
             const D2D1_RECT_F num_rect = D2D1::RectF(
                 x - theme_->list_bullet_offset - LIST_NUMBER_PAD_RIGHT,

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -335,7 +335,7 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float entry_
         flush();
     }
 
-    if (node.type == NodeType::BlockQuote && node.alert_type != AlertType::None && node.alert_label_length > 0) {
+    if (node.type == NodeType::BlockQuote && node.alert_type != AlertType::None && node.alert_label_length() > 0) {
         static constexpr BrushId ALERT_BRUSH[] = {
             BrushId::AlertNote,
             BrushId::AlertTip,
@@ -346,7 +346,7 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float entry_
         static_assert(std::size(ALERT_BRUSH) == ALERT_TYPE_COUNT);
         const auto idx = AlertColorIndex(node.alert_type);
         if (idx < ALERT_TYPE_COUNT) {
-            const auto range = wv.WideRange(0, node.alert_label_length);
+            const auto range = wv.WideRange(0, node.alert_label_length());
             entry.text_layout->SetDrawingEffect(Brush(ALERT_BRUSH[idx]), range);
             MENDO_COUNT_INC(g_effect_stats.set_drawing_effect);
         }

--- a/src/ui/search_state.cpp
+++ b/src/ui/search_state.cpp
@@ -47,7 +47,7 @@ void SearchState::ExecuteSearch(const std::pmr::vector<Node>& nodes)
         else if (const auto& text = node.GetText(); !text.empty()) {
             // ビットマップ描画ノードはテキストハイライト不可のため検索対象外
             if (node.type == NodeType::Image ||
-                (node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language))) {
+                (node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language()))) {
                 continue;
             }
             const auto search_text = case_sensitive_ ? text : lower_cache_.GetText(i);
@@ -96,7 +96,7 @@ void SearchState::EnsureLowercaseCache(const std::pmr::vector<Node>& nodes)
             table.offsets.assign(tbl->cell_text_starts.begin(), tbl->cell_text_starts.end());
             lower_cache_.tables.emplace(static_cast<int>(i), std::move(table));
         }
-        else if (node.type == NodeType::Image || (node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language))) {
+        else if (node.type == NodeType::Image || (node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language()))) {
             // 検索対象外ノードは空スライス
             lower_cache_.offsets.push_back(static_cast<uint32_t>(lower_cache_.buffer.size()));
         }

--- a/tests/mock_text_measurer.h
+++ b/tests/mock_text_measurer.h
@@ -33,7 +33,7 @@ public:
         }
 
         // ダイアグラム系コードブロック: 実装と同じく既存の高さを保持する
-        if (node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language)) {
+        if (node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language())) {
             if (entry.height <= 0) {
                 entry.height = 60.0f; // プレースホルダー高さ
             }

--- a/tests/test_copy_button.cpp
+++ b/tests/test_copy_button.cpp
@@ -150,7 +150,7 @@ TEST_F(CopyButtonTest, LatexMathBlockReturnsNegative)
     int latex_idx = -1;
     for (size_t i = 0; i < pr.nodes.size(); i++) {
         if (pr.nodes[i].type == NodeType::CodeBlock &&
-            pr.nodes[i].code_language == SyntaxLanguage::LatexMath) {
+            pr.nodes[i].code_language() == SyntaxLanguage::LatexMath) {
             latex_idx = static_cast<int>(i);
             break;
         }

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -304,7 +304,7 @@ TEST(DocumentTest, BuildIndicesDiagramNodes)
     EXPECT_EQ(diagrams.size(), 1u);
     // cppコードブロックはダイアグラムインデックスに含まれない
     const auto& nodes = doc.GetNodes();
-    EXPECT_EQ(nodes[diagrams[0]].code_language, SyntaxLanguage::Mermaid);
+    EXPECT_EQ(nodes[diagrams[0]].code_language(), SyntaxLanguage::Mermaid);
 }
 
 TEST(DocumentTest, BuildIndicesTocAndAnchorConsistent)

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -1119,14 +1119,12 @@ TEST(FindAnchorNodeIndex, DuplicateAnchors)
 
     Node h1;
     h1.type = NodeType::Heading;
-    h1.ensure_heading();
-    h1.heading_data()->anchor_id = "title";
+    h1.ensure_anchor_id_mut() = "title";
     nodes.emplace_back(std::move(h1));
 
     Node h2;
     h2.type = NodeType::Heading;
-    h2.ensure_heading();
-    h2.heading_data()->anchor_id = "title-1";
+    h2.ensure_anchor_id_mut() = "title-1";
     nodes.emplace_back(std::move(h2));
 
     // 最初のマッチが優先される

--- a/tests/test_hit_test_service.cpp
+++ b/tests/test_hit_test_service.cpp
@@ -330,7 +330,7 @@ TEST_F(HitTestServiceTest, SaveButton_DiagramWithoutBitmapReturnsNegative)
     int mermaid_idx = -1;
     for (size_t i = 0; i < pr.nodes.size(); ++i) {
         if (pr.nodes[i].type == NodeType::CodeBlock &&
-            IsDiagramLanguage(pr.nodes[i].code_language)) {
+            IsDiagramLanguage(pr.nodes[i].code_language())) {
             mermaid_idx = static_cast<int>(i);
             break;
         }

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -565,7 +565,7 @@ TEST(RecomputeYPositionsTest, HeadingSpacing)
 
     Node heading;
     heading.type = NodeType::Heading;
-    heading.heading_level = 3; // h3はheading_spacing_below（下線なし）を使う
+    heading.ensure_heading()->heading_level = 3; // h3はheading_spacing_below（下線なし）を使う
 
     Node para2;
     para2.type = NodeType::Paragraph;
@@ -603,14 +603,14 @@ TEST(RecomputeYPositionsTest, H1H2UseLargerSpacingBelow)
     // h3以降は heading_spacing_below が使われることを検証する。
     Node h1;
     h1.type = NodeType::Heading;
-    h1.heading_level = 1;
+    h1.ensure_heading()->heading_level = 1;
 
     Node p1;
     p1.type = NodeType::Paragraph;
 
     Node h3;
     h3.type = NodeType::Heading;
-    h3.heading_level = 3;
+    h3.ensure_heading()->heading_level = 3;
 
     Node p2;
     p2.type = NodeType::Paragraph;
@@ -871,11 +871,11 @@ TEST(RecomputeYPositionsTest, MultipleHeadingsHaveCorrectSpacing)
     Theme theme = GetLightTheme();
     Node heading_a;
     heading_a.type = NodeType::Heading;
-    heading_a.heading_level = 3;
+    heading_a.ensure_heading()->heading_level = 3;
 
     Node heading_b;
     heading_b.type = NodeType::Heading;
-    heading_b.heading_level = 3;
+    heading_b.ensure_heading()->heading_level = 3;
 
     std::pmr::vector<Node> nodes;
     nodes.emplace_back(std::move(heading_a));
@@ -1323,12 +1323,12 @@ TEST(EstimateNodeHeightsTest, HeadingHeightScalesWithLevel)
     // H1とH3を推定して、H1の方が高いことを確認
     Node h1;
     h1.type = NodeType::Heading;
-    h1.heading_level = 1;
+    h1.ensure_heading()->heading_level = 1;
     h1.SetText("Title");
 
     Node h3;
     h3.type = NodeType::Heading;
-    h3.heading_level = 3;
+    h3.ensure_heading()->heading_level = 3;
     h3.SetText("Title");
 
     std::pmr::vector<Node> nodes;
@@ -1497,7 +1497,7 @@ TEST(EstimateNodeHeightsTest, AllNodeTypesProducePositiveHeight)
         n.type = type;
         n.SetText(text);
         if (type == NodeType::Heading) {
-            n.heading_level = 2;
+            n.ensure_heading()->heading_level = 2;
         }
         if (type == NodeType::Table) {
             n.ensure_table();
@@ -1597,7 +1597,7 @@ TEST(RecomputeYPositionsTest, DISABLED_BenchLargeDocument)
         switch (i % 5) {
         case 0:
             nodes[i].type = NodeType::Heading;
-            nodes[i].heading_level = 2;
+            nodes[i].ensure_heading()->heading_level = 2;
             break;
         case 1:
             nodes[i].type = NodeType::Paragraph;

--- a/tests/test_layout_cache.cpp
+++ b/tests/test_layout_cache.cpp
@@ -197,7 +197,7 @@ TEST(LayoutCacheTest, TextTopMatchesFenwickDerivedValue)
     std::pmr::vector<Node> nodes;
     nodes.resize(5);
     nodes[0].type = NodeType::Heading;
-    nodes[0].heading_level = 1;
+    nodes[0].ensure_heading()->heading_level = 1;
     nodes[1].type = NodeType::Paragraph;
     nodes[2].type = NodeType::CodeBlock;
     nodes[3].type = NodeType::ListItem;

--- a/tests/test_measurer_parity.cpp
+++ b/tests/test_measurer_parity.cpp
@@ -39,8 +39,12 @@ private:
     {
         Node n;
         n.type = src.type;
-        n.heading_level = src.heading_level;
-        n.code_language = src.code_language;
+        if (src.has_heading()) {
+            n.ensure_heading()->heading_level = src.heading_level();
+        }
+        if (src.has_code()) {
+            n.ensure_code()->code_language = src.code_language();
+        }
         if (!src.GetText().empty()) {
             n.SetText(src.GetText());
         }
@@ -106,7 +110,7 @@ TEST_F(MeasurerParityTest, DiagramCodeBlockUsesPlaceholderHeight)
 {
     Node node;
     node.type = NodeType::CodeBlock;
-    node.code_language = SyntaxLanguage::Mermaid;
+    node.ensure_code()->code_language = SyntaxLanguage::Mermaid;
     const auto h = MeasureBoth(node, 600.0f);
     EXPECT_GE(h.mock, 60.0f);
     EXPECT_GE(h.dwrite, 60.0f);
@@ -121,7 +125,7 @@ TEST_F(MeasurerParityTest, HeadingTallerThanParagraphInBoth)
 
     Node heading;
     heading.type = NodeType::Heading;
-    heading.heading_level = 1;
+    heading.ensure_heading()->heading_level = 1;
     heading.SetText("Sample text");
 
     const auto p = MeasureBoth(para, 600.0f);

--- a/tests/test_mermaid_lifecycle.cpp
+++ b/tests/test_mermaid_lifecycle.cpp
@@ -92,7 +92,7 @@ TEST(MermaidLifecycle, MermaidCodeBlockTriggersInit)
 {
     Node node;
     node.type = NodeType::CodeBlock;
-    node.code_language = SyntaxLanguage::Mermaid;
+    node.ensure_code()->code_language = SyntaxLanguage::Mermaid;
     EXPECT_TRUE(ShouldTriggerInitForNode(node));
 }
 
@@ -100,7 +100,7 @@ TEST(MermaidLifecycle, LatexMathCodeBlockTriggersInit)
 {
     Node node;
     node.type = NodeType::CodeBlock;
-    node.code_language = SyntaxLanguage::LatexMath;
+    node.ensure_code()->code_language = SyntaxLanguage::LatexMath;
     EXPECT_TRUE(ShouldTriggerInitForNode(node));
 }
 
@@ -108,7 +108,7 @@ TEST(MermaidLifecycle, CppCodeBlockDoesNotTriggerInit)
 {
     Node node;
     node.type = NodeType::CodeBlock;
-    node.code_language = SyntaxLanguage::Cpp;
+    node.ensure_code()->code_language = SyntaxLanguage::Cpp;
     EXPECT_FALSE(ShouldTriggerInitForNode(node));
 }
 
@@ -117,7 +117,7 @@ TEST(MermaidLifecycle, NonCodeBlockDoesNotTriggerInit)
     Node node;
     node.type = NodeType::Paragraph;
     // CodeBlock ではない場合、言語によらず false
-    node.code_language = SyntaxLanguage::Mermaid;
+    node.ensure_code()->code_language = SyntaxLanguage::Mermaid;
     EXPECT_FALSE(ShouldTriggerInitForNode(node));
 }
 
@@ -125,6 +125,6 @@ TEST(MermaidLifecycle, NoneLanguageCodeBlockDoesNotTriggerInit)
 {
     Node node;
     node.type = NodeType::CodeBlock;
-    node.code_language = SyntaxLanguage::None;
+    node.ensure_code()->code_language = SyntaxLanguage::None;
     EXPECT_FALSE(ShouldTriggerInitForNode(node));
 }

--- a/tests/test_parallel_measure_stress.cpp
+++ b/tests/test_parallel_measure_stress.cpp
@@ -37,7 +37,7 @@ Node MakeStressNode(size_t i, bool include_code_block)
 
     if (include_code_block && bucket < 2) {
         n.type = NodeType::CodeBlock;
-        n.code_language = SyntaxLanguage::Cpp;
+        n.ensure_code()->code_language = SyntaxLanguage::Cpp;
         std::string text = "int v_" + std::to_string(i) + " = 0;";
         n.SetText(text.c_str());
         return n;
@@ -55,7 +55,7 @@ Node MakeStressNode(size_t i, bool include_code_block)
     }
     if (bucket < 14) {
         n.type = NodeType::Heading;
-        n.heading_level = static_cast<int8_t>(1 + (i % 6));
+        n.ensure_heading()->heading_level = static_cast<int8_t>(1 + (i % 6));
         std::string text = "Heading " + std::to_string(i);
         n.SetText(text.c_str());
         return n;
@@ -122,7 +122,7 @@ public:
     {
         MockTextMeasurer::MeasureNode(node, entry, max_width, tokens_out, viewport);
 
-        if (node.type != NodeType::CodeBlock || IsDiagramLanguage(node.code_language)) {
+        if (node.type != NodeType::CodeBlock || IsDiagramLanguage(node.code_language())) {
             return;
         }
         const uint32_t seed = node.source_offset;

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -42,7 +42,7 @@ TEST(Parser, HeadingH1)
     auto nodes = ParseMarkdown("# Title").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Heading);
-    EXPECT_EQ(nodes[0].heading_level, 1);
+    EXPECT_EQ(nodes[0].heading_level(), 1);
     EXPECT_EQ(nodes[0].GetText(), "Title");
 }
 
@@ -50,7 +50,7 @@ TEST(Parser, HeadingH2)
 {
     auto nodes = ParseMarkdown("## Subtitle").nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].heading_level, 2);
+    EXPECT_EQ(nodes[0].heading_level(), 2);
 }
 
 TEST(Parser, HeadingH3ToH6)
@@ -60,7 +60,7 @@ TEST(Parser, HeadingH3ToH6)
         md += " Test";
         auto nodes = ParseMarkdown(md).nodes;
         ASSERT_EQ(nodes.size(), 1u) << "level=" << level;
-        EXPECT_EQ(nodes[0].heading_level, level) << "level=" << level;
+        EXPECT_EQ(nodes[0].heading_level(), level) << "level=" << level;
     }
 }
 
@@ -216,7 +216,7 @@ TEST(Parser, UnorderedList)
     ASSERT_EQ(nodes.size(), 3u);
     for (const auto& node : nodes) {
         EXPECT_EQ(node.type, NodeType::ListItem);
-        EXPECT_EQ(node.list_number, 0); // 順序なしリスト
+        EXPECT_EQ(node.list_number(), 0); // 順序なしリスト
     }
     EXPECT_EQ(nodes[0].GetText(), "item1");
     EXPECT_EQ(nodes[1].GetText(), "item2");
@@ -349,17 +349,17 @@ TEST(Parser, OrderedList)
     for (const auto& node : nodes) {
         EXPECT_EQ(node.type, NodeType::ListItem);
     }
-    EXPECT_EQ(nodes[0].list_number, 1);
-    EXPECT_EQ(nodes[1].list_number, 2);
-    EXPECT_EQ(nodes[2].list_number, 3);
+    EXPECT_EQ(nodes[0].list_number(), 1);
+    EXPECT_EQ(nodes[1].list_number(), 2);
+    EXPECT_EQ(nodes[2].list_number(), 3);
 }
 
 TEST(Parser, OrderedListStartsFromN)
 {
     auto nodes = ParseMarkdown("5. five\n6. six").nodes;
     ASSERT_EQ(nodes.size(), 2u);
-    EXPECT_EQ(nodes[0].list_number, 5);
-    EXPECT_EQ(nodes[1].list_number, 6);
+    EXPECT_EQ(nodes[0].list_number(), 5);
+    EXPECT_EQ(nodes[1].list_number(), 6);
 }
 
 TEST(Parser, ListIndentLevel)
@@ -376,7 +376,7 @@ TEST(Parser, TaskListChecked)
     auto nodes = ParseMarkdown("- [x] done").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::TaskListItem);
-    EXPECT_TRUE(nodes[0].task_checked);
+    EXPECT_TRUE(nodes[0].task_checked());
     EXPECT_EQ(nodes[0].GetText(), "done");
 }
 
@@ -385,14 +385,14 @@ TEST(Parser, TaskListUnchecked)
     auto nodes = ParseMarkdown("- [ ] todo").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::TaskListItem);
-    EXPECT_FALSE(nodes[0].task_checked);
+    EXPECT_FALSE(nodes[0].task_checked());
 }
 
 TEST(Parser, TaskListUpperX)
 {
     auto nodes = ParseMarkdown("- [X] also done").nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_TRUE(nodes[0].task_checked);
+    EXPECT_TRUE(nodes[0].task_checked());
 }
 
 // ---- 引用ブロック ----
@@ -652,9 +652,9 @@ TEST(Parser, NestedOrderedList)
 {
     auto nodes = ParseMarkdown("1. a\n   1. b\n      1. c").nodes;
     ASSERT_GE(nodes.size(), 3u);
-    EXPECT_EQ(nodes[0].list_number, 1);
-    EXPECT_EQ(nodes[1].list_number, 1);
-    EXPECT_EQ(nodes[2].list_number, 1);
+    EXPECT_EQ(nodes[0].list_number(), 1);
+    EXPECT_EQ(nodes[1].list_number(), 1);
+    EXPECT_EQ(nodes[2].list_number(), 1);
     EXPECT_LT(nodes[0].indent_level, nodes[1].indent_level);
 }
 
@@ -662,9 +662,9 @@ TEST(Parser, MixedListNesting)
 {
     auto nodes = ParseMarkdown("1. ordered\n   - unordered\n   - unordered2").nodes;
     ASSERT_GE(nodes.size(), 3u);
-    EXPECT_GT(nodes[0].list_number, 0);
-    EXPECT_EQ(nodes[1].list_number, 0);
-    EXPECT_EQ(nodes[2].list_number, 0);
+    EXPECT_GT(nodes[0].list_number(), 0);
+    EXPECT_EQ(nodes[1].list_number(), 0);
+    EXPECT_EQ(nodes[2].list_number(), 0);
 }
 
 // ---- 言語指定付きコードブロック ----
@@ -674,7 +674,7 @@ TEST(Parser, CodeBlockWithLanguage)
     auto nodes = ParseMarkdown("```cpp\nint x = 1;\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::CodeBlock);
-    EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Cpp);
+    EXPECT_EQ(nodes[0].code_language(), SyntaxLanguage::Cpp);
 }
 
 TEST(Parser, CodeBlockNoTrailingNewline)
@@ -954,7 +954,7 @@ TEST(Parser, MermaidCodeBlock)
     auto nodes = ParseMarkdown("```mermaid\ngraph TD;\n  A-->B;\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::CodeBlock);
-    EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Mermaid);
+    EXPECT_EQ(nodes[0].code_language(), SyntaxLanguage::Mermaid);
 }
 
 // ---- LaTeX display math ($$...$$) ----
@@ -964,7 +964,7 @@ TEST(Parser, LatexDisplayMathSingleLinePromotedToCodeBlock)
     auto result = ParseMarkdown("$$E = mc^2$$");
     ASSERT_EQ(result.nodes.size(), 1u);
     EXPECT_EQ(result.nodes[0].type, NodeType::CodeBlock);
-    EXPECT_EQ(result.nodes[0].code_language, SyntaxLanguage::LatexMath);
+    EXPECT_EQ(result.nodes[0].code_language(), SyntaxLanguage::LatexMath);
     EXPECT_EQ(result.nodes[0].GetText(), "E = mc^2");
     // diagram_indices に登録される（描画パイプラインに流すため）
     ASSERT_EQ(result.diagram_indices.size(), 1u);
@@ -977,7 +977,7 @@ TEST(Parser, LatexDisplayMathWithOtherContentFallsBackToText)
     auto nodes = ParseMarkdown("before $$x+y$$ after").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Paragraph);
-    EXPECT_NE(nodes[0].code_language, SyntaxLanguage::LatexMath);
+    EXPECT_NE(nodes[0].code_language(), SyntaxLanguage::LatexMath);
     // フォールバック時は $$ 区切りが復元されていること
     const std::string text(nodes[0].GetText());
     EXPECT_NE(text.find("$$x+y$$"), std::string::npos);
@@ -997,7 +997,7 @@ TEST(Parser, LatexInlineMathRemainsAsText)
     auto nodes = ParseMarkdown("value is $x$ here").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Paragraph);
-    EXPECT_NE(nodes[0].code_language, SyntaxLanguage::LatexMath);
+    EXPECT_NE(nodes[0].code_language(), SyntaxLanguage::LatexMath);
     const std::string text(nodes[0].GetText());
     EXPECT_NE(text.find("$x$"), std::string::npos);
 }
@@ -1018,7 +1018,7 @@ TEST(Parser, PlainDollarSignsNotMisdetectedAsMath)
     auto nodes = ParseMarkdown("The price is $5 or $10.").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Paragraph);
-    EXPECT_NE(nodes[0].code_language, SyntaxLanguage::LatexMath);
+    EXPECT_NE(nodes[0].code_language(), SyntaxLanguage::LatexMath);
     const std::string text(nodes[0].GetText());
     EXPECT_NE(text.find("$5"), std::string::npos);
     EXPECT_NE(text.find("$10"), std::string::npos);
@@ -1030,7 +1030,7 @@ TEST(Parser, LatexDisplayMathMultiline)
     auto result = ParseMarkdown("$$\nE = mc^2\n$$");
     ASSERT_EQ(result.nodes.size(), 1u);
     EXPECT_EQ(result.nodes[0].type, NodeType::CodeBlock);
-    EXPECT_EQ(result.nodes[0].code_language, SyntaxLanguage::LatexMath);
+    EXPECT_EQ(result.nodes[0].code_language(), SyntaxLanguage::LatexMath);
     // 中身に 'E = mc^2' が含まれること（md4c の改行扱いに依存するが、式本体は保持される）
     const auto& body = result.nodes[0].GetText();
     EXPECT_NE(body.find("E = mc^2"), std::string::npos);
@@ -1050,7 +1050,7 @@ TEST(Parser, LatexDisplayMathLineCountMatchesNewlines)
         auto result = ParseMarkdown(src);
         ASSERT_EQ(result.nodes.size(), 1u);
         ASSERT_EQ(result.nodes[0].type, NodeType::CodeBlock);
-        ASSERT_EQ(result.nodes[0].code_language, SyntaxLanguage::LatexMath);
+        ASSERT_EQ(result.nodes[0].code_language(), SyntaxLanguage::LatexMath);
         const auto text = result.nodes[0].GetText();
         const auto expected = static_cast<int>(std::ranges::count(text, '\n'));
         EXPECT_EQ(result.nodes[0].line_count, expected);
@@ -1064,7 +1064,7 @@ TEST(Parser, LatexDisplayMathSurroundingParagraphs)
     ASSERT_EQ(result.nodes.size(), 3u);
     EXPECT_EQ(result.nodes[0].type, NodeType::Paragraph);
     EXPECT_EQ(result.nodes[1].type, NodeType::CodeBlock);
-    EXPECT_EQ(result.nodes[1].code_language, SyntaxLanguage::LatexMath);
+    EXPECT_EQ(result.nodes[1].code_language(), SyntaxLanguage::LatexMath);
     EXPECT_EQ(result.nodes[1].GetText(), "E=mc^2");
     EXPECT_EQ(result.nodes[2].type, NodeType::Paragraph);
     ASSERT_EQ(result.diagram_indices.size(), 1u);
@@ -1178,7 +1178,7 @@ TEST(Parser, AlertLabelIsBold)
     // 最初のランはラベル部分で太字であるべき
     EXPECT_TRUE(nodes[0].runs[0].bold());
     EXPECT_EQ(nodes[0].runs[0].start, 0u);
-    EXPECT_EQ(nodes[0].runs[0].length, nodes[0].alert_label_length);
+    EXPECT_EQ(nodes[0].runs[0].length, nodes[0].alert_label_length());
 }
 
 TEST(Parser, AlertLabelLength)
@@ -1186,11 +1186,11 @@ TEST(Parser, AlertLabelLength)
     // alert_label_length は UTF-8 byte。ℹ (U+2139) は 3 byte、❗ (U+2757) も 3 byte。
     auto nodes = ParseMarkdown("> [!NOTE]\n> text").nodes;
     ASSERT_GE(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].alert_label_length, 8u); // ℹ 3 + ' ' 1 + "NOTE" 4
+    EXPECT_EQ(nodes[0].alert_label_length(), 8u); // ℹ 3 + ' ' 1 + "NOTE" 4
 
     auto nodes2 = ParseMarkdown("> [!IMPORTANT]\n> text").nodes;
     ASSERT_GE(nodes2.size(), 1u);
-    EXPECT_EQ(nodes2[0].alert_label_length, 13u); // ❗ 3 + ' ' 1 + "IMPORTANT" 9
+    EXPECT_EQ(nodes2[0].alert_label_length(), 13u); // ❗ 3 + ' ' 1 + "IMPORTANT" 9
 }
 
 TEST(Parser, AlertRunPositionsAreValid)
@@ -1224,7 +1224,7 @@ TEST(Parser, AlertOnlyFirstNodeHasLabel)
     // 最初のノードだけ alert_label_length > 0
     int label_count = 0;
     for (const auto& node : nodes) {
-        if (node.alert_label_length > 0)
+        if (node.alert_label_length() > 0)
             label_count++;
     }
     EXPECT_EQ(label_count, 1);
@@ -1236,7 +1236,7 @@ TEST(Parser, RegularBlockquoteUnaffected)
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::BlockQuote);
     EXPECT_EQ(nodes[0].alert_type, AlertType::None);
-    EXPECT_EQ(nodes[0].alert_label_length, 0u);
+    EXPECT_EQ(nodes[0].alert_label_length(), 0u);
     EXPECT_EQ(nodes[0].GetText(), "Just a normal quote");
 }
 
@@ -1301,7 +1301,7 @@ TEST(Parser, Alert_IgnoredWhenStartedInsideNestedBlockquote)
     for (const auto& n : nodes) {
         EXPECT_EQ(n.alert_type, AlertType::None)
             << "ネスト内の Alert マーカーは無効化される";
-        EXPECT_EQ(n.alert_label_length, 0u);
+        EXPECT_EQ(n.alert_label_length(), 0u);
     }
 }
 
@@ -1612,7 +1612,7 @@ TEST(Parser, SyntaxTokensEmptyAfterParse)
     auto nodes = ParseMarkdown("```cpp\nint x = 42;\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::CodeBlock);
-    EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Cpp);
+    EXPECT_EQ(nodes[0].code_language(), SyntaxLanguage::Cpp);
     // パース時にはトークン化されないことを確認（レンダラーで遅延実行）
     EXPECT_TRUE(nodes[0].syntax_tokens().empty());
 }
@@ -1621,7 +1621,7 @@ TEST(Parser, SyntaxTokensEmptyForMermaid)
 {
     auto nodes = ParseMarkdown("```mermaid\ngraph TD\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Mermaid);
+    EXPECT_EQ(nodes[0].code_language(), SyntaxLanguage::Mermaid);
     EXPECT_TRUE(nodes[0].syntax_tokens().empty());
 }
 

--- a/tests/test_search_state.cpp
+++ b/tests/test_search_state.cpp
@@ -524,7 +524,7 @@ TEST(SearchStateTest, MermaidCodeBlockExcludedFromSearch)
     std::pmr::vector<Node> nodes;
     Node mermaid;
     mermaid.type = NodeType::CodeBlock;
-    mermaid.code_language = SyntaxLanguage::Mermaid;
+    mermaid.ensure_code()->code_language = SyntaxLanguage::Mermaid;
     mermaid.SetText("graph TD; A-->B");
     nodes.push_back(std::move(mermaid));
     nodes.push_back(MakeTextNode("graph description"));
@@ -541,7 +541,7 @@ TEST(SearchStateTest, NonMermaidCodeBlockIncludedInSearch)
     std::pmr::vector<Node> nodes;
     Node code;
     code.type = NodeType::CodeBlock;
-    code.code_language = SyntaxLanguage::Cpp;
+    code.ensure_code()->code_language = SyntaxLanguage::Cpp;
     code.SetText("int main()");
     nodes.push_back(std::move(code));
     SearchState s;

--- a/tests/test_syntax.cpp
+++ b/tests/test_syntax.cpp
@@ -646,49 +646,49 @@ TEST(Syntax, ParserExtractsLanguageCpp)
     auto nodes = ParseMarkdown("```cpp\nint x = 1;\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::CodeBlock);
-    EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Cpp);
+    EXPECT_EQ(nodes[0].code_language(), SyntaxLanguage::Cpp);
 }
 
 TEST(Syntax, ParserExtractsLanguagePython)
 {
     auto nodes = ParseMarkdown("```python\ndef foo(): pass\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Python);
+    EXPECT_EQ(nodes[0].code_language(), SyntaxLanguage::Python);
 }
 
 TEST(Syntax, ParserExtractsLanguageJs)
 {
     auto nodes = ParseMarkdown("```js\nconst x = 1;\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::JavaScript);
+    EXPECT_EQ(nodes[0].code_language(), SyntaxLanguage::JavaScript);
 }
 
 TEST(Syntax, ParserNoLanguage)
 {
     auto nodes = ParseMarkdown("```\nplain code\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::None);
+    EXPECT_EQ(nodes[0].code_language(), SyntaxLanguage::None);
 }
 
 TEST(Syntax, ParserExtractsLanguageRust)
 {
     auto nodes = ParseMarkdown("```rust\nfn main() {}\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Rust);
+    EXPECT_EQ(nodes[0].code_language(), SyntaxLanguage::Rust);
 }
 
 TEST(Syntax, ParserUnknownLanguage)
 {
     auto nodes = ParseMarkdown("```java\nclass Main {}\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::None);
+    EXPECT_EQ(nodes[0].code_language(), SyntaxLanguage::None);
 }
 
 TEST(Syntax, ParserCaseInsensitiveLanguage)
 {
     auto nodes = ParseMarkdown("```CPP\nint x;\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Cpp);
+    EXPECT_EQ(nodes[0].code_language(), SyntaxLanguage::Cpp);
 }
 
 // ---- 追加エッジケース ----
@@ -1767,40 +1767,40 @@ TEST(Syntax, ParserExtractsLanguageGo)
 {
     auto nodes = ParseMarkdown("```go\nfunc main() {}\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Go);
+    EXPECT_EQ(nodes[0].code_language(), SyntaxLanguage::Go);
 }
 
 TEST(Syntax, ParserExtractsLanguageTs)
 {
     auto nodes = ParseMarkdown("```typescript\nconst x: number = 1;\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::TypeScript);
+    EXPECT_EQ(nodes[0].code_language(), SyntaxLanguage::TypeScript);
 }
 
 TEST(Syntax, ParserExtractsLanguageBash)
 {
     auto nodes = ParseMarkdown("```bash\necho hello\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Bash);
+    EXPECT_EQ(nodes[0].code_language(), SyntaxLanguage::Bash);
 }
 
 TEST(Syntax, ParserExtractsLanguagePwsh)
 {
     auto nodes = ParseMarkdown("```powershell\nWrite-Host hello\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::PowerShell);
+    EXPECT_EQ(nodes[0].code_language(), SyntaxLanguage::PowerShell);
 }
 
 TEST(Syntax, ParserExtractsLanguageCmd)
 {
     auto nodes = ParseMarkdown("```cmd\necho hello\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Cmd);
+    EXPECT_EQ(nodes[0].code_language(), SyntaxLanguage::Cmd);
 }
 
 TEST(Syntax, ParserExtractsLanguageJson)
 {
     auto nodes = ParseMarkdown("```json\n{\"k\": 1}\n```").nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].code_language, SyntaxLanguage::Json);
+    EXPECT_EQ(nodes[0].code_language(), SyntaxLanguage::Json);
 }

--- a/tests/test_text_measurer.cpp
+++ b/tests/test_text_measurer.cpp
@@ -252,7 +252,7 @@ TEST_F(MockLayoutTest, MermaidBlockGetsPlaceholderHeight)
     engine_.ComputeLayout(nodes, cache, 800.0f);
 
     for (size_t i = 0; i < nodes.size(); i++) {
-        if (nodes[i].code_language == SyntaxLanguage::Mermaid) {
+        if (nodes[i].code_language() == SyntaxLanguage::Mermaid) {
             EXPECT_GT(cache[i].height, 0.0f) << "Mermaidブロックのプレースホルダー高さは正であるべき";
             EXPECT_FALSE(cache[i].layout_dirty);
         }
@@ -269,7 +269,7 @@ TEST_F(MockLayoutTest, MermaidHeightPreservedAcrossLayoutCycles)
 
     // ビットマップレンダリング完了後の高さを模擬（300 DIP）
     for (size_t i = 0; i < nodes.size(); i++) {
-        if (nodes[i].code_language == SyntaxLanguage::Mermaid) {
+        if (nodes[i].code_language() == SyntaxLanguage::Mermaid) {
             cache[i].height = 300.0f; // ビットマップ描画サイズ
             cache.GetDiagram(i).width = 400.0f;
             cache.GetDiagram(i).height = 300.0f;
@@ -281,7 +281,7 @@ TEST_F(MockLayoutTest, MermaidHeightPreservedAcrossLayoutCycles)
     engine_.LayoutNodes(nodes, cache, 600.0f);
 
     for (size_t i = 0; i < nodes.size(); i++) {
-        if (nodes[i].code_language == SyntaxLanguage::Mermaid) {
+        if (nodes[i].code_language() == SyntaxLanguage::Mermaid) {
             EXPECT_FLOAT_EQ(cache[i].height, 300.0f)
                 << "Mermaidブロックの高さはレイアウト再計算後も保持されるべき";
             // ダイアグラムエントリも保持
@@ -302,7 +302,7 @@ TEST_F(MockLayoutTest, MermaidHeightPreservedAtZeroWidth)
 
     // ビットマップ描画後の高さを設定
     for (size_t i = 0; i < nodes.size(); i++) {
-        if (nodes[i].code_language == SyntaxLanguage::Mermaid) {
+        if (nodes[i].code_language() == SyntaxLanguage::Mermaid) {
             cache[i].height = 250.0f;
         }
     }
@@ -312,7 +312,7 @@ TEST_F(MockLayoutTest, MermaidHeightPreservedAtZeroWidth)
     engine_.LayoutNodes(nodes, cache, 0.0f);
 
     for (size_t i = 0; i < nodes.size(); i++) {
-        if (nodes[i].code_language == SyntaxLanguage::Mermaid) {
+        if (nodes[i].code_language() == SyntaxLanguage::Mermaid) {
             EXPECT_FLOAT_EQ(cache[i].height, 250.0f)
                 << "幅0でのレイアウトでもMermaidブロックの高さは保持されるべき";
         }
@@ -323,7 +323,7 @@ TEST_F(MockLayoutTest, MermaidHeightPreservedAtZeroWidth)
     engine_.LayoutNodes(nodes, cache, 800.0f);
 
     for (size_t i = 0; i < nodes.size(); i++) {
-        if (nodes[i].code_language == SyntaxLanguage::Mermaid) {
+        if (nodes[i].code_language() == SyntaxLanguage::Mermaid) {
             EXPECT_FLOAT_EQ(cache[i].height, 250.0f)
                 << "幅復帰後もMermaidブロックの高さは保持されるべき";
         }

--- a/tests/test_types.cpp
+++ b/tests/test_types.cpp
@@ -121,14 +121,14 @@ TEST(NodeTest, DefaultState)
 {
     Node node;
     EXPECT_EQ(node.type, NodeType::Paragraph);
-    EXPECT_EQ(node.heading_level, 0);
+    EXPECT_EQ(node.heading_level(), 0);
     EXPECT_EQ(node.indent_level, 0);
-    EXPECT_EQ(node.list_number, 0);
-    EXPECT_FALSE(node.task_checked);
+    EXPECT_EQ(node.list_number(), 0);
+    EXPECT_FALSE(node.task_checked());
     EXPECT_TRUE(node.GetText().empty());
     EXPECT_TRUE(node.runs.empty());
     EXPECT_TRUE(node.anchor_id().empty());
-    EXPECT_EQ(node.code_language, SyntaxLanguage::None);
+    EXPECT_EQ(node.code_language(), SyntaxLanguage::None);
     EXPECT_FALSE(node.has_table());
 }
 
@@ -516,8 +516,7 @@ TEST(NodeTest, AnchorIdWithoutHeadingData)
 TEST(NodeTest, AnchorIdWithHeadingData)
 {
     Node node;
-    node.ensure_heading();
-    node.heading_data()->anchor_id = "test-anchor";
+    node.ensure_anchor_id_mut() = "test-anchor";
     EXPECT_EQ(node.anchor_id(), "test-anchor");
 }
 
@@ -540,7 +539,7 @@ TEST(NodeTest, MermaidCodeBlockTextStored)
 {
     Node node;
     node.type = NodeType::CodeBlock;
-    node.code_language = SyntaxLanguage::Mermaid;
+    node.ensure_code()->code_language = SyntaxLanguage::Mermaid;
     node.SetText("graph TD;A-->B");
     EXPECT_EQ(node.GetText(), "graph TD;A-->B");
 }
@@ -549,7 +548,7 @@ TEST(NodeTest, LatexMathCodeBlockTextStored)
 {
     Node node;
     node.type = NodeType::CodeBlock;
-    node.code_language = SyntaxLanguage::LatexMath;
+    node.ensure_code()->code_language = SyntaxLanguage::LatexMath;
     node.SetText("E = mc^2");
     EXPECT_EQ(node.GetText(), "E = mc^2");
 }
@@ -558,7 +557,7 @@ TEST(NodeTest, NonDiagramCodeBlockTextStored)
 {
     Node node;
     node.type = NodeType::CodeBlock;
-    node.code_language = SyntaxLanguage::Cpp;
+    node.ensure_code()->code_language = SyntaxLanguage::Cpp;
     node.SetText("int main() { return 0; }");
     EXPECT_EQ(node.GetText(), "int main() { return 0; }");
 }
@@ -569,4 +568,75 @@ TEST(NodeTest, ParagraphTextStored)
     node.type = NodeType::Paragraph;
     node.SetText("paragraph content");
     EXPECT_EQ(node.GetText(), "paragraph content");
+}
+
+// variant alternative の排他性: 別種を ensure すると元のデータは破棄される。
+// parser は BeginNode 直後に 1 種類だけ ensure する契約だが、契約違反を回帰検出するためのテスト。
+TEST(NodeTest, EnsureCodeReplacesHeading)
+{
+    Node node;
+    node.ensure_heading()->heading_level = 3;
+    EXPECT_TRUE(node.has_heading());
+
+    node.ensure_code()->code_language = SyntaxLanguage::Cpp;
+    EXPECT_FALSE(node.has_heading());
+    EXPECT_TRUE(node.has_code());
+    EXPECT_EQ(node.heading_level(), 0);
+    EXPECT_EQ(node.code_language(), SyntaxLanguage::Cpp);
+}
+
+// ensure_table() は冪等で、連続呼出しで同じ NodeTableData ポインタを返す。
+TEST(NodeTest, EnsureTableIsIdempotent)
+{
+    Node node;
+    auto* tbl1 = node.ensure_table();
+    auto* tbl2 = node.ensure_table();
+    EXPECT_EQ(tbl1, tbl2);
+    EXPECT_TRUE(node.has_table());
+}
+
+// ensure_image() の冪等性。
+TEST(NodeTest, EnsureImageIsIdempotent)
+{
+    Node node;
+    auto* img1 = node.ensure_image();
+    auto* img2 = node.ensure_image();
+    EXPECT_EQ(img1, img2);
+    EXPECT_TRUE(node.has_image());
+}
+
+// alert_type は伝播ロジック (parser.cpp:DetectAlertAt) のため Node 直下に残し、
+// alert_label_length のみ alert_data に閉じ込めた。BlockQuote 本体は両方を持ち、
+// 伝播先ノードは alert_type のみで alert_data は不在のはず。
+TEST(NodeTest, AlertTypeAndDataAreIndependent)
+{
+    Node body;
+    body.type = NodeType::BlockQuote;
+    body.alert_type = AlertType::Warning;
+    body.ensure_alert()->alert_label_length = 8u;
+    EXPECT_EQ(body.alert_type, AlertType::Warning);
+    EXPECT_TRUE(body.has_alert());
+    EXPECT_EQ(body.alert_label_length(), 8u);
+
+    Node propagated;
+    propagated.type = NodeType::Paragraph;
+    propagated.alert_type = AlertType::Warning;
+    EXPECT_EQ(propagated.alert_type, AlertType::Warning);
+    EXPECT_FALSE(propagated.has_alert());
+    EXPECT_EQ(propagated.alert_label_length(), 0u);
+}
+
+// list_data の互換 getter: 持たないノードは task_checked=false, list_number=0。
+TEST(NodeTest, ListGettersDefaultsWhenNoData)
+{
+    Node node;
+    EXPECT_FALSE(node.has_list());
+    EXPECT_EQ(node.list_number(), 0);
+    EXPECT_FALSE(node.task_checked());
+
+    node.ensure_list()->list_number = 5;
+    node.ensure_list()->task_checked = true;
+    EXPECT_TRUE(node.has_list());
+    EXPECT_EQ(node.list_number(), 5);
+    EXPECT_TRUE(node.task_checked());
 }

--- a/tests/test_view_stats.cpp
+++ b/tests/test_view_stats.cpp
@@ -1,10 +1,15 @@
 #include <gtest/gtest.h>
 #include "document.h"
+#include <algorithm>
+#include <array>
 #include <chrono>
 #include <fstream>
 #include <iostream>
+#include <numeric>
+#include <ranges>
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -219,6 +224,179 @@ TEST(ViewStats, SimpleParagraphIsViewed)
             std::cout << "  paragraph is_view=" << n.IsViewMode()
                       << ", text.size()=" << n.GetText().size() << "\n";
         }
+    }
+}
+
+// Node::runs (small_vector<TextRun, N>) の SBO 値が妥当かを test.md で計測する。
+// 各ノードの runs.size() ヒストグラムと、SBO=1..8 での hit 率を出力する。
+TEST(ViewStats, RunsSizeHistogramTestMd)
+{
+    auto bytes = ReadFileBytes("example/test.md");
+    if (bytes.empty()) {
+        GTEST_SKIP() << "example/test.md not found";
+    }
+    auto doc = Document::FromMarkdown(std::move(bytes), L"test.md");
+
+    // 個別バケット (0..10) と 11+ ひとまとめ。
+    std::array<size_t, 12> buckets{};
+    size_t total = 0;
+    size_t total_runs = 0;
+    size_t max_runs = 0;
+    for (const auto& n : doc.GetNodes()) {
+        const auto sz = n.runs.size();
+        total++;
+        total_runs += sz;
+        max_runs = std::max(max_runs, static_cast<size_t>(sz));
+        const size_t idx = std::min<size_t>(sz, 11);
+        buckets[idx]++;
+    }
+
+    auto pct = [&](size_t n) {
+        return total > 0 ? (100.0 * n / total) : 0.0;
+    };
+
+    std::cout << "=== runs.size() histogram (test.md, all NodeTypes) ===\n";
+    std::cout << "  total nodes: " << total << ", total runs: " << total_runs
+              << ", avg: " << (total > 0 ? static_cast<double>(total_runs) / total : 0.0)
+              << ", max: " << max_runs << "\n";
+    for (size_t i = 0; i <= 10; ++i) {
+        std::cout << "  size=" << i << ": " << buckets[i] << " nodes (" << pct(buckets[i]) << "%)\n";
+    }
+    std::cout << "  size>=11: " << buckets[11] << " nodes (" << pct(buckets[11]) << "%)\n";
+
+    // SBO=N で SBO 内に収まるノード割合 (N 以下)
+    auto cumulative_le = [&](size_t n) {
+        size_t s = 0;
+        for (size_t i = 0; i <= std::min<size_t>(n, 11); ++i) {
+            s += buckets[i];
+        }
+        return s;
+    };
+    std::cout << "=== SBO hit rate (size <= N) ===\n";
+    for (size_t sbo : { 1u, 2u, 3u, 4u, 6u, 8u }) {
+        const size_t hit = cumulative_le(sbo);
+        std::cout << "  SBO=" << sbo << ": hit " << hit << " / " << total
+                  << " (" << pct(hit) << "%), miss " << (total - hit)
+                  << " (" << pct(total - hit) << "%)\n";
+    }
+
+    EXPECT_GT(total, 0u);
+}
+
+// runs を実際に使うノード型 (Heading/Paragraph/ListItem/BlockQuote/TaskListItem) に絞った
+// 分布。Table/Image/HR/CodeBlock は runs が常に空に近いので統計を歪める。
+TEST(ViewStats, RunsSizeHistogramTextNodesOnly)
+{
+    auto bytes = ReadFileBytes("example/test.md");
+    if (bytes.empty()) {
+        GTEST_SKIP() << "example/test.md not found";
+    }
+    auto doc = Document::FromMarkdown(std::move(bytes), L"test.md");
+
+    auto is_text_node = [](NodeType t) {
+        return t == NodeType::Heading || t == NodeType::Paragraph || t == NodeType::ListItem ||
+               t == NodeType::BlockQuote || t == NodeType::TaskListItem;
+    };
+
+    std::array<size_t, 12> buckets{};
+    size_t total = 0;
+    size_t total_runs = 0;
+    size_t max_runs = 0;
+    for (const auto& n : doc.GetNodes()) {
+        if (!is_text_node(n.type)) {
+            continue;
+        }
+        const auto sz = n.runs.size();
+        total++;
+        total_runs += sz;
+        max_runs = std::max(max_runs, static_cast<size_t>(sz));
+        const size_t idx = std::min<size_t>(sz, 11);
+        buckets[idx]++;
+    }
+
+    auto pct = [&](size_t n) {
+        return total > 0 ? (100.0 * n / total) : 0.0;
+    };
+
+    std::cout << "=== runs.size() histogram (test.md, text nodes only) ===\n";
+    std::cout << "  total text nodes: " << total << ", total runs: " << total_runs
+              << ", avg: " << (total > 0 ? static_cast<double>(total_runs) / total : 0.0)
+              << ", max: " << max_runs << "\n";
+    for (size_t i = 0; i <= 10; ++i) {
+        std::cout << "  size=" << i << ": " << buckets[i] << " nodes (" << pct(buckets[i]) << "%)\n";
+    }
+    std::cout << "  size>=11: " << buckets[11] << " nodes (" << pct(buckets[11]) << "%)\n";
+
+    auto cumulative_le = [&](size_t n) {
+        size_t s = 0;
+        for (size_t i = 0; i <= std::min<size_t>(n, 11); ++i) {
+            s += buckets[i];
+        }
+        return s;
+    };
+    std::cout << "=== SBO hit rate (text nodes, size <= N) ===\n";
+    for (size_t sbo : { 1u, 2u, 3u, 4u, 6u, 8u }) {
+        const size_t hit = cumulative_le(sbo);
+        std::cout << "  SBO=" << sbo << ": hit " << hit << " / " << total
+                  << " (" << pct(hit) << "%), miss " << (total - hit)
+                  << " (" << pct(total - hit) << "%)\n";
+    }
+
+    EXPECT_GT(total, 0u);
+}
+
+// NodeType 別の runs.size() の中央値・平均・最大。
+TEST(ViewStats, RunsSizeBreakdownByNodeType)
+{
+    auto bytes = ReadFileBytes("example/test.md");
+    if (bytes.empty()) {
+        GTEST_SKIP() << "example/test.md not found";
+    }
+    auto doc = Document::FromMarkdown(std::move(bytes), L"test.md");
+
+    auto bucket_label = [](NodeType t) -> const char* {
+        switch (t) {
+        case NodeType::Heading:      return "Heading";
+        case NodeType::Paragraph:    return "Paragraph";
+        case NodeType::CodeBlock:    return "CodeBlock";
+        case NodeType::HorizontalRule: return "HR";
+        case NodeType::ListItem:     return "ListItem";
+        case NodeType::BlockQuote:   return "BlockQuote";
+        case NodeType::Table:        return "Table";
+        case NodeType::TaskListItem: return "TaskListItem";
+        case NodeType::Image:        return "Image";
+        }
+        return "?";
+    };
+
+    std::cout << "=== runs.size() per NodeType (test.md) ===\n";
+    std::cout << "  type            | count | sum  | avg  | median | max | sbo4_hit\n";
+    for (NodeType type : { NodeType::Heading, NodeType::Paragraph, NodeType::CodeBlock,
+                           NodeType::ListItem, NodeType::BlockQuote, NodeType::Table,
+                           NodeType::TaskListItem, NodeType::Image, NodeType::HorizontalRule }) {
+        std::vector<size_t> sizes;
+        for (const auto& n : doc.GetNodes()) {
+            if (n.type == type) {
+                sizes.push_back(n.runs.size());
+            }
+        }
+        if (sizes.empty()) {
+            continue;
+        }
+        std::sort(sizes.begin(), sizes.end());
+        const size_t sum = std::accumulate(sizes.begin(), sizes.end(), size_t{ 0 });
+        const size_t median = sizes[sizes.size() / 2];
+        const size_t max_v = sizes.back();
+        const size_t sbo4_hit = std::ranges::count_if(sizes, [](size_t s) { return s <= 4; });
+        const double avg = static_cast<double>(sum) / sizes.size();
+        const double sbo4_pct = 100.0 * sbo4_hit / sizes.size();
+        std::cout << "  " << bucket_label(type)
+                  << " | count=" << sizes.size()
+                  << " sum=" << sum
+                  << " avg=" << avg
+                  << " median=" << median
+                  << " max=" << max_v
+                  << " sbo4_hit=" << sbo4_hit << " (" << sbo4_pct << "%)\n";
     }
 }
 

--- a/tests/test_view_stats.cpp
+++ b/tests/test_view_stats.cpp
@@ -227,83 +227,20 @@ TEST(ViewStats, SimpleParagraphIsViewed)
     }
 }
 
-// Node::runs (small_vector<TextRun, N>) の SBO 値が妥当かを test.md で計測する。
-// 各ノードの runs.size() ヒストグラムと、SBO=1..8 での hit 率を出力する。
-TEST(ViewStats, RunsSizeHistogramTestMd)
-{
-    auto bytes = ReadFileBytes("example/test.md");
-    if (bytes.empty()) {
-        GTEST_SKIP() << "example/test.md not found";
-    }
-    auto doc = Document::FromMarkdown(std::move(bytes), L"test.md");
+namespace {
 
-    // 個別バケット (0..10) と 11+ ひとまとめ。
+// runs.size() のヒストグラムを集計し、SBO=1..8 ヒット率を標準出力に書き出す。
+// predicate で集計対象を絞り込む (例: 特定 NodeType のみ)。
+template <class Pred>
+size_t RunRunsSizeHistogram(const Document& doc, std::string_view label, std::string_view total_label,
+                            std::string_view sbo_label, Pred pred)
+{
     std::array<size_t, 12> buckets{};
     size_t total = 0;
     size_t total_runs = 0;
     size_t max_runs = 0;
     for (const auto& n : doc.GetNodes()) {
-        const auto sz = n.runs.size();
-        total++;
-        total_runs += sz;
-        max_runs = std::max(max_runs, static_cast<size_t>(sz));
-        const size_t idx = std::min<size_t>(sz, 11);
-        buckets[idx]++;
-    }
-
-    auto pct = [&](size_t n) {
-        return total > 0 ? (100.0 * n / total) : 0.0;
-    };
-
-    std::cout << "=== runs.size() histogram (test.md, all NodeTypes) ===\n";
-    std::cout << "  total nodes: " << total << ", total runs: " << total_runs
-              << ", avg: " << (total > 0 ? static_cast<double>(total_runs) / total : 0.0)
-              << ", max: " << max_runs << "\n";
-    for (size_t i = 0; i <= 10; ++i) {
-        std::cout << "  size=" << i << ": " << buckets[i] << " nodes (" << pct(buckets[i]) << "%)\n";
-    }
-    std::cout << "  size>=11: " << buckets[11] << " nodes (" << pct(buckets[11]) << "%)\n";
-
-    // SBO=N で SBO 内に収まるノード割合 (N 以下)
-    auto cumulative_le = [&](size_t n) {
-        size_t s = 0;
-        for (size_t i = 0; i <= std::min<size_t>(n, 11); ++i) {
-            s += buckets[i];
-        }
-        return s;
-    };
-    std::cout << "=== SBO hit rate (size <= N) ===\n";
-    for (size_t sbo : { 1u, 2u, 3u, 4u, 6u, 8u }) {
-        const size_t hit = cumulative_le(sbo);
-        std::cout << "  SBO=" << sbo << ": hit " << hit << " / " << total
-                  << " (" << pct(hit) << "%), miss " << (total - hit)
-                  << " (" << pct(total - hit) << "%)\n";
-    }
-
-    EXPECT_GT(total, 0u);
-}
-
-// runs を実際に使うノード型 (Heading/Paragraph/ListItem/BlockQuote/TaskListItem) に絞った
-// 分布。Table/Image/HR/CodeBlock は runs が常に空に近いので統計を歪める。
-TEST(ViewStats, RunsSizeHistogramTextNodesOnly)
-{
-    auto bytes = ReadFileBytes("example/test.md");
-    if (bytes.empty()) {
-        GTEST_SKIP() << "example/test.md not found";
-    }
-    auto doc = Document::FromMarkdown(std::move(bytes), L"test.md");
-
-    auto is_text_node = [](NodeType t) {
-        return t == NodeType::Heading || t == NodeType::Paragraph || t == NodeType::ListItem ||
-               t == NodeType::BlockQuote || t == NodeType::TaskListItem;
-    };
-
-    std::array<size_t, 12> buckets{};
-    size_t total = 0;
-    size_t total_runs = 0;
-    size_t max_runs = 0;
-    for (const auto& n : doc.GetNodes()) {
-        if (!is_text_node(n.type)) {
+        if (!pred(n)) {
             continue;
         }
         const auto sz = n.runs.size();
@@ -318,8 +255,8 @@ TEST(ViewStats, RunsSizeHistogramTextNodesOnly)
         return total > 0 ? (100.0 * n / total) : 0.0;
     };
 
-    std::cout << "=== runs.size() histogram (test.md, text nodes only) ===\n";
-    std::cout << "  total text nodes: " << total << ", total runs: " << total_runs
+    std::cout << "=== " << label << " ===\n";
+    std::cout << "  " << total_label << ": " << total << ", total runs: " << total_runs
               << ", avg: " << (total > 0 ? static_cast<double>(total_runs) / total : 0.0)
               << ", max: " << max_runs << "\n";
     for (size_t i = 0; i <= 10; ++i) {
@@ -327,20 +264,61 @@ TEST(ViewStats, RunsSizeHistogramTextNodesOnly)
     }
     std::cout << "  size>=11: " << buckets[11] << " nodes (" << pct(buckets[11]) << "%)\n";
 
-    auto cumulative_le = [&](size_t n) {
-        size_t s = 0;
-        for (size_t i = 0; i <= std::min<size_t>(n, 11); ++i) {
-            s += buckets[i];
-        }
-        return s;
-    };
-    std::cout << "=== SBO hit rate (text nodes, size <= N) ===\n";
+    std::cout << "=== " << sbo_label << " ===\n";
     for (size_t sbo : { 1u, 2u, 3u, 4u, 6u, 8u }) {
-        const size_t hit = cumulative_le(sbo);
+        size_t hit = 0;
+        for (size_t i = 0; i <= std::min<size_t>(sbo, 11); ++i) {
+            hit += buckets[i];
+        }
         std::cout << "  SBO=" << sbo << ": hit " << hit << " / " << total
                   << " (" << pct(hit) << "%), miss " << (total - hit)
                   << " (" << pct(total - hit) << "%)\n";
     }
+    return total;
+}
+
+} // namespace
+
+// Node::runs (small_vector<TextRun, N>) の SBO 値が妥当かを test.md で計測する。
+// 各ノードの runs.size() ヒストグラムと、SBO=1..8 での hit 率を出力する。
+TEST(ViewStats, RunsSizeHistogramTestMd)
+{
+    auto bytes = ReadFileBytes("example/test.md");
+    if (bytes.empty()) {
+        GTEST_SKIP() << "example/test.md not found";
+    }
+    auto doc = Document::FromMarkdown(std::move(bytes), L"test.md");
+
+    const size_t total = RunRunsSizeHistogram(
+        doc,
+        "runs.size() histogram (test.md, all NodeTypes)",
+        "total nodes",
+        "SBO hit rate (size <= N)",
+        [](const Node&) { return true; });
+
+    EXPECT_GT(total, 0u);
+}
+
+// runs を実際に使うノード型 (Heading/Paragraph/ListItem/BlockQuote/TaskListItem) に絞った
+// 分布。Table/Image/HR/CodeBlock は runs が常に空に近いので統計を歪める。
+TEST(ViewStats, RunsSizeHistogramTextNodesOnly)
+{
+    auto bytes = ReadFileBytes("example/test.md");
+    if (bytes.empty()) {
+        GTEST_SKIP() << "example/test.md not found";
+    }
+    auto doc = Document::FromMarkdown(std::move(bytes), L"test.md");
+
+    const size_t total = RunRunsSizeHistogram(
+        doc,
+        "runs.size() histogram (test.md, text nodes only)",
+        "total text nodes",
+        "SBO hit rate (text nodes, size <= N)",
+        [](const Node& n) {
+            return n.type == NodeType::Heading || n.type == NodeType::Paragraph ||
+                   n.type == NodeType::ListItem || n.type == NodeType::BlockQuote ||
+                   n.type == NodeType::TaskListItem;
+        });
 
     EXPECT_GT(total, 0u);
 }


### PR DESCRIPTION
## Summary

- `Node` 構造体を再設計し sizeof を **216B → 144B (-33%)** に圧縮。重データ (anchor_id / tokens / table / image) を `pmr_unique_ptr` で外出しし、小スカラ (heading_level / code_language / list_number / alert_label_length / task_checked) を `std::variant` の対応 alternative にまとめた
- ホットパス周辺の重複アクセスやリーキーな variant 直アクセスを整理
  - `dwrite_measurer` の token-emit を公開アクセサ経由に戻す
  - `parser` MD_BLOCK_LI で `ensure_list()` を 1 回に統合、unordered list では `NodeListData` の確保自体を回避
  - `layout_cache::InvalidateDiagramBitmaps` を `type==CodeBlock` で先にゲート
- 6 個の `ensure_*` を `EnsureAlt<T>` / `EnsurePtrAlt<Ptr>` template helper に集約
- `static_assert(sizeof(Node) <= 144)` でサイレントなサイズリグレッションを防止
- `tests/test_view_stats.cpp` の `RunsSizeHistogram*` 重複を template helper に集約、新規 `tests/test_types.cpp` のケースで accessor の不変条件を検証

## Test plan

- [x] `cmake --build build --config Release` がクリーンに通る
- [x] `build/tests/Release/mendo_tests.exe --gtest_brief=1` で 2213 tests / 131 suites すべて PASS
- [x] `static_assert(sizeof(Node) <= 144)` がトリップせずビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)