### PR TITLE
refactor: アプリ全体の /simplify レビュー指摘を解消

### DIFF
--- a/example/test.md
+++ b/example/test.md
@@ -273,6 +273,11 @@ public:
     void SetImeComposition(std::pmr::wstring comp);
     RECT GetSearchEditRect();
 
+    // 起動時に I/O + パースをウィンドウ生成と並行起動する。Init 末尾で hwnd が
+    // 解禁されたタイミングで worker が PARSE_COMPLETE をポストし、通常の async
+    // ロード経路に合流する。
+    void StartPreloadAsync(std::pmr::wstring path);
+
 private:
     void Dispatch(const AppAction& action);
 
@@ -287,17 +292,16 @@ private:
 
     // コアサービス
     Renderer           renderer_;
-    TaskScheduler      scheduler_;
+    TaskScheduler      scheduler_;          // 汎用ワーカー（画像/Mermaid/キャッシュ書き込み）
+    TaskScheduler      layout_scheduler_;   // レイアウト計測専用ワーカー
     MermaidFileCache   file_cache_; // mermaid_renderer_ より先に宣言（破棄順序の保証）
     MermaidRenderer    mermaid_renderer_;
     ImageLoader        image_loader_;
     FileWatcher        file_watcher_;
-    DocumentService    doc_service_{ file_watcher_ };
-    AppController      controller_;
     ConfigService&     config_;
     ThemeService       theme_service_{ config_ };
     SessionService     session_{ config_ };
-    FileLoadService    file_load_service_{ doc_service_ };
+    FileLoadService    file_load_service_;
 
     // 全状態集約
     AppState state_;
@@ -309,10 +313,9 @@ private:
     Win32Host                    win32_host_;
     SideEffectExecutor           effect_executor_;
 
-    // SVG クリップボードコピー用の LRU キャッシュ
-    static constexpr size_t MAX_SVG_CACHE_ENTRIES = 64;
-    LruCache<uint64_t, std::pmr::wstring> svg_cache_{ MAX_SVG_CACHE_ENTRIES };
-    bool svg_copy_in_flight_ = false;
+    // クリップボード/画像保存 (コードコピー・PNG 保存・SVG コピー)。SVG の
+    // 非同期コピー用 LRU キャッシュもこの中に閉じている。
+    ClipboardManager clipboard_manager_;
 };
 ```
 
@@ -331,7 +334,8 @@ private:
 | `app_mouse_hover.cpp` | ホバー処理（`OnMouseHover`, `HandleMdPaneHover`） |
 | `app_navigate.cpp` | リンク・アンカーナビゲーション（`HandleLinkClick`） |
 | `app_context_menu.cpp` | カスタムコンテキストメニュー処理 |
-| `app_clipboard.cpp` | クリップボード・画像保存（`SetClipboardText`, `SaveDiagramAsPng`, `CopyDiagramAsSvg`） |
+| `app_clipboard.cpp` | クリップボード・画像保存（`SetClipboardText` 等のフリー関数） |
+| `clipboard_manager.h / .cpp` | `ClipboardManager`（コピー/PNG 保存/SVG コピーを集約。 SVG LRU キャッシュを内包） |
 | `app_controller.cpp` | `AppController::HandleKeyDown` / `HandleMouseWheel` |
 | `reducer.cpp` | `Reduce(state, action)`（in-place 更新、副作用リストを返す） |
 | `side_effect_executor.cpp` | `SideEffectExecutor::Execute` / `ExecuteOne`（IWin32Host 経由で実行） |
@@ -464,7 +468,18 @@ struct ViewState {
     PaneController    panes;
     ScrollRestoration scroll_restore;
     NavHistory        nav_history;
-    float             cached_total_height = 0.0f;
+
+    // ブロック単位の横スクロール。キーは LayoutCache のノードインデックス。
+    // 永続化しない (ファイルロード/リロードでクリア)。スクロールバー本体は
+    // 「ホバー中とドラッグ中のブロック」だけ描画するので、map のサイズは
+    // ユーザー操作実績分に限定される。
+    std::pmr::unordered_map<int, float> block_scroll_x;
+    int   hovered_h_block      = -1;
+    int   h_drag_node          = -1;
+    float h_drag_start_x       = 0.0f;
+    float h_drag_start_scroll  = 0.0f;
+
+    float GetBlockScrollX(int node_index) const;
 };
 
 struct InteractionState {
@@ -487,29 +502,33 @@ struct WindowState {
     bool           is_sizing = false;
     bool           window_active = true;
     float          cached_dpi_scale = 1.0f;
-    ThemeConstants cached_theme;
 };
 
 struct AppState {
     DocumentState    document;     // ドキュメント + LayoutCache
-    ViewState        view;         // ViewportManager + PaneController + ScrollRestoration + NavHistory
+    ViewState        view;         // ViewportManager + PaneController + ScrollRestoration + NavHistory + 横スクロール
     InteractionState interaction;  // MouseGesture + SwipeDetector + Tooltip + ToastNotifier 等
     SearchGroup      search;       // SearchState + SearchBarController
-    WindowState      window;       // TitleBar + DPI + テーマ定数キャッシュ
+    WindowState      window;       // TitleBar + DPI
+
+    // Renderer 所有 Theme への非所有参照。App::InitializeRenderer 後に設定され、
+    // 以降 `renderer_.SetTheme` 経由で in-place 更新されるためポインタは安定。
+    // reducer が spacing_above 等を参照するのに使う。
+    const Theme*     theme = nullptr;
 
     FileExplorer     file_explorer;
     ContextMenu      ctx_menu;
     int              active_toc_index = -1;
 
-    // wide テキストへのオフセットなので wstring_view::npos で揃える
-    size_t           reload_diff_pos       = std::wstring_view::npos;
+    // 差分位置は UTF-8 byte offset。AnalyzeReloadDiff の string_view 引数と同じドメイン。
+    size_t           reload_diff_pos       = std::string_view::npos;
     // 短縮タイマーで再リロード予約済み（DeferPrefixShrink / partial-read race）
     bool             pending_reload_retry  = false;
 
     std::pmr::wstring cached_title_text = L"mendo";
-    PaneLayout        cached_pane_layout{};
-    float             cached_window_width_for_layout = 0.0f;
-    bool              pane_layout_valid = false;
+
+    // ペインレイアウトのキャッシュ。 `Invalidate()` で次回再計算を強制する。
+    PaneLayoutCache   pane_layout_cache;
 };
 
 // AppState 関連のフリー関数
@@ -542,7 +561,9 @@ classDiagram
         +PaneController panes
         +ScrollRestoration scroll_restore
         +NavHistory nav_history
-        +float cached_total_height
+        +pmr::unordered_map~int,float~ block_scroll_x
+        +int hovered_h_block
+        +int h_drag_node
     }
 
     class InteractionState {
@@ -565,7 +586,6 @@ classDiagram
         +bool is_sizing
         +bool window_active
         +float cached_dpi_scale
-        +ThemeConstants cached_theme
     }
 
     AppState --> DocumentState
@@ -587,7 +607,7 @@ classDiagram
 SideEffectList Reduce(AppState& state, const AppAction& action);
 ```
 
