### PR TITLE
fix: code-review 指摘 15 件を一括対応

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -419,9 +419,8 @@ void App::OnDestroy()
     file_cache_.Shutdown();
     file_cache_.SaveIndex();
 
-    // Help 表示中の終了で session_ を上書きしないよう、LastFilePath と ScrollPosition は
-    // 同じ IsHelpPath ガード内で扱う。SaveScrollPosition だけ漏れていると、次回起動時に
-    // 別ファイル A 上で Help の node index を復元してしまい誤位置にジャンプする。
+    // SaveScrollPosition だけ IsHelpPath ガード外に置くと、Help 表示中に終了したとき
+    // 前回 LastFilePath に Help の node index が紐付き、次回起動時に誤位置へジャンプする。
     if (!IsHelpPath(state_.document.doc.GetFilePath())) {
         session_.SaveLastFilePath(state_.document.doc.GetFilePath());
         if (const int node = state_.view.viewport.FindFirstVisibleNode(state_.document.layout_cache, state_.document.doc.GetNodes().size()); node >= 0) {

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -405,6 +405,9 @@ void App::OnCaptureChanged()
 
 void App::ShowToast(std::wstring_view message)
 {
+    if (message.empty()) {
+        return;
+    }
     effect_executor_.ExecuteOne(effect::ShowToast{ std::pmr::wstring{ message } });
 }
 

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -419,8 +419,17 @@ void App::OnDestroy()
     file_cache_.Shutdown();
     file_cache_.SaveIndex();
 
+    // Help 表示中の終了で session_ を上書きしないよう、LastFilePath と ScrollPosition は
+    // 同じ IsHelpPath ガード内で扱う。SaveScrollPosition だけ漏れていると、次回起動時に
+    // 別ファイル A 上で Help の node index を復元してしまい誤位置にジャンプする。
     if (!IsHelpPath(state_.document.doc.GetFilePath())) {
         session_.SaveLastFilePath(state_.document.doc.GetFilePath());
+        if (const int node = state_.view.viewport.FindFirstVisibleNode(state_.document.layout_cache, state_.document.doc.GetNodes().size()); node >= 0) {
+            // 復元側 (NodeOffsetToScrollY) と同じ cache[node].text_top を読む。
+            // Fenwick PrefixSum 経由は加算順が違うため大規模ノードで誤差が累積する。
+            const float text_top = state_.document.layout_cache[node].text_top;
+            session_.SaveScrollPosition(node, state_.view.viewport.GetScrollY(), text_top);
+        }
     }
 
     {
@@ -432,13 +441,6 @@ void App::OnDestroy()
             .toc_width = panes.GetSidePaneWidth(PaneTarget::Toc),
         };
         session_.SavePaneState(s);
-    }
-
-    if (const int node = state_.view.viewport.FindFirstVisibleNode(state_.document.layout_cache, state_.document.doc.GetNodes().size()); node >= 0) {
-        // 復元側 (NodeOffsetToScrollY) と同じ cache[node].text_top を読む。
-        // Fenwick PrefixSum 経由は加算順が違うため大規模ノードで誤差が累積する。
-        const float text_top = state_.document.layout_cache[node].text_top;
-        session_.SaveScrollPosition(node, state_.view.viewport.GetScrollY(), text_top);
     }
 
     config_.SaveWString("General", "Language", i18n::GetLangKey());

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -29,6 +29,11 @@ void App::LoadHelpDocument()
     file_load_service_.StopLoading();
     EmitEffect(effect::StopFileWatch{});
     ResetViewForNewDocument();
+    // FinishLoadMarkdownFile と同じ後処理: SearchState の lowercase キャッシュが旧 nodes ポインタを
+    // 保持したままになるのを防ぎ、TOC ハイライトも初期化する。
+    state_.search.search_bar_ctrl.Reset();
+    EmitEffect(effect::SearchUnfocus{ /*clear_text=*/true });
+    state_.active_toc_index = -1;
 
     std::pmr::string utf8(reinterpret_cast<const char*>(rc.data()), rc.size());
     state_.document.doc = Document::FromMarkdown(std::move(utf8), HELP_PATH);

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -29,8 +29,7 @@ void App::LoadHelpDocument()
     file_load_service_.StopLoading();
     EmitEffect(effect::StopFileWatch{});
     ResetViewForNewDocument();
-    // FinishLoadMarkdownFile と同じ後処理: SearchState の lowercase キャッシュが旧 nodes ポインタを
-    // 保持したままになるのを防ぎ、TOC ハイライトも初期化する。
+    // SearchState の lowercase キャッシュが旧 nodes ポインタを保持したまま誤再利用されるのを防ぐ。
     state_.search.search_bar_ctrl.Reset();
     EmitEffect(effect::SearchUnfocus{ /*clear_text=*/true });
     state_.active_toc_index = -1;

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -86,6 +86,11 @@ bool App::Init(HWND hwnd)
         image_loader_.SetRenderTarget(new_rt);
         image_loader_.ClearCache();
         resource_manager_.LoadImages();
+        // layout_cache 内の IDWriteTextLayout は旧 RT 由来の ID2D1Brush を SetDrawingEffect 経由で
+        // 保持しており、新 RT で描画すると色が落ちる/拒否される。effects_applied を落として
+        // 次フレームの ApplyNodeEffects で新ブラシを再適用させる。同時に Mermaid/画像の
+        // DiagramEntry::bitmap も新 RT 系で再生成させる。
+        state_.document.layout_cache.InvalidateEffectsAndDiagramBitmaps(state_.document.doc.GetNodes());
     });
 
     theme_service_.LoadDarkMode();

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -86,10 +86,8 @@ bool App::Init(HWND hwnd)
         image_loader_.SetRenderTarget(new_rt);
         image_loader_.ClearCache();
         resource_manager_.LoadImages();
