### PR TITLE
refactor: SourceOffset 系の型を size_t に統一

### DIFF
--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -176,7 +176,7 @@ using NodeImagePtr = mendo::pmr_unique_ptr<NodeImageData>;
 
 // Node::SourceOffsetFrom() が未設定 (view_.data() == nullptr) のときに返す値。
 // HorizontalRule のようなテキストを持たないノードはオフセットを持たない。
-inline constexpr uint32_t kUnsetSourceOffset = std::numeric_limits<uint32_t>::max();
+inline constexpr size_t kUnsetSourceOffset = std::numeric_limits<size_t>::max();
 
 struct Node {
     TextRunList runs;
@@ -234,13 +234,13 @@ struct Node {
     }
 
     // base (= Document::raw_text_.data()) 起算の UTF-8 byte オフセット。未設定時は kUnsetSourceOffset。
-    constexpr uint32_t SourceOffsetFrom(const char* base) const noexcept
+    constexpr size_t SourceOffsetFrom(const char* base) const noexcept
     {
-        return HasSourceOffset() ? static_cast<uint32_t>(view_.data() - base) : kUnsetSourceOffset;
+        return HasSourceOffset() ? static_cast<size_t>(view_.data() - base) : kUnsetSourceOffset;
     }
 
     // ソース位置 (および任意の view 長) を埋める。length=0 は owned モードでの位置追跡用。
-    constexpr void SetSourceOffset(const char* base, uint32_t offset, uint32_t length = 0) noexcept
+    constexpr void SetSourceOffset(const char* base, size_t offset, size_t length = 0) noexcept
     {
         view_ = std::string_view{ base + offset, length };
     }
@@ -303,7 +303,7 @@ struct Node {
     // 連続 NORMAL/CODE/LATEXMATH のみで構成されるノード向けの view 設定 API。
     // raw_text_ の (source_offset_value, length) 範囲をそのまま表示テキストとして使う。
     // 引数順は SetSourceOffset(base, offset, length) と揃えてある。
-    constexpr void SetTextView(const char* view_base, uint32_t source_offset_value, uint32_t length, int32_t line_count_value) noexcept
+    constexpr void SetTextView(const char* view_base, size_t source_offset_value, size_t length, int32_t line_count_value) noexcept
     {
         owned_text_.clear();
         SetSourceOffset(view_base, source_offset_value, length);

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -154,12 +154,12 @@ struct ParseContext {
     // 一致するノードは Node::owned_text_ を確保せず raw_text_ への view に倒せる。
     // span マークアップ (** _ ` 等) や BR/SOFTBR/ENTITY 混在のノードは不一致で owned 経路に落ちる。
     // offset は呼び出し側で SourceOffsetFrom した結果を渡す (FinalizeCurrentNode で再利用するため)。
-    bool CurrentTextMatchesRawSliceAt(uint32_t offset) const noexcept
+    bool CurrentTextMatchesRawSliceAt(size_t offset) const noexcept
     {
         // 高頻度呼び出し (100MB で 40万回超) のため MENDO_PROFILE は外す。
         // zone overhead が ~120ms 単位で計測自体を歪めるため。
         const size_t len = current_text.size();
-        if (static_cast<size_t>(offset) + len > markdown_size) {
+        if (offset + len > markdown_size) {
             return false;
         }
         // current_node_owned_only で span/entity 混在は事前に弾けるため、ここまで来たノードは大半が
@@ -177,13 +177,12 @@ struct ParseContext {
         // 昇格処理 (TryPromoteParagraphToDisplayMath 等) がテキストを直接設定済みのノードは、
         // current_text で上書きすると line_count ごと巻き戻るのでスキップする。
         if (current_node && !current_text.empty() && !current_node->HasText()) {
-            const uint32_t offset = current_node->SourceOffsetFrom(markdown_base);
-            if (!current_node_owned_only && offset != kUnsetSourceOffset
-                && CurrentTextMatchesRawSliceAt(offset)) {
+            const auto offset = current_node->SourceOffsetFrom(markdown_base);
+            if (!current_node_owned_only && offset != kUnsetSourceOffset && CurrentTextMatchesRawSliceAt(offset)) {
                 current_node->SetTextView(
                     markdown_base,
                     offset,
-                    static_cast<uint32_t>(current_text.size()),
+                    current_text.size(),
                     current_node->line_count);
             }
             else {
@@ -798,7 +797,7 @@ int OnText(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, void* userdata)
         const auto base_addr = reinterpret_cast<uintptr_t>(ctx->markdown_base);
         const auto end_addr = base_addr + ctx->markdown_size * sizeof(char);
         if (text_addr >= base_addr && text_addr < end_addr) {
-            const auto offset = static_cast<uint32_t>((text_addr - base_addr) / sizeof(char));
+            const auto offset = static_cast<size_t>((text_addr - base_addr) / sizeof(char));
             ctx->current_node->SetSourceOffset(ctx->markdown_base, offset);
         }
     }

--- a/src/core/reload.cpp
+++ b/src/core/reload.cpp
@@ -28,8 +28,7 @@ ReloadDecision AnalyzeReloadDiff(std::string_view old_text, std::string_view new
     return { ReloadOp::FullReload, diff_pos };
 }
 
-int FindNodeBySourceOffset(const std::pmr::vector<Node>& nodes, const char* raw_base,
-                           uint32_t diff_offset) noexcept
+int FindNodeBySourceOffset(const std::pmr::vector<Node>& nodes, const char* raw_base, size_t diff_offset) noexcept
 {
     // source_offset はパース順で基本的に単調増加するため二分探索を使用。
     // 未設定ノードに当たった場合は左に有効ノードを探してから判定する。
@@ -37,7 +36,7 @@ int FindNodeBySourceOffset(const std::pmr::vector<Node>& nodes, const char* raw_
     int result = -1;
     while (lo <= hi) {
         const int mid = lo + (hi - lo) / 2;
-        const uint32_t offset = nodes[mid].SourceOffsetFrom(raw_base);
+        const auto offset = nodes[mid].SourceOffsetFrom(raw_base);
         if (offset == kUnsetSourceOffset) {
             int probe = mid - 1;
             while (probe >= lo && !nodes[probe].HasSourceOffset()) {
@@ -47,7 +46,7 @@ int FindNodeBySourceOffset(const std::pmr::vector<Node>& nodes, const char* raw_
                 lo = mid + 1;
             }
             else {
-                const uint32_t probe_offset = nodes[probe].SourceOffsetFrom(raw_base);
+                const auto probe_offset = nodes[probe].SourceOffsetFrom(raw_base);
                 if (probe_offset <= diff_offset) {
                     result = probe;
                     lo = mid + 1;
@@ -78,7 +77,7 @@ float CalcScrollYForDiff(
     float fallback_scroll) noexcept
 {
     const char* const raw_base = content.data();
-    const int changed_node = FindNodeBySourceOffset(nodes, raw_base, static_cast<uint32_t>(diff_pos));
+    const auto changed_node = FindNodeBySourceOffset(nodes, raw_base, diff_pos);
     if (changed_node < 0 || changed_node >= static_cast<int>(cache.size())) {
         return fallback_scroll;
     }
@@ -89,12 +88,12 @@ float CalcScrollYForDiff(
     float node_y = cache[changed_node].text_top;
     const float node_h = cache[changed_node].height;
 
-    const uint32_t node_start = nodes[changed_node].SourceOffsetFrom(raw_base);
+    const auto node_start = nodes[changed_node].SourceOffsetFrom(raw_base);
     if (node_start != kUnsetSourceOffset) {
-        uint32_t next_start = static_cast<uint32_t>(content.size());
+        auto next_start = content.size();
         const auto node_count = static_cast<int>(nodes.size());
         for (int i = changed_node + 1; i < node_count; ++i) {
-            const uint32_t off = nodes[i].SourceOffsetFrom(raw_base);
+            const auto off = nodes[i].SourceOffsetFrom(raw_base);
             if (off != kUnsetSourceOffset && off > node_start) {
                 next_start = off;
                 break;

--- a/src/core/reload.h
+++ b/src/core/reload.h
@@ -42,8 +42,7 @@ ReloadDecision AnalyzeReloadDiff(std::string_view old_text, std::string_view new
 
 // source_offset が diff_offset 以下の最後のノードを返す。該当なしの場合は -1。
 // raw_base は Node::view_ の指す raw_text バッファ先頭 (= Document::GetRawText().data())。
-[[nodiscard]] int FindNodeBySourceOffset(const std::pmr::vector<Node>& nodes, const char* raw_base,
-                                         uint32_t diff_offset) noexcept;
+[[nodiscard]] int FindNodeBySourceOffset(const std::pmr::vector<Node>& nodes, const char* raw_base, size_t diff_offset) noexcept;
 
 // diff 位置のノードに基づくスクロールY座標を計算する。
 // ノードが見つからない場合は fallback_scroll を返す。

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -174,9 +174,9 @@ TEST(DocumentTest, RawTextSourceOffsetConsistency)
     // source_offset 位置の文字がノードのテキスト先頭と対応する
     const char* const raw_base = raw.data();
     for (const auto& n : nodes) {
-        const uint32_t off = n.SourceOffsetFrom(raw_base);
+        const size_t off = n.SourceOffsetFrom(raw_base);
         if (off != kUnsetSourceOffset && off < raw.size()) {
-            EXPECT_LT(off, static_cast<uint32_t>(raw.size()));
+            EXPECT_LT(off, raw.size());
         }
     }
 }
@@ -192,7 +192,7 @@ TEST(DocumentTest, SourceOffsetPointsToNodeTextStart)
     const char* const raw_base = raw.data();
     bool checked_any = false;
     for (const auto& n : nodes) {
-        const uint32_t off = n.SourceOffsetFrom(raw_base);
+        const size_t off = n.SourceOffsetFrom(raw_base);
         if (off == kUnsetSourceOffset) {
             continue;
         }
@@ -223,11 +223,11 @@ TEST(DocumentTest, SourceOffsetSurvivesEmbeddedNullInCodeBlock)
     const char* const raw_base = raw.data();
     bool checked_any = false;
     for (const auto& n : nodes) {
-        const uint32_t off = n.SourceOffsetFrom(raw_base);
+        const size_t off = n.SourceOffsetFrom(raw_base);
         if (off == kUnsetSourceOffset) {
             continue;
         }
-        EXPECT_LT(off, static_cast<uint32_t>(raw.size()))
+        EXPECT_LT(off, raw.size())
             << "source_offset must remain within input buffer when md4c emits MD_TEXT_NULLCHAR";
         checked_any = true;
     }

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -1569,7 +1569,7 @@ static int SimulateEditAndFindNode(std::string_view old_md, std::string_view new
     if (nodes.empty()) {
         return -1;
     }
-    return FindNodeBySourceOffset(nodes, new_md.data(), static_cast<uint32_t>(diff_pos));
+    return FindNodeBySourceOffset(nodes, new_md.data(), diff_pos);
 }
 
 TEST(DiffToNode, EditMiddleParagraph)
@@ -1799,11 +1799,11 @@ TEST(IsPrefixOnlyDiff, IntegrationWithFindFirstDifference)
 // ヘルパー: source_offset を等間隔に設定したノード列を構築する。
 // CalcScrollYForDiff は content.data() を base に source_offset を取り出すため、
 // テスト側でも同じバッファ (base) を MakeNodes に渡す必要がある。
-static std::pmr::vector<Node> MakeNodes(const char* base, int count, uint32_t offset_step = 100)
+static std::pmr::vector<Node> MakeNodes(const char* base, int count, size_t offset_step = 100)
 {
     std::pmr::vector<Node> nodes(count);
     for (int i = 0; i < count; ++i) {
-        nodes[i].SetSourceOffset(base, static_cast<uint32_t>(i) * offset_step);
+        nodes[i].SetSourceOffset(base, i * offset_step);
     }
     return nodes;
 }

--- a/tests/test_parallel_measure_stress.cpp
+++ b/tests/test_parallel_measure_stress.cpp
@@ -32,7 +32,7 @@ Node MakeStressNode(size_t i, bool include_code_block)
 {
     Node n;
     // 派生 mock のトークン seed として使うため、必ず source_offset を埋める。
-    n.SetSourceOffset(SourceOffsetTestBase(), static_cast<uint32_t>(i));
+    n.SetSourceOffset(SourceOffsetTestBase(), i);
     const size_t bucket = i % 20;
 
     if (include_code_block && bucket < 2) {
@@ -125,12 +125,13 @@ public:
         if (node.type != NodeType::CodeBlock || IsDiagramLanguage(node.code_language())) {
             return;
         }
-        const uint32_t seed = node.SourceOffsetFrom(SourceOffsetTestBase());
-        const auto MakeTok = [seed](uint32_t k) {
+        const size_t seed = node.SourceOffsetFrom(SourceOffsetTestBase());
+        const auto seed32 = static_cast<uint32_t>(seed);
+        const auto MakeTok = [seed32](uint32_t k) {
             return SyntaxToken{
-                .start = seed + k * 10u,
-                .length = (seed % 7u) + 1u + k,
-                .type = static_cast<SyntaxTokenType>((seed + k) % 4u),
+                .start = seed32 + k * 10u,
+                .length = (seed32 % 7u) + 1u + k,
+                .type = static_cast<SyntaxTokenType>((seed32 + k) % 4u),
             };
         };
         std::pmr::vector<SyntaxToken> dummy{ MakeTok(0), MakeTok(1), MakeTok(2) };

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1369,7 +1369,7 @@ TEST(Parser, AlertTextStartsWithLabelThenNewline)
 // ---- ソースオフセット ----
 
 // ParseMarkdown 直後は view_.data() が入力 string_view (= 引数のリテラル) を指すため、
-// その先頭ポインタを base に取って SourceOffsetFrom() で uint32 offset を取り出す。
+// その先頭ポインタを base に取って SourceOffsetFrom() で byte offset を取り出す。
 TEST(Parser, SourceOffsetSingleParagraph)
 {
     std::string_view md = "Hello world";
@@ -1411,9 +1411,9 @@ TEST(Parser, SourceOffsetIncreasing)
         "End";
     auto nodes = ParseMarkdown(md).nodes;
     ASSERT_GE(nodes.size(), 3u);
-    uint32_t prev = 0;
+    size_t prev = 0;
     for (size_t i = 0; i < nodes.size(); ++i) {
-        const uint32_t off = nodes[i].SourceOffsetFrom(md.data());
+        const size_t off = nodes[i].SourceOffsetFrom(md.data());
         if (off != kUnsetSourceOffset) {
             EXPECT_GE(off, prev) << "ノード " << i << " の source_offset が前のノードより小さい";
             prev = off;
@@ -1496,9 +1496,9 @@ TEST(Parser, SourceOffsetNestedList)
     std::string_view md = "- outer\n  - inner\n- next";
     auto nodes = ParseMarkdown(md).nodes;
     ASSERT_GE(nodes.size(), 3u);
-    uint32_t prev = 0;
+    size_t prev = 0;
     for (size_t i = 0; i < nodes.size(); ++i) {
-        const uint32_t off = nodes[i].SourceOffsetFrom(md.data());
+        const size_t off = nodes[i].SourceOffsetFrom(md.data());
         if (off != kUnsetSourceOffset) {
             EXPECT_GE(off, prev) << "ノード " << i << " の offset が前のノードより小さい";
             prev = off;
@@ -1543,14 +1543,14 @@ TEST(Parser, SourceOffsetMixedDocument)
     auto nodes = ParseMarkdown(md).nodes;
     ASSERT_GE(nodes.size(), 6u);
 
-    uint32_t prev = 0;
+    size_t prev = 0;
     for (size_t i = 0; i < nodes.size(); ++i) {
-        const uint32_t off = nodes[i].SourceOffsetFrom(md.data());
+        const size_t off = nodes[i].SourceOffsetFrom(md.data());
         if (off != kUnsetSourceOffset) {
             EXPECT_GE(off, prev)
                 << "ノード " << i << " (type="
                 << static_cast<int>(nodes[i].type) << ") の offset が不正";
-            EXPECT_LT(off, static_cast<uint32_t>(md.size()))
+            EXPECT_LT(off, md.size())
                 << "ノード " << i << " の offset がソース長を超えている";
             prev = off;
         }

--- a/tests/test_view_stats.cpp
+++ b/tests/test_view_stats.cpp
@@ -395,7 +395,7 @@ TEST(ViewStats, DumpFirstOwnedCodeBlocks)
         }
         const bool is_view = n.IsViewMode();
         const std::string_view text = n.GetText();
-        const uint32_t off = n.SourceOffsetFrom(raw_base);
+        const size_t off = n.SourceOffsetFrom(raw_base);
         std::cout << "[" << (is_view ? "view " : "owned") << "] source_offset=" << off
                   << " text.size()=" << text.size() << " line_count=" << n.line_count;
         if (off != kUnsetSourceOffset && off < raw.size()) {


### PR DESCRIPTION
## Summary
- `kUnsetSourceOffset` / `Node::SourceOffsetFrom()` の戻り値型を `uint32_t` → `size_t` に変更。あわせて `SetSourceOffset` / `SetTextView` / `FindNodeBySourceOffset` の引数も `size_t` に揃えた。
- 元々 `view_.data() - base` (`ptrdiff_t` = 64bit) を `uint32_t` に narrowing していたため、4GB 超ソースで `static_cast<uint32_t>` が silently truncate するリスクがあった。size_t 化で当該キャスト群を全除去し、API 型でファイルサイズ上限の前提が明示される形にした。
- `CalcScrollYForDiff` の `static_cast<uint32_t>(diff_pos)`、テストヘルパの不要キャストも併せて整理。

## 設計メモ
- `Node` 構造体には offset を保持しておらず (`std::string_view view_` の data() から計算)、戻り値型の変更で sizeof(Node) は不変 — メモリ影響なし。
- ホットパス (`OnText` / `FinalizeCurrentNode` / `CurrentTextMatchesRawSliceAt`) は元々 64bit レジスタで計算してから 32bit に narrow していたので、size_t 化は zext/narrow 命令の除去にすぎず性能は中立～微増。
- `kUnsetSourceOffset = SIZE_MAX` でも、`offset != kUnsetSourceOffset` ガードが呼び出し側にあるため `offset + len` のラップアラウンド経路は到達不能 (旧 uint32_t 時代と同じ挙動)。

## Test plan
- [x] `cmake --build build --config Release` 成功
- [x] `build/tests/Release/mendo_tests.exe --gtest_brief=1` で 2285 tests PASSED
- [x] `/simplify` レビュー (再利用 / 品質 / 効率の 3 観点) 通過し、指摘 2 件 (冗長キャスト) を反映済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)