-`Reducer` は `AppState` を **in-place で変更** し、実行すべき副作用の `SideEffectList` を返す。テーマや DPI、ペインレイアウト等の定数は `AppState::window.cached_theme`（`ThemeConstants`）と `cached_pane_layout` 経由で参照する。これらの値が古くなったら `pane_layout_valid = false` にして次回再計算する。
+`Reducer` は `AppState` を **in-place で変更** し、実行すべき副作用の `SideEffectList` を返す。テーマ定数は `AppState::theme`（Renderer 所有 `Theme` への安定ポインタ）経由で参照する。ペインレイアウトは `AppState::pane_layout_cache`（`PaneLayoutCache`）にキャッシュされ、値が古くなったら `pane_layout_cache.Invalidate()` で次回再計算を強制する。
 
 > **Note**: 関数型「純粋関数」スタイル（新 state を返す）ではなく in-place 更新スタイルを採用するのは、`AppState` 内部の `std::pmr::vector<Node>` や `std::pmr::deque` などの大型コンテナを毎回コピーすると性能上のオーバーヘッドが大きいためである。`SideEffectList` のみが新規 vector として生成される。
 
@@ -684,6 +704,35 @@ using SideEffectList = std::pmr::vector<SideEffect>;
 
 > **命名上の注意**: `<windows.h>` が `PostMessage` / `SetWindowText` をマクロ化するため、衝突を避けるべく `PostWindowMessage` / `SetWindowTitle` の名称を採用している。
 
+##### ScrollDrag ヘルパ（`src/app/scroll_drag.h`）
+
+スプリッタ / Md スクロールバー / Pane スクロールバー / 検索入力ドラッグ / テキスト選択ドラッグなど、開始時に `SetCapture`、終了時に `ReleaseCapture` を必ずペアで発火させたいユースケースを統一する薄い骨格関数群。3 系統に分散していた個別実装を統合した。
+
+```cpp
+namespace mendo {
+
+inline constexpr detail::NoOpFn no_op{};   // 「post 側不要」を明示する sentinel
+
+// begin → SetCapture → post の順で実行。begin は SetCapture より前に
+// 完了している必要があるドラッグ state 初期化を担う。
+template <std::invocable Begin, std::invocable Post>
+inline void RunScrollDragStarted(SideEffectList& effects, Begin&& begin, Post&& post);
+
+template <std::invocable Begin>
+inline void RunScrollDragStarted(SideEffectList& effects, Begin&& begin);
+
+// finalize → ReleaseCapture → post の順。
+template <std::invocable Finalize, std::invocable Post>
+inline void RunScrollDragEnded(SideEffectList& effects, Finalize&& finalize, Post&& post);
+
+template <std::invocable Finalize>
+inline void RunScrollDragEnded(SideEffectList& effects, Finalize&& finalize);
+
+} // namespace mendo
+```
+
+テンプレート + `std::invocable` + `mendo::no_op` センチネルにより、per-event ホットパスでの heap 確保と間接呼び出しをゼロに保つ（`std::function` での type erasure を回避）。`Moved` 側は「apply → emit」しかなく関数化価値が薄いため、`RunScrollDragMoved` は設けず reducer で直書きとしている。早期 return 条件は呼び出し側の guard 句に出すことで、false 時の lambda 構築コストも回避する。これにより `Md/Pane/BlockHScroll` 系の 9 個の reducer が新 API に書き換えられた。
+
 #### 3.4.4 SideEffectExecutor / IWin32Host
 
 `SideEffectExecutor` は `SideEffectList` を受け取り、各副作用を `IWin32Host` 経由で実行する。`IWin32Host` は Win32 の境界インターフェースで、テスト時にはモックに差し替え可能。
