### PR TITLE
refactor: アプリ全体の /simplify レビュー指摘を解消 (13 + 4 件)

### DIFF
--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -53,13 +53,15 @@ bool App::Init(HWND hwnd)
                             [this](std::wstring_view m) { ShowToast(m); });
 
     resource_manager_.Init(
-        state_.document.doc,
-        state_.document.layout_cache,
-        state_.view.viewport,
-        image_loader_,
-        mermaid_renderer_,
-        theme_service_,
-        renderer_.GetTheme(),
+        ResourceManagerDeps{
+            .doc = &state_.document.doc,
+            .cache = &state_.document.layout_cache,
+            .viewport = &state_.view.viewport,
+            .image_loader = &image_loader_,
+            .mermaid = &mermaid_renderer_,
+            .theme_service = &theme_service_,
+            .theme = &renderer_.GetTheme(),
+        },
         AppResourceManagerCallbacks{ this });
     win32_host_.Init(hwnd_, cursors_);
     effect_executor_.Init(

--- a/src/app/app_scroll.cpp
+++ b/src/app/app_scroll.cpp
@@ -130,7 +130,7 @@ void App::OnDeferredLayout()
     bool more;
     {
         MENDO_PROFILE("ProcessDirtyBatch");
-        more = layout_service_->ProcessDirtyBatch(state_.document.doc, state_.document.layout_cache, md_width, 200, ResourceManager::BATCH_TIME_BUDGET_US, md_height, ResourceManager::EVICT_BUFFER_SCREENS);
+        more = layout_service_->ProcessDirtyBatch(state_.document.doc, state_.document.layout_cache, md_width, 200, ResourceManager::BATCH_TIME_BUDGET_US, LayoutService::ViewportLimit{ md_height, ResourceManager::EVICT_BUFFER_SCREENS });
     }
 
     // 中間バッチでは SyncMaxScroll のクランプを遅延させる。

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -346,10 +346,8 @@ BlockHScrollGeometry ResolveBlockHScrollGeometry(const AppState& state, int node
         state.pane_layout_cache.Get().md_rect.width);
 }
 
-// scroll_x を [0, max] に詰めて map に反映する。0 になった場合はエントリを削除する。
 // HitTestService 側のキャッシュキーには block_scroll_x が含まれないため、
 // 値が変わったタイミングで effects_generation を進めて last_md_hit_ の再計算を強制する。