-        // layout_cache 内の IDWriteTextLayout は旧 RT 由来の ID2D1Brush を SetDrawingEffect 経由で
-        // 保持しており、新 RT で描画すると色が落ちる/拒否される。effects_applied を落として
-        // 次フレームの ApplyNodeEffects で新ブラシを再適用させる。同時に Mermaid/画像の
-        // DiagramEntry::bitmap も新 RT 系で再生成させる。
+        // IDWriteTextLayout が SetDrawingEffect 経由で AddRef した旧 RT 由来のブラシと、
+        // DiagramEntry::bitmap が新 RT で描画拒否されるのを防ぐ。
         state_.document.layout_cache.InvalidateEffectsAndDiagramBitmaps(state_.document.doc.GetNodes());
     });
 

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -201,8 +201,7 @@ void ReduceSelectAll(AppState& state, SideEffectList& effects)
 void ReduceClearSelection(AppState& state, SideEffectList& effects)
 {
     if (state.search.search_state.IsVisible()) {
-        // CloseSearchBarAction と同じ経路を通し、search_state.Hide() に加えて
-        // SEARCH_CARET タイマー / has_focus_ / IME 状態を一括クリアする。
+        // search_state.Hide() 単独だと SEARCH_CARET タイマー / has_focus_ / IME 状態が残留する。
         state.search.search_bar_ctrl.OnClose();
     }
     else {
@@ -382,8 +381,8 @@ void ReduceHWheel(AppState& state, SideEffectList& effects, const HWheelAction& 
                 PushEffect(effects, effect::InvalidateWindow{});
             }
         }
-        // target がブロック上にある以上、自然幅==可視幅で can_scroll()==false でも
-        // 戻る/進むナビゲーションへ落とさない。ブロック上の操作は swipe_detector へ漏らさず吸収する。
+        // target がブロック上にある以上、can_scroll()==false でも swipe_detector へは流さない
+        // (戻る/進むの暴発を防ぐ)。
         return;
     }
 

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -201,7 +201,9 @@ void ReduceSelectAll(AppState& state, SideEffectList& effects)
 void ReduceClearSelection(AppState& state, SideEffectList& effects)
 {
     if (state.search.search_state.IsVisible()) {
-        state.search.search_state.Hide();
+        // CloseSearchBarAction と同じ経路を通し、search_state.Hide() に加えて
+        // SEARCH_CARET タイマー / has_focus_ / IME 状態を一括クリアする。
+        state.search.search_bar_ctrl.OnClose();
     }
     else {
         state.view.viewport.ClearSelection();
@@ -379,8 +381,10 @@ void ReduceHWheel(AppState& state, SideEffectList& effects, const HWheelAction& 
             if (ApplyBlockHScrollDelta(state, target, cur + dx, geom.scroll_max())) {
                 PushEffect(effects, effect::InvalidateWindow{});
             }
-            return;
         }
+        // target がブロック上にある以上、自然幅==可視幅で can_scroll()==false でも
+        // 戻る/進むナビゲーションへ落とさない。ブロック上の操作は swipe_detector へ漏らさず吸収する。
+        return;
     }
 
     const bool had_overlay = state.interaction.swipe_detector.IsOverlayVisible();

--- a/src/core/document_service.cpp
+++ b/src/core/document_service.cpp
@@ -15,12 +15,16 @@ std::expected<Document, FileLoadError> DocumentService::LoadFile(const std::pmr:
 
 std::expected<Document, FileLoadError> DocumentService::LoadFile(const std::pmr::wstring& path, std::stop_token stop_token)
 {
+    // I/O 前にも check しないと、呼び出し時点で既にキャンセル済みでも無駄に同期 I/O を実行する。
+    if (stop_token.stop_requested()) {
+        return std::unexpected(FileLoadError::Cancelled);
+    }
     auto result = FileLoader::LoadFile(path);
     if (!result) {
         return std::unexpected(result.error());
     }
     if (stop_token.stop_requested()) {
-        return std::unexpected(FileLoadError::ReadFailed);
+        return std::unexpected(FileLoadError::Cancelled);
     }
     MENDO_PROFILE("Document::FromMarkdown");
     return Document::FromMarkdown(std::move(result->text), result->byte_size, path, stop_token);

--- a/src/core/document_service.cpp
+++ b/src/core/document_service.cpp
@@ -13,6 +13,19 @@ std::expected<Document, FileLoadError> DocumentService::LoadFile(const std::pmr:
     return Document::FromMarkdown(std::move(result->text), result->byte_size, path);
 }
 
+std::expected<Document, FileLoadError> DocumentService::LoadFile(const std::pmr::wstring& path, std::stop_token stop_token)
+{
+    auto result = FileLoader::LoadFile(path);
+    if (!result) {
+        return std::unexpected(result.error());
+    }
+    if (stop_token.stop_requested()) {
+        return std::unexpected(FileLoadError::ReadFailed);
+    }
+    MENDO_PROFILE("Document::FromMarkdown");
+    return Document::FromMarkdown(std::move(result->text), result->byte_size, path, stop_token);
+}
+
 // 仮想パスや存在しないパスは「大きい」扱いにする (非同期ロード経路で失敗を検出させるため)。
 bool DocumentService::IsLargerThan(const std::pmr::wstring& path, DWORD threshold) noexcept
 {

--- a/src/core/document_service.h
+++ b/src/core/document_service.h
@@ -7,7 +7,6 @@
 class DocumentService {
 public:
     static std::expected<Document, FileLoadError> LoadFile(const std::pmr::wstring& path);
-    // stop_token 版: Parse 中も協調キャンセル可能。Preloader / AsyncLoadCoordinator 用。
     static std::expected<Document, FileLoadError> LoadFile(const std::pmr::wstring& path, std::stop_token stop_token);
 
     // 非同期ロード経路に乗せる対象か。app_threshold::ASYNC_LOAD_BYTES を超えるサイズ。

--- a/src/core/document_service.h
+++ b/src/core/document_service.h
@@ -2,10 +2,13 @@
 #include "document.h"
 #include "file_loader.h"
 #include <expected>
+#include <stop_token>
 
 class DocumentService {
 public:
     static std::expected<Document, FileLoadError> LoadFile(const std::pmr::wstring& path);
+    // stop_token 版: Parse 中も協調キャンセル可能。Preloader / AsyncLoadCoordinator 用。
+    static std::expected<Document, FileLoadError> LoadFile(const std::pmr::wstring& path, std::stop_token stop_token);
 
     // 非同期ロード経路に乗せる対象か。app_threshold::ASYNC_LOAD_BYTES を超えるサイズ。
     // ファイル取得失敗時 (アクセス不能/仮想パス等) も true を返し、async 経路で reject させる。

--- a/src/io/async_load_coordinator.cpp
+++ b/src/io/async_load_coordinator.cpp
@@ -26,8 +26,8 @@ void AsyncLoadCoordinator::Start(TaskScheduler& scheduler, std::pmr::wstring pat
 {
     ResetSinks();
     in_flight_ = true;
-    // 連続 Start で前 worker のキャプチャ済み stop_token を協調キャンセルできるよう、
-    // 差し替え前に必ず request_stop しておく (Cancel と対称)。
+    // 前 worker のキャプチャ済み stop_token を協調キャンセルする。これを呼ばないと
+    // 古い source は stop_requested=false のまま残り続ける。
     stop_source_.request_stop();
     // request_stop 済みの source は再使用不可なので Start 毎に作り直す。
     stop_source_ = std::stop_source{};

--- a/src/io/async_load_coordinator.cpp
+++ b/src/io/async_load_coordinator.cpp
@@ -26,6 +26,9 @@ void AsyncLoadCoordinator::Start(TaskScheduler& scheduler, std::pmr::wstring pat
 {
     ResetSinks();
     in_flight_ = true;
+    // 連続 Start で前 worker のキャプチャ済み stop_token を協調キャンセルできるよう、
+    // 差し替え前に必ず request_stop しておく (Cancel と対称)。
+    stop_source_.request_stop();
     // request_stop 済みの source は再使用不可なので Start 毎に作り直す。
     stop_source_ = std::stop_source{};
     auto stop_token = stop_source_.get_token();

--- a/src/io/file_loader.h
+++ b/src/io/file_loader.h
@@ -16,6 +16,7 @@ enum class FileLoadError : uint8_t {
     NotFound,   // ファイルが見つからない、またはアクセス拒否
     TooLarge,   // ファイルサイズが MAX_FILE_SIZE を超過
     ReadFailed, // 読み込み中のI/Oエラー
+    Cancelled,  // 協調キャンセル (stop_token 経由)。UI にはトースト表示しない契約。
 };
 
 inline std::wstring_view FileLoadErrorMessage(FileLoadError e, const auto& strings) noexcept
@@ -27,6 +28,8 @@ inline std::wstring_view FileLoadErrorMessage(FileLoadError e, const auto& strin
         return strings.toast_file_too_large;
     case FileLoadError::ReadFailed:
         return strings.toast_file_read_failed;
+    case FileLoadError::Cancelled:
+        return {};
     default:
         return strings.toast_file_not_found;
     }

--- a/src/io/preloader.cpp
+++ b/src/io/preloader.cpp
@@ -34,7 +34,7 @@ void Preloader::Start(std::pmr::wstring path)
     thread_ = std::jthread([this, ctx, path = std::move(path)](std::stop_token st) mutable {
         MENDO_PROFILE("Preload::worker");
 
-        // stop_token を Parse に伝搬してアプリ終了時の数百 ms ハングを回避する。
+        // stop_token なしだと Parse 完走まで終了時の join が数百 ms ブロックする。
         auto load_result = DocumentService::LoadFile(path, st);
         // sink 書き込み前に abort 確認。直後の publish + main 側即破棄を回避。
         if (st.stop_requested()) {

--- a/src/io/preloader.cpp
+++ b/src/io/preloader.cpp
@@ -34,7 +34,8 @@ void Preloader::Start(std::pmr::wstring path)
     thread_ = std::jthread([this, ctx, path = std::move(path)](std::stop_token st) mutable {
         MENDO_PROFILE("Preload::worker");
 
-        auto load_result = DocumentService::LoadFile(path);
+        // stop_token を Parse に伝搬してアプリ終了時の数百 ms ハングを回避する。
+        auto load_result = DocumentService::LoadFile(path, st);
         // sink 書き込み前に abort 確認。直後の publish + main 側即破棄を回避。
         if (st.stop_requested()) {
             return;

--- a/src/layout/parallel_measure.cpp
+++ b/src/layout/parallel_measure.cpp
@@ -131,10 +131,17 @@ DirtyBatchResult RunParallel(
                 const size_t end = std::min(begin + chunk_size, indices.size());
                 const std::span<const size_t> chunk_indices{ indices.data() + begin, end - begin };
                 const std::span<std::pmr::vector<SyntaxToken>> chunk_slots{ slot_tokens.data() + begin, end - begin };
-                const bool posted = scheduler.Post([&, chunk_indices, chunk_slots]() {
-                    MENDO_PROFILE("MeasureNode.worker");
-                    run_chunk(chunk_indices, chunk_slots);
-                });
+                bool posted = false;
+                try {
+                    posted = scheduler.Post([&, chunk_indices, chunk_slots]() {
+                        MENDO_PROFILE("MeasureNode.worker");
+                        run_chunk(chunk_indices, chunk_slots);
+                    });
+                } catch (...) {
+                    // Post 構築 (move_only_function の heap allocate / queue push) の例外。
+                    // latch.count_down() を確実に呼ぶため同期 fallback に倒す。
+                    OutputDebugStringW(L"[mendo] RunParallel scheduler.Post threw exception\n");
+                }
                 if (!posted) {
                     MENDO_PROFILE("MeasureNode.fallback");
                     run_chunk(chunk_indices, chunk_slots);

--- a/src/layout/parallel_measure.cpp
+++ b/src/layout/parallel_measure.cpp
@@ -138,8 +138,7 @@ DirtyBatchResult RunParallel(
                         run_chunk(chunk_indices, chunk_slots);
                     });
                 } catch (...) {
-                    // Post 構築 (move_only_function の heap allocate / queue push) の例外。
-                    // latch.count_down() を確実に呼ぶため同期 fallback に倒す。
+                    // Post 自体が throw すると latch.count_down() が漏れて wait() が永久ブロック。
                     OutputDebugStringW(L"[mendo] RunParallel scheduler.Post threw exception\n");
                 }
                 if (!posted) {

--- a/src/mermaid/mermaid_file_cache.cpp
+++ b/src/mermaid/mermaid_file_cache.cpp
@@ -375,7 +375,11 @@ void MermaidFileCache::DecrementTotalSize(uint32_t png_size) noexcept
 
 void MermaidFileCache::ClearAll()
 {
+    // write_gen_ を進めただけでは「ガード通過済みで WriteAllBytes 実行直前」の
+    // worker は止まらず、ClearAll 完了直後に PNG をディスクへ "復活" させ得る。
+    // Shutdown と同じく latch_.Wait() で in-flight writer の完了を待ってから消す。
     write_gen_.fetch_add(1);
+    latch_.Wait();
 
     const auto dir = GetCacheDir();
     if (!dir.empty()) {

--- a/src/mermaid/mermaid_file_cache.cpp
+++ b/src/mermaid/mermaid_file_cache.cpp
@@ -375,9 +375,8 @@ void MermaidFileCache::DecrementTotalSize(uint32_t png_size) noexcept
 
 void MermaidFileCache::ClearAll()
 {
-    // write_gen_ を進めただけでは「ガード通過済みで WriteAllBytes 実行直前」の
-    // worker は止まらず、ClearAll 完了直後に PNG をディスクへ "復活" させ得る。
-    // Shutdown と同じく latch_.Wait() で in-flight writer の完了を待ってから消す。
+    // write_gen_ 進捗だけでは「ガード通過済みで WriteAllBytes 直前」の worker を止められず、
+    // 削除後に PNG が "復活" して orphan としてディスクに残る。
     write_gen_.fetch_add(1);
     latch_.Wait();
 

--- a/src/nav/nav.cpp
+++ b/src/nav/nav.cpp
@@ -115,7 +115,6 @@ bool NavHistory::GoForward(const NavEntry& current, NavEntry& out)
     }
 
     back_stack_.emplace_back(ToInternal(current));
-    // GoBack/Push と対称に MAX_HISTORY を超えたら最古を解放する。
     // 抜けると往復で容量超過 + path slot 参照が滞留する。
     if (back_stack_.size() > MAX_HISTORY) {
         ReleasePath(back_stack_.front().path_index);

--- a/src/nav/nav.cpp
+++ b/src/nav/nav.cpp
@@ -115,6 +115,12 @@ bool NavHistory::GoForward(const NavEntry& current, NavEntry& out)
     }
 
     back_stack_.emplace_back(ToInternal(current));
+    // GoBack/Push と対称に MAX_HISTORY を超えたら最古を解放する。
+    // 抜けると往復で容量超過 + path slot 参照が滞留する。
+    if (back_stack_.size() > MAX_HISTORY) {
+        ReleasePath(back_stack_.front().path_index);
+        back_stack_.pop_front();
+    }
     const auto top = forward_stack_.back();
     out = ToExternal(top);
     forward_stack_.pop_back();

--- a/src/render/renderer_pane.cpp
+++ b/src/render/renderer_pane.cpp
@@ -40,8 +40,7 @@ static void DrawPaneScrollbar(
 
     const float track_height = content_height;
     const float thumb_ratio = content_height / total_content_height;
-    // track_height < PANE_SCROLLBAR_THUMB_MIN (極小ペイン) で thumb_height > track_height
-    // となるとサムがコンテンツ領域より上に飛び出す。track 内にクランプする。
+    // track_height < PANE_SCROLLBAR_THUMB_MIN でサムが枠外へ飛び出すのを防ぐ。
     const float thumb_height = std::min(track_height, std::max(PANE_SCROLLBAR_THUMB_MIN, track_height * thumb_ratio));
 
     const float scroll_ratio = scroll_y / (total_content_height - content_height);
@@ -149,9 +148,7 @@ static void DrawSidePaneImpl(const SidePaneDrawContext& sp, DrawItemFn draw_item
 
         const HRESULT end_hr = rt->EndDraw();
         if (FAILED(end_hr)) {
-            // compatible RT が device-lost 等で失敗。古い bitmap を後続フレームに使い回すと
-            // main_rt 側で wrong-device エラーが再発するため、cache を破棄して次フレームに
-            // 再生成させる。main_rt の EndDraw で実際の device-lost が拾われて復旧する。
+            // device-lost で失敗した bitmap を使い回すと main_rt で wrong-device 再発する。
             sp.cache.Reset();
             return;
         }

--- a/src/render/renderer_pane.cpp
+++ b/src/render/renderer_pane.cpp
@@ -40,7 +40,9 @@ static void DrawPaneScrollbar(
 
     const float track_height = content_height;
     const float thumb_ratio = content_height / total_content_height;
-    const float thumb_height = std::max(PANE_SCROLLBAR_THUMB_MIN, track_height * thumb_ratio);
+    // track_height < PANE_SCROLLBAR_THUMB_MIN (極小ペイン) で thumb_height > track_height
+    // となるとサムがコンテンツ領域より上に飛び出す。track 内にクランプする。
+    const float thumb_height = std::min(track_height, std::max(PANE_SCROLLBAR_THUMB_MIN, track_height * thumb_ratio));
 
     const float scroll_ratio = scroll_y / (total_content_height - content_height);
     const float thumb_y = content_top + scroll_ratio * (track_height - thumb_height);
@@ -145,7 +147,14 @@ static void DrawSidePaneImpl(const SidePaneDrawContext& sp, DrawItemFn draw_item
         const float total_content = static_cast<float>(sp.item_count) * sp.theme.pane_item_height;
         DrawPaneScrollbar(rt, sp.scrollbar_thumb_brush, sp.rect.width, content_top, content_height, sp.scroll.scroll_y, total_content);
 
-        rt->EndDraw();
+        const HRESULT end_hr = rt->EndDraw();
+        if (FAILED(end_hr)) {
+            // compatible RT が device-lost 等で失敗。古い bitmap を後続フレームに使い回すと
+            // main_rt 側で wrong-device エラーが再発するため、cache を破棄して次フレームに
+            // 再生成させる。main_rt の EndDraw で実際の device-lost が拾われて復旧する。
+            sp.cache.Reset();
+            return;
+        }
         sp.cache.dirty = false;
         sp.cache.cached_scroll_y = sp.scroll.scroll_y;
         sp.cache.cached_bitmap.Reset();

--- a/src/render/renderer_search.cpp
+++ b/src/render/renderer_search.cpp
@@ -285,7 +285,10 @@ int Renderer::HitTestSearchInput(std::wstring_view query, float local_x, float m
     if (!layout) {
         return 0;
     }
-    BOOL is_trailing, is_inside;
+    // HitTestPoint が失敗 (E_FAIL 等) で out 引数未書込みでも未初期化値の読み出しを避ける。
+    // hit_test_service.cpp の他 2 箇所と同じ慣習。
+    BOOL is_trailing = FALSE;
+    BOOL is_inside = FALSE;
     DWRITE_HIT_TEST_METRICS htm{};
     layout->HitTestPoint(local_x, 0.0f, &is_trailing, &is_inside, &htm);
     return static_cast<int>(htm.textPosition) + (is_trailing ? 1 : 0);

--- a/src/render/renderer_search.cpp
+++ b/src/render/renderer_search.cpp
@@ -285,8 +285,7 @@ int Renderer::HitTestSearchInput(std::wstring_view query, float local_x, float m
     if (!layout) {
         return 0;
     }
-    // HitTestPoint が失敗 (E_FAIL 等) で out 引数未書込みでも未初期化値の読み出しを避ける。
-    // hit_test_service.cpp の他 2 箇所と同じ慣習。
+    // HitTestPoint が失敗時に out 引数未書込みでも未初期化値を読まないようにする。
     BOOL is_trailing = FALSE;
     BOOL is_inside = FALSE;
     DWRITE_HIT_TEST_METRICS htm{};

--- a/src/ui/pane_layout.cpp
+++ b/src/ui/pane_layout.cpp
@@ -63,8 +63,7 @@ PaneScrollInfo ComputeScrollInfo(const PaneRect& rect, float header_height, floa
 {
     PaneScrollInfo info{};
     info.content_top = rect.y + header_height;
-    // rect.height < header_height (極小ウィンドウ) で content_height が負になると
-    // max_scroll が過大になり thumb_height も負側へ倒れる。0 でクランプして連鎖を断つ。
+    // 負を許すと max_scroll が過大化し thumb_height も負側へ倒れて scrollbar 計算が連鎖破綻する。
     info.content_height = std::max(0.0f, rect.height - header_height);
     info.total_content = total_content;
     info.max_scroll = std::max(0.0f, total_content - info.content_height);

--- a/src/ui/pane_layout.cpp
+++ b/src/ui/pane_layout.cpp
@@ -63,7 +63,9 @@ PaneScrollInfo ComputeScrollInfo(const PaneRect& rect, float header_height, floa
 {
     PaneScrollInfo info{};
     info.content_top = rect.y + header_height;
-    info.content_height = rect.height - header_height;
+    // rect.height < header_height (極小ウィンドウ) で content_height が負になると
+    // max_scroll が過大になり thumb_height も負側へ倒れる。0 でクランプして連鎖を断つ。
+    info.content_height = std::max(0.0f, rect.height - header_height);
     info.total_content = total_content;
     info.max_scroll = std::max(0.0f, total_content - info.content_height);
     const float thumb_ratio = (total_content > 0) ? info.content_height / total_content : 1.0f;

--- a/tests/test_reducer.cpp
+++ b/tests/test_reducer.cpp
@@ -26,8 +26,7 @@ protected:
         theme.splitter_width = 4.0f;
         theme.zoom = 1.0f;
         state.theme = &theme;
-        // ReduceClearSelection は CloseSearchBarAction と同じく search_bar_ctrl.OnClose() を
-        // 経由するため、内部 state_ ポインタを初期化しておかないと nullptr deref になる。
+        // search_bar_ctrl は内部 state_ ポインタを Init で受け取る (未呼び出しだと nullptr deref)。
         state.search.search_bar_ctrl.Init(
             state.search.search_state,
             state.view.viewport,

--- a/tests/test_reducer.cpp
+++ b/tests/test_reducer.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "app_constants.h"
+#include "app_search_bar_callbacks.h"
 #include "reducer.h"
 #include "document.h"
 #include "app_state.h"
@@ -25,6 +26,13 @@ protected:
         theme.splitter_width = 4.0f;
         theme.zoom = 1.0f;
         state.theme = &theme;
+        // ReduceClearSelection は CloseSearchBarAction と同じく search_bar_ctrl.OnClose() を
+        // 経由するため、内部 state_ ポインタを初期化しておかないと nullptr deref になる。
+        state.search.search_bar_ctrl.Init(
+            state.search.search_state,
+            state.view.viewport,
+            state.document.layout_cache,
+            AppSearchBarCallbacks{});
     }
 };
 


### PR DESCRIPTION
## Summary

xhigh-effort `/code-review` で「アプリ全体」を対象にレビューした結果 (CONFIRMED 12 件 + PLAUSIBLE 3 件 = 15 件) を一括修正。

### 対応 15 件

**並行性 / 非同期 (4 件)**
- 3 `parallel_measure::scheduler.Post` 構築/コピーの例外で `latch.count_down` が漏れ UI が永久ハングする → try/catch で同期 fallback に倒す
- 10 `AsyncLoadCoordinator::Start` が前 `stop_source_` に `request_stop()` を呼ばず連続 Start で前 worker をキャンセルできない → Cancel と対称化
- 12 `Preloader` worker が `DocumentService::LoadFile(path)` を `stop_token` 無しで呼んで Parse 中キャンセル不能 → `DocumentService::LoadFile(path, stop_token)` オーバーロードを追加して移行
- 5 `MermaidFileCache::ClearAll` が `write_gen_++` のみで `latch_.Wait()` を呼ばず orphan PNG が残留 → Shutdown と同じ順序に統一

**device-lost / 描画 (3 件)**
- 1 + 13 `Renderer::RecreateRenderTarget` 後に `layout_cache` 内 `IDWriteTextLayout` の effects / `DiagramEntry::bitmap` が残り、リンク色 / Mermaid bitmap が新 RT で破綻 → `SetDeviceLostCallback` に `InvalidateEffectsAndDiagramBitmaps` を追加
- 15 `renderer_pane` 中間 `bitmap_rt->EndDraw()` の HRESULT を捨てて壊れた bitmap を後フレームで描画 → 失敗時 cache を Reset

**状態機械 / reducer (3 件)**
- 8 `ReduceClearSelection` (ESC) が `search_state.Hide()` のみで `OnClose` 経由しないため SEARCH_CARET タイマー / has_focus_ / IME 状態が残留 → `CloseSearchBarAction` と同じ `OnClose()` 経由に統一
- 6 `ReduceHWheel` が target ブロック上で `can_scroll==false` のとき `swipe_detector` へフォールスルーして戻る/進む暴発 → target が確定している以上 swipe へ流さない
- 4 `LoadHelpDocument` が `search_bar_ctrl.Reset` / `active_toc_index = -1` / `SearchUnfocus` を呼ばず、ヘルプ後の検索でキャッシュ汚染 → `FinishLoadMarkdownFile` と同じ後処理に揃える

**セッション / 履歴 (2 件)**
- 2 `App::OnDestroy` の `SaveScrollPosition` が `IsHelpPath` ガード外で Help node を LastFilePath の値に紐付け、次回起動で別ファイル上の誤位置にジャンプ → `SaveLastFilePath` と同じガード内に移動
- 14 `NavHistory::GoForward` が `back_stack_` の MAX_HISTORY 超過チェックを欠落し PathSlot refcount のドリフト → Push/GoBack と同じ pop_front + ReleasePath を追加

**UI / レイアウト (3 件)**
- 11 `DrawPaneScrollbar` で `thumb_height > track_height` のときサムがコンテンツ枠外に飛ぶ → `std::min(track_height, ...)` クランプ
- 9 `ComputeScrollInfo` で `rect.height < header_height` のとき `content_height` が負になり scrollbar 計算が連鎖破綻 → `std::max(0.0f, ...)` クランプ
- 7 `renderer_search::HitTestPoint` で未初期化 `BOOL is_trailing/is_inside` を読む UB → `hit_test_service.cpp` と同じ `FALSE` 初期化

## Test plan

- [x] `cmake --build build --config Release -- /nologo` ビルド成功
- [x] `build/tests/Release/mendo_tests.exe --gtest_brief=1` 全 2269 件 PASS
- [ ] 手動: ファイル開く → スリープ/復帰 → リンク色・シンタックス色復旧 (#1)
- [ ] 手動: ファイル A 開く → F1 → 終了 → 再起動で A の正しい位置に復元 (#2)
- [ ] 手動: 検索バーで文字入力 → F1 → 別ファイルで再検索 → 正しい位置にハイライト (#4)
- [ ] 手動: Mermaid 含む文書 → テーマ切替反復 → orphan PNG が残らない (#5)
- [ ] 手動: 自然幅≤可視幅のテーブル上で 2 本指水平スワイプ → 履歴遷移しない (#6)
- [ ] 手動: Ctrl+F → 何か入力 → ESC → SEARCH_CARET タイマー停止 (#8)
- [ ] 手動: ウィンドウを極端に低くリサイズ → サイドペインのスクロールバー破綻なし (#9, #11)
- [ ] 手動: 大きいファイルでリロード連打 → CPU 2 倍にならない (#10)
- [ ] 手動: 大きい preload 状態で即終了 → Join がブロックしない (#12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)