@@ -720,7 +769,50 @@ public:
 };
 ```
 
-`Win32Host` が本番実装で、`HWND` と `CursorManager*` を保持する。トースト表示・コンテキストメニュー描画・レイアウト再計算といった「アプリ内ロジック」は `IWin32Host` を経由せず、`SideEffectExecutor` が `App` 内のサービス（`App`/`ResourceManager`/`LayoutService`）を直接呼ぶ設計になっている — `IWin32Host` はあくまで Win32 API 境界を跨ぐための adapter に絞られる。
+`Win32Host` が本番実装で、`HWND` と `CursorManager*` を保持する。トースト表示・コンテキストメニュー描画・レイアウト再計算といった「アプリ内ロジック」は `IWin32Host` を経由せず、`SideEffectExecutor` が `App` 内のサービス（`App`/`LayoutService`）を直接呼ぶ設計になっている — `IWin32Host` はあくまで Win32 API 境界を跨ぐための adapter に絞られる。
+
+`SideEffectExecutor` 自体は `SideEffectExecutorT<Cb>` template として宣言され、宣言は `side_effect_executor.h`、実装は `side_effect_executor_impl.h` に分離する。具象 Cb は `AppSideEffectCallbacks`（`app_side_effect_callbacks.{h,cpp}`）で、`load_file` / `invalidate_pane_cache` / `apply_theme_change` / `schedule_bitmap_manage` / `request_mermaid_renders` などの「アプリ内ロジック」呼び出しを App メンバへ転送する。これにより `SideEffectExecutor` から `ResourceManager` への直接結合が解消され、`Callbacks` 自身も `template<class Cb>` 化されているため direct call にコンパイルされる。
+
+```cpp
+template <class Cb>
+class SideEffectExecutorT {
+public:
+    void Init(IWin32Host& host, FileWatcher& file_watcher, AppState& state,
+              LayoutService& layout_service, Cb cb);
+    void Execute(const SideEffectList& effects);
+    void ExecuteOne(const SideEffect& e);
+};
+
+struct AppSideEffectCallbacks {
+    App* app = nullptr;
+    void load_file(std::wstring_view path);
+    void reload_file();
+    void open_file_dialog();
+    void invalidate_pane_cache(PaneZone pane);
+    void refresh_pane_layout();
+    void renderer_resize(UINT w, UINT h);
+    void renderer_set_dpi(float dpi);
+    void apply_theme_change(const effect::ApplyThemeChange& e);
+    void process_deferred_layout();
+    void tick_loading_animation();
+    void process_mermaid_batch_timer();
+    void process_bitmap_manage();
+    void handle_parse_complete();
+    void show_context_menu(int x, int y);
+    void sync_toc_active();
+    void schedule_bitmap_manage();
+    void schedule_mermaid_batch();
+    void load_images();
+    void request_mermaid_renders();
+    void cancel_mermaid_batch();
+    void on_app_image_loaded();
+    // 他、destroy / clear_file_cache / mermaid_init_retry /
+    // perform_resize_end / perform_sizing_update など
+};
+
+using SideEffectExecutor = SideEffectExecutorT<AppSideEffectCallbacks>;
+extern template class SideEffectExecutorT<AppSideEffectCallbacks>;
+```
 
 ---
 
@@ -1748,6 +1840,8 @@ struct MdPaneHitContext {
     // ボタンヒットテスト用
     float content_width  = 0.0f;
     float md_pane_height = 0.0f;
+    // ブロック単位の横スクロール量。null は全ノード 0 として扱う。
+    const std::pmr::unordered_map<int, float>* block_scroll_x = nullptr;
 };
 
 class HitTestService {
@@ -1986,26 +2080,16 @@ public:
 
 検索バーのUI状態（フォーカス、キャレット、ドラッグ選択、ホバー）を管理する。Win32 操作はコールバック経由で App に委譲する。
 
-```cpp
-class SearchBarController {
-public:
-    struct Callbacks {
-        std::move_only_function<void()> invalidate;                   // ウィンドウ全体の再描画
-        std::move_only_function<void()> invalidate_search_bar;        // 検索バー領域のみ再描画
-        std::move_only_function<void(UINT_PTR, UINT)> set_timer;
-        std::move_only_function<void(UINT_PTR)> kill_timer;
-        std::move_only_function<void()> focus_select_all;             // 全選択でフォーカス
-        std::move_only_function<void(int)> focus_set_caret;           // キャレット位置指定
-        std::move_only_function<void(int, int)> focus_set_selection;  // anchor, caret 指定
-        std::move_only_function<void()> unfocus;
-        std::move_only_function<float()> get_md_pane_height;
-        std::move_only_function<void(float)> on_scroll_changed;
-    };
+Callbacks は `std::move_only_function` の type erasure を避けるため `template<class Cb>` 形式に統一されている。各メンバ呼び出しは direct call となり、`mendo.exe` Release バイナリで約 9.7KB の縮小を達成した。具体的な `Cb` は `app_search_bar_callbacks.{h,cpp}` の `AppSearchBarCallbacks` で、`App*` を保持して各メソッドを App メンバへ転送する。宣言は `search_bar_controller.h`、実装は `search_bar_controller_impl.h`、明示的インスタンス化は `app_search_bar_callbacks.cpp` で行う。
 
+```cpp
+template <class Cb>
+class SearchBarControllerT {
+public:
     static constexpr UINT_PTR TIMER_CARET    = 7;
     static constexpr UINT_PTR TIMER_DEBOUNCE = 9;
 
-    void Init(SearchState& state, ViewportManager& viewport, LayoutCache& cache, Callbacks cb);
+    void Init(SearchState& state, ViewportManager& viewport, LayoutCache& cache, Cb cb);
 
     // イベントハンドラ
     void OnOpen(const std::pmr::vector<Node>& nodes);
@@ -2042,7 +2126,26 @@ public:
 
     void Reset();
 };
+
+// 具象 Cb (mendo target)
+struct AppSearchBarCallbacks {
+    App* app = nullptr;
+    void invalidate();
+    void invalidate_search_bar();
+    void set_timer(app_timer::Id id, UINT ms);
+    void kill_timer(app_timer::Id id);
+    void focus_select_all();
+    void unfocus();
+    float get_md_pane_height();
+    void on_scroll_changed(float md_pane_height);
+    void on_wrap_around();
+};
+
+using SearchBarController = SearchBarControllerT<AppSearchBarCallbacks>;
+extern template class SearchBarControllerT<AppSearchBarCallbacks>;
 ```
+
+`AppState`（`mendo_core`）の値メンバとして保持されるため struct サイズは `mendo_core` から見える必要があるが、メソッド本体は App を触るため `mendo` target 側でしか定義できない。`mendo_tests` 向けには `tests/app_search_bar_callbacks_stub.cpp` の no-op 実装でリンクを通している。
 
 ホバー領域は `SearchBarHitZone`（`ui_types.h`）で定義され、None / SearchInput / Up / Down / Close / CaseSensitive / Highlight などを含む。
 
@@ -2233,29 +2336,19 @@ public:
 
 App から画像読み込み、Mermaidバッチ処理、ビットマップ解放の責務を分離する。
 
-```cpp
-class ResourceManager {
-public:
-    struct Callbacks {
-        std::move_only_function<void()> invalidate;
-        std::move_only_function<void(UINT_PTR, UINT)> set_timer;
-        std::move_only_function<void(UINT_PTR)> kill_timer;
-        std::move_only_function<float()> get_content_width;
-        std::move_only_function<float()> get_viewport_height;
-        std::move_only_function<float()> get_indent_width;
-        std::move_only_function<void()> recompute_layout;
-        std::move_only_function<void()> recompute_layout_anchored;
-    };
+Callbacks は `SearchBarController` と同様に `template<class Cb>` 形式。具象 Cb は `AppResourceManagerCallbacks`（`app_resource_manager_callbacks.{h,cpp}`）で、宣言は `resource_manager.h` / 実装は `resource_manager_impl.h` に分離する。
 
-    static constexpr UINT_PTR TIMER_MERMAID_BATCH    = 10;
-    static constexpr UINT_PTR TIMER_BITMAP_MANAGE    = 11;
-    static constexpr float    EVICT_BUFFER_SCREENS    = 5.0f;
-    static constexpr float    PREFETCH_BUFFER_SCREENS = 3.0f;
-    static constexpr int      BATCH_TIME_BUDGET_US    = 6000;
+```cpp
+template <class Cb>
+class ResourceManagerT {
+public:
+    static constexpr float EVICT_BUFFER_SCREENS    = 5.0f;
+    static constexpr float PREFETCH_BUFFER_SCREENS = 3.0f;
+    static constexpr int   BATCH_TIME_BUDGET_US    = 6000;
 
     void Init(Document& doc, LayoutCache& cache, ViewportManager& viewport,
               ImageLoader& image_loader, IMermaidRenderer& mermaid,
-              ThemeService& theme_service, Callbacks cb);
+              ThemeService& theme_service, const Theme& theme, Cb cb);
 
     // 画像
     int  ApplyCachedImages(bool respect_viewport = true);
@@ -2280,9 +2373,25 @@ public:
     // ファイル切替時クリーンアップ
     void ClearResolvedPaths() noexcept;
 };
