### PR TITLE
fix: loose list の bullet と文字の Y ズレを修正 (#237)

### DIFF
--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -533,3 +533,10 @@ constexpr bool IsScrollableCodeBlock(const Node& node) noexcept
 {
     return node.type == NodeType::CodeBlock && !IsDiagramLanguage(node.code_language());
 }
+
+// loose list の LI (md4c が中身を MD_BLOCK_P に外出しするためテキストを持たない枠)。
+// 高さ / spacing / cull / bullet 描画で同じ判定を共有するため集約する (issue#237)。
+constexpr bool IsEmptyListItemContainer(const Node& node) noexcept
+{
+    return (node.type == NodeType::ListItem || node.type == NodeType::TaskListItem) && !node.HasText();
+}

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -264,7 +264,8 @@ void DWriteTextMeasurer::MeasureNode(
 
     const auto& text = node.GetText();
     if (text.empty()) {
-        entry.height = theme_->paragraph_spacing;
+        // loose LI で paragraph_spacing を入れると bullet と直下 P の文字 Y が分離する (issue#237)。
+        entry.height = IsEmptyListItemContainer(node) ? 0.0f : theme_->paragraph_spacing;
         entry.layout_dirty = false;
         return;
     }

--- a/src/layout/layout_computer.cpp
+++ b/src/layout/layout_computer.cpp
@@ -53,7 +53,8 @@ float GetSpacingBelow(const Node& node, const Theme& theme) noexcept
         return theme.paragraph_spacing + theme.code_block_spacing_above;
     case NodeType::ListItem:
     case NodeType::TaskListItem:
-        return theme.list_item_spacing;
+        // 空 LI に sb を入れると直下 P の text_top が下ズレし bullet と分離する (issue#237)。
+        return IsEmptyListItemContainer(node) ? 0.0f : theme.list_item_spacing;
     case NodeType::HorizontalRule:
         return 0.0f;
     case NodeType::Table:
@@ -115,10 +116,15 @@ float EstimateNodeHeight(const Node& node, const Theme& theme) noexcept
     }
     case NodeType::Image:
         return std::max(MIN_DIAGRAM_PLACEHOLDER_HEIGHT, theme.font_size_body * 3.0f);
-    case NodeType::Paragraph:
     case NodeType::ListItem:
-    case NodeType::BlockQuote:
     case NodeType::TaskListItem:
+        // 空 LI に高さを与えると bullet と直下 P の文字 Y が分離する (issue#237)。
+        if (IsEmptyListItemContainer(node)) {
+            return 0.0f;
+        }
+        return line_height * static_cast<float>(1 + node.line_count);
+    case NodeType::Paragraph:
+    case NodeType::BlockQuote:
         if (!node.HasText()) {
             return theme.paragraph_spacing;
         }

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -216,10 +216,14 @@ void CommandGenerator::GenerateNode(
             node_bottom += theme_->heading_spacing_below_h1h2 * HEADING_UNDERLINE_OFFSET_RATIO + theme_->GetHeadingUnderlineThickness(lv);
         }
     }
-    // 空 LI は height=0 だが bullet/checkbox は first_line_h*0.5 下に描かれるため、
-    // node_bottom を line height 分拡張しないと viewport 上端で bullet が一瞬消える。
+    // 空 LI は height=0 だが bullet/checkbox は entry_text_top より下に描かれるため、
+    // node_bottom を実描画下端まで拡張しないと viewport 上端で一瞬消える。
+    // TaskListItem の checkbox (1.5x) は ListItem の bullet 1 行分 (1.3x) より背が高い。
     else if (IsEmptyListItemContainer(node)) {
-        node_bottom += theme_->font_size_body * FALLBACK_LINE_HEIGHT_FACTOR;
+        const float factor = (node.type == NodeType::TaskListItem)
+                                 ? TASK_CHECKBOX_HEIGHT_FACTOR
+                                 : FALLBACK_LINE_HEIGHT_FACTOR;
+        node_bottom += theme_->font_size_body * factor;
     }
     if (node_bottom < fc.viewport_top || entry_text_top > fc.viewport_bottom) {
         return;

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -216,6 +216,11 @@ void CommandGenerator::GenerateNode(
             node_bottom += theme_->heading_spacing_below_h1h2 * HEADING_UNDERLINE_OFFSET_RATIO + theme_->GetHeadingUnderlineThickness(lv);
         }
     }
