### PR TITLE
refactor: テスト専用だった Node::SetText (1 引数版) を削除

### DIFF
--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -283,23 +283,6 @@ struct Node {
         return GetText();
     }
 
-    constexpr void SetText(const char* s)
-    {
-        SetText(std::string_view{ s });
-    }
-
-    constexpr void SetText(std::string_view s)
-    {
-        owned_text_.assign(s);
-        FinalizeOwnedTextLineCount();
-    }
-
-    constexpr void SetText(std::pmr::string&& s) noexcept
-    {
-        owned_text_ = std::move(s);
-        FinalizeOwnedTextLineCount();
-    }
-
     // 連続 NORMAL/CODE/LATEXMATH のみで構成されるノード向けの view 設定 API。
     // raw_text_ の (source_offset_value, length) 範囲をそのまま表示テキストとして使う。
     // 引数順は SetSourceOffset(base, offset, length) と揃えてある。
@@ -508,12 +491,6 @@ private:
     constexpr void DemoteToOwned() noexcept
     {
         view_ = std::string_view{ view_.data(), 0 };
-    }
-
-    constexpr void FinalizeOwnedTextLineCount() noexcept
-    {
-        line_count = static_cast<int32_t>(std::ranges::count(owned_text_, mendo::doc_lf));
-        DemoteToOwned();
     }
 
     // parser 契約: BeginNode 直後の Node は monostate で、対応する 1 種類だけが ensure される。

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -1092,10 +1092,9 @@ void TransformAlertNode(Node& node, AlertType type, size_t marker_end)
         new_runs.emplace_back(adjusted);
     }
 
-    // node.SetText の中で line_count を再カウントすると O(text) で改行を数え直すため、
-    // ここで差分計算する。マーカー [!TYPE] 本体には改行が入らず、
-    // DetectAlertMarker で 1 文字だけスキップする文字が \n の場合のみ改行 1 個。
-    // count を走査せず、marker_end 直前の 1 文字だけを見ればよい。
+    // 全文走査で改行を数え直すと O(text) かかるため、ここで差分計算する。
+    // マーカー [!TYPE] 本体には改行が入らず、DetectAlertMarker で 1 文字だけスキップする
+    // 文字が \n の場合のみ改行 1 個。marker_end 直前の 1 文字だけを見ればよい。
     const int32_t marker_newlines = (marker_end > 0 && current_text[marker_end - 1] == mendo::doc_lf);
     const int32_t new_line_count = node.line_count - marker_newlines + has_content;
     node.SetTextWithLineCount(std::move(new_text), new_line_count);

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -95,7 +95,7 @@ TEST(DocumentTest, GetNodesMut)
 
     // 可変参照を通じてノードを変更
     auto& nodes = doc.GetNodesMut();
-    nodes[0].SetText("modified");
+    nodes[0].SetTextWithLineCount(std::string_view{ "modified" }, 0);
     EXPECT_EQ(doc.GetNodes()[0].GetText(), "modified");
 }
 
@@ -157,7 +157,7 @@ TEST(DocumentTest, GetRawTextIndependentOfNodes)
 {
     // ノードの変更が raw_text_ に影響しないことを確認
     auto doc = Document::FromMarkdown("hello", L"test.md");
-    doc.GetNodesMut()[0].SetText("modified");
+    doc.GetNodesMut()[0].SetTextWithLineCount(std::string_view{ "modified" }, 0);
     // raw_text_ はパース入力のまま
     EXPECT_EQ(doc.GetRawText(), "hello");
 }

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -157,7 +157,7 @@ TEST(ExtractSelectedTextAsHtml, EscapesSpecialChars)
 {
     Node n;
     n.type = NodeType::Paragraph;
-    n.SetText("a<b&c>d\"e'f");
+    n.SetTextWithLineCount(std::string_view{ "a<b&c>d\"e'f" }, 0);
     std::pmr::vector<Node> nodes;
     nodes.emplace_back(std::move(n));
     auto sel = TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(nodes[0].GetText().size()));
@@ -265,7 +265,7 @@ TEST(ExtractSelectedTextAsHtml, CodeBlockDarkModeUsesDarkColors)
 static TextSelection MakeTableFullSelection(Node& table)
 {
     if (table.GetText().empty()) {
-        table.SetText("table");
+        table.SetTextWithLineCount(std::string_view{ "table" }, 0);
     }
     return TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(table.GetText().size()));
 }
