### PR TITLE
refactor: 冗長・重複処理の削減と共通ヘルパへの集約

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -454,14 +454,27 @@ void App::OnDestroy()
     }
 }
 
+SearchBarLayout App::ComputeSearchBarLayoutForMd(const PaneRect& md_rect) const
+{
+    return ComputeSearchBarLayout(
+        md_rect.x,
+        md_rect.width,
+        md_rect.y + md_rect.height,
+        !state_.search.search_state.GetQuery().empty());
+}
+
+int App::HitTestSearchInputPos(const SearchBarLayout& sbl, std::wstring_view query_wide, float dip_x) const
+{
+    return renderer_.HitTestSearchInput(query_wide, dip_x - sbl.text_left(), sbl.text_width());
+}
+
 RECT App::GetSearchEditRect()
 {
     if (!state_.search.search_state.IsVisible()) {
         return { 0, 0, 1, 1 };
     }
     const auto& layout = GetPaneLayout();
-    const auto& r = layout.md_rect;
-    const auto sbl = ComputeSearchBarLayout(r.x, r.width, r.y + r.height, !state_.search.search_state.GetQuery().empty());
+    const auto sbl = ComputeSearchBarLayoutForMd(layout.md_rect);
     const float s = state_.window.cached_dpi_scale;
     return {
         static_cast<LONG>(sbl.input_rect.left * s),

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -129,6 +129,8 @@ public:
         Dispatch(ImeCompositionAction{ std::move(comp) });
     }
     RECT GetSearchEditRect();
+    SearchBarLayout ComputeSearchBarLayoutForMd(const PaneRect& md_rect) const;
+    int HitTestSearchInputPos(const SearchBarLayout& sbl, std::wstring_view query_wide, float dip_x) const;
 
     // Init() より前に呼ぶこと。preload 即時完了パスは Init 内で復元情報を参照する。
     constexpr void SetPendingRestoreNode(int node, int offset) noexcept
@@ -212,7 +214,6 @@ private:
     void ScheduleDeferredLayoutIfNeeded();
     void InvalidateMdPane(const PaneRect& md_rect);
     void InvalidateHitPositions();
-    void ScrollTo(float position);
     void OnResizeEnd();
     void RefreshPaneLayout();
     void RefreshFilePane();

--- a/src/app/app_mouse.cpp
+++ b/src/app/app_mouse.cpp
@@ -128,12 +128,9 @@ void App::OnMouseMove(int px, int py)
 
     if (state_.search.search_bar_ctrl.IsDragging()) {
         const auto layout = GetPaneLayout();
-        const auto& r = layout.md_rect;
         const auto& query_wide = state_.search.search_bar_ctrl.GetQueryWide();
-        const auto sbl = ComputeSearchBarLayout(r.x, r.width, r.y + r.height, !query_wide.empty());
-        const float text_left = sbl.input_rect.left + SEARCH_INPUT_TEXT_PAD_LEFT;
-        const float input_w = sbl.input_rect.right - SEARCH_INPUT_TEXT_PAD_RIGHT - text_left;
-        const int pos = renderer_.HitTestSearchInput(query_wide, dip.x - text_left, input_w);
+        const auto sbl = ComputeSearchBarLayoutForMd(layout.md_rect);
+        const int pos = HitTestSearchInputPos(sbl, query_wide, dip.x);
         Dispatch(SearchInputDragMovedAction{ pos });
         return;
     }

--- a/src/app/app_mouse_click.cpp
+++ b/src/app/app_mouse_click.cpp
@@ -14,8 +14,7 @@ bool App::HandleSearchBarClick(float dip_x, float dip_y, const PaneLayout& pane_
     if (!state_.search.search_state.IsVisible()) {
         return false;
     }
-    const auto& r = pane_layout.md_rect;
-    const auto sbl = ComputeSearchBarLayout(r.x, r.width, r.y + r.height, !state_.search.search_state.GetQuery().empty());
+    const auto sbl = ComputeSearchBarLayoutForMd(pane_layout.md_rect);
     if (dip_y < sbl.bar_top) {
         return false;
     }
@@ -41,10 +40,8 @@ bool App::HandleSearchBarClick(float dip_x, float dip_y, const PaneLayout& pane_
         OnSearchClose();
         break;
     case SearchBarHitZone::Input: {
-        const float text_left = sbl.input_rect.left + SEARCH_INPUT_TEXT_PAD_LEFT;
-        const float input_w = sbl.input_rect.right - SEARCH_INPUT_TEXT_PAD_RIGHT - text_left;
         const auto& query_wide = state_.search.search_bar_ctrl.GetQueryWide();
-        const int pos = renderer_.HitTestSearchInput(query_wide, dip_x - text_left, input_w);
+        const int pos = HitTestSearchInputPos(sbl, query_wide, dip_x);
         if (is_double_click) {
             // 検索 EDIT は非表示で WM_LBUTTONDBLCLK を直接受けないため、
             // 自前で単語境界を計算して EM_SETSEL を発行する。

--- a/src/app/app_mouse_hover.cpp
+++ b/src/app/app_mouse_hover.cpp
@@ -36,8 +36,7 @@ bool App::IsOverMdScrollbar(float dip_x, float dip_y)
 void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const PaneLayout& pane_layout)
 {
     if (state_.search.search_state.IsVisible()) {
-        const auto& r = pane_layout.md_rect;
-        const auto sbl = ComputeSearchBarLayout(r.x, r.width, r.y + r.height, !state_.search.search_state.GetQuery().empty());
+        const auto sbl = ComputeSearchBarLayoutForMd(pane_layout.md_rect);
         const auto old_hover = state_.search.search_bar_ctrl.GetHover();
 
         if (dip_y >= sbl.bar_top) {

--- a/src/app/app_scroll.cpp
+++ b/src/app/app_scroll.cpp
@@ -13,13 +13,6 @@ void App::InvalidateHitPositions()
     Dispatch(ClearTooltipAction{});
 }
 
-void App::ScrollTo(float position)
-{
-    state_.view.viewport.ScrollTo(position);
-    InvalidateHitPositions();
-    EmitEffect(effect::SyncTocActive{});
-}
-
 void App::SyncTocActiveAndAutoScroll()
 {
     if (!state_.view.panes.IsSidePaneVisible(PaneTarget::Toc)) {

--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -1,4 +1,5 @@
 #include "document.h"
+#include "ascii_util.h"
 #include "document_utils.h"
 #include "fnv1a.h"
 #include "parser.h"
@@ -169,10 +170,7 @@ int Document::FindAnchorIndex(std::string_view anchor) const
     }
     char stack_buf[256];
     if (anchor.size() <= sizeof(stack_buf)) {
-        for (size_t i = 0; i < anchor.size(); ++i) {
-            const char c = anchor[i];
-            stack_buf[i] = (c >= 'A' && c <= 'Z') ? static_cast<char>(c + ('a' - 'A')) : c;
-        }
+        ascii_util::AsciiToLowerOnly(anchor.data(), stack_buf, anchor.size());
         return FindNormalizedAnchorIndex(std::string_view{ stack_buf, anchor.size() });
     }
     const std::pmr::string target = ToLowerAscii(anchor);

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -661,22 +661,22 @@ int OnEnterSpan(MD_SPANTYPE type, void* detail, void* userdata)
         ctx->paragraph_has_other_content = true;
     }
 
+    const auto enter_span_flag = [ctx](uint8_t& counter, uint8_t flag) {
+        ++counter;
+        ctx->current_run_flags |= flag;
+    };
     switch (type) {
     case MD_SPAN_STRONG:
-        ++ctx->bold_count;
-        ctx->current_run_flags |= TextRun::kBold;
+        enter_span_flag(ctx->bold_count, TextRun::kBold);
         break;
     case MD_SPAN_EM:
-        ++ctx->italic_count;
-        ctx->current_run_flags |= TextRun::kItalic;
+        enter_span_flag(ctx->italic_count, TextRun::kItalic);
         break;
     case MD_SPAN_CODE:
-        ++ctx->code_count;
-        ctx->current_run_flags |= TextRun::kCode;
+        enter_span_flag(ctx->code_count, TextRun::kCode);
         break;
     case MD_SPAN_DEL:
-        ++ctx->strikethrough_count;
-        ctx->current_run_flags |= TextRun::kStrikethrough;
+        enter_span_flag(ctx->strikethrough_count, TextRun::kStrikethrough);
         break;
     case MD_SPAN_A: {
         auto* const a = static_cast<MD_SPAN_A_DETAIL*>(detail);
@@ -725,26 +725,23 @@ int OnLeaveSpan(MD_SPANTYPE type, void* /*detail*/, void* userdata)
     ctx->FlushPendingRun();
 
     // md4c は enter/leave が常にバランスする契約なのでアンダーフローは起きない。
+    const auto leave_span_flag = [ctx](uint8_t& counter, uint8_t flag) {
+        if (--counter == 0) {
+            ctx->current_run_flags &= static_cast<uint8_t>(~flag);
+        }
+    };
     switch (type) {
     case MD_SPAN_STRONG:
-        if (--ctx->bold_count == 0) {
-            ctx->current_run_flags &= static_cast<uint8_t>(~TextRun::kBold);
-        }
+        leave_span_flag(ctx->bold_count, TextRun::kBold);
         break;
     case MD_SPAN_EM:
-        if (--ctx->italic_count == 0) {
-            ctx->current_run_flags &= static_cast<uint8_t>(~TextRun::kItalic);
-        }
+        leave_span_flag(ctx->italic_count, TextRun::kItalic);
         break;
     case MD_SPAN_CODE:
-        if (--ctx->code_count == 0) {
-            ctx->current_run_flags &= static_cast<uint8_t>(~TextRun::kCode);
-        }
+        leave_span_flag(ctx->code_count, TextRun::kCode);
         break;
     case MD_SPAN_DEL:
-        if (--ctx->strikethrough_count == 0) {
-            ctx->current_run_flags &= static_cast<uint8_t>(~TextRun::kStrikethrough);
-        }
+        leave_span_flag(ctx->strikethrough_count, TextRun::kStrikethrough);
         break;
     case MD_SPAN_A:
         ctx->current_link_url_index = -1;

--- a/src/core/selection_html.cpp
+++ b/src/core/selection_html.cpp
@@ -25,19 +25,8 @@ std::pmr::string ExtractSelectedText(const std::pmr::vector<Node>& nodes, const 
         }
         const std::string_view text = nodes[i].LinearizedText();
 
-        uint32_t start = 0;
-        uint32_t end = static_cast<uint32_t>(text.size());
-        if (i == selection.start_node) {
-            start = selection.start_pos;
-        }
-        if (i == selection.end_node) {
-            end = selection.end_pos;
-        }
-
-        if (start < end && start < text.size()) {
-            if (end > text.size()) {
-                end = static_cast<uint32_t>(text.size());
-            }
+        const auto [start, end] = selection.ClampedRange(i, text.size());
+        if (start < end) {
             result.append(text.data() + start, end - start);
         }
         if (i < selection.end_node) {
@@ -578,17 +567,7 @@ std::pmr::string ExtractSelectedTextAsHtml(const std::pmr::vector<Node>& nodes, 
         const auto& node = nodes[i];
         const auto& text = node.GetText();
 
-        uint32_t start = 0;
-        uint32_t end = static_cast<uint32_t>(text.size());
-        if (i == selection.start_node) {
-            start = selection.start_pos;
-        }
-        if (i == selection.end_node) {
-            end = selection.end_pos;
-        }
-        if (end > text.size()) {
-            end = static_cast<uint32_t>(text.size());
-        }
+        const auto [start, end] = selection.ClampedRange(i, text.size());
 
         if (IsListNode(node)) {
             const char* want_close = IsOrderedList(node) ? "</ol>" : "</ul>";

--- a/src/core/text_types.h
+++ b/src/core/text_types.h
@@ -73,6 +73,28 @@ struct TextSelection {
     uint32_t end_pos = 0;
     bool active = false;
 
+    struct NodeRange {
+        uint32_t start;
+        uint32_t end;
+    };
+
+    // node_index に対応する選択範囲 [start, end)。end は text_size でクランプ済み。
+    constexpr NodeRange ClampedRange(int node_index, size_t text_size) const noexcept
+    {
+        uint32_t start = 0;
+        uint32_t end = static_cast<uint32_t>(text_size);
+        if (node_index == start_node) {
+            start = start_pos;
+        }
+        if (node_index == end_node) {
+            end = end_pos;
+        }
+        if (end > text_size) {
+            end = static_cast<uint32_t>(text_size);
+        }
+        return { start, end };
+    }
+
     friend constexpr bool operator==(const TextSelection&, const TextSelection&) noexcept = default;
 
     constexpr void Clear() noexcept

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -364,6 +364,19 @@ void DWriteTextMeasurer::MeasureNode(
     entry.invalidate_per_frame_hl_caches();
 }
 
+void DWriteTextMeasurer::BuildCellLayout(const NodeTableData* tbl, size_t r, size_t c, size_t ci, IDWriteTextFormat* row_fmt, TableLayoutData& tl) const
+{
+    const auto text = tbl->GetCellText(r, c);
+    if (text.empty()) {
+        return;
+    }
+    const mendo::WideViewForDWrite wv{ text };
+    mendo::CreateDocTextLayout(dwrite_, wv, row_fmt, LAYOUT_INFINITY, LAYOUT_INFINITY, &tl.cell_layouts[ci]);
+    if (tl.cell_layouts[ci]) {
+        ApplyRunFormatting(tl.cell_layouts[ci].Get(), tbl->GetCellRuns(r, c), wv, RunFormatScope::ForCell());
+    }
+}
+
 void DWriteTextMeasurer::MeasureTableCells(Node& node, NodeLayoutEntry& entry, std::pmr::vector<float>& natural_widths) const
 {
     MENDO_PROFILE("MeasureTableCells");
@@ -378,16 +391,9 @@ void DWriteTextMeasurer::MeasureTableCells(Node& node, NodeLayoutEntry& entry, s
         const bool is_header = tbl->IsHeaderRow(r);
         IDWriteTextFormat* const row_fmt = is_header ? fmt_bold : fmt;
         for (size_t c = 0; c < col_count; c++) {
-            const auto text = tbl->GetCellText(r, c);
-            if (text.empty()) {
-                continue;
-            }
             const size_t ci = tl.CellIndex(r, c);
-            const mendo::WideViewForDWrite wv{ text };
-            mendo::CreateDocTextLayout(dwrite_, wv, row_fmt, LAYOUT_INFINITY, LAYOUT_INFINITY, &tl.cell_layouts[ci]);
-
+            BuildCellLayout(tbl, r, c, ci, row_fmt, tl);
             if (tl.cell_layouts[ci]) {
-                ApplyRunFormatting(tl.cell_layouts[ci].Get(), tbl->GetCellRuns(r, c), wv, RunFormatScope::ForCell());
                 DWRITE_TEXT_METRICS metrics{};
                 tl.cell_layouts[ci]->GetMetrics(&metrics);
                 natural_widths[c] = std::max(natural_widths[c], metrics.width);
@@ -427,15 +433,7 @@ void DWriteTextMeasurer::RestoreNullCellLayouts(Node& node, NodeLayoutEntry& ent
             if (ci >= tl.cell_layouts.size() || tl.cell_layouts[ci]) {
                 continue;
             }
-            const auto text = tbl->GetCellText(r, c);
-            if (text.empty()) {
-                continue;
-            }
-            const mendo::WideViewForDWrite wv{ text };
-            mendo::CreateDocTextLayout(dwrite_, wv, row_fmt, LAYOUT_INFINITY, LAYOUT_INFINITY, &tl.cell_layouts[ci]);
-            if (tl.cell_layouts[ci]) {
-                ApplyRunFormatting(tl.cell_layouts[ci].Get(), tbl->GetCellRuns(r, c), wv, RunFormatScope::ForCell());
-            }
+            BuildCellLayout(tbl, r, c, ci, row_fmt, tl);
         }
     }
 }
@@ -466,7 +464,7 @@ void DWriteTextMeasurer::FinalizeTableLayout(
     const auto row_count = tbl->row_count;
     bool any_row_unrestored = false;
     for (size_t r = 0; r < row_count; r++) {
-        float row_height = theme_->font_size_body * 1.4f;
+        float row_height = theme_->font_size_body * TABLE_ROW_HEIGHT_FACTOR;
         bool row_has_null_cell = false;
         for (size_t c = 0; c < col_count; c++) {
             const float cw = (c < tl.col_widths.size()) ? tl.col_widths[c] : DEFAULT_COLUMN_WIDTH;

--- a/src/layout/dwrite_measurer.h
+++ b/src/layout/dwrite_measurer.h
@@ -7,6 +7,8 @@
 #include <memory_resource>
 #include <span>
 
+struct NodeTableData;
+struct TableLayoutData;
 
 // ITextMeasurer の DirectWrite 実装。IDWriteTextFormat (重い再利用可能オブジェクト) を
 // theme ごとに所有し、計測のたびに per-call で IDWriteTextLayout を生成する分業構造。
@@ -20,11 +22,17 @@ public:
         theme_ = &theme;
     }
 
-    void MeasureNode(Node& node, NodeLayoutEntry& entry, float max_width,
-                     std::pmr::vector<SyntaxToken>* tokens_out = nullptr,
-                     MeasureViewportRange viewport = {}) const override;
-    void MeasureTable(Node& node, NodeLayoutEntry& entry, float max_width,
-                      MeasureViewportRange viewport = {}) const override;
+    void MeasureNode(
+        Node& node,
+        NodeLayoutEntry& entry,
+        float max_width,
+        std::pmr::vector<SyntaxToken>* tokens_out = nullptr,
+        MeasureViewportRange viewport = {}) const override;
+    void MeasureTable(
+        Node& node,
+        NodeLayoutEntry& entry,
+        float max_width,
+        MeasureViewportRange viewport = {}) const override;
 
     // 外部のIDWriteFactoryで初期化する（Initの前に呼び出す必要がある）。
     void SetFactory(IDWriteFactory* factory) noexcept
@@ -62,6 +70,9 @@ private:
     bool CreateAllFormats();
     IDWriteTextFormat* GetTextFormat(const Node& node) const noexcept;
     void ApplyRunFormatting(IDWriteTextLayout* layout, std::span<const TextRun> runs, const mendo::WideViewForDWrite& view, RunFormatScope scope) const;
+    // MeasureTableCells / RestoreNullCellLayouts 共通のセル生成処理。空セルは layout を
+    // null のまま残し、呼び出し側のスキップ判定に委ねる。
+    void BuildCellLayout(const NodeTableData* tbl, size_t r, size_t c, size_t ci, IDWriteTextFormat* row_fmt, TableLayoutData& tl) const;
     void MeasureTableCells(Node& node, NodeLayoutEntry& entry, std::pmr::vector<float>& natural_widths) const;
     void RestoreNullCellLayouts(Node& node, NodeLayoutEntry& entry, MeasureViewportRange viewport) const;
     void FinalizeTableLayout(Node& node, NodeLayoutEntry& entry, float max_width, size_t col_count, std::pmr::vector<float>& natural_widths) const;

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -98,12 +98,9 @@ void LayoutEngine::ComputeLayout(std::pmr::vector<Node>& nodes, LayoutCache& cac
         const float sa = GetSpacingAbove(node, *theme_);
         const float sb = GetSpacingBelow(node, *theme_);
 
-        y += sa;
-        entry.text_top = y;
-        y += entry.height;
-        y += sb;
-
-        block_heights_buf_.push_back(sa + entry.height + sb);
+        const auto adv = AdvanceNodeY(y, sa, entry.height, sb);
+        entry.text_top = adv.text_top;
+        block_heights_buf_.push_back(adv.block_height);
 
         // 幅の変更がなく、ビューポートを超えた後に高さの変更もなければ、
         // 残りの Y 位置は変わらないので早期終了する。

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -14,6 +14,7 @@ class TaskScheduler;
 class Document;
 
 // レガシー呼び出しサイト互換: 自由関数とユーティリティは mendo::layout namespace へ移動済み。
+using mendo::layout::AdvanceNodeY;
 using mendo::layout::ComputeColumnWidths;
 using mendo::layout::EstimateInvisibleNodeHeight;
 using mendo::layout::EstimateNodeHeight;

--- a/src/layout/layout_computer.cpp
+++ b/src/layout/layout_computer.cpp
@@ -133,8 +133,7 @@ float EstimateNodeHeight(const Node& node, const Theme& theme) noexcept
     std::unreachable();
 }
 
-void EstimateNodeHeights(const std::pmr::vector<Node>& nodes, LayoutCache& cache, const Theme& theme,
-                         std::stop_token stop_token)
+void EstimateNodeHeights(const std::pmr::vector<Node>& nodes, LayoutCache& cache, const Theme& theme, std::stop_token stop_token)
 {
     MENDO_PROFILE("EstimateNodeHeights");
     // ノードの種類に応じた既定の高さを割り当て、Y座標を累積計算する。
@@ -157,13 +156,10 @@ void EstimateNodeHeights(const std::pmr::vector<Node>& nodes, LayoutCache& cache
         const float sa = GetSpacingAbove(node, theme);
         const float sb = GetSpacingBelow(node, theme);
 
-        y += sa;
+        const auto adv = AdvanceNodeY(y, sa, h, sb);
         cache[i].height = h;
-        cache[i].text_top = y;
-        y += h;
-        y += sb;
-
-        block_heights.push_back(sa + h + sb);
+        cache[i].text_top = adv.text_top;
+        block_heights.push_back(adv.block_height);
     }
     cache.BuildBlockHeights(block_heights);
 }
@@ -235,17 +231,13 @@ YPositionResult RecomputeYPositions(
         const float sa = GetSpacingAbove(nodes[i], theme);
         const float sb = GetSpacingBelow(nodes[i], theme);
 
-        y += sa;
-        entry.text_top = y;
-        y += entry.height;
-        y += sb;
-
-        const float block_height = sa + entry.height + sb;
+        const auto adv = AdvanceNodeY(y, sa, entry.height, sb);
+        entry.text_top = adv.text_top;
         if (can_bulk_build) {
-            block_heights.push_back(block_height);
+            block_heights.push_back(adv.block_height);
         }
         else {
-            cache.SetBlockHeight(i, block_height);
+            cache.SetBlockHeight(i, adv.block_height);
         }
     }
 

--- a/src/layout/layout_computer.h
+++ b/src/layout/layout_computer.h
@@ -21,6 +21,22 @@ inline float NodeTextXOffset(const Node& node, const Theme& theme) noexcept
 float GetSpacingAbove(const Node& node, const Theme& theme) noexcept;
 float GetSpacingBelow(const Node& node, const Theme& theme) noexcept;
 
+struct YAdvance {
+    float text_top;
+    float block_height;
+};
+
+// 1 ノード分の Y 進行。加算順序 (above → height → below) は大規模ファイルでの
+// catastrophic cancellation 回避のため既存の累積順序を厳密に保持する。
+inline YAdvance AdvanceNodeY(float& y, float spacing_above, float height, float spacing_below) noexcept
+{
+    y += spacing_above;
+    const float text_top = y;
+    y += height;
+    y += spacing_below;
+    return { text_top, spacing_above + height + spacing_below };
+}
+
 // ノード i の「テキスト上端 Y」を Fenwick から O(log N) で取得する。
 // entry.text_top と同値で、margin_top + PrefixSum(i) + spacing_above[i] を返す。
 inline float TextTopOf(const LayoutCache& cache, size_t i, const Node& node, const Theme& theme) noexcept

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -333,11 +333,6 @@ void MermaidRenderer::CancelPending()
     }
 }
 
-uint64_t MermaidRenderer::HashCode(std::string_view code_utf8, float max_width, bool dark_mode) const noexcept
-{
-    return mermaid_util::HashCode(code_utf8, max_width, dark_mode);
-}
-
 void MermaidRenderer::ApplyCachedBitmap(NodeLayoutEntry& layout_entry, DiagramEntry& diagram_entry, const CachedBitmap& cached) noexcept
 {
     diagram_entry.bitmap = cached.bitmap;

--- a/src/mermaid/mermaid.h
+++ b/src/mermaid/mermaid.h
@@ -113,7 +113,6 @@ private:
     void DoCapturePreview(int worker_idx);
     void OnCaptureComplete(int worker_idx, uint64_t code_hash, IStream* png_stream);
     void FinishWorkerRequest(Worker& worker);
-    uint64_t HashCode(std::string_view code_utf8, float max_width, bool dark_mode) const noexcept;
     HRESULT CreateBitmapFromPngStream(IStream* stream, ID2D1Bitmap** bitmap, float* width, float* height);
 
     HWND hwnd_ = nullptr; // メインウィンドウ

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -374,14 +374,7 @@ void CommandGenerator::GenNodeTextDecorations(DrawCommandList& cmds, const Frame
 
     const auto& selection = fc.selection;
     if (selection.active && node_index >= selection.start_node && node_index <= selection.end_node) {
-        uint32_t sel_start = 0;
-        uint32_t sel_end = static_cast<uint32_t>(node.GetText().size());
-        if (node_index == selection.start_node) {
-            sel_start = selection.start_pos;
-        }
-        if (node_index == selection.end_node) {
-            sel_end = selection.end_pos;
-        }
+        const auto [sel_start, sel_end] = selection.ClampedRange(node_index, node.GetText().size());
         if (sel_end > sel_start) {
             GenSelectionHighlightCached(cmds, node, entry, sel_start, sel_end - sel_start, text_x, entry_text_top);
         }
@@ -718,13 +711,7 @@ void CommandGenerator::GenSelectionHighlightCached(DrawCommandList& cmds, const 
         MENDO_COUNT_INC(g_cmd_gen_stats.sel_hl_cache_hit);
     }
     for (const auto& r : cache.rects) {
-        cmds.emplace_back(FillRectCmd{
-            D2D1::RectF(
-                origin_x + r.left,
-                origin_y + r.top,
-                origin_x + r.right,
-                origin_y + r.bottom),
-            SELECTION_COLOR, BrushId::Selection });
+        cmds.emplace_back(FillRectCmd{ OffsetRectF(r, origin_x, origin_y), SELECTION_COLOR, BrushId::Selection });
     }
 }
 
@@ -814,8 +801,7 @@ void CommandGenerator::EmitSearchHlCommands(
         const D2D1_COLOR_F color = is_current ? theme_->search_highlight_current_color : theme_->search_highlight_color;
         const BrushId hl_brush = is_current ? BrushId::SearchHighlightCurrent : BrushId::SearchHighlight;
         for (uint32_t k = rb; k < re; ++k) {
-            const auto& r = cache.rects[k];
-            cmds.emplace_back(FillRectCmd{ D2D1::RectF(origin_x + r.left, origin_y + r.top, origin_x + r.right, origin_y + r.bottom), color, hl_brush });
+            cmds.emplace_back(FillRectCmd{ OffsetRectF(cache.rects[k], origin_x, origin_y), color, hl_brush });
         }
     }
 }
@@ -875,14 +861,11 @@ void CommandGenerator::GenTable(
     const float table_width = tl.cached_table_width;
 
     bool has_selection = selection.active && (node_index >= selection.start_node) && (node_index <= selection.end_node);
-    uint32_t sel_start = 0, sel_end = static_cast<uint32_t>(tbl->concat_text.size());
+    uint32_t sel_start = 0, sel_end = 0;
     if (has_selection) {
-        if (node_index == selection.start_node) {
-            sel_start = selection.start_pos;
-        }
-        if (node_index == selection.end_node) {
-            sel_end = selection.end_pos;
-        }
+        const auto range = selection.ClampedRange(node_index, tbl->concat_text.size());
+        sel_start = range.start;
+        sel_end = range.end;
         if (sel_end <= sel_start) {
             has_selection = false;
         }

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -34,17 +34,17 @@ inline UINT32 FetchHitTestMetrics(IDWriteTextLayout* layout, UINT32 start, UINT3
     return count;
 }
 
+inline D2D1_RECT_F OffsetRectF(const D2D1_RECT_F& r, float origin_x, float origin_y) noexcept
+{
+    return D2D1::RectF(origin_x + r.left, origin_y + r.top, origin_x + r.right, origin_y + r.bottom);
+}
+
 // インラインコードの背景矩形を描画する。
 // bgsにはパディング適用済みのレイアウト原点相対矩形が格納されている。
 inline void GenInlineCodeBgs(DrawCommandList& cmds, std::span<const InlineCodeBg> bgs, float origin_x, float origin_y, D2D1_COLOR_F color)
 {
     for (const auto& bg : bgs) {
-        const D2D1_RECT_F rect = D2D1::RectF(
-            origin_x + bg.left,
-            origin_y + bg.top,
-            origin_x + bg.right,
-            origin_y + bg.bottom);
-        cmds.emplace_back(FillRoundedRectCmd{ rect, INLINE_CODE_CORNER, INLINE_CODE_CORNER, color });
+        cmds.emplace_back(FillRoundedRectCmd{ OffsetRectF(bg, origin_x, origin_y), INLINE_CODE_CORNER, INLINE_CODE_CORNER, color });
     }
 }
 
@@ -57,13 +57,7 @@ inline size_t GenCellInlineCodeBgs(DrawCommandList& cmds, std::span<const CellIn
         ++cursor;
     }
     while (cursor < bgs.size() && bgs[cursor].cell_index == cell_index) {
-        const auto& src = bgs[cursor].rect;
-        const D2D1_RECT_F rect = D2D1::RectF(
-            origin_x + src.left,
-            origin_y + src.top,
-            origin_x + src.right,
-            origin_y + src.bottom);
-        cmds.emplace_back(FillRoundedRectCmd{ rect, INLINE_CODE_CORNER, INLINE_CODE_CORNER, color });
+        cmds.emplace_back(FillRoundedRectCmd{ OffsetRectF(bgs[cursor].rect, origin_x, origin_y), INLINE_CODE_CORNER, INLINE_CODE_CORNER, color });
         ++cursor;
     }
     return cursor;

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -228,7 +228,7 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry, float entry
     }
 
     for (size_t r = r_begin; r < r_end; r++) {
-        const float row_h = (r < tl.row_heights.size()) ? tl.row_heights[r] : (theme_.font_size_body * 1.4f);
+        const float row_h = (r < tl.row_heights.size()) ? tl.row_heights[r] : (theme_.font_size_body * TABLE_ROW_HEIGHT_FACTOR);
         const float row_bottom = row_y + row_h + border;
 
         const bool row_visible = (viewport_top < 0.0f) || (row_bottom >= viewport_top && row_y <= viewport_bottom);

--- a/src/render/renderer_search.cpp
+++ b/src/render/renderer_search.cpp
@@ -55,7 +55,7 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
 
     // レイアウトを1回だけ作成し、描画とキャレット計測で共用する。
     // IMEコンポジション中は確定済みテキスト+変換中テキストを合成して表示。
-    const float text_left = sbl.input_rect.left + SEARCH_INPUT_TEXT_PAD_LEFT;
+    const float text_left = sbl.text_left();
     float caret_x = text_left;
 
     const bool has_comp = !sb.ime_composition.empty();
@@ -76,7 +76,7 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
     std::pmr::wstring display_buf{ GetThreadLocalPoolResource() };
 
     if (fmt_.search_input && (!sb.query.empty() || has_comp) && backend_.GetDWriteFactory()) {
-        const float input_w = sbl.input_rect.right - SEARCH_INPUT_TEXT_PAD_RIGHT - text_left;
+        const float input_w = sbl.text_width();
         const float input_h = sbl.input_rect.bottom - sbl.input_rect.top;
 
         // 比較は scalar → 空になりやすい ime_comp → query の順で短絡させる
@@ -193,7 +193,7 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
 
     // コンポジション中はIME側がキャレットを表示するため非表示
     if (sb.caret_visible && !has_comp) {
-        caret_x = std::min(caret_x + 1.0f, sbl.input_rect.right - SEARCH_INPUT_TEXT_PAD_RIGHT);
+        caret_x = std::min(caret_x + 1.0f, sbl.text_right());
         rt()->DrawLine(
             D2D1::Point2F(caret_x, sbl.input_rect.top + 3.0f),
             D2D1::Point2F(caret_x, sbl.input_rect.bottom - 3.0f),

--- a/src/util/file_io.h
+++ b/src/util/file_io.h
@@ -54,10 +54,11 @@ bool IsFileLargerThan(const std::filesystem::path& path, size_t reference_size, 
 [[nodiscard]] bool WriteAllBytes(const std::filesystem::path& path, const void* data, size_t size);
 
 // tmp ファイルへ書いてから MoveFileExW(REPLACE_EXISTING) で原子的に置き換える。
-// rename が失敗 (クロスボリューム等) した場合は tmp を削除し path へ直接書き込む。
+// rename が失敗 (クロスボリューム等) した場合は tmp を削除し false を返す。直書きフォールバックは
+// CREATE_ALWAYS が原本を切り詰めてから失敗しうるため行わない。
 // tmp パスは `<path>.tmp` 固定 — 同じ path への並行呼び出しは tmp が衝突するため、
 // 呼び出し側で排他制御すること (現 callsite は UI スレッド単一発火で安全)。
-// 戻り値は最終的に何らかの形で書き込めたか。
+// 戻り値はアトミックな置換に成功したか。false の場合は原本が変更されていないことを保証する。
 bool AtomicWriteAllBytes(const std::filesystem::path& path, const void* data, size_t size);
 
 // ファイル名・フルパス比較ユーティリティ。

--- a/src/util/ui_constants.h
+++ b/src/util/ui_constants.h
@@ -174,6 +174,20 @@ struct SearchBarLayout {
     D2D1_RECT_F icon_rect{};
     float bar_top = 0.0f;
     float bar_bottom = 0.0f;
+
+    // 検索入力のテキスト描画領域。描画(renderer_search)とヒットテスト(app)で共有する。
+    float text_left() const noexcept
+    {
+        return input_rect.left + SEARCH_INPUT_TEXT_PAD_LEFT;
+    }
+    float text_right() const noexcept
+    {
+        return input_rect.right - SEARCH_INPUT_TEXT_PAD_RIGHT;
+    }
+    float text_width() const noexcept
+    {
+        return text_right() - text_left();
+    }
 };
 
 inline SearchBarLayout ComputeSearchBarLayout(float md_left, float md_width, float md_bottom, bool has_query) noexcept


### PR DESCRIPTION
## 概要
アプリ全体を調査し、冗長・重複していた処理を削減・共通化するリファクタです。動作は変更せず (behavior-preserving)、全2274テストが通過します。

## 主な変更

### デッドコード・バグ・コメント
- 未使用メソッド削除: `App::ScrollTo`, `MermaidRenderer::HashCode`
- テーブル行高フォールバックの直書き `1.4f` を定数 `TABLE_ROW_HEIGHT_FACTOR` に統一（描画とヒット判定の不整合リスクを除去）
- `AtomicWriteAllBytes` のヘッダコメントを実装（直書きフォールバック廃止）に整合

### 共通ヘルパへの集約
- `OffsetRectF`: 矩形の原点平行移動（render 4箇所）
- `TextSelection::ClampedRange`: 選択範囲のノード別 `[start,end)` 算出（selection_html 2 + command_generator 2 = 4箇所を SSOT 化。stale selection への防御も追加）
- `AdvanceNodeY`: Y座標累積（3箇所。catastrophic cancellation 回避のため加算順序を厳密保持）
- `BuildCellLayout`: テーブルセル layout 生成（dwrite_measurer 2箇所）
- `SearchBarLayout::text_left()/text_right()/text_width()`: 検索バーのテキスト領域算出を app/renderer 両層で共有
- parser の span フラグ操作、document の ASCII 小文字化（SIMD 済み `AsciiToLowerOnly` へ）

## 検証
- `cmake --build build --config Release` ビルド成功
- `mendo_tests.exe` 全2274テスト PASS
- multi-agent コードレビュー（high → xhigh）で correctness バグゼロを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