-// 値変化が 1e-3f 未満なら false を返し、呼び出し側で InvalidateWindow をスキップさせる。
 bool ApplyBlockHScrollDelta(AppState& state, int node_index, float new_value, float scroll_max)
 {
     const float clamped = std::clamp(new_value, 0.0f, scroll_max);
@@ -733,7 +731,7 @@ void ReduceTextSelectionMoved(AppState& state, SideEffectList& effects, const Te
     if (!state.view.viewport.IsDragging() || a.node_index < 0) {
         return;
     }
-    // 同一位置への WM_MOUSEMOVE ではフル再描画を抑止する (16ms 周期で連発するため)。
+    // WM_MOUSEMOVE は 16ms 周期で連発するため、選択が同値なら早期 return。
     const auto next = TextSelection::MakeOrdered(
         state.view.viewport.GetAnchorNode(),
         state.view.viewport.GetAnchorPos(),

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -311,10 +311,7 @@ void ReduceResize(AppState& state, SideEffectList& effects, const ResizeAction& 
 
 void ReduceDpiChanged(AppState& state, SideEffectList& effects, const DpiChangedAction& a)
 {
-    state.window.cached_dpi_scale = static_cast<float>(a.dpi) / 96.0f;
-    if (state.window.cached_dpi_scale <= 0.0f) {
-        state.window.cached_dpi_scale = 1.0f;
-    }
+    state.window.cached_dpi_scale = DpiScaleFrom(static_cast<float>(a.dpi));
     state.pane_layout_cache.Invalidate();
     // DPI 変更では IDWriteTextLayout (DIP 単位) は不変。effects_generation のみ進める。
     state.document.layout_cache.NotifyDpiChanged();
@@ -352,12 +349,13 @@ BlockHScrollGeometry ResolveBlockHScrollGeometry(const AppState& state, int node
 // scroll_x を [0, max] に詰めて map に反映する。0 になった場合はエントリを削除する。
 // HitTestService 側のキャッシュキーには block_scroll_x が含まれないため、
 // 値が変わったタイミングで effects_generation を進めて last_md_hit_ の再計算を強制する。
-void ApplyBlockHScrollDelta(AppState& state, int node_index, float new_value, float scroll_max)
+// 値変化が 1e-3f 未満なら false を返し、呼び出し側で InvalidateWindow をスキップさせる。
+bool ApplyBlockHScrollDelta(AppState& state, int node_index, float new_value, float scroll_max)
 {
     const float clamped = std::clamp(new_value, 0.0f, scroll_max);
     const float prev = state.view.GetBlockScrollX(node_index);
     if (std::abs(prev - clamped) < 1e-3f) {
-        return;
+        return false;
     }
     if (clamped <= 0.0f) {
         state.view.block_scroll_x.erase(node_index);
@@ -366,6 +364,7 @@ void ApplyBlockHScrollDelta(AppState& state, int node_index, float new_value, fl
         state.view.block_scroll_x[node_index] = clamped;
     }
     state.document.layout_cache.IncrementEffectsGeneration();
+    return true;
 }
 
 } // namespace
@@ -379,8 +378,9 @@ void ReduceHWheel(AppState& state, SideEffectList& effects, const HWheelAction& 
         if (geom.can_scroll()) {
             const float dx = static_cast<float>(a.delta) / WHEEL_DELTA * HSCROLL_DIP_PER_NOTCH;
             const float cur = state.view.GetBlockScrollX(target);
-            ApplyBlockHScrollDelta(state, target, cur + dx, geom.scroll_max());
-            PushEffect(effects, effect::InvalidateWindow{});
+            if (ApplyBlockHScrollDelta(state, target, cur + dx, geom.scroll_max())) {
+                PushEffect(effects, effect::InvalidateWindow{});
+            }
             return;
         }
     }
@@ -440,8 +440,9 @@ void ReduceBlockHScrollDragMoved(AppState& state, SideEffectList& effects, const
     const float thumb_w = BlockHScrollbarThumbWidth(geom.visible_width, geom.natural_width);
     const float drag_range = std::max(1.0f, geom.visible_width - thumb_w);
     const float scroll_max = geom.scroll_max();
-    ApplyBlockHScrollDelta(state, sv.h_drag_node, sv.h_drag_start_scroll + dip_delta * scroll_max / drag_range, scroll_max);
-    PushEffect(effects, effect::InvalidateWindow{});
+    if (ApplyBlockHScrollDelta(state, sv.h_drag_node, sv.h_drag_start_scroll + dip_delta * scroll_max / drag_range, scroll_max)) {
+        PushEffect(effects, effect::InvalidateWindow{});
+    }
 }
 
 void ReduceBlockHScrollDragEnded(AppState& state, SideEffectList& effects, const BlockHScrollDragEndedAction&)
@@ -732,11 +733,16 @@ void ReduceTextSelectionMoved(AppState& state, SideEffectList& effects, const Te
     if (!state.view.viewport.IsDragging() || a.node_index < 0) {
         return;
     }
-    state.view.viewport.SetSelection(TextSelection::MakeOrdered(
+    // 同一位置への WM_MOUSEMOVE ではフル再描画を抑止する (16ms 周期で連発するため)。
+    const auto next = TextSelection::MakeOrdered(
         state.view.viewport.GetAnchorNode(),
         state.view.viewport.GetAnchorPos(),
         a.node_index,
-        a.text_pos));
+        a.text_pos);
+    if (next == state.view.viewport.GetSelection()) {
+        return;
+    }
+    state.view.viewport.SetSelection(next);
     PushEffect(effects, effect::InvalidateWindow{});
 }
 

--- a/src/app/resource_manager.h
+++ b/src/app/resource_manager.h
@@ -13,6 +13,18 @@ class IMermaidRenderer;
 class ThemeService;
 struct Theme;
 
+// ResourceManager が依存するサービス群を 1 つにまとめる DI コンテナ。
+// 各ポインタは ResourceManager の生存期間中 valid である必要がある。
+struct ResourceManagerDeps {
+    Document* doc = nullptr;
+    LayoutCache* cache = nullptr;
+    ViewportManager* viewport = nullptr;
+    ImageLoader* image_loader = nullptr;
+    IMermaidRenderer* mermaid = nullptr;
+    ThemeService* theme_service = nullptr;
+    const Theme* theme = nullptr;
+};
+
 // 画像・Mermaidリソースのライフサイクル管理。
 // Appから画像読み込み、Mermaidバッチ処理、ビットマップ解放の責務を分離する。
 template <class Cb>
@@ -23,7 +35,7 @@ public:
     static constexpr int BATCH_TIME_BUDGET_US = 6000;
 
     ResourceManagerT() = default;
-    void Init(Document& doc, LayoutCache& cache, ViewportManager& viewport, ImageLoader& image_loader, IMermaidRenderer& mermaid, ThemeService& theme_service, const Theme& theme, Cb cb);
+    void Init(const ResourceManagerDeps& deps, Cb cb);
 
     // respect_viewport=true: 可視範囲のみ走査し、未キャッシュは非同期ロード起動（通常描画用）。
     // respect_viewport=false: 全画像を走査、未キャッシュは無視（リロード時のスクロール計算前用）。

--- a/src/app/resource_manager_impl.h
+++ b/src/app/resource_manager_impl.h
@@ -34,23 +34,15 @@ inline IndexSlice VisibleSlice(const std::pmr::vector<size_t>& sorted_indices, s
 } // namespace resource_manager_detail
 
 template <class Cb>
-void ResourceManagerT<Cb>::Init(
-    Document& doc,
-    LayoutCache& cache,
-    ViewportManager& viewport,
-    ImageLoader& image_loader,
-    IMermaidRenderer& mermaid,
-    ThemeService& theme_service,
-    const Theme& theme,
-    Cb cb)
+void ResourceManagerT<Cb>::Init(const ResourceManagerDeps& deps, Cb cb)
 {
-    doc_ = &doc;
-    cache_ = &cache;
-    viewport_ = &viewport;
-    image_loader_ = &image_loader;
-    mermaid_ = &mermaid;
-    theme_service_ = &theme_service;
-    theme_ = &theme;
+    doc_ = deps.doc;
+    cache_ = deps.cache;
+    viewport_ = deps.viewport;
+    image_loader_ = deps.image_loader;
+    mermaid_ = deps.mermaid;
+    theme_service_ = deps.theme_service;
+    theme_ = deps.theme;
     cb_ = std::move(cb);
 }
 

--- a/src/core/syntax.cpp
+++ b/src/core/syntax.cpp
@@ -94,6 +94,30 @@ constexpr size_t ScanString(std::string_view text, size_t pos, char quote, bool 
     return i;
 }
 
+// C++ 生文字列 R"DELIM(...)DELIM" をスキャン。quote_pos は開きの '"'、paren は '(' の位置。
+// 終端 )DELIM" を見つけたらその直後位置を返し、未終端なら text.size() を返す。
+constexpr size_t ScanCppRawString(std::string_view text, size_t quote_pos, size_t paren) noexcept
+{
+    const std::string_view delim = text.substr(quote_pos + 1, paren - quote_pos - 1);
+    const size_t end_marker_len = 1 + delim.size() + 1; // ')' + delim + '"'
+    size_t k = paren + 1;
+    while (k + end_marker_len <= text.size()) {
+        const size_t found = text.find(')', k);
+        if (found == std::string_view::npos || found + end_marker_len > text.size()) {
+            break;
+        }
+        if (text[found + 1 + delim.size()] != '"') {
+            k = found + 1;
+            continue;
+        }
+        if (delim.empty() || text.compare(found + 1, delim.size(), delim) == 0) {
+            return found + end_marker_len;
+        }
+        k = found + 1;
+    }
+    return text.size();
+}
+
 // Pythonのトリプルクォート文字列をスキャン（pos はトリプルクォートの最初の引用符を指す）。
 constexpr size_t ScanTripleQuote(std::string_view text, size_t pos, char quote) noexcept
 {
@@ -379,33 +403,7 @@ std::pmr::vector<SyntaxToken> TokenizeImpl(
                 // デリミタを検索: R"DELIM( ... )DELIM"
                 const size_t paren = text.find('(', i + 1);
                 if (paren != std::string_view::npos) {
-                    // end_marker = ')' + delim + '"'。delim は view のまま比較してヒープ確保しない。
-                    const std::string_view delim = text.substr(i + 1, paren - i - 1);
-                    const size_t end_marker_len = 1 + delim.size() + 1; // ')' + delim + '"'
-                    size_t end_pos = std::string_view::npos;
-                    // 生文字列の本文中で ')' は通常レアなので、find で間引いてから delim と '"' を確認する。
-                    size_t k = paren + 1;
-                    while (k + end_marker_len <= text.size()) {
-                        const auto found = text.find(')', k);
-                        if (found == std::string_view::npos || found + end_marker_len > text.size()) {
-                            break;
-                        }
-                        if (text[found + 1 + delim.size()] != '"') {
-                            k = found + 1;
-                            continue;
-                        }
-                        if (delim.empty() || text.compare(found + 1, delim.size(), delim) == 0) {
-                            end_pos = found;
-                            break;
-                        }
-                        k = found + 1;
-                    }
-                    if (end_pos != std::string_view::npos) {
-                        i = end_pos + end_marker_len;
-                    }
-                    else {
-                        i = text.size();
-                    }
+                    i = ScanCppRawString(text, i, paren);
                 }
                 else {
                     i = ScanString(text, i, c, false);

--- a/src/core/text_types.h
+++ b/src/core/text_types.h
@@ -73,6 +73,8 @@ struct TextSelection {
     uint32_t end_pos = 0;
     bool active = false;
 
+    friend constexpr bool operator==(const TextSelection&, const TextSelection&) noexcept = default;
+
     constexpr void Clear() noexcept
     {
         start_node = -1;

--- a/src/io/config_service.cpp
+++ b/src/io/config_service.cpp
@@ -11,6 +11,21 @@
 #pragma comment(lib, "shell32.lib")
 #pragma comment(lib, "ole32.lib")
 
+// ini 永続化キー。生文字列を散らさず一覧化し、タイポを静的に検出可能にする。
+// 既存の ini ファイル下位互換が要求されるため値の変更は禁止。
+namespace {
+using namespace std::literals;
+constexpr auto kSectionSession = "Session"sv;
+constexpr auto kKeyLastFile = "LastFile"sv;
+constexpr auto kKeyScrollNode = "ScrollNode"sv;
+constexpr auto kKeyScrollOffset = "ScrollOffset"sv;
+constexpr auto kSectionPane = "Pane"sv;
+constexpr auto kKeyShowFile = "ShowFile"sv;
+constexpr auto kKeyShowToc = "ShowToc"sv;
+constexpr auto kKeyFileWidth = "FileWidth"sv;
+constexpr auto kKeyTocWidth = "TocWidth"sv;
+} // namespace
+
 void ConfigService::SetConfigDirOverride(const std::filesystem::path& dir)
 {
     config_dir_override_ = dir;
@@ -160,12 +175,12 @@ void SessionService::SaveLastFilePath(std::wstring_view path)
     if (path.empty()) {
         return;
     }
-    config_.SaveWString("Session", "LastFile", path);
+    config_.SaveWString(kSectionSession, kKeyLastFile, path);
 }
 
 std::pmr::wstring SessionService::LoadLastFilePath() const
 {
-    std::pmr::wstring path = config_.LoadWString("Session", "LastFile");
+    std::pmr::wstring path = config_.LoadWString(kSectionSession, kKeyLastFile);
     if (path.empty()) {
         return {};
     }
@@ -181,17 +196,17 @@ std::pmr::wstring SessionService::LoadLastFilePath() const
 
 void SessionService::SavePaneState(const PaneState& state)
 {
-    config_.SaveBool("Pane", "ShowFile", state.show_file);
-    config_.SaveBool("Pane", "ShowToc", state.show_toc);
-    config_.SaveInt("Pane", "FileWidth", static_cast<int>(std::lround(state.file_width)));
-    config_.SaveInt("Pane", "TocWidth", static_cast<int>(std::lround(state.toc_width)));
+    config_.SaveBool(kSectionPane, kKeyShowFile, state.show_file);
+    config_.SaveBool(kSectionPane, kKeyShowToc, state.show_toc);
+    config_.SaveInt(kSectionPane, kKeyFileWidth, static_cast<int>(std::lround(state.file_width)));
+    config_.SaveInt(kSectionPane, kKeyTocWidth, static_cast<int>(std::lround(state.toc_width)));
 }
 
 SessionService::PaneState SessionService::LoadPaneState(float client_width, float min_width, float default_width) const
 {
     PaneState s;
-    s.show_file = config_.LoadBool("Pane", "ShowFile", true);
-    s.show_toc = config_.LoadBool("Pane", "ShowToc", true);
+    s.show_file = config_.LoadBool(kSectionPane, kKeyShowFile, true);
+    s.show_toc = config_.LoadBool(kSectionPane, kKeyShowToc, true);
 
     const int default_int = static_cast<int>(default_width);
     const int min_int = static_cast<int>(min_width);
@@ -205,8 +220,8 @@ SessionService::PaneState SessionService::LoadPaneState(float client_width, floa
     // LoadInt は範囲外時に default_int を返すが、その既定値自体が
     // 狭いウィンドウでは dynamic_max を超えうる。最終結果も clamp してから
     // 適用し、SetXxxPaneWidth 側の最小値 clamp に過剰な幅が漏れないようにする。
-    const int file_w = std::clamp(config_.LoadInt("Pane", "FileWidth", default_int, min_int, dynamic_max), min_int, dynamic_max);
-    const int toc_w = std::clamp(config_.LoadInt("Pane", "TocWidth", default_int, min_int, dynamic_max), min_int, dynamic_max);
+    const int file_w = std::clamp(config_.LoadInt(kSectionPane, kKeyFileWidth, default_int, min_int, dynamic_max), min_int, dynamic_max);
+    const int toc_w = std::clamp(config_.LoadInt(kSectionPane, kKeyTocWidth, default_int, min_int, dynamic_max), min_int, dynamic_max);
     s.file_width = static_cast<float>(file_w);
     s.toc_width = static_cast<float>(toc_w);
     return s;
@@ -215,14 +230,14 @@ SessionService::PaneState SessionService::LoadPaneState(float client_width, floa
 void SessionService::SaveScrollPosition(int node, float scroll_y, float node_y)
 {
     const int offset = static_cast<int>(std::lround(scroll_y - node_y));
-    config_.SaveInt("Session", "ScrollNode", node);
-    config_.SaveInt("Session", "ScrollOffset", offset);
+    config_.SaveInt(kSectionSession, kKeyScrollNode, node);
+    config_.SaveInt(kSectionSession, kKeyScrollOffset, offset);
 }
 
 SessionService::ScrollPosition SessionService::LoadScrollPosition() const
 {
     return {
-        .node = config_.LoadInt("Session", "ScrollNode", -1, -1, 1000000),
-        .offset = config_.LoadInt("Session", "ScrollOffset", 0, -1000000, 1000000),
+        .node = config_.LoadInt(kSectionSession, kKeyScrollNode, -1, -1, 1000000),
+        .offset = config_.LoadInt(kSectionSession, kKeyScrollOffset, 0, -1000000, 1000000),
     };
 }

--- a/src/io/image_loader.cpp
+++ b/src/io/image_loader.cpp
@@ -44,17 +44,8 @@ bool ImageLoader::Init(ID2D1RenderTarget* rt, IWICImagingFactory* wic)
         wic_factory_ = wic;
         return true;
     }
-    HRESULT hr = CoCreateInstance(
-        CLSID_WICImagingFactory,
-        nullptr,
-        CLSCTX_INPROC_SERVER,
-        IID_PPV_ARGS(&wic_factory_));
-    if (FAILED(hr)) {
-        mendo::LogHrFailure(L"ImageLoader CoCreateInstance(WIC)", hr);
-        wic_factory_.Reset();
-        return false;
-    }
-    return true;
+    wic_factory_ = wic_util::CreateWicFactory(L"ImageLoader CoCreateInstance(WIC)");
+    return wic_factory_ != nullptr;
 }
 
 void ImageLoader::InitAsync(HWND hwnd, UINT msg_id, TaskScheduler& scheduler)

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -231,12 +231,12 @@ void LayoutService::ViewportLayout(Document& doc, LayoutCache& cache, float widt
     viewport_.ApplyScrollTarget(cache);
 }
 
-bool LayoutService::ProcessDirtyBatch(Document& doc, LayoutCache& cache, float width, int batch_size, int time_budget_us, std::optional<ViewportLimit> viewport)
+bool LayoutService::ProcessDirtyBatch(Document& doc, LayoutCache& cache, float width, int batch_size, int time_budget_us, ViewportLimit viewport)
 {
     bool more;
-    if (viewport && viewport->height > 0.0f) {
+    if (viewport.height > 0.0f) {
         const float vp_top = viewport_.GetScrollY();
-        more = engine_.ProcessDirtyBatch(doc.GetNodesMut(), cache, width, batch_size, time_budget_us, vp_top, viewport->height, viewport->buffer_screens);
+        more = engine_.ProcessDirtyBatch(doc.GetNodesMut(), cache, width, batch_size, time_budget_us, vp_top, viewport.height, viewport.buffer_screens);
     }
     else {
         more = engine_.ProcessDirtyBatch(doc.GetNodesMut(), cache, width, batch_size, time_budget_us);

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -231,12 +231,12 @@ void LayoutService::ViewportLayout(Document& doc, LayoutCache& cache, float widt
     viewport_.ApplyScrollTarget(cache);
 }
 
-bool LayoutService::ProcessDirtyBatch(Document& doc, LayoutCache& cache, float width, int batch_size, int time_budget_us, float viewport_height, float buffer_screens)
+bool LayoutService::ProcessDirtyBatch(Document& doc, LayoutCache& cache, float width, int batch_size, int time_budget_us, std::optional<ViewportLimit> viewport)
 {
     bool more;
-    if (viewport_height > 0.0f) {
+    if (viewport && viewport->height > 0.0f) {
         const float vp_top = viewport_.GetScrollY();
-        more = engine_.ProcessDirtyBatch(doc.GetNodesMut(), cache, width, batch_size, time_budget_us, vp_top, viewport_height, buffer_screens);
+        more = engine_.ProcessDirtyBatch(doc.GetNodesMut(), cache, width, batch_size, time_budget_us, vp_top, viewport->height, viewport->buffer_screens);
     }
     else {
         more = engine_.ProcessDirtyBatch(doc.GetNodesMut(), cache, width, batch_size, time_budget_us);

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -8,6 +8,7 @@
 #include "viewport_manager.h"
 #include <dwrite.h>
 #include <memory_resource>
+#include <optional>
 
 class TaskScheduler;
 
@@ -97,9 +98,16 @@ public:
     }
 
     void ViewportLayout(Document& doc, LayoutCache& cache, float width, float height);
+
+    // 増分レイアウトのビューポート絞り込み。指定すると可視範囲 + 周辺バッファのみ
+    // 処理し、未指定なら全 dirty を順次処理する。
+    struct ViewportLimit {
+        float height = 0.0f;
+        float buffer_screens = 5.0f;
+    };
     bool ProcessDirtyBatch(
         Document& doc, LayoutCache& cache, float width, int batch_size, int time_budget_us = 0,
-        float viewport_height = -1.0f, float buffer_screens = 5.0f);
+        std::optional<ViewportLimit> viewport = std::nullopt);
     bool EnsureVisibleLayout(Document& doc, LayoutCache& cache, float width, float height);
     void RecomputeAfterDiagram(Document& doc, LayoutCache& cache, const Theme& theme) noexcept;
 

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -8,7 +8,6 @@
 #include "viewport_manager.h"
 #include <dwrite.h>
 #include <memory_resource>
-#include <optional>
 
 class TaskScheduler;
 
@@ -99,15 +98,15 @@ public:
 
     void ViewportLayout(Document& doc, LayoutCache& cache, float width, float height);
 
-    // 増分レイアウトのビューポート絞り込み。指定すると可視範囲 + 周辺バッファのみ
-    // 処理し、未指定なら全 dirty を順次処理する。
+    // 増分レイアウトのビューポート絞り込み。height > 0 で可視範囲 + 周辺バッファのみ
+    // 処理し、height <= 0 (デフォルト) なら全 dirty を順次処理する。
     struct ViewportLimit {
         float height = 0.0f;
         float buffer_screens = 5.0f;
     };
     bool ProcessDirtyBatch(
         Document& doc, LayoutCache& cache, float width, int batch_size, int time_budget_us = 0,
-        std::optional<ViewportLimit> viewport = std::nullopt);
+        ViewportLimit viewport = {});
     bool EnsureVisibleLayout(Document& doc, LayoutCache& cache, float width, float height);
     void RecomputeAfterDiagram(Document& doc, LayoutCache& cache, const Theme& theme) noexcept;
 

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -70,15 +70,7 @@ void MermaidRenderer::Init(
         wic_factory_ = wic;
     }
     else {
-        const HRESULT hr = CoCreateInstance(
-            CLSID_WICImagingFactory,
-            nullptr,
-            CLSCTX_INPROC_SERVER,
-            IID_PPV_ARGS(&wic_factory_));
-        if (FAILED(hr)) {
-            LogHrFailure(L"MermaidRenderer CoCreateInstance(WIC)", hr);
-            wic_factory_.Reset();
-        }
+        wic_factory_ = wic_util::CreateWicFactory(L"MermaidRenderer CoCreateInstance(WIC)");
     }
 }
 
@@ -203,62 +195,7 @@ void MermaidRenderer::SetupWorker(int index)
             const auto f = [this, index](ICoreWebView2*, ICoreWebView2WebMessageReceivedEventArgs* args) -> HRESULT {
                 LPWSTR msg = nullptr;
                 if (SUCCEEDED(args->TryGetWebMessageAsString(&msg)) && msg) {
-                    auto& w = workers_[index];
-                    const auto parsed = mermaid_util::ParseWebMessage(msg);
-                    using mermaid_util::WebMessageKind;
-                    const auto& req = parsed.request;
-                    const bool req_id_match = req.valid && req.id == w.current_request.request_id;
-                    switch (parsed.kind) {
-                    case WebMessageKind::Ready:
-                        if (parsed.ready_dpr > 0) {
-                            w.dpr = parsed.ready_dpr;
-                        }
-                        w.ready = true;
-                        w.init_retries = 0;
-                        // 最初のワーカーが準備完了した時点でon_readyを呼び出す。
-                        // 残りのワーカーは準備でき次第プールに参加する。
-                        if (!lifecycle_.IsReady()) {
-                            lifecycle_.MarkReady();
-                            if (on_all_ready_) {
-                                auto cb = std::move(on_all_ready_);
-                                cb();
-                            }
-                        }
-                        ProcessQueue();
-                        break;
-                    case WebMessageKind::RenderResult:
-                        if (req_id_match && req.has_payload) {
-                            OnRenderResult(index, req.payload);
-                        }
-                        break;
-                    case WebMessageKind::CaptureReady:
-                        if (req_id_match) {
-                            DoCapturePreview(index);
-                        }
-                        break;
-                    case WebMessageKind::SvgResult:
-                        if (req_id_match && w.current_request.svg_only) {
-                            std::pmr::wstring svg{ req.has_payload ? req.payload : std::wstring_view{} };
-                            InvokeSvgCallbackIfAny(w.current_request, std::move(svg), false);
-                            FinishWorkerRequest(w);
-                        }
-                        break;
-                    case WebMessageKind::RenderError:
-                        if (req_id_match) {
-                            InvokeSvgCallbackIfAny(w.current_request, {}, false);
-                            FinishWorkerRequest(w);
-                        }
-                        break;
-                    case WebMessageKind::Failed:
-                        // mermaid.jsの読み込みに失敗した場合、ページを再読み込みして再試行する
-                        if (w.init_retries < MAX_WORKER_RETRIES && w.webview) {
-                            ++w.init_retries;
-                            LogHrFailure(L"Navigate(retry)", w.webview->Navigate(APP_LOCAL_INDEX_URL));
-                        }
-                        break;
-                    case WebMessageKind::Unknown:
-                        break;
-                    }
+                    DispatchWebMessage(index, mermaid_util::ParseWebMessage(msg));
                     CoTaskMemFree(msg);
                 }
                 return S_OK;
@@ -599,6 +536,65 @@ void MermaidRenderer::RenderInWorker(Worker& worker)
         worker.current_request.request_id, worker.current_request.request_id);
 
     LogHrFailure(L"ExecuteScript(render)", worker.webview->ExecuteScript(js.c_str(), nullptr));
+}
+
+void MermaidRenderer::DispatchWebMessage(int index, const mermaid_util::ParsedWebMessage& parsed)
+{
+    using mermaid_util::WebMessageKind;
+    auto& w = workers_[index];
+    const auto& req = parsed.request;
+    const bool req_id_match = req.valid && req.id == w.current_request.request_id;
+    switch (parsed.kind) {
+    case WebMessageKind::Ready:
+        if (parsed.ready_dpr > 0) {
+            w.dpr = parsed.ready_dpr;
+        }
+        w.ready = true;
+        w.init_retries = 0;
+        // 最初のワーカーが準備完了した時点でon_readyを呼び出す。
+        // 残りのワーカーは準備でき次第プールに参加する。
+        if (!lifecycle_.IsReady()) {
+            lifecycle_.MarkReady();
+            if (on_all_ready_) {
+                auto cb = std::move(on_all_ready_);
+                cb();
+            }
+        }
+        ProcessQueue();
+        return;
+    case WebMessageKind::RenderResult:
+        if (req_id_match && req.has_payload) {
+            OnRenderResult(index, req.payload);
+        }
+        return;
+    case WebMessageKind::CaptureReady:
+        if (req_id_match) {
+            DoCapturePreview(index);
+        }
+        return;
+    case WebMessageKind::SvgResult:
+        if (req_id_match && w.current_request.svg_only) {
+            std::pmr::wstring svg{ req.has_payload ? req.payload : std::wstring_view{} };
+            InvokeSvgCallbackIfAny(w.current_request, std::move(svg), false);
+            FinishWorkerRequest(w);
+        }
+        return;
+    case WebMessageKind::RenderError:
+        if (req_id_match) {
+            InvokeSvgCallbackIfAny(w.current_request, {}, false);
+            FinishWorkerRequest(w);
+        }
+        return;
+    case WebMessageKind::Failed:
+        // mermaid.jsの読み込みに失敗した場合、ページを再読み込みして再試行する
+        if (w.init_retries < MAX_WORKER_RETRIES && w.webview) {
+            ++w.init_retries;
+            LogHrFailure(L"Navigate(retry)", w.webview->Navigate(APP_LOCAL_INDEX_URL));
+        }
+        return;
+    case WebMessageKind::Unknown:
+        return;
+    }
 }
 
 void MermaidRenderer::OnRenderResult(int worker_idx, std::wstring_view json)

--- a/src/mermaid/mermaid.h
+++ b/src/mermaid/mermaid.h
@@ -107,6 +107,9 @@ private:
     void ProcessQueue();
     void RenderInWorker(Worker& worker);
     void OnRenderResult(int worker_idx, std::wstring_view json);
+    // WebMessageReceived から受け取った parsed メッセージを worker[index] にディスパッチする。
+    // ラムダ本体を 6 段ネストから 1 行に減らすため case 振り分けをメンバ関数に集約する。
+    void DispatchWebMessage(int index, const mermaid_util::ParsedWebMessage& parsed);
     void DoCapturePreview(int worker_idx);
     void OnCaptureComplete(int worker_idx, uint64_t code_hash, IStream* png_stream);
     void FinishWorkerRequest(Worker& worker);

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -253,7 +253,7 @@ void CommandGenerator::GenerateNode(
                 fc.pane_transform, scroll_x, needs_clip);
             GenTable(cmds, fc, node, entry, node_index, x, entry_text_top, scroll_x);
         }
-        EmitBlockHScrollbarIfActive(cmds, fc, node_index, x, BlockHScrollbarBarY(entry_text_top, entry.height, 0.0f), BlockHScrollGeometry{ natural_w, cw }, scroll_x);
+        EmitBlockHScrollbarIfActive(cmds, fc, node_index, x, BlockHScrollbarBarY(entry_text_top, entry.height, 0.0f), BlockHScrollGeometry{ .natural_width = natural_w, .visible_width = cw }, scroll_x);
         return;
     }
 
@@ -287,7 +287,7 @@ void CommandGenerator::GenerateNode(
                     fc.pane_transform, scroll_x, needs_clip);
                 GenNodeTextDecorations(cmds, fc, node, entry, node_index, x, text_x, entry_text_top);
             }
-            EmitBlockHScrollbarIfActive(cmds, fc, node_index, x, BlockHScrollbarBarY(entry_text_top, entry.height, pad), BlockHScrollGeometry{ natural_w, cw }, scroll_x);
+            EmitBlockHScrollbarIfActive(cmds, fc, node_index, x, BlockHScrollbarBarY(entry_text_top, entry.height, pad), BlockHScrollGeometry{ .natural_width = natural_w, .visible_width = cw }, scroll_x);
         }
         GenCopyButton(cmds, entry, x, cw, node_index == fc.hovered.copy, entry_text_top);
         return;

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -253,7 +253,7 @@ void CommandGenerator::GenerateNode(
                 fc.pane_transform, scroll_x, needs_clip);
             GenTable(cmds, fc, node, entry, node_index, x, entry_text_top, scroll_x);
         }
-        EmitBlockHScrollbarIfActive(cmds, fc, node_index, x, BlockHScrollbarBarY(entry_text_top, entry.height, 0.0f), cw, natural_w, scroll_x);
+        EmitBlockHScrollbarIfActive(cmds, fc, node_index, x, BlockHScrollbarBarY(entry_text_top, entry.height, 0.0f), BlockHScrollGeometry{ natural_w, cw }, scroll_x);
         return;
     }
 
@@ -287,7 +287,7 @@ void CommandGenerator::GenerateNode(
                     fc.pane_transform, scroll_x, needs_clip);
                 GenNodeTextDecorations(cmds, fc, node, entry, node_index, x, text_x, entry_text_top);
             }
-            EmitBlockHScrollbarIfActive(cmds, fc, node_index, x, BlockHScrollbarBarY(entry_text_top, entry.height, pad), cw, natural_w, scroll_x);
+            EmitBlockHScrollbarIfActive(cmds, fc, node_index, x, BlockHScrollbarBarY(entry_text_top, entry.height, pad), BlockHScrollGeometry{ natural_w, cw }, scroll_x);
         }
         GenCopyButton(cmds, entry, x, cw, node_index == fc.hovered.copy, entry_text_top);
         return;
@@ -438,17 +438,17 @@ void CommandGenerator::GenSvgCopyButton(DrawCommandList& cmds, float bitmap_righ
     GenOverlayButton(cmds, btn, L'\uE8C8', is_hovered);
 }
 
-void CommandGenerator::EmitBlockHScrollbarIfActive(DrawCommandList& cmds, const FrameContext& fc, int node_index, float block_x, float bar_y, float visible_width, float natural_width, float scroll_x)
+void CommandGenerator::EmitBlockHScrollbarIfActive(DrawCommandList& cmds, const FrameContext& fc, int node_index, float block_x, float bar_y, const BlockHScrollGeometry& geom, float scroll_x)
 {
-    if (natural_width <= visible_width || visible_width <= 0.0f) {
+    if (!geom.can_scroll()) {
         return;
     }
     if (node_index != fc.h_scroll.hovered_block && node_index != fc.h_scroll.drag_block) {
         return;
     }
-    const float track_w = visible_width;
-    const float thumb_w = BlockHScrollbarThumbWidth(visible_width, natural_width);
-    const float scroll_max = natural_width - visible_width;
+    const float track_w = geom.visible_width;
+    const float thumb_w = BlockHScrollbarThumbWidth(geom.visible_width, geom.natural_width);
+    const float scroll_max = geom.scroll_max();
     const float ratio = (scroll_max > 0.0f) ? std::clamp(scroll_x / scroll_max, 0.0f, 1.0f) : 0.0f;
     // bullet と同じく Identity transform + 物理ピクセル snap で描画する。
     // pane_transform の md_x が非整数 (DPI 1 以外) のとき、サブピクセル位置で
@@ -805,45 +805,35 @@ void CommandGenerator::EmitSearchHlCommands(
     }
 }
 
-void CommandGenerator::GenTableRowBg(DrawCommandList& cmds, bool is_header, bool is_even_row, float x, float y, float table_width, float row_h, float border)
+void CommandGenerator::GenTableRowBg(DrawCommandList& cmds, const TableRowGeom& g, bool is_header, bool is_even_row)
 {
     if (is_header) {
-        cmds.emplace_back(FillRectCmd{ D2D1::RectF(x, y, x + table_width, y + row_h + border), theme_->code_bg_color, BrushId::CodeBg });
+        cmds.emplace_back(FillRectCmd{ D2D1::RectF(g.x, g.y, g.x + g.table_width, g.y + g.row_h + g.border), theme_->code_bg_color, BrushId::CodeBg });
     }
     else if (is_even_row) {
         // cached_stripe_color_ と Renderer の brushes_[TableStripe] は同じ式 (renderer_resources.cpp) で算出する。
-        cmds.emplace_back(FillRectCmd{ D2D1::RectF(x, y, x + table_width, y + row_h + border), cached_stripe_color_, BrushId::TableStripe });
+        cmds.emplace_back(FillRectCmd{ D2D1::RectF(g.x, g.y, g.x + g.table_width, g.y + g.row_h + g.border), cached_stripe_color_, BrushId::TableStripe });
     }
 }
 
-void CommandGenerator::GenTableCellContent(
-    DrawCommandList& cmds,
-    std::string_view cell_text,
-    bool is_header,
-    IDWriteTextLayout* cell_layout,
-    float text_x,
-    float text_y,
-    bool has_selection,
-    uint32_t sel_start,
-    uint32_t sel_end,
-    uint32_t flat_offset)
+void CommandGenerator::GenTableCellContent(DrawCommandList& cmds, std::string_view cell_text, const CellDrawContext& ctx)
 {
-    if (has_selection && cell_layout) {
+    if (ctx.has_selection && ctx.layout) {
         const uint32_t cell_len = static_cast<uint32_t>(cell_text.size());
-        const uint32_t ov_start = std::max(sel_start, flat_offset);
-        const uint32_t ov_end = std::min(sel_end, flat_offset + cell_len);
+        const uint32_t ov_start = std::max(ctx.sel_start, ctx.flat_offset);
+        const uint32_t ov_end = std::min(ctx.sel_end, ctx.flat_offset + cell_len);
         if (ov_end > ov_start) {
             // sel_start/sel_end は UTF-8 byte offset。HitTestTextRange 用に UTF-16 へ変換する。
-            const auto wr = cell_wv_.WideRange(cell_text, ov_start - flat_offset, ov_end - ov_start);
+            const auto wr = cell_wv_.WideRange(cell_text, ov_start - ctx.flat_offset, ov_end - ov_start);
             if (wr.length > 0) {
-                GenSelectionHighlight(cmds, cell_layout, wr.startPosition, wr.length, text_x, text_y);
+                GenSelectionHighlight(cmds, ctx.layout, wr.startPosition, wr.length, ctx.text_x, ctx.text_y);
             }
         }
     }
-    if (cell_layout) {
-        const D2D1_COLOR_F cell_color = is_header ? theme_->heading_color : theme_->text_color;
-        const BrushId cell_brush = is_header ? BrushId::Heading : BrushId::Text;
-        cmds.emplace_back(DrawTextLayoutCmd{ D2D1::Point2F(text_x, text_y), cell_layout, cell_color, cell_brush });
+    if (ctx.layout) {
+        const D2D1_COLOR_F cell_color = ctx.is_header ? theme_->heading_color : theme_->text_color;
+        const BrushId cell_brush = ctx.is_header ? BrushId::Heading : BrushId::Text;
+        cmds.emplace_back(DrawTextLayoutCmd{ D2D1::Point2F(ctx.text_x, ctx.text_y), ctx.layout, cell_color, cell_brush });
     }
 }
 
@@ -896,7 +886,7 @@ void CommandGenerator::GenTable(
         }
 
         const bool is_header_row = tbl->IsHeaderRow(r);
-        GenTableRowBg(cmds, is_header_row, r % 2 == 0, offset_x, y, table_width, row_h, border);
+        GenTableRowBg(cmds, TableRowGeom{ offset_x, y, table_width, row_h, border }, is_header_row, r % 2 == 0);
 
         // 行上部の水平線
         cmds.emplace_back(DrawLineCmd{ D2D1::Point2F(offset_x, y), D2D1::Point2F(offset_x + table_width, y), theme_->hr_color, border, BrushId::Hr });
@@ -926,7 +916,16 @@ void CommandGenerator::GenTable(
 
                 const auto cell_text = tbl->GetCellText(r, c);
                 const uint32_t cell_flat = tbl->CellTextStart(r, c);
-                GenTableCellContent(cmds, cell_text, is_header_row, cell_layout, text_x, text_y, has_selection, sel_start, sel_end, cell_flat);
+                GenTableCellContent(cmds, cell_text, CellDrawContext{
+                    .layout = cell_layout,
+                    .text_x = text_x,
+                    .text_y = text_y,
+                    .flat_offset = cell_flat,
+                    .sel_start = sel_start,
+                    .sel_end = sel_end,
+                    .has_selection = has_selection,
+                    .is_header = is_header_row,
+                });
             }
 
             cx += cw + cell_padding * 2.0f + border;

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "block_h_scroll.h"
 #include "block_h_scroll_context.h"
 #include "d2d_util.h"
 #include "doc_dwrite_bridge.h"
@@ -155,8 +156,28 @@ private:
 
     void GenHorizontalRule(DrawCommandList& cmds, const NodeLayoutEntry& entry, float x, float w, float entry_text_top);
     void GenTable(DrawCommandList& cmds, const FrameContext& fc, const Node& node, const NodeLayoutEntry& entry, int node_index, float x, float entry_text_top, float h_scroll_x = 0.0f);
-    void GenTableRowBg(DrawCommandList& cmds, bool is_header, bool is_even_row, float x, float y, float table_width, float row_h, float border);
-    void GenTableCellContent(DrawCommandList& cmds, std::string_view cell_text, bool is_header, IDWriteTextLayout* cell_layout, float text_x, float text_y, bool has_selection, uint32_t sel_start, uint32_t sel_end, uint32_t flat_offset);
+    // テーブル 1 行分の幾何。GenTableRowBg と内部ループで使い回す。
+    struct TableRowGeom {
+        float x;
+        float y;
+        float table_width;
+        float row_h;
+        float border;
+    };
+    void GenTableRowBg(DrawCommandList& cmds, const TableRowGeom& geom, bool is_header, bool is_even_row);
+    // テーブルセル 1 個分の描画コンテキスト。GenTable から GenTableCellContent へ橋渡しする。
+    // selection 関連は (has_selection, sel_start, sel_end, flat_offset) を 1 まとまりで扱う。
+    struct CellDrawContext {
+        IDWriteTextLayout* layout = nullptr;
+        float text_x = 0.0f;
+        float text_y = 0.0f;
+        uint32_t flat_offset = 0;
+        uint32_t sel_start = 0;
+        uint32_t sel_end = 0;
+        bool has_selection = false;
+        bool is_header = false;
+    };
+    void GenTableCellContent(DrawCommandList& cmds, std::string_view cell_text, const CellDrawContext& ctx);
     void GenCodeBlockBg(DrawCommandList& cmds, const NodeLayoutEntry& entry, float x, float w, float entry_text_top);
     void GenOverlayButton(DrawCommandList& cmds, D2D1_RECT_F btn, wchar_t icon, bool is_hovered);
     void GenCopyButton(DrawCommandList& cmds, const NodeLayoutEntry& entry, float x, float w, bool is_hovered, float entry_text_top);
@@ -164,7 +185,8 @@ private:
     void GenSvgCopyButton(DrawCommandList& cmds, float bitmap_right, float bitmap_top, bool is_hovered);
     // ブロックローカルの水平スクロールバー。ホバー中 / ドラッグ中の対象ブロックでのみ emit する。
     // block_x はブロック左端、bar_y はバー上端 (ペイン内ローカル座標)。
-    void EmitBlockHScrollbarIfActive(DrawCommandList& cmds, const FrameContext& fc, int node_index, float block_x, float bar_y, float visible_width, float natural_width, float scroll_x);
+    // geom.visible_width / natural_width は BlockHScrollGeometry と同じ意味。
+    void EmitBlockHScrollbarIfActive(DrawCommandList& cmds, const FrameContext& fc, int node_index, float block_x, float bar_y, const BlockHScrollGeometry& geom, float scroll_x);
     void GenListBullet(DrawCommandList& cmds, const FrameContext& fc, const Node& node, const NodeLayoutEntry& entry, float x, float entry_text_top);
     void GenBlockQuoteGroupDecorations(DrawCommandList& cmds, const FrameContext& fc, const std::pmr::vector<Node>& nodes, const LayoutCache& cache, int node_count, int first_visible);
     void GenDiagramPlaceholder(DrawCommandList& cmds, float x, float y, float w, float h);

--- a/src/render/d2d_render_backend.cpp
+++ b/src/render/d2d_render_backend.cpp
@@ -1,5 +1,7 @@
 #include "d2d_render_backend.h"
 #include "log_hr.h"
+#include "ui_constants.h"
+#include "wic_util.h"
 
 using Microsoft::WRL::ComPtr;
 
@@ -33,7 +35,7 @@ bool D2DRenderBackend::Init(HWND hwnd)
 
     dpi_ = static_cast<float>(GetDpiForWindow(hwnd));
     if (dpi_ == 0.0f) {
-        dpi_ = 96.0f;
+        dpi_ = DEFAULT_DPI;
     }
 
     const D2D1_FACTORY_OPTIONS opts{};
@@ -58,13 +60,8 @@ bool D2DRenderBackend::Init(HWND hwnd)
 
     // Renderer・ImageLoader で共有。アイコン／画像／ダイアグラムは WIC が無いと
     // 機能しないため fail-fast。
-    hr = CoCreateInstance(
-        CLSID_WICImagingFactory,
-        nullptr,
-        CLSCTX_INPROC_SERVER,
-        IID_PPV_ARGS(&wic_factory_));
-    if (FAILED(hr)) {
-        mendo::LogHrFailure(L"WIC ImagingFactory creation", hr);
+    wic_factory_ = wic_util::CreateWicFactory(L"WIC ImagingFactory creation");
+    if (!wic_factory_) {
         return false;
     }
 

--- a/src/render/render_params.h
+++ b/src/render/render_params.h
@@ -32,9 +32,7 @@ struct ToastRenderState {
 };
 
 struct TitleBarRenderState {
-    // --- 8バイトアライメント ---
     std::wstring_view title_text;
-    // --- 4バイトアライメント ---
     TitleBarButton open_file;
     TitleBarButton help;
     TitleBarButton theme_toggle;
@@ -44,12 +42,10 @@ struct TitleBarRenderState {
     TitleBarButton minimize;
     TitleBarButton maximize;
     TitleBarButton close;
-    // --- 4バイトアライメント ---
     DipRect icon_rect{};
     DipRect title_text_rect{};
     float height = 0.0f;
     float window_width = 0.0f;
-    // --- 1バイトアライメント ---
     // ホバー中のボタン。各 TitleBarButton に bool を持たせず一元管理する。
     TitleBarHitZone hovered_zone = TitleBarHitZone::None;
     bool is_dark_mode = false;
@@ -127,15 +123,12 @@ struct PaneCache {
 };
 
 struct SearchBarRenderState {
-    // --- 8バイトアライメント ---
     std::wstring_view query;
     std::wstring_view ime_composition; // IME変換中のコンポジション文字列
-    // --- 4バイトアライメント ---
     int current_match = -1; // 0-based、-1 = マッチなし
     int total_matches = 0;
     int caret_pos = -1;       // キャレット位置（-1 = テキスト末尾）
     int selection_start = -1; // 選択開始位置（caret_posと異なる場合、選択範囲あり）
-    // --- 1バイトアライメント ---
     bool visible = false;
     bool has_focus = false;
     bool caret_visible = false; // キャレット（点滅制御）
@@ -151,7 +144,6 @@ struct SearchBarRenderState {
 };
 
 struct RenderParams {
-    // --- 8バイトアライメント (参照 = ポインタ) ---
     const std::pmr::vector<Node>& nodes;
     const LayoutCache& cache;
     const TextSelection& selection;
@@ -161,12 +153,10 @@ struct RenderParams {
     const GestureRenderState& gesture;
     const ToastRenderState& toast;
     const SearchBarRenderState& search_bar;
-    // --- 4バイトアライメント ---
     float scroll_y = 0.0f;
     float total_content_height = 0.0f;
     int nav_hovered = 0;
     HoveredButtons hovered;
-    // --- 1バイトアライメント ---
     bool can_go_back = false;
     bool can_go_forward = false;
     bool has_dirty_nodes = false;

--- a/src/theme/theme_service.cpp
+++ b/src/theme/theme_service.cpp
@@ -1,6 +1,14 @@
 #include "theme_service.h"
 #include <cassert>
 
+// ini 永続化キー。既存設定との互換性のため値の変更は禁止。
+namespace {
+using namespace std::literals;
+constexpr auto kSectionView = "View"sv;
+constexpr auto kKeyDarkMode = "DarkMode"sv;
+constexpr auto kKeyZoomLevel = "ZoomLevel"sv;
+} // namespace
+
 ThemeService::ThemeService(ConfigService& config) noexcept
     : config_(config)
 {
@@ -29,20 +37,20 @@ bool ThemeService::ToggleDarkMode() noexcept
 
 void ThemeService::SaveDarkMode()
 {
-    config_.SaveBool("View", "DarkMode", dark_mode_);
+    config_.SaveBool(kSectionView, kKeyDarkMode, dark_mode_);
 }
 
 void ThemeService::LoadDarkMode()
 {
-    dark_mode_ = config_.LoadBool("View", "DarkMode", false);
+    dark_mode_ = config_.LoadBool(kSectionView, kKeyDarkMode, false);
 }
 
 void ThemeService::SaveZoomLevel(int zoom_index)
 {
-    config_.SaveInt("View", "ZoomLevel", zoom_index);
+    config_.SaveInt(kSectionView, kKeyZoomLevel, zoom_index);
 }
 
 int ThemeService::LoadZoomIndex() const
 {
-    return config_.LoadInt("View", "ZoomLevel", ZOOM_DEFAULT_INDEX, 0, ZOOM_STEP_COUNT - 1);
+    return config_.LoadInt(kSectionView, kKeyZoomLevel, ZOOM_DEFAULT_INDEX, 0, ZOOM_STEP_COUNT - 1);
 }

--- a/src/util/wic_util.h
+++ b/src/util/wic_util.h
@@ -1,10 +1,28 @@
 #pragma once
+#include "log_hr.h"
 #include <wincodec.h>
 #include <d2d1.h>
 #include <wrl/client.h>
 #include <optional>
 
 namespace wic_util {
+
+// CLSID_WICImagingFactory の CoCreateInstance を共通化する。
+// 失敗時は context 文字列付きで LogHrFailure を流し nullptr を返す。
+inline Microsoft::WRL::ComPtr<IWICImagingFactory> CreateWicFactory(const wchar_t* context) noexcept
+{
+    Microsoft::WRL::ComPtr<IWICImagingFactory> factory;
+    const HRESULT hr = CoCreateInstance(
+        CLSID_WICImagingFactory,
+        nullptr,
+        CLSCTX_INPROC_SERVER,
+        IID_PPV_ARGS(&factory));
+    if (FAILED(hr)) {
+        mendo::LogHrFailure(context, hr);
+        return nullptr;
+    }
+    return factory;
+}
 
 // WIC デコード結果。ピクセルサイズと FormatConverter を保持する。
 struct DecodeResult {

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -25,6 +25,17 @@ static constexpr wchar_t WINDOW_CLASS[] = L"mendoWindow";
 // 0xF000以上はシステム予約（SC_KEYMENU=0xF100等）のため、下位4bitが0のカスタム値を使う
 static constexpr UINT SC_RESET_WINDOW = 0x0010;
 
+// ini 永続化キー。既存設定との互換性のため値の変更は禁止。
+namespace {
+using namespace std::literals;
+constexpr auto kSectionWindow = "Window"sv;
+constexpr auto kKeyWindowX = "X"sv;
+constexpr auto kKeyWindowY = "Y"sv;
+constexpr auto kKeyWindowWidth = "Width"sv;
+constexpr auto kKeyWindowHeight = "Height"sv;
+constexpr auto kKeyWindowMaximized = "Maximized"sv;
+} // namespace
+
 Win32Window::Win32Window(ConfigService& config)
     : config_(config), app_(std::make_unique<App>(config))
 {
@@ -612,10 +623,7 @@ LRESULT Win32Window::HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam)
     return DefWindowProcW(hwnd_, msg, wParam, lParam);
 }
 
-// ============================================================
 // システムメニュー（タスクバー右クリック）
-// ============================================================
-
 void Win32Window::InitSystemMenu()
 {
     MENDO_PROFILE("Win32Window::InitSystemMenu");
@@ -647,10 +655,7 @@ void Win32Window::ResetWindowPlacement()
     SetWindowPos(hwnd_, nullptr, x, y, w, h, SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
 }
 
-// ============================================================
 // ウィンドウ配置の永続化
-// ============================================================
-
 void Win32Window::SaveWindowPlacement()
 {
     WINDOWPLACEMENT wp{};
@@ -659,27 +664,27 @@ void Win32Window::SaveWindowPlacement()
         return;
     }
     const auto& rc = wp.rcNormalPosition;
-    config_.SaveInt("Window", "X", rc.left);
-    config_.SaveInt("Window", "Y", rc.top);
-    config_.SaveInt("Window", "Width", rc.right - rc.left);
-    config_.SaveInt("Window", "Height", rc.bottom - rc.top);
+    config_.SaveInt(kSectionWindow, kKeyWindowX, rc.left);
+    config_.SaveInt(kSectionWindow, kKeyWindowY, rc.top);
+    config_.SaveInt(kSectionWindow, kKeyWindowWidth, rc.right - rc.left);
+    config_.SaveInt(kSectionWindow, kKeyWindowHeight, rc.bottom - rc.top);
 
     // 最小化中に閉じた場合も、元が最大化だったかを正しく保存する
     const bool was_maximized = (wp.showCmd == SW_SHOWMAXIMIZED) || ((wp.showCmd == SW_SHOWMINIMIZED) && (wp.flags & WPF_RESTORETOMAXIMIZED));
-    config_.SaveBool("Window", "Maximized", was_maximized);
+    config_.SaveBool(kSectionWindow, kKeyWindowMaximized, was_maximized);
 }
 
 bool Win32Window::RestoreWindowPlacement(int nCmdShow)
 {
     // 保存済みのウィンドウサイズを読み込み（なければデフォルト表示へフォールバック）
-    const int w = config_.LoadInt("Window", "Width", 0, 100, 100000);
-    const int h = config_.LoadInt("Window", "Height", 0, 100, 100000);
+    const int w = config_.LoadInt(kSectionWindow, kKeyWindowWidth, 0, 100, 100000);
+    const int h = config_.LoadInt(kSectionWindow, kKeyWindowHeight, 0, 100, 100000);
     if (w == 0 || h == 0) {
         return false;
     }
-    const int x = config_.LoadInt("Window", "X", 0, -100000, 100000);
-    const int y = config_.LoadInt("Window", "Y", 0, -100000, 100000);
-    const bool maximized = config_.LoadBool("Window", "Maximized", false);
+    const int x = config_.LoadInt(kSectionWindow, kKeyWindowX, 0, -100000, 100000);
+    const int y = config_.LoadInt(kSectionWindow, kKeyWindowY, 0, -100000, 100000);
+    const bool maximized = config_.LoadBool(kSectionWindow, kKeyWindowMaximized, false);
 
     WINDOWPLACEMENT wp{};
     wp.length = sizeof(wp);
@@ -709,10 +714,7 @@ void Win32Window::RestoreScrollPosition()
     app_->SetPendingRestoreNode(pos.node, pos.offset);
 }
 
-// ============================================================
 // 検索EDITコントロールのサブクラスプロシージャ
-// ============================================================
-
 LRESULT CALLBACK Win32Window::SearchEditProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, UINT_PTR /*uIdSubclass*/, DWORD_PTR dwRefData)
 {
     auto* self = reinterpret_cast<Win32Window*>(dwRefData);

--- a/tests/test_resource_manager.cpp
+++ b/tests/test_resource_manager.cpp
@@ -211,8 +211,17 @@ protected:
         std::pmr::string utf8(md);
         doc_ = Document::FromMarkdown(std::move(utf8), kTestDocPath);
         cache_ = SeedLayoutCache(doc_.GetNodes().size(), block_height);
-        rm_.Init(doc_, cache_, viewport_, image_loader_, mock_mermaid_, theme_service_, theme_,
-                 TestResourceManagerCallbacks{ &tracker_ });
+        rm_.Init(
+            ResourceManagerDeps{
+                .doc = &doc_,
+                .cache = &cache_,
+                .viewport = &viewport_,
+                .image_loader = &image_loader_,
+                .mermaid = &mock_mermaid_,
+                .theme_service = &theme_service_,
+                .theme = &theme_,
+            },
+            TestResourceManagerCallbacks{ &tracker_ });
     }
 
     Document doc_;


### PR DESCRIPTION
## Summary

- 直前の `6a5d804` で対応した /simplify レビュー指摘 13 件に加え、本ブランチで再度 /simplify を回して挙がった追加 4 件をフォローアップで解消 (`a859baf`)。
- 触れた領域: app (reducer/scroll/init/resource_manager) / core (syntax/text_types) / io (config/image_loader) / layout / mermaid / render (command_generator/d2d_backend/render_params) / theme / util (wic) / window / tests。

### 追加で解消した 4 件 (a859baf)

- `BlockHScrollGeometry{ natural_w, cw }` を designated init `{ .natural_width=..., .visible_width=... }` に変更しフィールド順依存を排除 (`command_generator.cpp:256,290`)。
- `LayoutService::ProcessDirtyBatch` の `std::optional<ViewportLimit>` + `height>0` 二重センチネルを `ViewportLimit{}` デフォルト引数に統一。`#include <optional>` も削除 (`layout.h` / `layout.cpp`)。
- `ApplyBlockHScrollDelta` の WHAT コメント 1 行を削除し WHY のみ残す (`reducer.cpp:352`)。
- `ReduceTextSelectionMoved` のコメントを WHY (`WM_MOUSEMOVE は 16ms 周期で連発する`) のみに圧縮 (`reducer.cpp:734`)。

### 13 件側のハイライト (6a5d804)

- `wic_util::CreateWicFactory` で `CoCreateInstance(CLSID_WICImagingFactory, ...)` の三箇所重複を集約 (image_loader / mermaid / d2d_render_backend)。
- DPI スケール計算を `DpiScaleFrom()` / `DEFAULT_DPI` に統一。
- `BlockHScrollGeometry` を `command_generator` の 3 箇所で再利用 (`can_scroll()` / `scroll_max()`)。
- `TextSelection::operator==` を defaulted 化し、`ReduceTextSelectionMoved` で同一位置 `WM_MOUSEMOVE` の no-op 再描画を抑止。
- `ApplyBlockHScrollDelta` を bool 化して水平ホイール/ドラッグの no-op `InvalidateWindow` を抑止。
- `mermaid.cpp` の WebView メッセージ多段ラムダを `DispatchWebMessage` + switch に平坦化。
- ini キーを `string_view` 定数化 (config_service / theme_service / window)。
- `CellDrawContext` / `TableRowGeom` / `ResourceManagerDeps` 構造体導入でパラメータスプロールを解消。
- `ScanCppRawString` を `syntax.cpp` に抽出。

## Test plan

- [x] `cmake --build build --config Release` 成功
- [x] `build/tests/Release/mendo_tests.exe --gtest_brief=1` で 2285 tests / 139 suites 全 pass (4.4s)
- [x] 手元で 100MB Markdown ロード・スクロール・水平スクロール・テキスト選択ドラッグ・Mermaid 描画を一通り確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)