@@ -346,7 +346,7 @@ TEST(ExtractSelectedTextAsHtml, TableWithoutDataFallsBackToPre)
     // table_data が空のノードに対しては <pre> フォールバックで出力される。
     Node n;
     n.type = NodeType::Table;
-    n.SetText("fallback");
+    n.SetTextWithLineCount(std::string_view{ "fallback" }, 0);
     std::pmr::vector<Node> nodes;
     nodes.emplace_back(std::move(n));
     auto sel = TextSelection::MakeOrdered(0, 0, 0, static_cast<uint32_t>(nodes[0].GetText().size()));
@@ -802,7 +802,7 @@ TEST(ExtractSelectedText, SelectionSpanningTableNode)
     // テーブル型ノード（線形化テキストを持つ）でのテスト
     Node table_node;
     table_node.type = NodeType::Table;
-    table_node.SetText("A\tB\n1\t2");
+    table_node.SetTextWithLineCount(std::string_view{ "A\tB\n1\t2" }, 1);
 
     std::pmr::vector<Node> nodes;
     nodes.emplace_back(std::move(table_node));
@@ -868,7 +868,7 @@ TEST(ExtractSelectedText, StartNodeOutOfRange)
 {
     std::pmr::vector<Node> nodes;
     Node n;
-    n.SetText("hello");
+    n.SetTextWithLineCount(std::string_view{ "hello" }, 0);
     nodes.emplace_back(std::move(n));
 
     TextSelection sel;
@@ -887,7 +887,7 @@ TEST(ExtractSelectedText, EndNodeOutOfRange)
 {
     std::pmr::vector<Node> nodes;
     Node n;
-    n.SetText("hello");
+    n.SetTextWithLineCount(std::string_view{ "hello" }, 0);
     nodes.emplace_back(std::move(n));
 
     TextSelection sel;
@@ -907,7 +907,7 @@ TEST(ExtractSelectedText, EndNodeOutOfRange)
 TEST(FindLinkAtPosition, MultipleLinkRuns)
 {
     Node node;
-    node.SetText("link1 link2");
+    node.SetTextWithLineCount(std::string_view{ "link1 link2" }, 0);
 
     node.ensure_link_urls().emplace_back("https://a.com");
     node.ensure_link_urls().emplace_back("https://b.com");

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <chrono>
 #include <d2d1.h>
 #include <filesystem>
@@ -32,12 +33,20 @@ constexpr bool ColorEq(D2D1_COLOR_F a, D2D1_COLOR_F b) noexcept
     return a.r == b.r && a.g == b.g && a.b == b.b && a.a == b.a;
 }
 
+// 本番 API SetTextWithLineCount は line_count を呼び出し側に渡させる契約だが、
+// 任意の文字列を受け取るテストヘルパーでは内容から自動算出したい。
+inline void SetNodeTextCounted(Node& n, std::string_view sv)
+{
+    const int32_t lc = static_cast<int32_t>(std::ranges::count(sv, mendo::doc_lf));
+    n.SetTextWithLineCount(sv, lc);
+}
+
 // テキスト持ちの Paragraph ノードを作るテスト用ヘルパー。
 inline Node MakeTextNode(const char* text)
 {
     Node n;
     n.type = NodeType::Paragraph;
-    n.SetText(text);
+    SetNodeTextCounted(n, std::string_view{ text });
     return n;
 }
 

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -1272,7 +1272,7 @@ TEST(EstimateNodeHeightsTest, SingleParagraph)
 {
     Node node;
     node.type = NodeType::Paragraph;
-    node.SetText("Hello world");
+    node.SetTextWithLineCount(std::string_view{ "Hello world" }, 0);
     std::pmr::vector<Node> nodes;
     nodes.emplace_back(std::move(node));
     LayoutCache cache;
@@ -1324,12 +1324,12 @@ TEST(EstimateNodeHeightsTest, HeadingHeightScalesWithLevel)
     Node h1;
     h1.type = NodeType::Heading;
     h1.ensure_heading()->heading_level = 1;
-    h1.SetText("Title");
+    h1.SetTextWithLineCount(std::string_view{ "Title" }, 0);
 
     Node h3;
     h3.type = NodeType::Heading;
     h3.ensure_heading()->heading_level = 3;
-    h3.SetText("Title");
+    h3.SetTextWithLineCount(std::string_view{ "Title" }, 0);
 
     std::pmr::vector<Node> nodes;
     nodes.emplace_back(std::move(h1));
@@ -1348,13 +1348,11 @@ TEST(EstimateNodeHeightsTest, CodeBlockScalesWithLineCount)
 
     Node short_code;
     short_code.type = NodeType::CodeBlock;
-    short_code.SetText("line1");
-    short_code.line_count = 0;
+    short_code.SetTextWithLineCount(std::string_view{ "line1" }, 0);
 
     Node long_code;
     long_code.type = NodeType::CodeBlock;
-    long_code.SetText("line1\nline2\nline3\nline4\nline5");
-    long_code.line_count = 4;
+    long_code.SetTextWithLineCount(std::string_view{ "line1\nline2\nline3\nline4\nline5" }, 4);
 
     std::pmr::vector<Node> nodes;
     nodes.emplace_back(std::move(short_code));
@@ -1447,13 +1445,11 @@ TEST(EstimateNodeHeightsTest, MultilineParagraphScalesWithLines)
 
     Node single;
     single.type = NodeType::Paragraph;
-    single.SetText("one line");
-    single.line_count = 0;
+    single.SetTextWithLineCount(std::string_view{ "one line" }, 0);
 
     Node multi;
     multi.type = NodeType::Paragraph;
-    multi.SetText("line1\nline2\nline3");
-    multi.line_count = 2;
+    multi.SetTextWithLineCount(std::string_view{ "line1\nline2\nline3" }, 2);
 
     std::pmr::vector<Node> nodes;
     nodes.emplace_back(std::move(single));
@@ -1471,7 +1467,7 @@ TEST(EstimateNodeHeightsTest, LayoutDirtyNotChanged)
     Theme theme = GetLightTheme();
     Node node;
     node.type = NodeType::Paragraph;
-    node.SetText("test");
+    node.SetTextWithLineCount(std::string_view{ "test" }, 0);
 
     std::pmr::vector<Node> nodes;
     nodes.emplace_back(std::move(node));
@@ -1495,7 +1491,7 @@ TEST(EstimateNodeHeightsTest, AllNodeTypesProducePositiveHeight)
     auto add_node = [&](NodeType type, const char* text = "content") {
         Node n;
         n.type = type;
-        n.SetText(text);
+        SetNodeTextCounted(n, std::string_view{ text });
         if (type == NodeType::Heading) {
             n.ensure_heading()->heading_level = 2;
         }

--- a/tests/test_layout_computer_invisible.cpp
+++ b/tests/test_layout_computer_invisible.cpp
@@ -13,8 +13,7 @@ Node MakeParagraphNode(int line_count = 0)
 {
     Node n;
     n.type = NodeType::Paragraph;
-    n.SetText("text");
-    n.line_count = line_count;
+    n.SetTextWithLineCount(std::string_view{ "text" }, line_count);
     return n;
 }
 
@@ -22,8 +21,7 @@ Node MakeCodeBlockNode(SyntaxLanguage lang, int line_count = 1)
 {
     Node n;
     n.type = NodeType::CodeBlock;
-    n.SetText("code");
-    n.line_count = line_count;
+    n.SetTextWithLineCount(std::string_view{ "code" }, line_count);
     n.ensure_code()->code_language = lang;
     return n;
 }

--- a/tests/test_measurer_parity.cpp
+++ b/tests/test_measurer_parity.cpp
@@ -46,7 +46,7 @@ private:
             n.ensure_code()->code_language = src.code_language();
         }
         if (!src.GetText().empty()) {
-            n.SetText(src.GetText());
+            n.SetTextWithLineCount(src.GetText(), src.line_count);
         }
         n.runs = src.runs;
         if (src.has_image()) {
@@ -121,12 +121,12 @@ TEST_F(MeasurerParityTest, HeadingTallerThanParagraphInBoth)
 {
     Node para;
     para.type = NodeType::Paragraph;
-    para.SetText("Sample text");
+    para.SetTextWithLineCount(std::string_view{ "Sample text" }, 0);
 
     Node heading;
     heading.type = NodeType::Heading;
     heading.ensure_heading()->heading_level = 1;
-    heading.SetText("Sample text");
+    heading.SetTextWithLineCount(std::string_view{ "Sample text" }, 0);
 
     const auto p = MeasureBoth(para, 600.0f);
     const auto h = MeasureBoth(heading, 600.0f);
@@ -142,12 +142,14 @@ TEST_F(MeasurerParityTest, LongerTextIsNotShorter)
 {
     Node short_node;
     short_node.type = NodeType::Paragraph;
-    short_node.SetText("Short");
+    short_node.SetTextWithLineCount(std::string_view{ "Short" }, 0);
 
     Node long_node;
     long_node.type = NodeType::Paragraph;
-    long_node.SetText("This is a much longer paragraph that should wrap across multiple lines "
-                      "at the given narrow max width, producing a taller layout result than the short one.");
+    long_node.SetTextWithLineCount(
+        std::string_view{ "This is a much longer paragraph that should wrap across multiple lines "
+                          "at the given narrow max width, producing a taller layout result than the short one." },
+        0);
 
     const auto s = MeasureBoth(short_node, 200.0f);
     const auto l = MeasureBoth(long_node, 200.0f);

--- a/tests/test_parallel_measure_stress.cpp
+++ b/tests/test_parallel_measure_stress.cpp
@@ -39,7 +39,7 @@ Node MakeStressNode(size_t i, bool include_code_block)
         n.type = NodeType::CodeBlock;
         n.ensure_code()->code_language = SyntaxLanguage::Cpp;
         std::string text = "int v_" + std::to_string(i) + " = 0;";
-        n.SetText(text.c_str());
+        n.SetTextWithLineCount(std::string_view{ text }, 0);
         return n;
     }
     if (bucket < 12) {
@@ -50,14 +50,14 @@ Node MakeStressNode(size_t i, bool include_code_block)
         for (size_t k = 0; k < len; ++k) {
             text.push_back(static_cast<wchar_t>('a' + ((i + k) % 26)));
         }
-        n.SetText(text.c_str());
+        n.SetTextWithLineCount(std::string_view{ text }, 0);
         return n;
     }
     if (bucket < 14) {
         n.type = NodeType::Heading;
         n.ensure_heading()->heading_level = static_cast<int8_t>(1 + (i % 6));
         std::string text = "Heading " + std::to_string(i);
-        n.SetText(text.c_str());
+        n.SetTextWithLineCount(std::string_view{ text }, 0);
         return n;
     }
     if (bucket == 14) {
@@ -87,7 +87,7 @@ Node MakeStressNode(size_t i, bool include_code_block)
         return n;
     }
     n.type = NodeType::Paragraph;
-    n.SetText("");
+    n.SetTextWithLineCount(std::string_view{ "" }, 0);
     return n;
 }
 

--- a/tests/test_search_state.cpp
+++ b/tests/test_search_state.cpp
@@ -508,7 +508,7 @@ TEST(SearchStateTest, ImageNodeExcludedFromSearch)
     std::pmr::vector<Node> nodes;
     Node img;
     img.type = NodeType::Image;
-    img.SetText("alt text with keyword");
+    img.SetTextWithLineCount(std::string_view{ "alt text with keyword" }, 0);
     nodes.push_back(std::move(img));
     nodes.push_back(MakeTextNode("keyword in paragraph"));
     SearchState s;
@@ -525,7 +525,7 @@ TEST(SearchStateTest, MermaidCodeBlockExcludedFromSearch)
     Node mermaid;
     mermaid.type = NodeType::CodeBlock;
     mermaid.ensure_code()->code_language = SyntaxLanguage::Mermaid;
-    mermaid.SetText("graph TD; A-->B");
+    mermaid.SetTextWithLineCount(std::string_view{ "graph TD; A-->B" }, 0);
     nodes.push_back(std::move(mermaid));
     nodes.push_back(MakeTextNode("graph description"));
     SearchState s;
@@ -542,7 +542,7 @@ TEST(SearchStateTest, NonMermaidCodeBlockIncludedInSearch)
     Node code;
     code.type = NodeType::CodeBlock;
     code.ensure_code()->code_language = SyntaxLanguage::Cpp;
-    code.SetText("int main()");
+    code.SetTextWithLineCount(std::string_view{ "int main()" }, 0);
     nodes.push_back(std::move(code));
     SearchState s;
     s.SetQuery("main");

--- a/tests/test_types.cpp
+++ b/tests/test_types.cpp
@@ -269,157 +269,12 @@ TEST(AlertColorIndex, CautionReturnsFour)
 
 // ---- Nodeアクセサ ----
 
-TEST(NodeTest, SetTextAndGetText)
-{
-    Node node;
-    node.SetText("Hello");
-    EXPECT_EQ(node.GetText(), "Hello");
-    EXPECT_TRUE(node.HasText());
-}
-
-TEST(NodeTest, SetTextStringView)
-{
-    Node node;
-    std::string_view sv = "Test text";
-    node.SetText(sv);
-    EXPECT_EQ(node.GetText(), "Test text");
-}
-
-TEST(NodeTest, SetTextMove)
-{
-    Node node;
-    std::pmr::string s = "Moved text";
-    node.SetText(std::move(s));
-    EXPECT_EQ(node.GetText(), "Moved text");
-}
-
-TEST(NodeTest, SetTextCountsNewlines)
-{
-    Node node;
-    node.SetText("line1\nline2\nline3");
-    EXPECT_EQ(node.line_count, 2);
-}
-
-TEST(NodeTest, SetTextOverwritesPrevious)
-{
-    Node node;
-    node.SetText("original");
-    node.SetText("new text");
-    EXPECT_EQ(node.GetText(), "new text");
-}
-
 // ---- Node::line_count ----
 
 TEST(NodeLineCount, DefaultIsZero)
 {
     Node node;
     EXPECT_EQ(node.line_count, 0);
-}
-
-TEST(NodeLineCount, EmptyText)
-{
-    Node node;
-    node.SetText("");
-    EXPECT_EQ(node.line_count, 0);
-}
-
-TEST(NodeLineCount, SingleLineNoNewline)
-{
-    Node node;
-    node.SetText("hello");
-    EXPECT_EQ(node.line_count, 0);
-}
-
-TEST(NodeLineCount, SingleNewline)
-{
-    Node node;
-    node.SetText("a\nb");
-    EXPECT_EQ(node.line_count, 1);
-}
-
-TEST(NodeLineCount, ConsecutiveNewlines)
-{
-    Node node;
-    node.SetText("a\n\n\nb");
-    EXPECT_EQ(node.line_count, 3);
-}
-
-TEST(NodeLineCount, LeadingNewline)
-{
-    Node node;
-    node.SetText("\nabc");
-    EXPECT_EQ(node.line_count, 1);
-}
-
-TEST(NodeLineCount, TrailingNewline)
-{
-    Node node;
-    node.SetText("abc\n");
-    EXPECT_EQ(node.line_count, 1);
-}
-
-TEST(NodeLineCount, OnlyNewlines)
-{
-    Node node;
-    node.SetText("\n\n\n\n");
-    EXPECT_EQ(node.line_count, 4);
-}
-
-TEST(NodeLineCount, CrLfCountsOnlyLf)
-{
-    // FinalizeSetText は '\n' のみ数える（\r は無視）
-    Node node;
-    node.SetText("a\r\nb\r\nc");
-    EXPECT_EQ(node.line_count, 2);
-}
-
-TEST(NodeLineCount, CarriageReturnOnlyNotCounted)
-{
-    Node node;
-    node.SetText("a\rb\rc");
-    EXPECT_EQ(node.line_count, 0);
-}
-
-TEST(NodeLineCount, CharPointerOverload)
-{
-    Node node;
-    const char* s = "x\ny\nz";
-    node.SetText(s);
-    EXPECT_EQ(node.line_count, 2);
-}
-
-TEST(NodeLineCount, StringViewOverload)
-{
-    Node node;
-    std::string_view sv = "line1\nline2";
-    node.SetText(sv);
-    EXPECT_EQ(node.line_count, 1);
-}
-
-TEST(NodeLineCount, PmrStringMoveOverload)
-{
-    Node node;
-    std::pmr::string s = "a\nb\nc\nd";
-    node.SetText(std::move(s));
-    EXPECT_EQ(node.line_count, 3);
-}
-
-TEST(NodeLineCount, OverwriteRecountsToFewer)
-{
-    Node node;
-    node.SetText("a\nb\nc\nd\ne"); // 4
-    EXPECT_EQ(node.line_count, 4);
-    node.SetText("single line"); // 0
-    EXPECT_EQ(node.line_count, 0);
-}
-
-TEST(NodeLineCount, OverwriteRecountsToMore)
-{
-    Node node;
-    node.SetText("single"); // 0
-    EXPECT_EQ(node.line_count, 0);
-    node.SetText("a\nb\nc"); // 2
-    EXPECT_EQ(node.line_count, 2);
 }
 
 TEST(NodeLineCount, SetTextWithLineCountStoresValueAsIs)
@@ -452,17 +307,6 @@ TEST(NodeLineCount, SetTextWithLineCountPmrMoveOverload)
     std::pmr::string s = "x\ny\nz";
     node.SetTextWithLineCount(std::move(s), 2);
     EXPECT_EQ(node.GetText(), "x\ny\nz");
-    EXPECT_EQ(node.line_count, 2);
-}
-
-TEST(NodeLineCount, SetTextAfterSetTextWithLineCountRecounts)
-{
-    // SetTextWithLineCount で意図的に「不一致」を入れた後、
-    // SetText を呼ぶと FinalizeSetText が走り、stale な値を上書きする。
-    Node node;
-    node.SetTextWithLineCount(std::string_view{ "x" }, 99);
-    EXPECT_EQ(node.line_count, 99);
-    node.SetText("a\nb\nc");
     EXPECT_EQ(node.line_count, 2);
 }
 
@@ -540,7 +384,7 @@ TEST(NodeTest, MermaidCodeBlockTextStored)
     Node node;
     node.type = NodeType::CodeBlock;
     node.ensure_code()->code_language = SyntaxLanguage::Mermaid;
-    node.SetText("graph TD;A-->B");
+    node.SetTextWithLineCount(std::string_view{ "graph TD;A-->B" }, 0);
     EXPECT_EQ(node.GetText(), "graph TD;A-->B");
 }
 
@@ -549,7 +393,7 @@ TEST(NodeTest, LatexMathCodeBlockTextStored)
     Node node;
     node.type = NodeType::CodeBlock;
     node.ensure_code()->code_language = SyntaxLanguage::LatexMath;
-    node.SetText("E = mc^2");
+    node.SetTextWithLineCount(std::string_view{ "E = mc^2" }, 0);
     EXPECT_EQ(node.GetText(), "E = mc^2");
 }
 
@@ -558,7 +402,7 @@ TEST(NodeTest, NonDiagramCodeBlockTextStored)
     Node node;
     node.type = NodeType::CodeBlock;
     node.ensure_code()->code_language = SyntaxLanguage::Cpp;
-    node.SetText("int main() { return 0; }");
+    node.SetTextWithLineCount(std::string_view{ "int main() { return 0; }" }, 0);
     EXPECT_EQ(node.GetText(), "int main() { return 0; }");
 }
 