+    // 空 LI は height=0 だが bullet/checkbox は first_line_h*0.5 下に描かれるため、
+    // node_bottom を line height 分拡張しないと viewport 上端で bullet が一瞬消える。
+    else if (IsEmptyListItemContainer(node)) {
+        node_bottom += theme_->font_size_body * FALLBACK_LINE_HEIGHT_FACTOR;
+    }
     if (node_bottom < fc.viewport_top || entry_text_top > fc.viewport_bottom) {
         return;
     }
@@ -298,6 +303,9 @@ void CommandGenerator::GenerateNode(
         break;
 
     case NodeType::TaskListItem:
+        // GenNodeTextDecorations は text_layout=nullptr (loose で空 TaskListItem) で early return
+        // するため、checkbox は case 側で emit する。
+        GenTaskListCheckbox(cmds, node, x, entry_text_top);
         break;
 
     case NodeType::BlockQuote:
@@ -347,7 +355,7 @@ CommandGenerator::NodeBaseStyle CommandGenerator::GetNodeBaseStyle(const Node& n
     std::unreachable();
 }
 
-void CommandGenerator::GenNodeTextDecorations(DrawCommandList& cmds, const FrameContext& fc, const Node& node, const NodeLayoutEntry& entry, int node_index, float x, float text_x, float entry_text_top)
+void CommandGenerator::GenNodeTextDecorations(DrawCommandList& cmds, const FrameContext& fc, const Node& node, const NodeLayoutEntry& entry, int node_index, float /*x*/, float text_x, float entry_text_top)
 {
     if (!entry.text_layout) {
         return;
@@ -376,8 +384,11 @@ void CommandGenerator::GenNodeTextDecorations(DrawCommandList& cmds, const Frame
     }
 
     cmds.emplace_back(DrawTextLayoutCmd{ D2D1::Point2F(text_x, entry_text_top), entry.text_layout.Get(), base_color, base_brush });
+}
 
-    if (node.type == NodeType::TaskListItem && formats_.icon_font) {
+void CommandGenerator::GenTaskListCheckbox(DrawCommandList& cmds, const Node& node, float x, float entry_text_top)
+{
+    if (formats_.icon_font) {
         const wchar_t icon = node.task_checked() ? L'\u2611' : L'\u2610'; // ☑ / ☐
         const float icon_size = theme_->font_size_body;
         const float cb_x = x - theme_->list_bullet_offset;

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -143,10 +143,13 @@ private:
 
     void GenerateNode(DrawCommandList& cmds, const FrameContext& fc, const Node& node, const NodeLayoutEntry& entry, const DiagramEntry& diagram, int node_index, float entry_text_top);
 
-    // ベースカラー、インラインコード背景、検索/選択ハイライト、本文テキスト、
-    // タスクリストチェックボックスを描画する。
-    void GenNodeTextDecorations(DrawCommandList& cmds, const FrameContext& fc, const Node& node,
-                                const NodeLayoutEntry& entry, int node_index, float x, float text_x, float entry_text_top);
+    // ベースカラー、インラインコード背景、検索/選択ハイライト、本文テキストを描画する。
+    void GenNodeTextDecorations(
+        DrawCommandList& cmds, const FrameContext& fc, const Node& node,
+        const NodeLayoutEntry& entry, int node_index, float x, float text_x, float entry_text_top);
+    // text_layout 非依存。loose task list (空 TaskListItem) でも GenNodeTextDecorations の
+    // early return を経由せず描画したいため独立メソッド化。
+    void GenTaskListCheckbox(DrawCommandList& cmds, const Node& node, float x, float entry_text_top);
 
     struct NodeBaseStyle {
         D2D1_COLOR_F color;

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -1071,13 +1071,16 @@ TEST(RecomputeYPositionsTest, BlockQuoteHasSpacingAbove)
 
 // ---- リスト項目のスペーシング ----
 
+// 空テキスト LI は issue#237 の修正で sb=0 (loose 扱い)。tight LI 間隔の検証には HasText() が要る。
 TEST(RecomputeYPositionsTest, ListItemUsesListItemSpacing)
 {
     Theme theme = GetLightTheme();
     Node li1;
     li1.type = NodeType::ListItem;
+    SetNodeTextCounted(li1, "a");
     Node li2;
     li2.type = NodeType::ListItem;
+    SetNodeTextCounted(li2, "b");
 
     std::pmr::vector<Node> nodes;
     nodes.emplace_back(std::move(li1));
@@ -1100,8 +1103,10 @@ TEST(RecomputeYPositionsTest, TaskListItemUsesListItemSpacing)
     Theme theme = GetLightTheme();
     Node tli1;
     tli1.type = NodeType::TaskListItem;
+    SetNodeTextCounted(tli1, "a");
     Node tli2;
     tli2.type = NodeType::TaskListItem;
+    SetNodeTextCounted(tli2, "b");
 
     std::pmr::vector<Node> nodes;
     nodes.emplace_back(std::move(tli1));
@@ -1576,6 +1581,99 @@ TEST_F(LayoutTest, UnorderedListBulletCenteredWithRealLayout)
         }
     }
     FAIL() << "FillEllipseCmd が見つからない";
+}
+
+// issue#237: loose list の LI (空) と直下 Paragraph の text_top は一致すべき。
+TEST_F(LayoutTest, LooseListBulletAlignsWithFollowingParagraphText)
+{
+    auto nodes = ParseMarkdown("- a\n\n- b").nodes;
+    LayoutCache cache;
+    cache.Resize(nodes.size());
+    engine_.ComputeLayout(nodes, cache, 800.0f);
+
+    ASSERT_EQ(nodes.size(), 4u);
+    ASSERT_EQ(nodes[0].type, NodeType::ListItem);
+    ASSERT_EQ(nodes[1].type, NodeType::Paragraph);
+    ASSERT_EQ(nodes[2].type, NodeType::ListItem);
+    ASSERT_EQ(nodes[3].type, NodeType::Paragraph);
+
+    EXPECT_NEAR(cache[0].text_top, cache[1].text_top, 0.01f);
+    EXPECT_NEAR(cache[2].text_top, cache[3].text_top, 0.01f);
+}
+
+// 空 LI の first_line_height はフォールバック (font_size*FALLBACK_LINE_HEIGHT_FACTOR) なので
+// 実 line metrics と完全一致しない → epsilon 3px で許容。
+TEST_F(LayoutTest, LooseListBulletCenteredOnFollowingParagraphLine)
+{
+    auto nodes = ParseMarkdown("- a\n\n- b").nodes;
+    LayoutCache cache;
+    cache.Resize(nodes.size());
+    engine_.ComputeLayout(nodes, cache, 800.0f);
+
+    ASSERT_EQ(nodes.size(), 4u);
+    ASSERT_NE(cache[1].text_layout.Get(), nullptr);
+    DWRITE_LINE_METRICS lm;
+    UINT32 lc;
+    ASSERT_TRUE(SUCCEEDED(cache[1].text_layout->GetLineMetrics(&lm, 1, &lc)));
+    ASSERT_GT(lc, 0u);
+
+    CommandGenerator gen;
+    gen.SetTheme(&theme_);
+    gen.SetFormats({ nullptr, nullptr, nullptr });
+    PaneRect md_pane{ 0, 0, 800.0f, 2000.0f };
+    auto cmds = gen.GenerateMdPane(nodes, cache, md_pane, 0.0f, TextSelection{});
+
+    const float expected_y = cache[1].text_top + lm.height * 0.5f;
+    bool found = false;
+    for (const auto& cmd : cmds) {
+        if (auto* e = std::get_if<FillEllipseCmd>(&cmd)) {
+            EXPECT_NEAR(e->center.y, expected_y, 3.0f);
+            found = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found) << "FillEllipseCmd が見つからない";
+}
+
+// 旧実装は checkbox 描画を GenNodeTextDecorations に置いており、loose の空 TaskListItem
+// (text_layout=nullptr) で early return され checkbox ごと消えていた。
+TEST_F(LayoutTest, LooseTaskListCheckboxIsEmitted)
+{
+    auto nodes = ParseMarkdown("- [ ] a\n\n- [x] b").nodes;
+    LayoutCache cache;
+    cache.Resize(nodes.size());
+    engine_.ComputeLayout(nodes, cache, 800.0f);
+
+    ASSERT_EQ(nodes.size(), 4u);
+    EXPECT_EQ(nodes[0].type, NodeType::TaskListItem);
+    EXPECT_FALSE(nodes[0].HasText());
+    EXPECT_EQ(nodes[2].type, NodeType::TaskListItem);
+    EXPECT_FALSE(nodes[2].HasText());
+
+    // checkbox 描画には formats_.icon_font (非 null) が必要。
+    Microsoft::WRL::ComPtr<IDWriteTextFormat> icon_fmt;
+    ASSERT_TRUE(SUCCEEDED(dwrite_factory_->CreateTextFormat(
+        L"Segoe UI Symbol", nullptr,
+        DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
+        theme_.font_size_body, L"", &icon_fmt)));
+
+    CommandGenerator gen;
+    gen.SetTheme(&theme_);
+    gen.SetFormats({ nullptr, icon_fmt.Get(), nullptr });
+    PaneRect md_pane{ 0, 0, 800.0f, 2000.0f };
+    auto cmds = gen.GenerateMdPane(nodes, cache, md_pane, 0.0f, TextSelection{});
+
+    int unchecked = 0;
+    int checked = 0;
+    for (const auto& cmd : cmds) {
+        if (auto* t = std::get_if<DrawTextCmd>(&cmd); t && t->text_len == 1) {
+            const wchar_t ch = t->text()[0];
+            if (ch == L'☐') ++unchecked;
+            else if (ch == L'☑') ++checked;
+        }
+    }
+    EXPECT_EQ(unchecked, 1);
+    EXPECT_EQ(checked, 1);
 }
 
 // 22000 ノード × 200 iter で RecomputeYPositions のフルパス (from_index=0) 経過時間を測る。

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -225,6 +225,21 @@ TEST(Parser, UnorderedList)
     EXPECT_EQ(nodes[2].GetText(), "item3");
 }
 
+// loose list は md4c が LI 中身を MD_BLOCK_P に外出しするため LI 自体は空 (issue#237 の原因)。
+TEST(Parser, UnorderedListLooseProducesParagraphChildren)
+{
+    auto nodes = ParseMarkdown("- a\n\n- b").nodes;
+    ASSERT_EQ(nodes.size(), 4u);
+    EXPECT_EQ(nodes[0].type, NodeType::ListItem);
+    EXPECT_FALSE(nodes[0].HasText());
+    EXPECT_EQ(nodes[1].type, NodeType::Paragraph);
+    EXPECT_EQ(nodes[1].GetText(), "a");
+    EXPECT_EQ(nodes[2].type, NodeType::ListItem);
+    EXPECT_FALSE(nodes[2].HasText());
+    EXPECT_EQ(nodes[3].type, NodeType::Paragraph);
+    EXPECT_EQ(nodes[3].GetText(), "b");
+}
+
 // ---- バグ #10: ネストされた引用ブロック ----
 
 TEST(Parser, NestedBlockquotePreservesOuterStyle)


### PR DESCRIPTION
## Summary

- loose list (項目間に空行あり) で bullet と文字の Y がズレるバグ (#237) を修正
- 根本原因: md4c が LI 中身を MD_BLOCK_P に外出しするため空 LI ノードができ、`paragraph_spacing` + `list_item_spacing` が積まれて直下 Paragraph の `text_top` が下にズレていた
- 空 LI 判定を `IsEmptyListItemContainer` ヘルパーに集約し、高さと spacing を 0 に
- 付随バグ修正: loose task list の checkbox 消失 (`GenTaskListCheckbox` を `case TaskListItem` で直接 emit)、viewport 上端での bullet 一時消失 (空 LI の cull に line height 分の余裕)

## Test plan

- [x] `Parser.UnorderedListLooseProducesParagraphChildren`: loose list の AST 構造確認
- [x] `LayoutTest.LooseListBulletAlignsWithFollowingParagraphText`: LI と直下 P の text_top 一致
- [x] `LayoutTest.LooseListBulletCenteredOnFollowingParagraphLine`: bullet 中心 Y が描画コマンドレベルで Paragraph 1 行目中心と整合
- [x] `LayoutTest.LooseTaskListCheckboxIsEmitted`: loose task list の checkbox (☐/☑) が描画される
- [x] 既存 `RecomputeYPositionsTest.{List,TaskList}ItemUsesListItemSpacing`: tight list 経路は `HasText()=true` で従来通り
- [x] 全 2269 テスト PASS (回帰なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)