+
+// 具象 Cb (mendo target)
+struct AppResourceManagerCallbacks {
+    App* app = nullptr;
+    void invalidate();
+    void set_timer(app_timer::Id id, UINT ms);
+    void kill_timer(app_timer::Id id);
+    float get_content_width();
+    float get_viewport_height();
+    float get_indent_width();
+    void recompute_layout();
+    void recompute_layout_anchored();
+};
+
+using ResourceManager = ResourceManagerT<AppResourceManagerCallbacks>;
+extern template class ResourceManagerT<AppResourceManagerCallbacks>;
 ```
 
-Mermaid はバッチ単位でレンダリングし、可視範囲外のビットマップを LRU 的に解放する（`EVICT_BUFFER_SCREENS` 画面分は保持、`PREFETCH_BUFFER_SCREENS` 画面分は先読み）。バッチごとの時間予算は `BATCH_TIME_BUDGET_US`（6ms）で打ち切り、UI 応答性を確保する。
+Mermaid はバッチ単位でレンダリングし、可視範囲外のビットマップを LRU 的に解放する（`EVICT_BUFFER_SCREENS` 画面分は保持、`PREFETCH_BUFFER_SCREENS` 画面分は先読み）。バッチごとの時間予算は `BATCH_TIME_BUDGET_US`（6ms）で打ち切り、UI 応答性を確保する。タイマー ID は `app_constants.h` の `app_timer::Id` enum で集約管理される。
 
 ---
 
@@ -3152,17 +3261,24 @@ src/
 │   ├── app_mouse_helpers.h        # マウスヘルパー
 │   ├── app_mouse_hover.cpp        # ホバー処理
 │   ├── app_navigate.cpp           # リンク・アンカーナビゲーション
-│   ├── app_clipboard.cpp          # クリップボード・画像保存
+│   ├── app_clipboard.cpp          # クリップボード関連フリー関数
 │   ├── app_context_menu.cpp       # コンテキストメニュー
+│   ├── clipboard_manager.h / .cpp # ClipboardManager (コピー/PNG 保存/SVG コピー)
 │   ├── app_state.h                # AppState (全状態集約)
 │   ├── app_events.h               # AppAction variant
 │   ├── app_constants.h            # タイマーID / WM_APP+N / WPARAM 定義
 │   ├── app_controller.h / .cpp    # AppController (Event→Action)
 │   ├── reducer.h / reducer.cpp    # Reducer (Action+State→Effects, in-place)
 │   ├── side_effect.h              # SideEffect 二段variant + PushEffect/HasEffect
-│   ├── side_effect_executor.h / .cpp # 副作用実行
+│   ├── scroll_drag.h              # RunScrollDragStarted/Ended (ホットパス用)
+│   ├── side_effect_executor.h     # SideEffectExecutorT<Cb> 宣言
+│   ├── side_effect_executor_impl.h # SideEffectExecutorT<Cb> 実装
+│   ├── app_side_effect_callbacks.h / .cpp # AppSideEffectCallbacks 具象 Cb
 │   ├── render_composer.h / .cpp   # render_composer namespace (State→各RenderState)
-│   ├── resource_manager.h / .cpp  # 画像・Mermaidリソース管理
+│   ├── resource_manager.h         # ResourceManagerT<Cb> 宣言
+│   ├── resource_manager_impl.h    # ResourceManagerT<Cb> 実装
+│   ├── app_resource_manager_callbacks.h / .cpp # AppResourceManagerCallbacks 具象 Cb
+│   ├── app_search_bar_callbacks.h / .cpp # AppSearchBarCallbacks 具象 Cb
 │   ├── win32_host.h               # IWin32Host インターフェース
 │   └── win32_host_impl.h / .cpp   # Win32Host 具象実装
 ├── window/                        # ウィンドウ層
@@ -3177,11 +3293,14 @@ src/
 │   ├── d2d_render_backend.h / .cpp # D2DRenderBackend 実装 (IRenderBackend)
 │   ├── render_params.h            # レンダリングパラメータ
 │   ├── draw_command.h             # DrawCommand variant + DrawCommandList
+│   ├── block_h_scroll_context.h   # コードブロック横スクロール描画コンテキスト
+│   ├── brush_id.h                 # ブラシ ID 定義
 │   ├── command_generator.h / .cpp # 描画コマンド生成
 │   └── command_executor.h / .cpp  # 描画コマンド実行
 ├── core/                          # コアドメイン
 │   ├── document_types.h           # Node, AlertType, NodeType, TableRow etc.
 │   ├── text_types.h               # TextRun, TextSelection etc.
+│   ├── raw_text.h                 # パース入力 UTF-8 の保持
 │   ├── parser.h / parser.cpp      # Markdown パース (md4c UTF-8)
 │   ├── parser_alerts.cpp          # GitHub Alerts 検出
 │   ├── document.h / document.cpp  # Document
@@ -3195,23 +3314,35 @@ src/
 ├── layout/                        # レイアウト層
 │   ├── layout.h / layout.cpp      # LayoutEngine + LayoutService
 │   ├── layout_cache.h             # LayoutCache (レイアウトデータ)
+│   ├── layout_computer.h / .cpp   # ノード Y 位置・高さ再計算ユーティリティ
+│   ├── dirty_scheduler.h / .cpp   # ダーティバッチ計測スケジューラ
+│   ├── doc_dwrite_bridge.h / .cpp # Document⇔DirectWrite 計測ブリッジ
+│   ├── parallel_measure.h / .cpp  # ワーカー並列計測サポート
+│   ├── measure_backend.h          # 計測バックエンド抽象 (本番/モック差し替え用)
 │   ├── text_measurer.h            # ITextMeasurer インターフェース
 │   └── dwrite_measurer.h / .cpp   # DirectWrite 実装
 ├── theme/                         # テーマ層
 │   ├── theme.h / theme.cpp        # Theme + ThemeConstants + theme_palette
+│   ├── theme_palette.h            # 配色パレット定義
 │   └── theme_service.h / .cpp     # テーマ管理サービス
 ├── nav/                           # ナビゲーション層
 │   └── nav.h / nav.cpp            # NavHistory + LinkClickResult / HandleLinkClick
 ├── input/                         # 入力処理層
 │   ├── hit_test_service.h / .cpp  # HitTestService + MdPaneHitContext + ButtonRect
 │   ├── mouse_gesture.h            # MouseGesture (ヘッダオンリー)
+│   ├── gesture_overlay.h          # GestureOverlay 描画用ステート
 │   └── swipe_detector.h           # SwipeDetector (ヘッダオンリー)
 ├── io/                            # I/O層
-│   ├── file_loader.h / .cpp       # FileLoader (LoadFile + OpenFileDialog)
+│   ├── file_loader.h / .cpp       # FileLoader (LoadFile)
+│   ├── file_dialog_service.h / .cpp # OpenFileDialog 等
 │   ├── file_watcher.h / .cpp      # ReadDirectoryChangesW 監視
 │   ├── file_load_service.h / .cpp # ロード制御 + アニメーション
 │   ├── file_explorer.h / .cpp     # ディレクトリブラウザ
 │   ├── image_loader.h / .cpp      # 非同期画像読み込み
+│   ├── preloader.h / .cpp         # 起動時の I/O + パース先行起動
+│   ├── async_load_coordinator.h / .cpp # 非同期ロード調停 (世代カウンタ管理)
+│   ├── async_load_result.h        # AsyncLoadResult (Document + LayoutCache)
+│   ├── loading_animation.h        # ローディングアニメーション状態
 │   ├── ini_parser.h               # IniParser (ヘッダオンリー)
 │   └── config_service.h / .cpp    # ConfigService + SessionService
 ├── mermaid/                       # Mermaid層
@@ -3219,7 +3350,7 @@ src/
 │   ├── mermaid_renderer_interface.h # IMermaidRenderer
 │   ├── mermaid_util.h / .cpp      # ヘルパー + mermaid_lifecycle::Lifecycle
 │   └── mermaid_file_cache.h / .cpp # 永続キャッシュ (MEMC v1)
-├── ui/                            # UI層
+├── ui/                            # UI層 (Win32/D2D 依存ありの可視層)
 │   ├── titlebar.h / titlebar.cpp  # TitleBar
 │   ├── context_menu.h / .cpp      # ContextMenu (D2D描画)
 │   ├── context_menu_impl.h        # 内部実装
@@ -3227,27 +3358,44 @@ src/
 │   ├── toast_notifier.h           # ToastNotifier (ヘッダオンリー)
 │   ├── tooltip.h / tooltip.cpp    # Tooltip + TooltipTarget
 │   ├── search_state.h / .cpp      # SearchState
-│   ├── search_bar_controller.h / .cpp # SearchBarController
-│   ├── viewport_manager.h         # ViewportManager + ScrollTarget
-│   ├── pane_layout.h / .cpp       # PaneLayout, PaneZone, PaneRect, ScrollState
+│   ├── search_bar_controller.h        # SearchBarControllerT<Cb> 宣言
+│   ├── search_bar_controller_impl.h   # SearchBarControllerT<Cb> 実装
+│   ├── pane_layout.cpp            # PaneLayout 計算実装 (宣言は util/pane_layout.h)
 │   ├── pane_controller.h / .cpp   # PaneController
 │   ├── cursor_manager.h           # CursorManager (ヘッダオンリー)
 │   ├── hover_throttle.h           # HoverThrottle (ヘッダオンリー)
-│   ├── ui_constants.h             # UI 定数 + ScrollRestoration + DipRect 関連
-│   ├── ui_types.h                 # PaneZone / NavButtonHover / HoveredButtons / 等
-│   ├── i18n.h                     # 国際化
-│   └── resource.h                 # リソースID
-└── util/                          # ユーティリティ層
+│   └── darkmode_util.h            # Win32 dark mode 切替ヘルパー
+└── util/                          # ユーティリティ層 (Win32 依存最小、テスト容易)
     ├── memory_resource.h          # PMR グローバルリソース
     ├── utility.h                  # 汎用ユーティリティ
     ├── string_convert.h           # UTF-8 ↔ Wide 変換 (ヘッダオンリー)
+    ├── utf8_codec.h               # UTF-8 低レベルコーデック
+    ├── doc_text.h                 # ドキュメントテキスト操作
     ├── file_io.h / .cpp           # ファイルI/Oヘルパー
     ├── stream_util.h              # ストリーム処理
     ├── wic_util.h                 # WIC ヘルパー
+    ├── d2d_util.h                 # Direct2D ヘルパー
     ├── ascii_util.h               # ASCII 操作
     ├── flat_map.h                 # FlatMap (線形検索順序マップ)
     ├── lru_cache.h                # LruCache (汎用LRU)
+    ├── fenwick.h                  # Fenwick tree (累積和)
+    ├── fnv1a.h                    # FNV-1a ハッシュ
+    ├── small_vector.h             # 小サイズ最適化 vector
+    ├── pmr_unique_ptr.h           # std::pmr アロケータ向け unique_ptr
+    ├── pmr_format.h               # std::pmr 対応 format
+    ├── overloaded.h               # std::visit 用 overloaded ヘルパー
+    ├── rc_resource.h              # 参照カウント付きリソース
+    ├── worker_latch.h             # ワーカー完了同期ラッチ
+    ├── block_h_scroll.h           # コードブロック横スクロール幾何計算
+    ├── clipboard_util.h           # クリップボード補助
+    ├── log_hr.h                   # HRESULT ログ出力
     ├── win_handle.h               # UniqueResource (RAII) + クリップボード関数
+    ├── i18n.h                     # 国際化
+    ├── resource.h                 # リソースID
+    ├── ui_constants.h             # UI 定数 + ScrollRestoration + DipRect 関連
+    ├── ui_types.h                 # PaneZone / NavButtonHover / HoveredButtons / 等
+    ├── pane_layout.h              # PaneLayout / PaneRect / ScrollState / PaneLayoutCache
+    ├── viewport_manager.h         # ViewportManager + ScrollTarget
     ├── task_scheduler.h / .cpp    # TaskScheduler
     └── profiler.h                 # パフォーマンス計測
 ```