@@ -566,7 +410,7 @@ TEST(NodeTest, ParagraphTextStored)
 {
     Node node;
     node.type = NodeType::Paragraph;
-    node.SetText("paragraph content");
+    node.SetTextWithLineCount(std::string_view{ "paragraph content" }, 0);
     EXPECT_EQ(node.GetText(), "paragraph content");
 }
 

--- a/tests/test_viewport_manager.cpp
+++ b/tests/test_viewport_manager.cpp
@@ -219,9 +219,9 @@ TEST(ViewportManagerTest, ClearSelection)
 TEST(ViewportManagerTest, SelectAll)
 {
     std::pmr::vector<Node> nodes(3);
-    nodes[0].SetText("hello");
-    nodes[1].SetText("world");
-    nodes[2].SetText("end");
+    nodes[0].SetTextWithLineCount(std::string_view{ "hello" }, 0);
+    nodes[1].SetTextWithLineCount(std::string_view{ "world" }, 0);
+    nodes[2].SetTextWithLineCount(std::string_view{ "end" }, 0);
 
     ViewportManager vm;
     vm.SelectAll(nodes);


### PR DESCRIPTION
## Summary

- 本番コードで未使用の `Node::SetText(const char*)` / `SetText(std::string_view)` / `SetText(std::pmr::string&&)` の 3 オーバーロードを削除。本番側はすべて `SetTextWithLineCount` または `SetTextView` 経由で line_count を呼び出し側責任にする契約に統一。
- 内部ヘルパー `FinalizeOwnedTextLineCount` も唯一の呼び出し元だった上記 SetText 削除に伴い除去。
- テスト側を `SetTextWithLineCount(text, line_count)` 呼び出しへ書き換え。任意の文字列を受け取るヘルパーで改行数を自動算出したい場合は `tests/test_helpers.h` に追加した `SetNodeTextCounted` を経由。
- SetText の挙動自体を検証していた 18 個のテスト (改行カウント、`\r` 無視、各オーバーロード解決等) は API ごと消えたため削除。`SetTextWithLineCount` 系のテストは保持。

## Test plan

- [x] `cmake --build build --config Release -- //v:q //nologo` でビルド成功
- [x] `build/tests/Release/mendo_tests.exe --gtest_brief=1` で全 2265 テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)