### PR TITLE
chore: bump version to v0.2.0.4

### DIFF
--- a/res/mendo.rc
+++ b/res/mendo.rc
@@ -9,8 +9,8 @@ IDI_APP_ICON ICON "mendo.ico"
 
 // Version info
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION    0,2,0,3
-PRODUCTVERSION 0,2,0,3
+FILEVERSION    0,2,0,4
+PRODUCTVERSION 0,2,0,4
 FILEFLAGSMASK  VS_FFI_FILEFLAGSMASK
 FILEFLAGS      0
 FILEOS         VOS_NT_WINDOWS32
@@ -22,12 +22,12 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription", "mendo - Insanely Fast Markdown Viewer"
-            VALUE "FileVersion", "0.2.0.3"
+            VALUE "FileVersion", "0.2.0.4"
             VALUE "InternalName", "mendo"
             VALUE "LegalCopyright", "Copyright (c) 2025 tanaton"
             VALUE "OriginalFilename", "mendo.exe"
             VALUE "ProductName", "mendo"
-            VALUE "ProductVersion", "0.2.0.3"
+            VALUE "ProductVersion", "0.2.0.4"
         END
     END
     BLOCK "VarFileInfo"

--- a/winget/tanaton.mendo.installer.yaml
+++ b/winget/tanaton.mendo.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: tanaton.mendo
-PackageVersion: 0.2.0.3
+PackageVersion: 0.2.0.4
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -10,7 +10,7 @@ NestedInstallerFiles:
     PortableCommandAlias: mendo
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/tanaton/mendo/releases/download/v0.2.0.3/mendo.zip
+    InstallerUrl: https://github.com/tanaton/mendo/releases/download/v0.2.0.4/mendo.zip
     InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/winget/tanaton.mendo.locale.en-US.yaml
+++ b/winget/tanaton.mendo.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: tanaton.mendo
-PackageVersion: 0.2.0.3
+PackageVersion: 0.2.0.4
 PackageLocale: en-US
 Publisher: tanaton
 PackageName: mendo

--- a/winget/tanaton.mendo.locale.ja-JP.yaml
+++ b/winget/tanaton.mendo.locale.ja-JP.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
 
 PackageIdentifier: tanaton.mendo
-PackageVersion: 0.2.0.3
+PackageVersion: 0.2.0.4
 PackageLocale: ja-JP
 Publisher: tanaton
 PackageName: mendo

--- a/winget/tanaton.mendo.yaml
+++ b/winget/tanaton.mendo.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: tanaton.mendo
-PackageVersion: 0.2.0.3
+PackageVersion: 0.2.0.4
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- バージョンを v0.2.0.3 → v0.2.0.4 に更新
- `res/mendo.rc` (FILEVERSION / PRODUCTVERSION / 文字列) および winget マニフェスト 4 ファイルを一括更新

## Test plan
- [x] ビルドが通ることを確認
- [x] `mendo.exe` のプロパティでバージョン 0.2.0.4 が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)