@@ -4020,7 +4168,7 @@ exit /b 0
 | 3 | AppState | app_state.h | mendo_core | あり (各サブgrp) |
 | 4 | AppController | app_controller.h/cpp | mendo_core | あり |
 | 5 | Reducer | reducer.h/cpp | mendo_core | あり |
-| 6 | SideEffectExecutor | side_effect_executor.h/cpp | mendo_core | あり |
+| 6 | SideEffectExecutor | side_effect_executor.h + _impl.h + app_side_effect_callbacks.h/cpp | mendo_core (T) / mendo (Cb) | あり |
 | 7 | RenderComposer | render_composer.h/cpp | mendo_core | あり |
 | 8 | IWin32Host | win32_host.h | mendo_core (IF) | モック |
 | 9 | Win32Host | win32_host_impl.h/cpp | mendo | 直接なし |
@@ -4055,9 +4203,9 @@ exit /b 0
 | 38 | ToastNotifier | toast_notifier.h | mendo_core | あり |
 | 39 | Tooltip + TooltipTarget | tooltip.h/cpp | mendo_core | TooltipTarget のみ |
 | 40 | SearchState | search_state.h/cpp | mendo_core | あり |
-| 41 | SearchBarController | search_bar_controller.h/cpp | mendo_core | あり |
+| 41 | SearchBarController | search_bar_controller.h + _impl.h + app_search_bar_callbacks.h/cpp | mendo_core (T) / mendo (Cb) | あり |
 | 42 | ImageLoader | image_loader.h/cpp | mendo_core | あり |
-| 43 | ResourceManager | resource_manager.h/cpp | mendo_core | あり |
+| 43 | ResourceManager | resource_manager.h + _impl.h + app_resource_manager_callbacks.h/cpp | mendo_core (T) / mendo (Cb) | あり |
 | 44 | i18n | i18n.h | mendo_core | あり |
 | 45 | IniParser | ini_parser.h | mendo_core | あり |
 | 46 | TaskScheduler | task_scheduler.h/cpp | mendo_core | あり |
@@ -4071,6 +4219,7 @@ exit /b 0
 | 54 | StringConvert | string_convert.h | mendo_core | あり |
 | 55 | MemoryResource | memory_resource.h | mendo_core | なし |
 | 56 | Profiler | profiler.h | mendo_core | なし |
+| 57 | ScrollDrag ヘルパ | scroll_drag.h | mendo_core (header-only) | reducer 経由 |
 
 ---
 

