### PR TITLE
fix: フォント未インストール環境でのフォールバック対応

### DIFF
--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -47,6 +47,7 @@ bool Renderer::Init(HWND hwnd)
         return false;
     }
 
+    ResolveThemeFonts();
     RecreateBrushes();
     RecreatePaneFormats();
     LoadAppIconBitmap();
@@ -68,6 +69,7 @@ bool Renderer::Init(HWND hwnd)
 void Renderer::SetTheme(const Theme& theme)
 {
     theme_ = theme;
+    ResolveThemeFonts();
     UpdateLayoutTheme();
     RecreatePaneFormats();
     cmd_generator_.SetTheme(&theme_);
@@ -93,6 +95,7 @@ void Renderer::SetDpi(float dpi) noexcept
 void Renderer::ApplyZoomFromBase(const Theme& base_theme, float new_zoom)
 {
     theme_ = base_theme;
+    ResolveThemeFonts();
     if (new_zoom != 1.0f) {
         theme_.ApplyZoom(new_zoom);
     }

--- a/src/render/renderer.h
+++ b/src/render/renderer.h
@@ -146,6 +146,7 @@ private:
     void ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float entry_text_top, float viewport_top = -1.0f, float viewport_bottom = -1.0f);
     void RecreateBrushes();
     void InvalidateBrushes() noexcept;
+    void ResolveThemeFonts();
     void RecreatePaneFormats();
     Microsoft::WRL::ComPtr<IDWriteTextFormat> CreatePaneFormat(const wchar_t* family, DWRITE_FONT_WEIGHT weight, float size, const wchar_t* locale);
     bool CheckEndDraw();

--- a/src/render/renderer_resources.cpp
+++ b/src/render/renderer_resources.cpp
@@ -132,6 +132,32 @@ void Renderer::InvalidateBrushes() noexcept
     fixed_brushes_cache_.fill(nullptr);
 }
 
+static std::wstring ResolveFontFamily(IDWriteFontCollection* collection, std::initializer_list<const wchar_t*> candidates)
+{
+    if (collection) {
+        for (const wchar_t* name : candidates) {
+            UINT32 index = 0;
+            BOOL exists = FALSE;
+            if (SUCCEEDED(collection->FindFamilyName(name, &index, &exists)) && exists) {
+                return name;
+            }
+        }
+    }
+    return *(candidates.end() - 1);
+}
+
+void Renderer::ResolveThemeFonts()
+{
+    auto* dw = backend_.GetDWriteFactory();
+    ComPtr<IDWriteFontCollection> collection;
+    if (dw) {
+        dw->GetSystemFontCollection(&collection, FALSE);
+    }
+    theme_.font_family = ResolveFontFamily(collection.Get(), { theme_.font_family.c_str(), L"Meiryo UI", L"Segoe UI" });
+    theme_.monospace_font = ResolveFontFamily(collection.Get(), { theme_.monospace_font.c_str(), L"Consolas", L"Courier New" });
+    theme_.icon_font = ResolveFontFamily(collection.Get(), { theme_.icon_font.c_str(), L"Segoe Fluent Icons", L"Segoe MDL2 Assets" });
+}
+
 ComPtr<IDWriteTextFormat> Renderer::CreatePaneFormat(const wchar_t* family, DWRITE_FONT_WEIGHT weight, float size, const wchar_t* locale)
 {
     auto* dw = backend_.GetDWriteFactory();
@@ -161,7 +187,7 @@ void Renderer::RecreatePaneFormats()
     constexpr DWRITE_PARAGRAPH_ALIGNMENT PA_CTR = DWRITE_PARAGRAPH_ALIGNMENT_CENTER;
 
     const wchar_t* const body_font = theme_.font_family.c_str();
-    const wchar_t* const icon_font = L"Segoe Fluent Icons";
+    const wchar_t* const icon_font = theme_.icon_font.c_str();
 
     struct FormatSpec {
         ComPtr<IDWriteTextFormat>* target;

--- a/src/theme/theme.cpp
+++ b/src/theme/theme.cpp
@@ -59,6 +59,7 @@ static void ApplyCommonLayout(Theme& t)
 {
     t.font_family = L"Yu Gothic UI";
     t.monospace_font = L"Consolas";
+    t.icon_font = L"Segoe Fluent Icons";
 
     t.font_size_body = 16.0f;
     t.font_size_h[0] = 32.0f;

--- a/src/theme/theme.h
+++ b/src/theme/theme.h
@@ -33,6 +33,7 @@ struct Theme {
     // フォント
     std::wstring font_family;
     std::wstring monospace_font;
+    std::wstring icon_font;
 
     // フォントサイズ（DIP単位）
     float font_size_body;

--- a/src/ui/context_menu_impl.h
+++ b/src/ui/context_menu_impl.h
@@ -81,6 +81,7 @@ struct ContextMenu::Impl {
 
     // 同一フォントでの Show 連発時に IDWriteTextFormat の再生成を抑止するためのキー。
     std::pmr::wstring cached_fmt_font_family;
+    std::pmr::wstring cached_fmt_icon_font;
     float cached_fmt_font_size = 0.0f;
 
     const Theme* theme = nullptr;

--- a/src/ui/context_menu_logic.cpp
+++ b/src/ui/context_menu_logic.cpp
@@ -89,6 +89,7 @@ void ContextMenu::Impl::CreateTextFormats(const Theme& t)
 {
     if (fmt_text && fmt_icon &&
         cached_fmt_font_family == std::wstring_view{ t.font_family } &&
+        cached_fmt_icon_font == std::wstring_view{ t.icon_font } &&
         cached_fmt_font_size == t.pane_font_size) {
         return;
     }
@@ -107,7 +108,7 @@ void ContextMenu::Impl::CreateTextFormats(const Theme& t)
     }
 
     dwrite_factory->CreateTextFormat(
-        L"Segoe Fluent Icons", nullptr,
+        t.icon_font.c_str(), nullptr,
         DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STYLE_NORMAL,
         DWRITE_FONT_STRETCH_NORMAL, ICON_FONT_SIZE,
         L"ja-jp", &fmt_icon);
@@ -118,6 +119,7 @@ void ContextMenu::Impl::CreateTextFormats(const Theme& t)
     }
 
     cached_fmt_font_family.assign(t.font_family.begin(), t.font_family.end());
+    cached_fmt_icon_font.assign(t.icon_font.begin(), t.icon_font.end());
     cached_fmt_font_size = t.pane_font_size;
 }
 


### PR DESCRIPTION
## Summary
- テーマフォント（Yu Gothic UI / Consolas / Segoe Fluent Icons）が未インストールの環境で、明示的なフォールバックチェーンによるフォント解決を追加
- `FindFamilyName` でシステムフォントの存在を事前チェックし、Theme レベルで `font_family` / `monospace_font` / `icon_font` を一括解決
- 全コードパス（Renderer / DWriteTextMeasurer / ContextMenu）が同じ解決済みフォントを使用するよう統一
- ContextMenu のアイコンフォントをハードコードから `Theme::icon_font` 経由に変更し、キャッシュキーにも追加

### フォールバックチェーン
| フィールド | 優先順 |
|---|---|
| `font_family` | Yu Gothic UI → Meiryo UI → Segoe UI |
| `monospace_font` | Consolas → Courier New |
| `icon_font` | Segoe Fluent Icons → Segoe MDL2 Assets |

Closes #243

## Test plan
- [x] ビルド成功
- [x] 全 2274 テスト PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)