### PR TITLE
refactor: Node の view 3 フィールドを std::string_view に統合

### DIFF
--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -121,9 +121,10 @@ std::pmr::wstring Document::GetDirectory() const
 
 void Document::ReplaceContent(ParseResult&& result)
 {
-    // 注意: 各ノードの view_.data() は parser が ParseMarkdown 呼び出し時の markdown_text.data() を既に注入済み。
-    // raw_text_ を差し替える経路 (FromMarkdown / ReplaceFromMarkdown) では ParseMarkdown(raw_text_)
-    // を渡しているため view_.data() のベースが raw_text_.data() と一致し、rebase 不要。
+    // private 化された内部 helper。呼び出し元 (FromMarkdown / ReplaceFromMarkdown) は
+    // 必ず ParseMarkdown(raw_text_) を渡しており、各ノードの view_.data() のベースが
+    // raw_text_.data() と一致するため rebase 不要。Document が後で move されたときの
+    // RebaseViews も同一 array (raw_text_) 内のポインタ減算で安全に成立する。
     nodes_ = std::move(result.nodes);
     image_node_indices_ = std::move(result.image_indices);
     diagram_node_indices_ = std::move(result.diagram_indices);

--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -66,6 +66,19 @@ void NormalizeNewlines(std::pmr::string& s)
 
 Document::Document(Document&& other) noexcept
 {
+    MoveFrom(std::move(other));
+}
+
+Document& Document::operator=(Document&& other) noexcept
+{
+    if (this != &other) {
+        MoveFrom(std::move(other));
+    }
+    return *this;
+}
+
+void Document::MoveFrom(Document&& other) noexcept
+{
     // raw_text_ を move する前に旧 base を捕捉。move 後の other.raw_text_.data() は空文字列を返すため。
     const char* const old_base = other.raw_text_.data();
     nodes_ = std::move(other.nodes_);
@@ -77,23 +90,6 @@ Document::Document(Document&& other) noexcept
     image_node_indices_ = std::move(other.image_node_indices_);
     diagram_node_indices_ = std::move(other.diagram_node_indices_);
     RebaseViews(old_base);
-}
-
-Document& Document::operator=(Document&& other) noexcept
-{
-    if (this != &other) {
-        const char* const old_base = other.raw_text_.data();
-        nodes_ = std::move(other.nodes_);
-        file_path_ = std::move(other.file_path_);
-        raw_text_ = std::move(other.raw_text_);
-        loaded_byte_size_ = other.loaded_byte_size_;
-        toc_ = std::move(other.toc_);
-        anchor_index_ = std::move(other.anchor_index_);
-        image_node_indices_ = std::move(other.image_node_indices_);
-        diagram_node_indices_ = std::move(other.diagram_node_indices_);
-        RebaseViews(old_base);
-    }
-    return *this;
 }
 
 Document Document::FromMarkdown(std::pmr::string text, size_t byte_size, std::wstring_view path,
@@ -138,7 +134,11 @@ void Document::RebaseViews(const char* old_base) noexcept
 {
     const char* const new_base = raw_text_.data();
     if (new_base == old_base) {
-        return; // move 後にバッファが同位置に居る (heap relocate なし) なら何もしない
+        // 同一 allocator 間の pmr::string move は O(1) でバッファ所有を譲渡する (data() 不変)
+        // ため、PMR allocator が一致する典型運用 (両 Document が new_delete_resource を使う) では
+        // ここで早期 return する。allocator 不一致時は要素コピーが走り data() が変わるので
+        // 全ノードを rebase する。
+        return;
     }
     for (auto& n : nodes_) {
         n.RebaseSourceOffset(old_base, new_base);

--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -65,14 +65,24 @@ void NormalizeNewlines(std::pmr::string& s)
 } // namespace
 
 Document::Document(Document&& other) noexcept
-    : nodes_(std::move(other.nodes_)), file_path_(std::move(other.file_path_)), raw_text_(std::move(other.raw_text_)), loaded_byte_size_(other.loaded_byte_size_), toc_(std::move(other.toc_)), anchor_index_(std::move(other.anchor_index_)), image_node_indices_(std::move(other.image_node_indices_)), diagram_node_indices_(std::move(other.diagram_node_indices_))
 {
-    InjectViewBase();
+    // raw_text_ を move する前に旧 base を捕捉。move 後の other.raw_text_.data() は空文字列を返すため。
+    const char* const old_base = other.raw_text_.data();
+    nodes_ = std::move(other.nodes_);
+    file_path_ = std::move(other.file_path_);
+    raw_text_ = std::move(other.raw_text_);
+    loaded_byte_size_ = other.loaded_byte_size_;
+    toc_ = std::move(other.toc_);
+    anchor_index_ = std::move(other.anchor_index_);
+    image_node_indices_ = std::move(other.image_node_indices_);
+    diagram_node_indices_ = std::move(other.diagram_node_indices_);
+    RebaseViews(old_base);
 }
 
 Document& Document::operator=(Document&& other) noexcept
 {
     if (this != &other) {
+        const char* const old_base = other.raw_text_.data();
         nodes_ = std::move(other.nodes_);
         file_path_ = std::move(other.file_path_);
         raw_text_ = std::move(other.raw_text_);
@@ -81,7 +91,7 @@ Document& Document::operator=(Document&& other) noexcept
         anchor_index_ = std::move(other.anchor_index_);
         image_node_indices_ = std::move(other.image_node_indices_);
         diagram_node_indices_ = std::move(other.diagram_node_indices_);
-        InjectViewBase();
+        RebaseViews(old_base);
     }
     return *this;
 }
@@ -115,22 +125,23 @@ std::pmr::wstring Document::GetDirectory() const
 
 void Document::ReplaceContent(ParseResult&& result)
 {
-    // 注意: view_base_ は parser が ParseMarkdown 呼び出し時の markdown_text.data() を既に注入済み。
+    // 注意: 各ノードの view_.data() は parser が ParseMarkdown 呼び出し時の markdown_text.data() を既に注入済み。
     // raw_text_ を差し替える経路 (FromMarkdown / ReplaceFromMarkdown) では ParseMarkdown(raw_text_)
-    // を渡しているため view_base_ = raw_text_.data() が一致し、ここでの再注入は不要。
+    // を渡しているため view_.data() のベースが raw_text_.data() と一致し、rebase 不要。
     nodes_ = std::move(result.nodes);
     image_node_indices_ = std::move(result.image_indices);
     diagram_node_indices_ = std::move(result.diagram_indices);
     BuildHeadingIndices(result.heading_indices);
 }
 
-void Document::InjectViewBase() noexcept
+void Document::RebaseViews(const char* old_base) noexcept
 {
-    const char* const base = raw_text_.data();
+    const char* const new_base = raw_text_.data();
+    if (new_base == old_base) {
+        return; // move 後にバッファが同位置に居る (heap relocate なし) なら何もしない
+    }
     for (auto& n : nodes_) {
-        if (n.IsViewMode()) {
-            n.view_base_ = base;
-        }
+        n.RebaseSourceOffset(old_base, new_base);
     }
 }
 

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -16,8 +16,8 @@ class Document {
 public:
     constexpr Document() noexcept = default;
 
-    // move-only: nodes_ は view モード時に raw_text_.data() を view_base_ に持つため、
-    // move 後に InjectViewBase() で再注入する必要がある。
+    // move-only: nodes_ は view モード時に raw_text_.data() を view_.data() に持つため、
+    // move 後に RebaseViews() で旧 base から新 base への delta を反映する必要がある。
     Document(const Document&) = delete;
     Document& operator=(const Document&) = delete;
     Document(Document&& other) noexcept;
@@ -89,16 +89,16 @@ public:
 private:
     void BuildHeadingIndices(const std::pmr::vector<size_t>& heading_indices);
 
-    // raw_text_.data() を view モードの全ノードに注入する。
-    // ReplaceContent / move 経路で呼ぶ。raw_text_ の relocate (resize/assign) は禁止契約のため、
-    // 通常のパース完了後は再注入不要だが、Document 自身の move 後はノードのアドレス参照が更新済み
-    // でも raw_text_ のヒープバッファは move 前後で同一とは限らないため都度呼び直す。
-    void InjectViewBase() noexcept;
+    // move 後にノードの view_ を新しい raw_text_.data() へ rebase する。
+    // raw_text_ の relocate (resize/assign) は禁止契約のため、通常のパース完了後は不要だが、
+    // Document 自身の move 後は raw_text_ のヒープバッファが移動する可能性があるため呼び直す。
+    // old_base は move 前 (raw_text_ を move する直前) に取得しておく必要がある。
+    void RebaseViews(const char* old_base) noexcept;
 
     std::pmr::vector<Node> nodes_;
     std::pmr::wstring file_path_;
     // RawText は append/resize 等の relocate API を提供しないため、view モードノードの
-    // view_base_ が指し続けるバッファの安全性が型レベルで担保される。差し替えは
+    // view_.data() が指し続けるバッファの安全性が型レベルで担保される。差し替えは
     // ReplaceFromMarkdown / FromMarkdown 経由の Replace() のみ許される。
     RawText raw_text_;
     size_t loaded_byte_size_ = 0;

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -95,6 +95,11 @@ private:
     // old_base は move 前 (raw_text_ を move する直前) に取得しておく必要がある。
     void RebaseViews(const char* old_base) noexcept;
 
+    // ムーブ構築/ムーブ代入で共有する移送処理。other の raw_text_ を move する前に
+    // old_base を確保しないと、move 後の other.raw_text_.data() が空文字列を指し
+    // rebase が壊れる。共通化により両経路で同じ順序を保証する。
+    void MoveFrom(Document&& other) noexcept;
+
     std::pmr::vector<Node> nodes_;
     std::pmr::wstring file_path_;
     // RawText は append/resize 等の relocate API を提供しないため、view モードノードの

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -71,7 +71,6 @@ public:
     {
         file_path_ = path;
     }
-    void ReplaceContent(ParseResult&& result);
     void ReplaceFromMarkdown(std::pmr::string text, size_t byte_size);
     int FindAnchorIndex(std::string_view anchor) const;
     // 既に anchor_id 形式（小文字 ASCII 正規化済み）と判明している入力向け。
@@ -87,6 +86,13 @@ public:
     }
 
 private:
+    // ParseResult を nodes_ に取り込み、TOC / anchor_index_ / image / diagram の各種
+    // インデックスを再構築する。
+    // 契約: 入力 ParseResult のノード view_ は raw_text_.data() を base にしていること。
+    // FromMarkdown / ReplaceFromMarkdown 経由でのみ呼ぶ。Document を後で move する際の
+    // RebaseViews が異種 array 間のポインタ減算を起こさないようこの不変条件が必要。
+    void ReplaceContent(ParseResult&& result);
+
     void BuildHeadingIndices(const std::pmr::vector<size_t>& heading_indices);
 
     // move 後にノードの view_ を新しい raw_text_.data() へ rebase する。

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -174,8 +174,8 @@ struct NodeImageData {
 };
 using NodeImagePtr = mendo::pmr_unique_ptr<NodeImageData>;
 
-// Node::source_offset が未設定であることを示すセンチネル値。
-// HorizontalRule のようなテキストを持たないノードはオフセットを記録しない。
+// Node::SourceOffsetFrom() が未設定 (view_.data() == nullptr) のときに返す値。
+// HorizontalRule のようなテキストを持たないノードはオフセットを持たない。
 inline constexpr uint32_t kUnsetSourceOffset = std::numeric_limits<uint32_t>::max();
 
 struct Node {
@@ -201,19 +201,20 @@ struct Node {
 
     // 表示テキストの owned バッファ。テキスト加工 (Alert / HTML entity / SOFTBR/BR / display math 昇格 / 表セル等)
     // を必要とするノードのみ確保する。raw_text_ の連続範囲をそのまま表示できるノードは view モードに倒し
-    // owned_text_ は空のまま raw_text_ を共有 view する (view_length > 0 と排他的不変条件)。
+    // owned_text_ は空のまま raw_text_ を共有 view する (view_.size() > 0 と排他的不変条件)。
     // SBO (~16 byte) により短い加工結果は 0 ヒープ確保で済む。
     std::pmr::string owned_text_;
 
-    // view モード時の参照ベース (= Document::raw_text_.data())。
-    // Document::InjectViewBase() が ReplaceContent / move 時に一括設定する。
-    const char* view_base_ = nullptr;
+    // raw_text_ 内のソース位置 + 表示モードを 1 本に統合した表現。
+    //   view_.data() == nullptr                : source_offset 未設定 (HorizontalRule 等)。
+    //   view_.data() != nullptr, view_.size() == 0 : owned モード。表示は owned_text_、data() は raw 内位置。
+    //   view_.data() != nullptr, view_.size()  > 0 : view モード。view_ をそのまま表示テキストとして使う。
+    // Document::RebaseViews() が move 時に rebase する。
+    std::string_view view_;
 
     // --- 4 バイトアライメント ---
-    uint32_t source_offset = kUnsetSourceOffset; // ソーステキスト内の UTF-8 byte オフセット (view モード時は view 開始位置)
-    int32_t blockquote_group = -1;               // 最外側 blockquote 単位のグループID（ネストしてもgroupは共有）
-    int32_t line_count = 0;                      // テキスト内の改行数（パース時にカウント済み）
-    uint32_t view_length = 0;                    // view モード時の長さ (UTF-8 byte)。owned モード時は 0。
+    int32_t blockquote_group = -1; // 最外側 blockquote 単位のグループID（ネストしてもgroupは共有）
+    int32_t line_count = 0;        // テキスト内の改行数（パース時にカウント済み）
 
     // --- 1 バイトアライメント ---
     NodeType type = NodeType::Paragraph;
@@ -224,7 +225,32 @@ struct Node {
 
     constexpr bool IsViewMode() const noexcept
     {
-        return view_length > 0;
+        return !view_.empty();
+    }
+
+    constexpr bool HasSourceOffset() const noexcept
+    {
+        return view_.data() != nullptr;
+    }
+
+    // base (= Document::raw_text_.data()) 起算の UTF-8 byte オフセット。未設定時は kUnsetSourceOffset。
+    constexpr uint32_t SourceOffsetFrom(const char* base) const noexcept
+    {
+        return HasSourceOffset() ? static_cast<uint32_t>(view_.data() - base) : kUnsetSourceOffset;
+    }
+
+    // ソース位置 (および任意の view 長) を埋める。length=0 は owned モードでの位置追跡用。
+    constexpr void SetSourceOffset(const char* base, uint32_t offset, uint32_t length = 0) noexcept
+    {
+        view_ = std::string_view{ base + offset, length };
+    }
+
+    // raw_text_ の data() が relocate された (Document move) 時に view_ を rebase する。
+    constexpr void RebaseSourceOffset(const char* old_base, const char* new_base) noexcept
+    {
+        if (HasSourceOffset()) {
+            view_ = std::string_view{ new_base + (view_.data() - old_base), view_.size() };
+        }
     }
 
     constexpr bool HasText() const noexcept
@@ -238,8 +264,8 @@ struct Node {
 
     constexpr std::string_view GetText() const noexcept
     {
-        if (IsViewMode() && view_base_ != nullptr) {
-            return { view_base_ + source_offset, view_length };
+        if (IsViewMode()) {
+            return view_;
         }
         return owned_text_;
     }
@@ -276,15 +302,12 @@ struct Node {
 
     // 連続 NORMAL/CODE/LATEXMATH のみで構成されるノード向けの view 設定 API。
     // raw_text_ の (source_offset_value, length) 範囲をそのまま表示テキストとして使う。
-    // Document::InjectViewBase() の手前で GetText() を呼ぶパス (parser 中の Heading anchor 生成等)
-    // のため view_base もここで同時設定する。move 後は InjectViewBase() で再注入される。
+    // parser 中の Heading anchor 生成等で GetText() が呼ばれるパスがあるため view_base もここで同時設定する。
     void SetTextView(uint32_t source_offset_value, uint32_t length, int32_t line_count_value, const char* view_base) noexcept
     {
         owned_text_.clear();
-        source_offset = source_offset_value;
-        view_length = length;
+        view_ = std::string_view{ view_base + source_offset_value, length };
         line_count = line_count_value;
-        view_base_ = view_base;
     }
 
     // text と line_count を一括更新する（呼び出し側が積算済みの line_count を渡す）。
@@ -292,14 +315,14 @@ struct Node {
     void SetTextWithLineCount(std::string_view s, int32_t line_count_value)
     {
         owned_text_.assign(s);
-        view_length = 0;
+        DemoteToOwned();
         line_count = line_count_value;
     }
 
     void SetTextWithLineCount(std::pmr::string&& s, int32_t line_count_value) noexcept
     {
         owned_text_ = std::move(s);
-        view_length = 0;
+        DemoteToOwned();
         line_count = line_count_value;
     }
 
@@ -480,11 +503,16 @@ struct Node {
     }
 
 private:
+    // owned モードへデモートする。view_.data() (= source_offset) は保持し size のみ 0 にする。
+    constexpr void DemoteToOwned() noexcept
+    {
+        view_ = std::string_view{ view_.data(), 0 };
+    }
+
     void FinalizeOwnedTextLineCount() noexcept
     {
         line_count = static_cast<int32_t>(std::ranges::count(owned_text_, mendo::doc_lf));
-        view_length = 0;
-        view_base_ = nullptr;
+        DemoteToOwned();
     }
 
     // parser 契約: BeginNode 直後の Node は monostate で、対応する 1 種類だけが ensure される。

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -302,11 +302,11 @@ struct Node {
 
     // 連続 NORMAL/CODE/LATEXMATH のみで構成されるノード向けの view 設定 API。
     // raw_text_ の (source_offset_value, length) 範囲をそのまま表示テキストとして使う。
-    // parser 中の Heading anchor 生成等で GetText() が呼ばれるパスがあるため view_base もここで同時設定する。
-    void SetTextView(uint32_t source_offset_value, uint32_t length, int32_t line_count_value, const char* view_base) noexcept
+    // 引数順は SetSourceOffset(base, offset, length) と揃えてある。
+    void SetTextView(const char* view_base, uint32_t source_offset_value, uint32_t length, int32_t line_count_value) noexcept
     {
         owned_text_.clear();
-        view_ = std::string_view{ view_base + source_offset_value, length };
+        SetSourceOffset(view_base, source_offset_value, length);
         line_count = line_count_value;
     }
 
@@ -503,7 +503,8 @@ struct Node {
     }
 
 private:
-    // owned モードへデモートする。view_.data() (= source_offset) は保持し size のみ 0 にする。
+    // owned モードへデモートする。設定済みなら view_.data() (= source_offset) を保持し size のみ 0 にする。
+    // 未設定 (data == nullptr) の場合は再代入しても string_view{nullptr, 0} のままで no-op。
     constexpr void DemoteToOwned() noexcept
     {
         view_ = std::string_view{ view_.data(), 0 };

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -145,11 +145,6 @@ struct ParseContext {
     const char* markdown_base = nullptr;
     size_t markdown_size = 0;
 
-    // 現在ノードの source_offset が既に設定済みか。
-    // OnText の uint32 比較 (current_node->source_offset == kUnsetSourceOffset) を毎テキストで
-    // 評価する代わりに、BeginNode でリセット → 範囲内マッチで設定 → 以降は素通しでよい。
-    bool node_source_offset_set = false;
-
     // 現在ノードが owned 経路確定か。span markup (** _ ` 等) の存在や、
     // entity 解決 / BR / SOFTBR で text を置換するケースは current_text と raw_slice が
     // 構造的に一致しなくなるため、FinalizeCurrentNode の memcmp を完全にスキップできる。
@@ -162,10 +157,10 @@ struct ParseContext {
     {
         // 高頻度呼び出し (100MB で 40万回超) のため MENDO_PROFILE は外す。
         // zone overhead が ~120ms 単位で計測自体を歪めるため。
-        if (!current_node || current_node->source_offset == kUnsetSourceOffset) {
+        if (!current_node || !current_node->HasSourceOffset()) {
             return false;
         }
-        const size_t offset = current_node->source_offset;
+        const size_t offset = current_node->SourceOffsetFrom(markdown_base);
         const size_t len = current_text.size();
         if (offset + len > markdown_size) {
             return false;
@@ -187,7 +182,7 @@ struct ParseContext {
         if (current_node && !current_text.empty() && !current_node->HasText()) {
             if (!current_node_owned_only && CurrentTextMatchesRawSlice()) {
                 current_node->SetTextView(
-                    static_cast<uint32_t>(current_node->source_offset),
+                    current_node->SourceOffsetFrom(markdown_base),
                     static_cast<uint32_t>(current_text.size()),
                     current_node->line_count,
                     markdown_base);
@@ -223,7 +218,6 @@ struct ParseContext {
             current_node->quote_outer_indent = static_cast<int8_t>(std::min(outermost_quote_indent, kInt8Max));
         }
         // runs は SBO 内で初期確保ゼロを狙う。reserve すると SBO の利点が消えるので呼ばない。
-        node_source_offset_set = false;
         current_node_owned_only = false;
     }
 
@@ -800,13 +794,13 @@ int OnText(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, void* userdata)
     // 異なる array 同士のポインタ減算は UB なので、範囲判定もオフセット計算も uintptr_t の
     // 整数演算で行う (std::less<T*> の total order はアドレスの数値順と一致する保証がない)。
     // 範囲外マッチ (静的リテラル) のときは flag を立てず、後続の実体テキストで上書きできるようにする。
-    if (!ctx->node_source_offset_set) [[unlikely]] {
+    if (!ctx->current_node->HasSourceOffset()) [[unlikely]] {
         const auto text_addr = reinterpret_cast<uintptr_t>(text);
         const auto base_addr = reinterpret_cast<uintptr_t>(ctx->markdown_base);
         const auto end_addr = base_addr + ctx->markdown_size * sizeof(char);
         if (text_addr >= base_addr && text_addr < end_addr) {
-            ctx->current_node->source_offset = static_cast<uint32_t>((text_addr - base_addr) / sizeof(char));
-            ctx->node_source_offset_set = true;
+            const auto offset = static_cast<uint32_t>((text_addr - base_addr) / sizeof(char));
+            ctx->current_node->SetSourceOffset(ctx->markdown_base, offset);
         }
     }
 

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -150,19 +150,16 @@ struct ParseContext {
     // 構造的に一致しなくなるため、FinalizeCurrentNode の memcmp を完全にスキップできる。
     bool current_node_owned_only = false;
 
-    // current_text が source の (source_offset, current_text.size()) 範囲とバイト一致するか。
+    // current_text が source の (offset, current_text.size()) 範囲とバイト一致するか。
     // 一致するノードは Node::owned_text_ を確保せず raw_text_ への view に倒せる。
     // span マークアップ (** _ ` 等) や BR/SOFTBR/ENTITY 混在のノードは不一致で owned 経路に落ちる。
-    bool CurrentTextMatchesRawSlice() const noexcept
+    // offset は呼び出し側で SourceOffsetFrom した結果を渡す (FinalizeCurrentNode で再利用するため)。
+    bool CurrentTextMatchesRawSliceAt(uint32_t offset) const noexcept
     {
         // 高頻度呼び出し (100MB で 40万回超) のため MENDO_PROFILE は外す。
         // zone overhead が ~120ms 単位で計測自体を歪めるため。
-        if (!current_node || !current_node->HasSourceOffset()) {
-            return false;
-        }
-        const size_t offset = current_node->SourceOffsetFrom(markdown_base);
         const size_t len = current_text.size();
-        if (offset + len > markdown_size) {
+        if (static_cast<size_t>(offset) + len > markdown_size) {
             return false;
         }
         // current_node_owned_only で span/entity 混在は事前に弾けるため、ここまで来たノードは大半が
@@ -180,12 +177,14 @@ struct ParseContext {
         // 昇格処理 (TryPromoteParagraphToDisplayMath 等) がテキストを直接設定済みのノードは、
         // current_text で上書きすると line_count ごと巻き戻るのでスキップする。
         if (current_node && !current_text.empty() && !current_node->HasText()) {
-            if (!current_node_owned_only && CurrentTextMatchesRawSlice()) {
+            const uint32_t offset = current_node->SourceOffsetFrom(markdown_base);
+            if (!current_node_owned_only && offset != kUnsetSourceOffset
+                && CurrentTextMatchesRawSliceAt(offset)) {
                 current_node->SetTextView(
-                    current_node->SourceOffsetFrom(markdown_base),
+                    markdown_base,
+                    offset,
                     static_cast<uint32_t>(current_text.size()),
-                    current_node->line_count,
-                    markdown_base);
+                    current_node->line_count);
             }
             else {
                 current_node->SetTextWithLineCount(current_text, current_node->line_count);

--- a/src/core/reload.cpp
+++ b/src/core/reload.cpp
@@ -28,7 +28,8 @@ ReloadDecision AnalyzeReloadDiff(std::string_view old_text, std::string_view new
     return { ReloadOp::FullReload, diff_pos };
 }
 
-int FindNodeBySourceOffset(const std::pmr::vector<Node>& nodes, uint32_t diff_offset) noexcept
+int FindNodeBySourceOffset(const std::pmr::vector<Node>& nodes, const char* raw_base,
+                           uint32_t diff_offset) noexcept
 {
     // source_offset はパース順で基本的に単調増加するため二分探索を使用。
     // 未設定ノードに当たった場合は左に有効ノードを探してから判定する。
@@ -36,21 +37,24 @@ int FindNodeBySourceOffset(const std::pmr::vector<Node>& nodes, uint32_t diff_of
     int result = -1;
     while (lo <= hi) {
         const int mid = lo + (hi - lo) / 2;
-        const uint32_t offset = nodes[mid].source_offset;
+        const uint32_t offset = nodes[mid].SourceOffsetFrom(raw_base);
         if (offset == kUnsetSourceOffset) {
             int probe = mid - 1;
-            while (probe >= lo && nodes[probe].source_offset == kUnsetSourceOffset) {
+            while (probe >= lo && !nodes[probe].HasSourceOffset()) {
                 probe--;
             }
             if (probe < lo) {
                 lo = mid + 1;
             }
-            else if (nodes[probe].source_offset <= diff_offset) {
-                result = probe;
-                lo = mid + 1;
-            }
             else {
-                hi = probe - 1;
+                const uint32_t probe_offset = nodes[probe].SourceOffsetFrom(raw_base);
+                if (probe_offset <= diff_offset) {
+                    result = probe;
+                    lo = mid + 1;
+                }
+                else {
+                    hi = probe - 1;
+                }
             }
             continue;
         }
@@ -73,7 +77,8 @@ float CalcScrollYForDiff(
     float viewport_height,
     float fallback_scroll) noexcept
 {
-    const int changed_node = FindNodeBySourceOffset(nodes, static_cast<uint32_t>(diff_pos));
+    const char* const raw_base = content.data();
+    const int changed_node = FindNodeBySourceOffset(nodes, raw_base, static_cast<uint32_t>(diff_pos));
     if (changed_node < 0 || changed_node >= static_cast<int>(cache.size())) {
         return fallback_scroll;
     }
@@ -84,13 +89,14 @@ float CalcScrollYForDiff(
     float node_y = cache[changed_node].text_top;
     const float node_h = cache[changed_node].height;
 
-    const uint32_t node_start = nodes[changed_node].source_offset;
+    const uint32_t node_start = nodes[changed_node].SourceOffsetFrom(raw_base);
     if (node_start != kUnsetSourceOffset) {
         uint32_t next_start = static_cast<uint32_t>(content.size());
         const auto node_count = static_cast<int>(nodes.size());
         for (int i = changed_node + 1; i < node_count; ++i) {
-            if (nodes[i].source_offset != kUnsetSourceOffset && nodes[i].source_offset > node_start) {
-                next_start = nodes[i].source_offset;
+            const uint32_t off = nodes[i].SourceOffsetFrom(raw_base);
+            if (off != kUnsetSourceOffset && off > node_start) {
+                next_start = off;
                 break;
             }
         }

--- a/src/core/reload.h
+++ b/src/core/reload.h
@@ -41,7 +41,9 @@ struct ReloadDecision {
 ReloadDecision AnalyzeReloadDiff(std::string_view old_text, std::string_view new_text) noexcept;
 
 // source_offset が diff_offset 以下の最後のノードを返す。該当なしの場合は -1。
-[[nodiscard]] int FindNodeBySourceOffset(const std::pmr::vector<Node>& nodes, uint32_t diff_offset) noexcept;
+// raw_base は Node::view_ の指す raw_text バッファ先頭 (= Document::GetRawText().data())。
+[[nodiscard]] int FindNodeBySourceOffset(const std::pmr::vector<Node>& nodes, const char* raw_base,
+                                         uint32_t diff_offset) noexcept;
 
 // diff 位置のノードに基づくスクロールY座標を計算する。
 // ノードが見つからない場合は fallback_scroll を返す。

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -77,8 +77,9 @@ TEST(DocumentTest, ReplaceContent)
     EXPECT_FALSE(doc.GetToc().GetEntries().empty());
     EXPECT_EQ(doc.GetNodes()[doc.GetToc().GetEntries()[0].node_index].GetText(), "First");
 
-    // 新しいコンテンツで置き換え
-    doc.ReplaceContent(ParseMarkdown("# Second\n## Sub"));
+    // 新しいコンテンツで置き換え (raw_text_ ごと差し替えるため ReplaceFromMarkdown を使う)
+    constexpr std::string_view kReplaced = "# Second\n## Sub";
+    doc.ReplaceFromMarkdown(std::pmr::string{ kReplaced }, kReplaced.size());
 
     // TOCが再構築されるべき
     EXPECT_GE(doc.GetToc().GetEntries().size(), 2u);
@@ -332,7 +333,8 @@ TEST(DocumentTest, BuildIndicesAfterReplaceContent)
     EXPECT_EQ(doc.GetToc().GetEntries().size(), 1u);
     EXPECT_EQ(doc.FindAnchorIndex("old"), 0);
 
-    doc.ReplaceContent(ParseMarkdown("# New\n\n## Sub"));
+    constexpr std::string_view kReplaced = "# New\n\n## Sub";
+    doc.ReplaceFromMarkdown(std::pmr::string{ kReplaced }, kReplaced.size());
     EXPECT_EQ(doc.GetToc().GetEntries().size(), 2u);
     EXPECT_EQ(doc.FindAnchorIndex("old"), -1);
     EXPECT_EQ(doc.FindAnchorIndex("new"), 0);

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -171,9 +171,11 @@ TEST(DocumentTest, RawTextSourceOffsetConsistency)
     ASSERT_GE(nodes.size(), 2u);
 
     // source_offset 位置の文字がノードのテキスト先頭と対応する
+    const char* const raw_base = raw.data();
     for (const auto& n : nodes) {
-        if (n.source_offset != kUnsetSourceOffset && n.source_offset < raw.size()) {
-            EXPECT_LT(n.source_offset, static_cast<uint32_t>(raw.size()));
+        const uint32_t off = n.SourceOffsetFrom(raw_base);
+        if (off != kUnsetSourceOffset && off < raw.size()) {
+            EXPECT_LT(off, static_cast<uint32_t>(raw.size()));
         }
     }
 }
@@ -186,17 +188,19 @@ TEST(DocumentTest, SourceOffsetPointsToNodeTextStart)
     const auto& nodes = doc.GetNodes();
     const auto& raw = doc.GetRawText();
 
+    const char* const raw_base = raw.data();
     bool checked_any = false;
     for (const auto& n : nodes) {
-        if (n.source_offset == kUnsetSourceOffset) {
+        const uint32_t off = n.SourceOffsetFrom(raw_base);
+        if (off == kUnsetSourceOffset) {
             continue;
         }
         if (!n.HasText()) {
             continue;
         }
-        ASSERT_LT(n.source_offset, raw.size());
-        EXPECT_EQ(raw[n.source_offset], n.GetText()[0])
-            << "node text starts at raw[" << n.source_offset << "]";
+        ASSERT_LT(off, raw.size());
+        EXPECT_EQ(raw[off], n.GetText()[0])
+            << "node text starts at raw[" << off << "]";
         checked_any = true;
     }
     EXPECT_TRUE(checked_any);
@@ -215,12 +219,14 @@ TEST(DocumentTest, SourceOffsetSurvivesEmbeddedNullInCodeBlock)
     const auto& raw = doc.GetRawText();
     ASSERT_FALSE(nodes.empty());
 
+    const char* const raw_base = raw.data();
     bool checked_any = false;
     for (const auto& n : nodes) {
-        if (n.source_offset == kUnsetSourceOffset) {
+        const uint32_t off = n.SourceOffsetFrom(raw_base);
+        if (off == kUnsetSourceOffset) {
             continue;
         }
-        EXPECT_LT(n.source_offset, static_cast<uint32_t>(raw.size()))
+        EXPECT_LT(off, static_cast<uint32_t>(raw.size()))
             << "source_offset must remain within input buffer when md4c emits MD_TEXT_NULLCHAR";
         checked_any = true;
     }

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -1450,105 +1450,105 @@ TEST(AnalyzeReloadDiff, CjkSuffixAppendedIsPrefixGrowth)
 TEST(FindNodeBySourceOffset, EmptyNodes)
 {
     std::pmr::vector<Node> nodes;
-    EXPECT_EQ(FindNodeBySourceOffset(nodes, 0), -1);
+    EXPECT_EQ(FindNodeBySourceOffset(nodes, SourceOffsetTestBase(), 0), -1);
 }
 
 TEST(FindNodeBySourceOffset, SingleNode)
 {
     std::pmr::vector<Node> nodes(1);
-    nodes[0].source_offset = 0;
-    EXPECT_EQ(FindNodeBySourceOffset(nodes, 0), 0);
-    EXPECT_EQ(FindNodeBySourceOffset(nodes, 100), 0);
+    nodes[0].SetSourceOffset(SourceOffsetTestBase(), 0);
+    EXPECT_EQ(FindNodeBySourceOffset(nodes, SourceOffsetTestBase(), 0), 0);
+    EXPECT_EQ(FindNodeBySourceOffset(nodes, SourceOffsetTestBase(), 100), 0);
 }
 
 TEST(FindNodeBySourceOffset, OffsetBeforeAllNodes)
 {
     std::pmr::vector<Node> nodes(2);
-    nodes[0].source_offset = 10;
-    nodes[1].source_offset = 20;
+    nodes[0].SetSourceOffset(SourceOffsetTestBase(), 10);
+    nodes[1].SetSourceOffset(SourceOffsetTestBase(), 20);
     // diff_offset=5 は最初のノード(offset=10)よりも前 → 該当なし
-    EXPECT_EQ(FindNodeBySourceOffset(nodes, 5), -1);
+    EXPECT_EQ(FindNodeBySourceOffset(nodes, SourceOffsetTestBase(), 5), -1);
 }
 
 TEST(FindNodeBySourceOffset, ExactMatch)
 {
     std::pmr::vector<Node> nodes(3);
-    nodes[0].source_offset = 0;
-    nodes[1].source_offset = 10;
-    nodes[2].source_offset = 25;
-    EXPECT_EQ(FindNodeBySourceOffset(nodes, 10), 1);
-    EXPECT_EQ(FindNodeBySourceOffset(nodes, 25), 2);
+    nodes[0].SetSourceOffset(SourceOffsetTestBase(), 0);
+    nodes[1].SetSourceOffset(SourceOffsetTestBase(), 10);
+    nodes[2].SetSourceOffset(SourceOffsetTestBase(), 25);
+    EXPECT_EQ(FindNodeBySourceOffset(nodes, SourceOffsetTestBase(), 10), 1);
+    EXPECT_EQ(FindNodeBySourceOffset(nodes, SourceOffsetTestBase(), 25), 2);
 }
 
 TEST(FindNodeBySourceOffset, BetweenNodes)
 {
     std::pmr::vector<Node> nodes(3);
-    nodes[0].source_offset = 0;
-    nodes[1].source_offset = 10;
-    nodes[2].source_offset = 25;
+    nodes[0].SetSourceOffset(SourceOffsetTestBase(), 0);
+    nodes[1].SetSourceOffset(SourceOffsetTestBase(), 10);
+    nodes[2].SetSourceOffset(SourceOffsetTestBase(), 25);
     // offset=15 はノード1(10)とノード2(25)の間 → ノード1を返す
-    EXPECT_EQ(FindNodeBySourceOffset(nodes, 15), 1);
+    EXPECT_EQ(FindNodeBySourceOffset(nodes, SourceOffsetTestBase(), 15), 1);
 }
 
 TEST(FindNodeBySourceOffset, SkipsUnsetOffsets)
 {
     std::pmr::vector<Node> nodes(3);
-    nodes[0].source_offset = 0;
-    nodes[1].source_offset = kUnsetSourceOffset; // 未設定（HorizontalRule等）
-    nodes[2].source_offset = 20;
+    nodes[0].SetSourceOffset(SourceOffsetTestBase(), 0);
+    // nodes[1] は SetSourceOffset を呼ばないため view_.data() == nullptr (= 未設定)
+    nodes[2].SetSourceOffset(SourceOffsetTestBase(), 20);
     // 未設定値は常に diff_offset 以上にならない（kUnsetSourceOffset <= diff_offset は通常 false）
     // → ノード0を返す
-    EXPECT_EQ(FindNodeBySourceOffset(nodes, 10), 0);
-    EXPECT_EQ(FindNodeBySourceOffset(nodes, 20), 2);
+    EXPECT_EQ(FindNodeBySourceOffset(nodes, SourceOffsetTestBase(), 10), 0);
+    EXPECT_EQ(FindNodeBySourceOffset(nodes, SourceOffsetTestBase(), 20), 2);
 }
 
 TEST(FindNodeBySourceOffset, ParsedMarkdown)
 {
-    auto nodes = ParseMarkdown("# Title\n\nParagraph\n\n## Section").nodes;
+    std::string_view md = "# Title\n\nParagraph\n\n## Section";
+    auto nodes = ParseMarkdown(md).nodes;
     ASSERT_GE(nodes.size(), 3u);
     // 各ノードが有効な source_offset を持つ
     for (const auto& n : nodes) {
-        EXPECT_NE(n.source_offset, kUnsetSourceOffset);
+        EXPECT_NE(n.SourceOffsetFrom(md.data()), kUnsetSourceOffset);
     }
     // 最初のノードの offset は "# " の後 = 2
-    EXPECT_EQ(nodes[0].source_offset, 2u);
+    EXPECT_EQ(nodes[0].SourceOffsetFrom(md.data()), 2u);
     // "Paragraph" は "# Title\n\n" = 9バイト目から
-    EXPECT_EQ(nodes[1].source_offset, 9u);
+    EXPECT_EQ(nodes[1].SourceOffsetFrom(md.data()), 9u);
 }
 
 TEST(FindNodeBySourceOffset, LastNodeForLargeOffset)
 {
     std::pmr::vector<Node> nodes(3);
-    nodes[0].source_offset = 0;
-    nodes[1].source_offset = 100;
-    nodes[2].source_offset = 200;
+    nodes[0].SetSourceOffset(SourceOffsetTestBase(), 0);
+    nodes[1].SetSourceOffset(SourceOffsetTestBase(), 100);
+    nodes[2].SetSourceOffset(SourceOffsetTestBase(), 200);
     // ソース末尾を超えるオフセット → 最後のノードを返す
-    EXPECT_EQ(FindNodeBySourceOffset(nodes, 999), 2);
+    EXPECT_EQ(FindNodeBySourceOffset(nodes, SourceOffsetTestBase(), 999), 2);
 }
 
 TEST(FindNodeBySourceOffset, AllUnsetOffsets)
 {
     // 全ノードが未設定（テキストなし）→ 該当なし
     std::pmr::vector<Node> nodes(3);
-    nodes[0].source_offset = kUnsetSourceOffset;
-    nodes[1].source_offset = kUnsetSourceOffset;
-    nodes[2].source_offset = kUnsetSourceOffset;
-    EXPECT_EQ(FindNodeBySourceOffset(nodes, 50), -1);
+    // 何も設定しないため view_.data() == nullptr (= 未設定)
+    EXPECT_EQ(FindNodeBySourceOffset(nodes, SourceOffsetTestBase(), 50), -1);
 }
 
 TEST(FindNodeBySourceOffset, MixedWithHorizontalRules)
 {
     // パース結果で HorizontalRule が混在するケース
-    auto nodes = ParseMarkdown("AAA\n\n---\n\nBBB").nodes;
+    std::string_view md = "AAA\n\n---\n\nBBB";
+    auto nodes = ParseMarkdown(md).nodes;
     ASSERT_GE(nodes.size(), 3u);
     // "AAA" offset=0, "---" は未設定, "BBB" offset=10
-    EXPECT_EQ(nodes[0].source_offset, 0u);
-    EXPECT_EQ(nodes[1].source_offset, kUnsetSourceOffset);
+    EXPECT_EQ(nodes[0].SourceOffsetFrom(md.data()), 0u);
+    EXPECT_EQ(nodes[1].SourceOffsetFrom(md.data()), kUnsetSourceOffset);
 
     // offset=5（"---"のソース位置付近）→ AAA(offset=0)を返す（HRはスキップ）
-    EXPECT_EQ(FindNodeBySourceOffset(nodes, 5), 0);
+    EXPECT_EQ(FindNodeBySourceOffset(nodes, md.data(), 5), 0);
     // offset=10（BBBのソース位置）→ BBBを返す
-    int bbb_idx = FindNodeBySourceOffset(nodes, 10);
+    int bbb_idx = FindNodeBySourceOffset(nodes, md.data(), 10);
     EXPECT_EQ(bbb_idx, 2);
 }
 
@@ -1557,7 +1557,8 @@ TEST(FindNodeBySourceOffset, MixedWithHorizontalRules)
 // ============================================================
 
 // ヘルパー: old→new の編集をシミュレートし、変更箇所のノードを特定する。
-// source_offset は wide 単位なので、wide のまま FindFirstDifference / ParseMarkdown を呼ぶ。
+// ParseMarkdown は引数 string_view の data() を view_ ベースとして埋め込むため、
+// FindNodeBySourceOffset にも同じ new_md.data() を base として渡す。
 static int SimulateEditAndFindNode(std::string_view old_md, std::string_view new_md)
 {
     size_t diff_pos = FindFirstDifference(old_md, new_md);
@@ -1568,7 +1569,7 @@ static int SimulateEditAndFindNode(std::string_view old_md, std::string_view new
     if (nodes.empty()) {
         return -1;
     }
-    return FindNodeBySourceOffset(nodes, static_cast<uint32_t>(diff_pos));
+    return FindNodeBySourceOffset(nodes, new_md.data(), static_cast<uint32_t>(diff_pos));
 }
 
 TEST(DiffToNode, EditMiddleParagraph)
@@ -1795,12 +1796,14 @@ TEST(IsPrefixOnlyDiff, IntegrationWithFindFirstDifference)
 // CalcScrollYForDiff
 // ============================================================
 
-// ヘルパー: source_offset を等間隔に設定したノード列を構築する
-static std::pmr::vector<Node> MakeNodes(int count, uint32_t offset_step = 100)
+// ヘルパー: source_offset を等間隔に設定したノード列を構築する。
+// CalcScrollYForDiff は content.data() を base に source_offset を取り出すため、
+// テスト側でも同じバッファ (base) を MakeNodes に渡す必要がある。
+static std::pmr::vector<Node> MakeNodes(const char* base, int count, uint32_t offset_step = 100)
 {
     std::pmr::vector<Node> nodes(count);
     for (int i = 0; i < count; ++i) {
-        nodes[i].source_offset = static_cast<uint32_t>(i) * offset_step;
+        nodes[i].SetSourceOffset(base, static_cast<uint32_t>(i) * offset_step);
     }
     return nodes;
 }
@@ -1815,19 +1818,20 @@ TEST(CalcScrollYForDiff, FallbackWhenNoNodes)
 TEST(CalcScrollYForDiff, FallbackWhenNodeNotFound)
 {
     // すべてのノードの source_offset が diff_pos より大きい
-    auto nodes = MakeNodes(3, 100);
-    nodes[0].source_offset = 50;
+    const std::string content = "content";
+    auto nodes = MakeNodes(content.data(), 3, 100);
+    nodes[0].SetSourceOffset(content.data(), 50);
     auto cache = MakeUniformCache(3);
     // diff_pos=10 < 全ノードの最小 offset(50) → -1 → fallback
-    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, "content", 10, 500.0f, 99.0f), 99.0f);
+    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, content, 10, 500.0f, 99.0f), 99.0f);
 }
 
 TEST(CalcScrollYForDiff, ScrollsToNodeStartWithMargin)
 {
     // 3ノード: offset=0,100,200 / y=0,100,200 / height=100
-    auto nodes = MakeNodes(3, 100);
-    auto cache = MakeUniformCache(3, 100.0f);
     std::string content(300, 'x');
+    auto nodes = MakeNodes(content.data(), 3, 100);
+    auto cache = MakeUniformCache(3, 100.0f);
 
     // diff_pos=0 → node 0, y=0, margin=500*0.2=100 → max(0, 0-100)=0
     EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, content, 0, 500.0f, 0.0f), 0.0f);
@@ -1842,9 +1846,9 @@ TEST(CalcScrollYForDiff, ScrollsToNodeStartWithMargin)
 TEST(CalcScrollYForDiff, IntraNodeFractionInterpolation)
 {
     // 2ノード: offset=0,100 / y=0,1000 / height=1000
-    auto nodes = MakeNodes(2, 100);
-    auto cache = MakeUniformCache(2, 1000.0f);
     std::string content(200, 'x');
+    auto nodes = MakeNodes(content.data(), 2, 100);
+    auto cache = MakeUniformCache(2, 1000.0f);
 
     // diff_pos=50 → node 0 (offset=0), next_start=100
     // fraction = (50-0)/(100-0) = 0.5
@@ -1857,9 +1861,9 @@ TEST(CalcScrollYForDiff, IntraNodeFractionInterpolation)
 TEST(CalcScrollYForDiff, FractionClampsToOne)
 {
     // diff_pos がノード範囲を超える場合でも fraction は 1.0 でクランプ
-    auto nodes = MakeNodes(2, 100);
-    auto cache = MakeUniformCache(2, 1000.0f);
     std::string content(200, 'x');
+    auto nodes = MakeNodes(content.data(), 2, 100);
+    auto cache = MakeUniformCache(2, 1000.0f);
 
     // diff_pos=99 → node 0, fraction=99/100=0.99
     // y = 0 + 1000*0.99 = 990, scroll = 990-20 = 970
@@ -1871,12 +1875,12 @@ TEST(CalcScrollYForDiff, FractionClampsToOne)
 TEST(CalcScrollYForDiff, SkipsUnsetSourceOffsets)
 {
     // ノード1の source_offset が未設定の場合、ノード2を next_start として使う
-    std::pmr::vector<Node> nodes(3);
-    nodes[0].source_offset = 0;
-    nodes[1].source_offset = kUnsetSourceOffset; // 未設定（HorizontalRule等）
-    nodes[2].source_offset = 200;
-    auto cache = MakeUniformCache(3, 100.0f);
     std::string content(300, 'x');
+    std::pmr::vector<Node> nodes(3);
+    nodes[0].SetSourceOffset(content.data(), 0);
+    // nodes[1] は未設定（HorizontalRule等）
+    nodes[2].SetSourceOffset(content.data(), 200);
+    auto cache = MakeUniformCache(3, 100.0f);
 
     // diff_pos=100 → node 0 (offset=0), next valid = node 2 (offset=200)
     // fraction = (100-0)/(200-0) = 0.5
@@ -1889,10 +1893,10 @@ TEST(CalcScrollYForDiff, SkipsUnsetSourceOffsets)
 TEST(CalcScrollYForDiff, LastNodeUsesContentSizeAsNextStart)
 {
     // 最後のノードでは content.size() が next_start として使われる
-    auto nodes = MakeNodes(1, 0);
-    nodes[0].source_offset = 0;
-    auto cache = MakeUniformCache(1, 1000.0f);
     std::string content(100, 'x');
+    auto nodes = MakeNodes(content.data(), 1, 0);
+    nodes[0].SetSourceOffset(content.data(), 0);
+    auto cache = MakeUniformCache(1, 1000.0f);
 
     // diff_pos=50, next_start=content.size()=100
     // fraction = 50/100 = 0.5
@@ -1905,11 +1909,12 @@ TEST(CalcScrollYForDiff, LastNodeUsesContentSizeAsNextStart)
 TEST(CalcScrollYForDiff, CacheSizeMismatchFallback)
 {
     // ノード数とキャッシュサイズが不一致の場合のフォールバック
-    auto nodes = MakeNodes(5, 100);
+    const std::string content(500, 'x');
+    auto nodes = MakeNodes(content.data(), 5, 100);
     auto cache = MakeUniformCache(3, 100.0f); // キャッシュは3つだけ
 
     // diff_pos=400 → node 4 だがキャッシュは3つ → fallback
-    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, std::string(500, 'x'), 400, 500.0f, 77.0f), 77.0f);
+    EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, content, 400, 500.0f, 77.0f), 77.0f);
 }
 
 TEST(CalcScrollYForDiff, ParsedMarkdownIntegration)
@@ -1982,9 +1987,9 @@ TEST(CalcScrollYForDiff, PrefixGrowthScrollsTowardAppendedTail)
 // 採用していることを担保する。
 TEST(CalcScrollYForDiff, ReadsCachedTextTopFieldNotFenwick)
 {
-    auto nodes = MakeNodes(3, 100);
-    auto cache = MakeUniformCache(3, 100.0f);
     std::string content(300, 'x');
+    auto nodes = MakeNodes(content.data(), 3, 100);
+    auto cache = MakeUniformCache(3, 100.0f);
 
     // cache[2].text_top を Fenwick が返す値 (=200) から大きくズラす。
     // 実機の累積誤差を模した状況で、フィールド直読なら 999 が、Fenwick 経由なら 200 が

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -1817,8 +1817,10 @@ TEST(CalcScrollYForDiff, FallbackWhenNoNodes)
 
 TEST(CalcScrollYForDiff, FallbackWhenNodeNotFound)
 {
-    // すべてのノードの source_offset が diff_pos より大きい
-    const std::string content = "content";
+    // すべてのノードの source_offset が diff_pos より大きい。
+    // content は MakeNodes が埋める最大 offset (200) + SetSourceOffset の上書き (50) を
+    // string_view{base + offset, 0} で構築できるサイズを確保する必要がある。
+    std::string content(300, 'x');
     auto nodes = MakeNodes(content.data(), 3, 100);
     nodes[0].SetSourceOffset(content.data(), 50);
     auto cache = MakeUniformCache(3);

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -12,9 +12,19 @@
 #include <thread>
 #include <utility>
 #include <windows.h>
+#include <vector>
 #include "document_types.h"
 #include "layout_cache.h"
 #include "side_effect.h"
+
+// Node::view_ は実バッファへの非 null ポインタを必要とする。テストでは中身が
+// 任意で十分大きい固定 base を返し、SetSourceOffset(base, offset) と SourceOffsetFrom(base)
+// のラウンドトリップ用に使う。サイズ 32KB は stress fixture の 22000 ノード + 余裕。
+inline const char* SourceOffsetTestBase() noexcept
+{
+    static const std::vector<char> buf(32 * 1024);
+    return buf.data();
+}
 
 // 同色判定。完全一致のみ（テストで使う色はテーマ定数なので浮動小数点誤差は問題にならない）。
 constexpr bool ColorEq(D2D1_COLOR_F a, D2D1_COLOR_F b) noexcept

--- a/tests/test_parallel_measure_stress.cpp
+++ b/tests/test_parallel_measure_stress.cpp
@@ -32,7 +32,7 @@ Node MakeStressNode(size_t i, bool include_code_block)
 {
     Node n;
     // 派生 mock のトークン seed として使うため、必ず source_offset を埋める。
-    n.source_offset = static_cast<uint32_t>(i);
+    n.SetSourceOffset(SourceOffsetTestBase(), static_cast<uint32_t>(i));
     const size_t bucket = i % 20;
 
     if (include_code_block && bucket < 2) {
@@ -125,7 +125,7 @@ public:
         if (node.type != NodeType::CodeBlock || IsDiagramLanguage(node.code_language())) {
             return;
         }
-        const uint32_t seed = node.source_offset;
+        const uint32_t seed = node.SourceOffsetFrom(SourceOffsetTestBase());
         const auto MakeTok = [seed](uint32_t k) {
             return SyntaxToken{
                 .start = seed + k * 10u,

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1368,50 +1368,55 @@ TEST(Parser, AlertTextStartsWithLabelThenNewline)
 
 // ---- ソースオフセット ----
 
+// ParseMarkdown 直後は view_.data() が入力 string_view (= 引数のリテラル) を指すため、
+// その先頭ポインタを base に取って SourceOffsetFrom() で uint32 offset を取り出す。
 TEST(Parser, SourceOffsetSingleParagraph)
 {
-    auto nodes = ParseMarkdown("Hello world").nodes;
+    std::string_view md = "Hello world";
+    auto nodes = ParseMarkdown(md).nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].source_offset, 0u);
+    EXPECT_EQ(nodes[0].SourceOffsetFrom(md.data()), 0u);
 }
 
 TEST(Parser, SourceOffsetHeading)
 {
     // "# Title" → テキスト "Title" はオフセット 2 から
-    auto nodes = ParseMarkdown("# Title").nodes;
+    std::string_view md = "# Title";
+    auto nodes = ParseMarkdown(md).nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].source_offset, 2u);
+    EXPECT_EQ(nodes[0].SourceOffsetFrom(md.data()), 2u);
 }
 
 TEST(Parser, SourceOffsetMultipleParagraphs)
 {
     // "First\n\nSecond\n\nThird"
     // "First" = offset 0, "Second" = offset 7, "Third" = offset 15
-    auto nodes = ParseMarkdown("First\n\nSecond\n\nThird").nodes;
+    std::string_view md = "First\n\nSecond\n\nThird";
+    auto nodes = ParseMarkdown(md).nodes;
     ASSERT_EQ(nodes.size(), 3u);
-    EXPECT_EQ(nodes[0].source_offset, 0u);
-    EXPECT_EQ(nodes[1].source_offset, 7u);
-    EXPECT_EQ(nodes[2].source_offset, 15u);
+    EXPECT_EQ(nodes[0].SourceOffsetFrom(md.data()), 0u);
+    EXPECT_EQ(nodes[1].SourceOffsetFrom(md.data()), 7u);
+    EXPECT_EQ(nodes[2].SourceOffsetFrom(md.data()), 15u);
 }
 
 TEST(Parser, SourceOffsetIncreasing)
 {
     // ノードの source_offset は単調増加であるべき
-    auto nodes = ParseMarkdown(
-                     "# Heading\n\n"
-                     "Paragraph\n\n"
-                     "- item1\n"
-                     "- item2\n\n"
-                     "```\ncode\n```\n\n"
-                     "End")
-                     .nodes;
+    std::string_view md =
+        "# Heading\n\n"
+        "Paragraph\n\n"
+        "- item1\n"
+        "- item2\n\n"
+        "```\ncode\n```\n\n"
+        "End";
+    auto nodes = ParseMarkdown(md).nodes;
     ASSERT_GE(nodes.size(), 3u);
     uint32_t prev = 0;
     for (size_t i = 0; i < nodes.size(); ++i) {
-        if (nodes[i].source_offset != kUnsetSourceOffset) {
-            EXPECT_GE(nodes[i].source_offset, prev)
-                << "ノード " << i << " の source_offset が前のノードより小さい";
-            prev = nodes[i].source_offset;
+        const uint32_t off = nodes[i].SourceOffsetFrom(md.data());
+        if (off != kUnsetSourceOffset) {
+            EXPECT_GE(off, prev) << "ノード " << i << " の source_offset が前のノードより小さい";
+            prev = off;
         }
     }
 }
@@ -1419,11 +1424,12 @@ TEST(Parser, SourceOffsetIncreasing)
 TEST(Parser, SourceOffsetCodeBlock)
 {
     // "```\nhello\n```" → コードブロック内テキストのオフセット
-    auto nodes = ParseMarkdown("```\nhello\n```").nodes;
+    std::string_view md = "```\nhello\n```";
+    auto nodes = ParseMarkdown(md).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::CodeBlock);
     // コードブロックのテキスト "hello" は "```\n" = 4バイト目から
-    EXPECT_EQ(nodes[0].source_offset, 4u);
+    EXPECT_EQ(nodes[0].SourceOffsetFrom(md.data()), 4u);
 }
 
 TEST(Parser, SourceOffsetEmptyInput)
@@ -1435,19 +1441,21 @@ TEST(Parser, SourceOffsetEmptyInput)
 TEST(Parser, SourceOffsetHorizontalRule)
 {
     // "---" はテキストを持たないのでsource_offsetは未設定のまま
-    auto nodes = ParseMarkdown("---").nodes;
+    std::string_view md = "---";
+    auto nodes = ParseMarkdown(md).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::HorizontalRule);
-    EXPECT_EQ(nodes[0].source_offset, kUnsetSourceOffset);
+    EXPECT_EQ(nodes[0].SourceOffsetFrom(md.data()), kUnsetSourceOffset);
 }
 
 TEST(Parser, SourceOffsetCjkMultiCodeUnit)
 {
     // source_offset は UTF-8 byte。
-    auto nodes = ParseMarkdown("あいう\n\ntest").nodes;
+    std::string_view md = "あいう\n\ntest";
+    auto nodes = ParseMarkdown(md).nodes;
     ASSERT_EQ(nodes.size(), 2u);
-    EXPECT_EQ(nodes[0].source_offset, 0u);
-    EXPECT_EQ(nodes[1].source_offset, 11u); // "あいう" 9 byte + "\n\n" 2
+    EXPECT_EQ(nodes[0].SourceOffsetFrom(md.data()), 0u);
+    EXPECT_EQ(nodes[1].SourceOffsetFrom(md.data()), 11u); // "あいう" 9 byte + "\n\n" 2
 }
 
 TEST(Parser, SourceOffsetUnorderedList)
@@ -1455,41 +1463,45 @@ TEST(Parser, SourceOffsetUnorderedList)
     // "- A\n- B\n- C"
     // "- " = 2バイト, "A" offset=2, "\n- " = 3バイト, "B" offset=5+2=7?
     // 実際: "- A\n" = 4, "- B\n" = 4, "- C" = 3
-    auto nodes = ParseMarkdown("- A\n- B\n- C").nodes;
+    std::string_view md = "- A\n- B\n- C";
+    auto nodes = ParseMarkdown(md).nodes;
     ASSERT_EQ(nodes.size(), 3u);
-    EXPECT_EQ(nodes[0].source_offset, 2u);  // "A" = "- " の後
-    EXPECT_EQ(nodes[1].source_offset, 6u);  // "B" = "- A\n- " の後
-    EXPECT_EQ(nodes[2].source_offset, 10u); // "C" = "- A\n- B\n- " の後
+    EXPECT_EQ(nodes[0].SourceOffsetFrom(md.data()), 2u);  // "A" = "- " の後
+    EXPECT_EQ(nodes[1].SourceOffsetFrom(md.data()), 6u);  // "B" = "- A\n- " の後
+    EXPECT_EQ(nodes[2].SourceOffsetFrom(md.data()), 10u); // "C" = "- A\n- B\n- " の後
 }
 
 TEST(Parser, SourceOffsetOrderedList)
 {
     // "1. First\n2. Second"
-    auto nodes = ParseMarkdown("1. First\n2. Second").nodes;
+    std::string_view md = "1. First\n2. Second";
+    auto nodes = ParseMarkdown(md).nodes;
     ASSERT_EQ(nodes.size(), 2u);
-    EXPECT_EQ(nodes[0].source_offset, 3u);  // "First" = "1. " の後
-    EXPECT_EQ(nodes[1].source_offset, 12u); // "Second" = "1. First\n2. " の後
+    EXPECT_EQ(nodes[0].SourceOffsetFrom(md.data()), 3u);  // "First" = "1. " の後
+    EXPECT_EQ(nodes[1].SourceOffsetFrom(md.data()), 12u); // "Second" = "1. First\n2. " の後
 }
 
 TEST(Parser, SourceOffsetBlockQuote)
 {
     // "> quoted\n\nnormal"
-    auto nodes = ParseMarkdown("> quoted\n\nnormal").nodes;
+    std::string_view md = "> quoted\n\nnormal";
+    auto nodes = ParseMarkdown(md).nodes;
     ASSERT_GE(nodes.size(), 2u);
-    EXPECT_EQ(nodes[0].source_offset, 2u); // "quoted" = "> " の後
+    EXPECT_EQ(nodes[0].SourceOffsetFrom(md.data()), 2u); // "quoted" = "> " の後
 }
 
 TEST(Parser, SourceOffsetNestedList)
 {
     // ネストされたリストでも単調増加
-    auto nodes = ParseMarkdown("- outer\n  - inner\n- next").nodes;
+    std::string_view md = "- outer\n  - inner\n- next";
+    auto nodes = ParseMarkdown(md).nodes;
     ASSERT_GE(nodes.size(), 3u);
     uint32_t prev = 0;
     for (size_t i = 0; i < nodes.size(); ++i) {
-        if (nodes[i].source_offset != kUnsetSourceOffset) {
-            EXPECT_GE(nodes[i].source_offset, prev)
-                << "ノード " << i << " の offset が前のノードより小さい";
-            prev = nodes[i].source_offset;
+        const uint32_t off = nodes[i].SourceOffsetFrom(md.data());
+        if (off != kUnsetSourceOffset) {
+            EXPECT_GE(off, prev) << "ノード " << i << " の offset が前のノードより小さい";
+            prev = off;
         }
     }
 }
@@ -1497,23 +1509,24 @@ TEST(Parser, SourceOffsetNestedList)
 TEST(Parser, SourceOffsetTable)
 {
     // テーブルノードの source_offset はヘッダの最初のセルテキスト
-    auto nodes = ParseMarkdown(
-                     "| A | B |\n"
-                     "|---|---|\n"
-                     "| 1 | 2 |")
-                     .nodes;
+    std::string_view md =
+        "| A | B |\n"
+        "|---|---|\n"
+        "| 1 | 2 |";
+    auto nodes = ParseMarkdown(md).nodes;
     ASSERT_EQ(nodes.size(), 1u);
     EXPECT_EQ(nodes[0].type, NodeType::Table);
     // "| " の後の "A" = offset 2
-    EXPECT_EQ(nodes[0].source_offset, 2u);
+    EXPECT_EQ(nodes[0].SourceOffsetFrom(md.data()), 2u);
 }
 
 TEST(Parser, SourceOffsetCodeBlockWithLanguage)
 {
     // "```cpp\nint x;\n```" → テキストは "```cpp\n" = 7バイト目から
-    auto nodes = ParseMarkdown("```cpp\nint x;\n```").nodes;
+    std::string_view md = "```cpp\nint x;\n```";
+    auto nodes = ParseMarkdown(md).nodes;
     ASSERT_EQ(nodes.size(), 1u);
-    EXPECT_EQ(nodes[0].source_offset, 7u);
+    EXPECT_EQ(nodes[0].SourceOffsetFrom(md.data()), 7u);
 }
 
 TEST(Parser, SourceOffsetMixedDocument)
@@ -1532,24 +1545,26 @@ TEST(Parser, SourceOffsetMixedDocument)
 
     uint32_t prev = 0;
     for (size_t i = 0; i < nodes.size(); ++i) {
-        if (nodes[i].source_offset != kUnsetSourceOffset) {
-            EXPECT_GE(nodes[i].source_offset, prev)
+        const uint32_t off = nodes[i].SourceOffsetFrom(md.data());
+        if (off != kUnsetSourceOffset) {
+            EXPECT_GE(off, prev)
                 << "ノード " << i << " (type="
                 << static_cast<int>(nodes[i].type) << ") の offset が不正";
-            EXPECT_LT(nodes[i].source_offset, static_cast<uint32_t>(md.size()))
+            EXPECT_LT(off, static_cast<uint32_t>(md.size()))
                 << "ノード " << i << " の offset がソース長を超えている";
-            prev = nodes[i].source_offset;
+            prev = off;
         }
     }
 }
 
 TEST(Parser, SourceOffsetTaskList)
 {
-    auto nodes = ParseMarkdown("- [x] done\n- [ ] todo").nodes;
+    std::string_view md = "- [x] done\n- [ ] todo";
+    auto nodes = ParseMarkdown(md).nodes;
     ASSERT_EQ(nodes.size(), 2u);
     // "- [x] " = 6バイト, "done" offset=6
-    EXPECT_EQ(nodes[0].source_offset, 6u);
-    EXPECT_EQ(nodes[1].source_offset, 17u); // "- [x] done\n- [ ] " = 17
+    EXPECT_EQ(nodes[0].SourceOffsetFrom(md.data()), 6u);
+    EXPECT_EQ(nodes[1].SourceOffsetFrom(md.data()), 17u); // "- [x] done\n- [ ] " = 17
 }
 
 // ---- line_count ----

--- a/tests/test_view_stats.cpp
+++ b/tests/test_view_stats.cpp
@@ -387,6 +387,7 @@ TEST(ViewStats, DumpFirstOwnedCodeBlocks)
     }
     auto doc = Document::FromMarkdown(std::move(bytes), L"test.md");
     const auto& raw = doc.GetRawText();
+    const char* const raw_base = raw.data();
     int dumped = 0;
     for (const auto& n : doc.GetNodes()) {
         if (n.type != NodeType::CodeBlock || !n.HasText()) {
@@ -394,11 +395,12 @@ TEST(ViewStats, DumpFirstOwnedCodeBlocks)
         }
         const bool is_view = n.IsViewMode();
         const std::string_view text = n.GetText();
-        std::cout << "[" << (is_view ? "view " : "owned") << "] source_offset=" << n.source_offset
+        const uint32_t off = n.SourceOffsetFrom(raw_base);
+        std::cout << "[" << (is_view ? "view " : "owned") << "] source_offset=" << off
                   << " text.size()=" << text.size() << " line_count=" << n.line_count;
-        if (n.source_offset != kUnsetSourceOffset && n.source_offset < raw.size()) {
-            const size_t avail = std::min<size_t>(text.size(), raw.size() - n.source_offset);
-            const std::string_view raw_slice{ raw.data() + n.source_offset, avail };
+        if (off != kUnsetSourceOffset && off < raw.size()) {
+            const size_t avail = std::min<size_t>(text.size(), raw.size() - off);
+            const std::string_view raw_slice{ raw.data() + off, avail };
             // 先頭 N 文字の差分位置を探す
             size_t first_diff = avail;
             for (size_t i = 0; i < avail; ++i) {


### PR DESCRIPTION
## Summary
- `Node::view_base_` (8B) + `source_offset` (4B) + `view_length` (4B) の 3 フィールドを `std::string_view view_` 1 本に統合。Node サイズ 144B 制約を維持しつつ、ソース位置と表示モードを 1 つの不変条件に集約 (`view_.data()` で未設定/owned/view の三状態を符号化)
- `Document::InjectViewBase` を `RebaseViews(old_base)` に変更。move 時に旧 base を捕捉して delta-rebase、`new_base == old_base` なら早期 return (PMR allocator 同一時の典型経路で no-op)
- `FindNodeBySourceOffset` に `raw_base` 引数を追加し、pointer 経由で uint32 offset を復元する API に統一
- /simplify レビュー指摘を反映: move ctor/assign の重複を `Document::MoveFrom` private helper に共通化、`SetTextView` 引数順を `SetSourceOffset` と揃え、`FinalizeCurrentNode` で `SourceOffsetFrom` の二重計算を解消

## Test plan
- [x] `cmake --build build --config Release` (警告なし)
- [x] `build/tests/Release/mendo_tests.exe --gtest_brief=1` — 2285 件全 PASS
- [x] 実機で大規模 Markdown (100MB クラス) を開いてリロード経路 (`RebaseViews` ホットパス) を確認
- [x] DocumentMove 経路 (`Document doc = std::move(other);`) を含むフローで view ノードのテキストが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)