--- a/example/test.md
+++ b/example/test.md
@@ -1214,12 +1214,11 @@ struct Theme {
     float GetHeadingSize(int level) const noexcept;
     constexpr float GetHeadingUnderlineThickness(int level) const noexcept;
     constexpr bool IsDark() const noexcept;
-    ThemeConstants ToReducerConstants() const noexcept;
     void ApplyZoom(float new_zoom) noexcept;
 };
 ```
 
-`ThemeConstants` は Reducer がテーマ寸法を参照するための軽量キャッシュ。
+Reducer は `AppState::theme`（`Renderer` 所有 `Theme` への非所有ポインタ）経由で寸法を直接参照する。
 
 #### 3.9.2 ThemeService — テーマ管理サービス
 
@@ -3322,7 +3321,7 @@ src/
 │   ├── text_measurer.h            # ITextMeasurer インターフェース
 │   └── dwrite_measurer.h / .cpp   # DirectWrite 実装
 ├── theme/                         # テーマ層
-│   ├── theme.h / theme.cpp        # Theme + ThemeConstants + theme_palette
+│   ├── theme.h / theme.cpp        # Theme + theme_palette
 │   ├── theme_palette.h            # 配色パレット定義
 │   └── theme_service.h / .cpp     # テーマ管理サービス
 ├── nav/                           # ナビゲーション層

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -37,7 +37,7 @@ bool App::Init(HWND hwnd)
 
     // PixelToDip 用に DPI スケールをキャッシュ（OnDpiChanged でも更新する）。
     const float init_dpi = static_cast<float>(GetDpiForWindow(hwnd_));
-    state_.window.cached_dpi_scale = (init_dpi > 0.0f) ? (init_dpi / DEFAULT_DPI) : 1.0f;
+    state_.window.cached_dpi_scale = DpiScaleFrom(init_dpi);
 
     scheduler_.Init(mermaid_util::ComputeWorkerCount(
         std::thread::hardware_concurrency()));

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -39,19 +39,24 @@ void ClearTooltip(AppState& state, SideEffectList& effects)
     PushEffect(effects, effect::ClearTooltip{});
 }
 
+// スクロール位置が変わった時に共通で発火する副作用列。
+// InvalidateWindow → BitmapManage の順序は test_reducer の HasEffectInOrder で契約として担保。
+void EmitScrollChangedSideEffects(AppState& state, SideEffectList& effects)
+{
+    state.interaction.hover_throttle.Reset();
+    ClearTooltip(state, effects);
+    PushEffect(effects, effect::InvalidateWindow{});
+    PushEffect(effects, effect::BitmapManage{});
+    PushEffect(effects, effect::SyncTocActive{});
+}
+
 void EmitScrollEffects(AppState& state, SideEffectList& effects, float old_scroll)
 {
     if (state.view.viewport.GetScrollY() != old_scroll) {
-        ClearTooltip(state, effects);
-        state.interaction.hover_throttle.Reset();
-        PushEffect(effects, effect::InvalidateWindow{});
-        PushEffect(effects, effect::BitmapManage{});
-        PushEffect(effects, effect::SyncTocActive{});
+        EmitScrollChangedSideEffects(state, effects);
     }
 }
 
-// TOC クリック / ナビゲーション復帰 / アンカー遷移でこの関数を通ることで、
-// tooltip クリア・invalidation・bitmap manage・TOC 同期の並びが常に一貫する。
 void ApplyScrollTargetAndEmit(AppState& state, SideEffectList& effects, int node, float offset)
 {
     state.view.viewport.SetScrollTarget(node, offset);
@@ -59,11 +64,7 @@ void ApplyScrollTargetAndEmit(AppState& state, SideEffectList& effects, int node
     // 末尾セクションへのジャンプで scroll_y > max_scroll になると、後続の DirectScrollBy で
     // 位置が一気に飛ぶ。事前クランプ + target 無効化で範囲外への復帰を抑える。
     state.view.viewport.ClampAndDetach();
-    state.interaction.hover_throttle.Reset();
-    ClearTooltip(state, effects);
-    PushEffect(effects, effect::InvalidateWindow{});
-    PushEffect(effects, effect::BitmapManage{});
-    PushEffect(effects, effect::SyncTocActive{});
+    EmitScrollChangedSideEffects(state, effects);
 }
 
 struct SidePaneContext {

--- a/src/io/config_service.cpp
+++ b/src/io/config_service.cpp
@@ -89,18 +89,8 @@ void ConfigService::Flush()
     }
 
     const auto ini_path = dir / L"settings.ini";
-    const auto tmp_path = dir / L"settings.ini.tmp";
-
     const std::string content = ini::Serialize(data_);
-    if (!WriteAllBytes(tmp_path, content.data(), content.size())) {
-        return;
-    }
-
-    if (!MoveFileExW(tmp_path.c_str(), ini_path.c_str(), MOVEFILE_REPLACE_EXISTING)) {
-        // renameが失敗した場合（クロスボリューム等）、直接書き込み（更なる失敗の救済手段はないので戻り値は破棄）
-        DeleteFileW(tmp_path.c_str());
-        (void)WriteAllBytes(ini_path, content.data(), content.size());
-    }
+    (void)AtomicWriteAllBytes(ini_path, content.data(), content.size());
 }
 
 void ConfigService::Clear() noexcept

--- a/src/io/image_loader.cpp
+++ b/src/io/image_loader.cpp
@@ -33,8 +33,8 @@ void ImageLoader::GetDpiScale(float& scale_x, float& scale_y) const
     if (render_target_) {
         render_target_->GetDpi(&dpi_x, &dpi_y);
     }
-    scale_x = (dpi_x > 0.0f) ? (dpi_x / DEFAULT_DPI) : 1.0f;
-    scale_y = (dpi_y > 0.0f) ? (dpi_y / DEFAULT_DPI) : 1.0f;
+    scale_x = DpiScaleFrom(dpi_x);
+    scale_y = DpiScaleFrom(dpi_y);
 }
 
 bool ImageLoader::Init(ID2D1RenderTarget* rt, IWICImagingFactory* wic)

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -70,11 +70,15 @@ void MermaidRenderer::Init(
         wic_factory_ = wic;
     }
     else {
-        CoCreateInstance(
+        const HRESULT hr = CoCreateInstance(
             CLSID_WICImagingFactory,
             nullptr,
             CLSCTX_INPROC_SERVER,
             IID_PPV_ARGS(&wic_factory_));
+        if (FAILED(hr)) {
+            LogHrFailure(L"MermaidRenderer CoCreateInstance(WIC)", hr);
+            wic_factory_.Reset();
+        }
     }
 }
 

--- a/src/mermaid/mermaid_file_cache.cpp
+++ b/src/mermaid/mermaid_file_cache.cpp
@@ -3,6 +3,7 @@
 #include "file_io.h"
 #include <algorithm>
 #include <cstring>
+#include <format>
 #include <memory>
 #include <chrono>
 #include <cmath>
@@ -55,8 +56,8 @@ std::filesystem::path MermaidFileCache::GetCacheDir() const
 std::filesystem::path MermaidFileCache::GetPngPath(const std::filesystem::path& dir, uint64_t key) const
 {
     wchar_t name[24];
-    swprintf_s(name, L"%016llx.png", key);
-    return dir / name;
+    const auto r = std::format_to_n(name, std::ranges::size(name) - 1, L"{:016x}.png", key);
+    return dir / std::wstring_view{ name, static_cast<size_t>(r.out - name) };
 }
 
 std::filesystem::path MermaidFileCache::GetPngPath(uint64_t key) const
@@ -186,16 +187,7 @@ void MermaidFileCache::SaveIndex()
         p += sizeof(record);
     }
 
-    const auto tmp_path = path.parent_path() / L"index.bin.tmp";
-    if (!WriteAllBytes(tmp_path, buf.get(), buf_size)) {
-        return;
-    }
-
-    if (!MoveFileExW(tmp_path.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING)) {
-        // renameが失敗した場合、直接書き込み（更なる失敗の救済手段はないので戻り値は破棄）
-        DeleteFileW(tmp_path.c_str());
-        (void)WriteAllBytes(path, buf.get(), buf_size);
-    }
+    (void)AtomicWriteAllBytes(path, buf.get(), buf_size);
 }
 
 bool MermaidFileCache::Lookup(uint64_t key, CacheEntry& entry, PngBlob& png)

--- a/src/mermaid/mermaid_file_cache.cpp
+++ b/src/mermaid/mermaid_file_cache.cpp
@@ -2,11 +2,13 @@
 #include "task_scheduler.h"
 #include "file_io.h"
 #include <algorithm>
+#include <chrono>
+#include <cmath>
 #include <cstring>
 #include <format>
 #include <memory>
-#include <chrono>
-#include <cmath>
+#include <ranges>
+#include <string_view>
 
 namespace {
 

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -185,7 +185,7 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry, float entry
     }
 
     const bool first_pass = !entry.effects_applied;
-    const auto row_count = tbl->row_count;
+    const auto row_count = static_cast<size_t>(tbl->row_count);
     const auto col_count = static_cast<size_t>(tbl->col_count);
     auto& tl = *entry.table_layout;
     if (first_pass) {
@@ -195,9 +195,34 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry, float entry
     }
 
     const float border = TABLE_BORDER_WIDTH;
-    float row_y = entry_text_top;
 
-    for (size_t r = 0; r < row_count; r++) {
+    // 2回目以降のパスは row_cum_y で可視範囲を二分探索し、その帯だけループする。
+    // 1万行テーブルの大半をスキップしていたフレーム毎の row_count 線形 continue を排除する。
+    size_t r_begin = 0;
+    size_t r_end = row_count;
+    const bool cull_by_viewport = !first_pass && viewport_top >= 0.0f && tl.row_cum_y.size() == row_count + 1;
+    if (cull_by_viewport) {
+        const float local_top = viewport_top - entry_text_top;
+        const float local_bottom = viewport_bottom - entry_text_top;
+        // row_cum_y[r+1] は行 r の下端 (= 次行の上端、border 込み)。最初に local_top を超える
+        // 境界点を upper_bound で求め、その 1 つ手前が viewport 先頭にかかる行。
+        auto upper = std::ranges::upper_bound(tl.row_cum_y, local_top);
+        if (upper != tl.row_cum_y.begin()) {
+            r_begin = static_cast<size_t>(std::ranges::distance(tl.row_cum_y.begin(), upper)) - 1;
+        }
+        auto lower = std::ranges::lower_bound(tl.row_cum_y, local_bottom);
+        if (lower != tl.row_cum_y.end()) {
+            const auto idx = static_cast<size_t>(std::ranges::distance(tl.row_cum_y.begin(), lower));
+            r_end = std::min(row_count, idx);
+        }
+    }
+
+    float row_y = entry_text_top;
+    if (r_begin > 0) {
+        row_y = entry_text_top + tl.row_cum_y[r_begin];
+    }
+
+    for (size_t r = r_begin; r < r_end; r++) {
         const float row_h = (r < tl.row_heights.size()) ? tl.row_heights[r] : (theme_.font_size_body * 1.4f);
         const float row_bottom = row_y + row_h + border;
 
@@ -482,7 +507,7 @@ void Renderer::Render(const RenderParams& p)
         // ヒットテストとの座標一致のためスナップ前の scroll_y を使う。
         const float viewport_top = p.scroll_y;
         const int first_visible = FindFirstVisibleNodeIndex(p.cache, p.nodes.size(), viewport_top);
-        const float dpi_scale = backend_.GetDpi() / DEFAULT_DPI;
+        const float dpi_scale = DpiScaleFrom(backend_.GetDpi());
         const auto& cmds = cmd_generator_.GenerateMdPane(p.nodes, p.cache, p.md_pane_rect, p.scroll_y, p.selection, first_visible, p.hovered, dpi_scale, p.block_h_scroll);
 
         cmd_executor_.Execute(cmds, rt(), &fixed_brushes_cache_);

--- a/src/theme/theme.cpp
+++ b/src/theme/theme.cpp
@@ -35,20 +35,6 @@ float Theme::GetHeadingSize(int level) const noexcept
     return font_size_h[level - 1];
 }
 
-ThemeConstants Theme::ToReducerConstants() const noexcept
-{
-    return ThemeConstants{
-        .pane_item_height = pane_item_height,
-        .pane_header_height = pane_header_height,
-        .splitter_width = splitter_width,
-        .margin_left = margin_left,
-        .margin_right = margin_right,
-        .heading_spacing_above = heading_spacing_above,
-        .zoom = zoom,
-        .is_dark = IsDark(),
-    };
-}
-
 void Theme::ApplyZoom(float new_zoom) noexcept
 {
     // 0/負値は通常の呼び出しでは発生しない (viewport ZOOM_MIN..ZOOM_MAX クランプ済み) が、

--- a/src/theme/theme.h
+++ b/src/theme/theme.h
@@ -5,18 +5,6 @@
 #include "document_types.h"
 #include "theme_palette.h"
 
-// Reducer がテーマ定数を参照するためのキャッシュ。
-struct ThemeConstants {
-    float pane_item_height = 28.0f;
-    float pane_header_height = 32.0f;
-    float splitter_width = 4.0f;
-    float margin_left = 0.0f;
-    float margin_right = 0.0f;
-    float heading_spacing_above = 0.0f;
-    float zoom = 1.0f;
-    bool is_dark = false;
-};
-
 struct Theme {
     // 色
     D2D1_COLOR_F bg_color;
@@ -110,7 +98,6 @@ struct Theme {
         return (bg_color.r + bg_color.g + bg_color.b) < 1.5f;
     }
 
-    ThemeConstants ToReducerConstants() const noexcept;
     void ApplyZoom(float new_zoom) noexcept;
 };
 

--- a/src/ui/context_menu.cpp
+++ b/src/ui/context_menu.cpp
@@ -8,6 +8,8 @@
 using Microsoft::WRL::ComPtr;
 using namespace context_menu_constants;
 
+static constexpr wchar_t kContextMenuClass[] = L"mendoContextMenu";
+
 bool ContextMenu::Impl::RegisterWindowClass()
 {
     static std::once_flag flag;
@@ -19,7 +21,7 @@ bool ContextMenu::Impl::RegisterWindowClass()
         wc.lpfnWndProc = WndProc;
         wc.hInstance = GetModuleHandleW(nullptr);
         wc.hCursor = LoadCursorW(nullptr, IDC_ARROW);
-        wc.lpszClassName = L"mendoContextMenu";
+        wc.lpszClassName = kContextMenuClass;
         registered_ok = (RegisterClassExW(&wc) != 0);
     });
     return registered_ok;
@@ -86,7 +88,7 @@ bool ContextMenu::Impl::CreatePopupWindow(int screen_x, int screen_y)
 
     hwnd = CreateWindowExW(
         WS_EX_TOOLWINDOW | WS_EX_TOPMOST,
-        L"mendoContextMenu", nullptr,
+        kContextMenuClass, nullptr,
         WS_POPUP,
         x, y, pixel_w, pixel_h,
         owner, nullptr, GetModuleHandleW(nullptr), this);

--- a/src/util/file_io.cpp
+++ b/src/util/file_io.cpp
@@ -72,3 +72,20 @@ bool WriteAllBytes(const std::filesystem::path& path, const void* data, size_t s
     }
     return true;
 }
+
+bool AtomicWriteAllBytes(const std::filesystem::path& path, const void* data, size_t size)
+{
+    std::filesystem::path tmp_path = path;
+    tmp_path += L".tmp";
+
+    if (!WriteAllBytes(tmp_path, data, size)) {
+        return false;
+    }
+
+    if (MoveFileExW(tmp_path.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING)) {
+        return true;
+    }
+
+    DeleteFileW(tmp_path.c_str());
+    return WriteAllBytes(path, data, size);
+}

--- a/src/util/file_io.h
+++ b/src/util/file_io.h
@@ -53,6 +53,13 @@ bool IsFileLargerThan(const std::filesystem::path& path, size_t reference_size, 
 
 [[nodiscard]] bool WriteAllBytes(const std::filesystem::path& path, const void* data, size_t size);
 
+// tmp ファイルへ書いてから MoveFileExW(REPLACE_EXISTING) で原子的に置き換える。
+// rename が失敗 (クロスボリューム等) した場合は tmp を削除し path へ直接書き込む。
+// tmp パスは `<path>.tmp` 固定 — 同じ path への並行呼び出しは tmp が衝突するため、
+// 呼び出し側で排他制御すること (現 callsite は UI スレッド単一発火で安全)。
+// 戻り値は最終的に何らかの形で書き込めたか。
+bool AtomicWriteAllBytes(const std::filesystem::path& path, const void* data, size_t size);
+
 // ファイル名・フルパス比較ユーティリティ。
 // `CompareStringOrdinal(..., TRUE)` ベースで NTFS と挙動が一致する
 // Unicode 込みの ordinal case-insensitive 比較を提供する。

--- a/src/util/ui_constants.h
+++ b/src/util/ui_constants.h
@@ -22,6 +22,12 @@ inline constexpr float DOT_FADE_FACTOR = 0.85f;
 // Windowsの基準DPI（100%スケーリング時の値）
 inline constexpr float DEFAULT_DPI = 96.0f;
 
+// dpi が 0 以下なら 1.0 (DPI 未初期化時のフォールバック)、それ以外は dpi / 96。
+inline constexpr float DpiScaleFrom(float dpi) noexcept
+{
+    return (dpi > 0.0f) ? (dpi / DEFAULT_DPI) : 1.0f;
+}
+
 // マウスホイールスクロールの倍率
 inline constexpr float MOUSE_WHEEL_SCROLL_MULTIPLIER = 0.8f;
 

--- a/tests/test_file_io.cpp
+++ b/tests/test_file_io.cpp
@@ -194,3 +194,89 @@ TEST_F(FileIoTest, IsFileLargerThan_CustomTolerance)
     // tolerance=200: 100 バイト差は範囲内 → false
     EXPECT_FALSE(IsFileLargerThan(path, 1000, 200));
 }
+
+// ═══════════════════════════════════════════════
+// AtomicWriteAllBytes: tmp → MoveFileExW(REPLACE_EXISTING) 経路
+// ═══════════════════════════════════════════════
+
+TEST_F(FileIoTest, AtomicWrite_NewFile_WritesContentAndCleansUpTmp)
+{
+    const auto path = temp_dir_ / L"atomic_new.bin";
+    auto tmp = path;
+    tmp += L".tmp";
+    const std::string payload = "atomic-new-content";
+
+    ASSERT_TRUE(AtomicWriteAllBytes(path, payload.data(), payload.size()));
+
+    auto [buf, size] = ReadAllBytes(path);
+    ASSERT_EQ(size, payload.size());
+    EXPECT_EQ(std::string(reinterpret_cast<const char*>(buf.get()), size), payload);
+    // tmp は MoveFileExW で消費される (残らない)
+    EXPECT_FALSE(fs::exists(tmp));
+}
+
+TEST_F(FileIoTest, AtomicWrite_OverwritesExistingFile)
+{
+    const auto path = temp_dir_ / L"atomic_overwrite.bin";
+    auto tmp = path;
+    tmp += L".tmp";
+    const std::string first = "first-content-longer-than-second";
+    const std::string second = "short";
+
+    ASSERT_TRUE(AtomicWriteAllBytes(path, first.data(), first.size()));
+    ASSERT_TRUE(AtomicWriteAllBytes(path, second.data(), second.size()));
+
+    auto [buf, size] = ReadAllBytes(path);
+    ASSERT_EQ(size, second.size());
+    EXPECT_EQ(std::string(reinterpret_cast<const char*>(buf.get()), size), second);
+    EXPECT_FALSE(fs::exists(tmp));
+}
+
+TEST_F(FileIoTest, AtomicWrite_ToInvalidPath_FailsAndLeavesNoTmp)
+{
+    // 親ディレクトリが存在しないので tmp 書き込みも失敗する。
+    // 直接書き込み fallback も到達しないので path も tmp も生成されない。
+    const auto path = temp_dir_ / L"no_such_dir" / L"atomic.bin";
+    auto tmp = path;
+    tmp += L".tmp";
+    const std::string payload = "data";
+
+    EXPECT_FALSE(AtomicWriteAllBytes(path, payload.data(), payload.size()));
+    EXPECT_FALSE(fs::exists(path));
+    EXPECT_FALSE(fs::exists(tmp));
+}
+
+TEST_F(FileIoTest, AtomicWrite_DoesNotLeavePreviousTmpBehind)
+{
+    // 既存の `<path>.tmp` がたとえ残っていても、新しい AtomicWriteAllBytes は
+    // 上書きで作り直し、MoveFileExW で消費するため最終的に残らない。
+    const auto path = temp_dir_ / L"atomic_stale_tmp.bin";
+    auto tmp = path;
+    tmp += L".tmp";
+    const std::string stale = "stale-tmp-leftover";
+    const std::string payload = "fresh-payload";
+
+    // 事前に残骸 tmp を仕込む
+    ASSERT_TRUE(WriteAllBytes(tmp, stale.data(), stale.size()));
+    ASSERT_TRUE(fs::exists(tmp));
+
+    ASSERT_TRUE(AtomicWriteAllBytes(path, payload.data(), payload.size()));
+
+    auto [buf, size] = ReadAllBytes(path);
+    ASSERT_EQ(size, payload.size());
+    EXPECT_EQ(std::string(reinterpret_cast<const char*>(buf.get()), size), payload);
+    EXPECT_FALSE(fs::exists(tmp));
+}
+
+TEST_F(FileIoTest, AtomicWrite_ZeroBytesProducesEmptyFile)
+{
+    const auto path = temp_dir_ / L"atomic_zero.bin";
+    auto tmp = path;
+    tmp += L".tmp";
+
+    ASSERT_TRUE(AtomicWriteAllBytes(path, "", 0));
+
+    EXPECT_TRUE(fs::exists(path));
+    EXPECT_EQ(fs::file_size(path), 0u);
+    EXPECT_FALSE(fs::exists(tmp));
+}


### PR DESCRIPTION
## Summary

- `/simplify` レビューで挙がった低リスク指摘をアプリ全体で解消
  - Theme: 未使用 `ThemeConstants` / `ToReducerConstants` を削除
  - `file_io`: `AtomicWriteAllBytes` を抽出し `ConfigService::Flush` と `MermaidFileCache::SaveIndex` の atomic rename パターンを集約
  - `ui_constants`: `DpiScaleFrom` ヘルパを追加して 3 callsite に適用
  - mermaid: WIC ファクトリ生成失敗時の HRESULT を `LogHrFailure` 経由に統一
  - `mermaid_file_cache`: `GetPngPath` の `swprintf_s` を `std::format_to_n` に置換
  - `reducer`: `EmitScrollChangedSideEffects` を抽出し副作用列の重複を集約
  - `context_menu`: クラス名リテラルを `kContextMenuClass` 定数に一元化
- パフォーマンス: `renderer.cpp` の `ApplyTableEffects` 2nd pass を `row_cum_y` の二分探索で可視帯のみ走査するよう変更（1 万行テーブルでフレーム毎の線形 `continue` を排除）
- `example/test.md` をリファクタリング後の構成（ClipboardManager 集約、`template<class Cb>` 化、scroll_drag ヘルパ、layout/io 配下の新ファイル群）に追従

## Test plan

- [ ] `cmake --build build --config Release` でビルドが通る
- [ ] `build/tests/Release/mendo_tests.exe --gtest_brief=1` がパスする
- [ ] 設定保存 (ConfigService::Flush) と Mermaid キャッシュ書き込み (MermaidFileCache::SaveIndex) が引き続き atomic rename で動作する
- [ ] 1 万行クラスのテーブルを含むファイルでスクロール時の CPU 使用率が改善している
- [ ] コンテキストメニューがダーク/ライト両テーマで正しく表示される
- [ ] スクロール系副作用 (Md / Pane / BlockHScroll) が以前と同じ順序・タイミングで発火する

🤖 Generated with [Claude Code](https://claude.com/claude-code)