### PR TITLE
fix: コードレビューで検出した不具合の修正

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -328,7 +328,7 @@ void App::OnMouseWheel(int px, int py, short delta, bool ctrl)
         return;
     }
 
-    // 縦スクロールが発生した時点で SwipeDetector の軸ロックを解除し、
+    // 縦スクロールが発生した時点で SwipeDetector の軸ロックを更新（再武装）し、
     // 直後の水平ホイールがスワイプとして誤検出されないようにする。
     const bool had_overlay = state_.interaction.swipe_detector.IsOverlayVisible();
     state_.interaction.swipe_detector.NotifyVScroll(GetTickCount64());

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -198,6 +198,7 @@ private:
 
     using HitResult = HitTestService::HitResult;
     HitResult HitTest(int screen_x, int screen_y);
+    HitResult HitTest(const MdPaneHitContext& ctx);
     std::optional<std::pmr::string> GetLinkAtHit(const HitResult& hit) const;
     MdPaneHitContext BuildMdPaneHitContext(int px, int py, const PaneLayout& pane_layout) const noexcept;
 

--- a/src/app/app_mouse.cpp
+++ b/src/app/app_mouse.cpp
@@ -8,7 +8,12 @@
 
 App::HitResult App::HitTest(int screen_x, int screen_y)
 {
-    return hit_test_.HitTest(BuildMdPaneHitContext(screen_x, screen_y, GetPaneLayout()));
+    return HitTest(BuildMdPaneHitContext(screen_x, screen_y, GetPaneLayout()));
+}
+
+App::HitResult App::HitTest(const MdPaneHitContext& ctx)
+{
+    return hit_test_.HitTest(ctx);
 }
 
 MdPaneHitContext App::BuildMdPaneHitContext(int px, int py, const PaneLayout& pane_layout) const noexcept

--- a/src/app/app_mouse_hover.cpp
+++ b/src/app/app_mouse_hover.cpp
@@ -99,7 +99,7 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
     }
 
     if (ht.TryMarkMoved(ht.last_md_hit_pos, ht.last_md_hit_tick, px, py)) {
-        const auto hit = HitTest(px, py);
+        const auto hit = HitTest(hit_ctx);
         const auto link = GetLinkAtHit(hit);
         const bool has_link = link.has_value();
         ht.last_md_cursor_hand = has_link;

--- a/src/app/app_resource_manager_callbacks.cpp
+++ b/src/app/app_resource_manager_callbacks.cpp
@@ -50,6 +50,9 @@ void AppResourceManagerCallbacks::recompute_layout_anchored()
         app->renderer_.GetTheme());
     const auto layout = app->GetPaneLayout();
     app->EmitEffect(effect::SyncMaxScroll{ layout.md_rect.height });
+    // リフローで停止中のカーソル直下のノード/リンクが変わりうるため、ホバーの
+    // ヒットキャッシュを無効化し次のマウス移動で再評価させる (カーソル形状の陳腐化対策)。
+    app->InvalidateHitPositions();
     app->Invalidate();
 }
 

--- a/src/app/app_resource_manager_callbacks.cpp
+++ b/src/app/app_resource_manager_callbacks.cpp
@@ -39,6 +39,9 @@ void AppResourceManagerCallbacks::recompute_layout()
         app->state_.document.doc,
         app->state_.document.layout_cache,
         app->renderer_.GetTheme());
+    // anchored 版と同様、リフローで停止中のカーソル直下のノード/リンクが変わりうるため
+    // ホバーのヒットキャッシュを無効化し次のマウス移動で再評価させる。
+    app->InvalidateHitPositions();
 }
 
 void AppResourceManagerCallbacks::recompute_layout_anchored()

--- a/src/app/clipboard_manager.cpp
+++ b/src/app/clipboard_manager.cpp
@@ -70,11 +70,12 @@ void ClipboardManager::SaveDiagramAsPng(const Document& doc, int node_index, flo
         return;
     }
 
-    if (WriteAllBytes(filename.c_str(), png.data.get(), png.size)) {
+    // 既存ファイルを上書き選択した場合でも、失敗時に原本を破壊しないよう
+    // tmp+rename のアトミック書き込みを使う。
+    if (AtomicWriteAllBytes(filename.c_str(), png.data.get(), png.size)) {
         show_toast_(i18n::S().toast_image_saved);
     }
     else {
-        DeleteFileW(filename.c_str());
         show_toast_(i18n::S().toast_image_save_failed);
     }
 }

--- a/src/app/resource_manager.h
+++ b/src/app/resource_manager.h
@@ -378,12 +378,13 @@ public:
 
         const auto& diagram_indices = deps_.doc->GetDiagramNodeIndices();
         const auto dia_keep = VisibleSlice(diagram_indices, static_cast<size_t>(first_keep), static_cast<size_t>(last_keep));
-        bool any_mermaid_evicted = false;
+        // オフスクリーンの diagram bitmap (layout 側) だけ解放する。レンダ済みビットマップの
+        // 二次キャッシュ (mermaid 内 LRU, 128 件) は自前で上限管理されるため全消去しない。
+        // 全消去すると可視中の図まで捨てて WebView2 再レンダの cliff を生むため。
         auto evict_mermaid = [&](size_t i) {
             auto& diagram = deps_.cache->GetDiagram(i);
             if (diagram.bitmap) {
                 diagram.bitmap.Reset();
-                any_mermaid_evicted = true;
             }
         };
         for (auto it = diagram_indices.begin(); it != dia_keep.begin; ++it) {
@@ -391,9 +392,6 @@ public:
         }
         for (auto it = dia_keep.end; it != diagram_indices.end(); ++it) {
             evict_mermaid(*it);
-        }
-        if (any_mermaid_evicted) {
-            deps_.mermaid->ClearCache();
         }
     }
 

--- a/src/core/document_types.h
+++ b/src/core/document_types.h
@@ -155,7 +155,8 @@ struct NodeCodeData {
 };
 
 struct NodeListData {
-    int32_t list_number = 0;   // 0 = 順序なし, >0 = 順序付きリスト番号
+    int32_t list_number = 0;   // 順序付きリストの番号 (ordered=true のとき有効。0 始まりも可)
+    bool ordered = false;
     bool task_checked = false; // TaskListItem のときのみ意味を持つ
 };
 
@@ -424,6 +425,11 @@ struct Node {
     {
         const auto* ld = list_data();
         return ld ? ld->list_number : 0;
+    }
+    constexpr bool list_ordered() const noexcept
+    {
+        const auto* ld = list_data();
+        return ld && ld->ordered;
     }
     constexpr bool task_checked() const noexcept
     {

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -396,7 +396,7 @@ int OnEnterBlock(MD_BLOCKTYPE type, void* detail, void* userdata)
         break;
 
     case MD_BLOCK_UL:
-        ctx->list_counter.push_back(0);
+        ctx->list_counter.push_back(-1); // unordered の番兵 (ordered の start は 0 以上)
         ctx->indent_level++;
         break;
 
@@ -411,15 +411,17 @@ int OnEnterBlock(MD_BLOCKTYPE type, void* detail, void* userdata)
         auto* const li = static_cast<MD_BLOCK_LI_DETAIL*>(detail);
         const bool is_task = li->is_task;
         ctx->BeginNode(is_task ? NodeType::TaskListItem : NodeType::ListItem);
-        // counter==0 (unordered list) かつ非 task のときは NodeListData を確保しない
-        // (デフォルト値 list_number=0 / task_checked=false が getter で返るため)。
-        const int counter = ctx->list_counter.empty() ? 0 : ctx->list_counter.back();
-        if (is_task || counter > 0) {
+        // unordered (counter<0) かつ非 task のときは NodeListData を確保しない
+        // (getter が ordered=false / list_number=0 / task_checked=false を返すため)。
+        const int counter = ctx->list_counter.empty() ? -1 : ctx->list_counter.back();
+        const bool ordered = (counter >= 0); // OL は start>=0、UL は番兵 -1
+        if (is_task || ordered) {
             auto* ld = ctx->current_node->ensure_list();
             if (is_task) {
                 ld->task_checked = (li->task_mark == 'x' || li->task_mark == 'X');
             }
-            if (counter > 0) {
+            if (ordered) {
+                ld->ordered = true;
                 ld->list_number = counter;
                 ctx->list_counter.back()++;
             }

--- a/src/core/selection_html.cpp
+++ b/src/core/selection_html.cpp
@@ -487,7 +487,7 @@ constexpr bool IsListNode(const Node& n) noexcept
 
 constexpr bool IsOrderedList(const Node& n) noexcept
 {
-    return IsListNode(n) && n.list_number() > 0;
+    return IsListNode(n) && n.list_ordered();
 }
 
 std::optional<std::pmr::string> FindLinkInRuns(std::span<const TextRun> runs, std::span<const std::pmr::string> link_urls, uint32_t pos)
@@ -545,7 +545,7 @@ std::pmr::string ExtractSelectedTextAsHtml(const std::pmr::vector<Node>& nodes, 
     size_t estimated = 0;
     for (int i = selection.start_node; i <= selection.end_node; ++i) {
         if (i >= 0 && i < static_cast<int>(nodes.size())) {
-            estimated += nodes[i].GetText().size();
+            estimated += nodes[i].LinearizedText().size();
         }
     }
     // シンタックスハイライトの span やテーブルの style 属性でタグのオーバーヘッドが増えるため、
@@ -565,7 +565,7 @@ std::pmr::string ExtractSelectedTextAsHtml(const std::pmr::vector<Node>& nodes, 
             continue;
         }
         const auto& node = nodes[i];
-        const auto& text = node.GetText();
+        const auto text = node.LinearizedText();
 
         const auto [start, end] = selection.ClampedRange(i, text.size());
 

--- a/src/core/syntax.cpp
+++ b/src/core/syntax.cpp
@@ -222,6 +222,7 @@ struct LexerConfig {
     bool hash_comment = false;         // #
     bool preprocessor = false;         // 行頭の#
     bool triple_quote = false;         // """ '''
+    bool raw_string = false;           // C++ R"(...)"
     bool backtick_string = false;      // `
     bool angle_block_comment = false;  // <# #>
     bool double_colon_comment = false; // ::
@@ -389,9 +390,9 @@ std::pmr::vector<SyntaxToken> TokenizeImpl(
 
         // 5. 文字列リテラル
         if (c == '"' || (c == '\'' && !Cfg.skip_single_quote)) {
-            // C++生文字列の確認: R"(...)"。preprocessor 言語 (C/C++) でのみ意味があるが、
-            // 元コードと挙動を揃えるため Cfg に依存しない判定にする。
-            if (c == '"' && i > 0 && text[i - 1] == 'R' && (i < 2 || !IsIdentChar(text[i - 2]))) {
+            // C++生文字列の確認: R"(...)"。raw_string 対応言語 (C/C++) のみで判定する。
+            // 他言語で識別子末尾の R + 文字列を誤って生文字列扱いしないようゲートする。
+            if (Cfg.raw_string && c == '"' && i > 0 && text[i - 1] == 'R' && (i < 2 || !IsIdentChar(text[i - 2]))) {
                 // 調整: Rは既にプレーンバッファにあるので除去する。
                 if (in_plain) {
                     if (static_cast<uint32_t>(i - 1) > plain_start) {
@@ -498,6 +499,7 @@ inline constexpr LexerConfig CPP_LEXER_CONFIG{
     .line_comment_slash = true,
     .block_comment = true,
     .preprocessor = true,
+    .raw_string = true,
 };
 inline constexpr LexerConfig PYTHON_LEXER_CONFIG{
     .hash_comment = true,

--- a/src/input/mouse_gesture.h
+++ b/src/input/mouse_gesture.h
@@ -101,7 +101,9 @@ public:
         case GestureDirection::Right:
             return GestureResult::Forward;
         default:
-            return GestureResult::None;
+            // 方向が確定しなかった右ドラッグは通常の右クリック扱いとし、
+            // コンテキストメニューを表示する (イベントを握り潰してメニューを失わない)。
+            return GestureResult::ShowContextMenu;
         }
     }
 

--- a/src/io/config_service.cpp
+++ b/src/io/config_service.cpp
@@ -202,7 +202,7 @@ void SessionService::SavePaneState(const PaneState& state)
     config_.SaveInt(kSectionPane, kKeyTocWidth, static_cast<int>(std::lround(state.toc_width)));
 }
 
-SessionService::PaneState SessionService::LoadPaneState(float client_width, float min_width, float default_width) const
+SessionService::PaneState SessionService::LoadPaneState([[maybe_unused]] float client_width, float min_width, float default_width) const
 {
     PaneState s;
     s.show_file = config_.LoadBool(kSectionPane, kKeyShowFile, true);
@@ -211,17 +211,13 @@ SessionService::PaneState SessionService::LoadPaneState(float client_width, floa
     const int default_int = static_cast<int>(default_width);
     const int min_int = static_cast<int>(min_width);
 
-    // クライアント幅に基づいて有効な最大ペイン幅を計算する
-    int dynamic_max = default_int;
-    if (client_width > 0.0f) {
-        dynamic_max = std::max(min_int, static_cast<int>(client_width) - min_int);
-    }
-
-    // LoadInt は範囲外時に default_int を返すが、その既定値自体が
-    // 狭いウィンドウでは dynamic_max を超えうる。最終結果も clamp してから
-    // 適用し、SetXxxPaneWidth 側の最小値 clamp に過剰な幅が漏れないようにする。
-    const int file_w = std::clamp(config_.LoadInt(kSectionPane, kKeyFileWidth, default_int, min_int, dynamic_max), min_int, dynamic_max);
-    const int toc_w = std::clamp(config_.LoadInt(kSectionPane, kKeyTocWidth, default_int, min_int, dynamic_max), min_int, dynamic_max);
+    // 過剰幅の制限はレイアウト側 (pane_layout: md_width = max(md_min_width, total_width - x) で
+    // MD ペイン下限を保証) に委ね、ここでは下限のみ保証する。client_width で上限 clamp すると
+    // 狭いウィンドウ起動時に保存値が min へ潰れ、終了時の再保存で恒久喪失するため。
+    // 破損 INI 対策に実用上限のみ設ける。
+    constexpr int kPaneWidthLoadMax = 10000;
+    const int file_w = config_.LoadInt(kSectionPane, kKeyFileWidth, default_int, min_int, kPaneWidthLoadMax);
+    const int toc_w = config_.LoadInt(kSectionPane, kKeyTocWidth, default_int, min_int, kPaneWidthLoadMax);
     s.file_width = static_cast<float>(file_w);
     s.toc_width = static_cast<float>(toc_w);
     return s;

--- a/src/io/config_service.cpp
+++ b/src/io/config_service.cpp
@@ -211,10 +211,10 @@ SessionService::PaneState SessionService::LoadPaneState([[maybe_unused]] float c
     const int default_int = static_cast<int>(default_width);
     const int min_int = static_cast<int>(min_width);
 
-    // 過剰幅の制限はレイアウト側 (pane_layout: md_width = max(md_min_width, total_width - x) で
-    // MD ペイン下限を保証) に委ね、ここでは下限のみ保証する。client_width で上限 clamp すると
-    // 狭いウィンドウ起動時に保存値が min へ潰れ、終了時の再保存で恒久喪失するため。
-    // 破損 INI 対策に実用上限のみ設ける。
+    // 過剰幅の表示制限は ComputePaneLayout 側 (side 幅を表示時に clamp して MD ペインと
+    // スプリッタを画面内に保つ。論理幅は不変) に委ね、ここでは下限のみ保証する。
+    // client_width で上限 clamp すると狭いウィンドウ起動時に保存値が min へ潰れ、
+    // 終了時の再保存で恒久喪失するため。破損 INI 対策に実用上限のみ設ける。
     constexpr int kPaneWidthLoadMax = 10000;
     const int file_w = config_.LoadInt(kSectionPane, kKeyFileWidth, default_int, min_int, kPaneWidthLoadMax);
     const int toc_w = config_.LoadInt(kSectionPane, kKeyTocWidth, default_int, min_int, kPaneWidthLoadMax);

--- a/src/io/file_explorer.cpp
+++ b/src/io/file_explorer.cpp
@@ -6,6 +6,20 @@
 #include <filesystem>
 #include <iterator>
 
+namespace {
+// 列挙エントリを一覧に含めるか。"."/".."・システム属性を除外し、
+// ディレクトリまたは Markdown ファイルのみ対象とする。
+bool ShouldListEntry(const WIN32_FIND_DATAW& fd) noexcept
+{
+    const std::wstring_view name{ fd.cFileName };
+    if (name == L"." || name == L".." || (fd.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM) != 0) {
+        return false;
+    }
+    const bool is_dir = (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+    return is_dir || IsMarkdownFile(fd.cFileName);
+}
+} // namespace
+
 void FileExplorer::SetDirectory(std::wstring_view dir_path)
 {
     std::pmr::wstring normalized{ dir_path };
@@ -53,17 +67,11 @@ void FileExplorer::Refresh()
     static constexpr size_t MAX_ENTRIES = 4096;
 
     for (;;) {
-        const std::wstring_view name{ fd.cFileName };
-        const bool skip = (name == L"." || name == L"..") ||
-                          (fd.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM) != 0;
-        if (!skip) {
-            const bool is_dir = (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
-            if (is_dir || IsMarkdownFile(fd.cFileName)) {
-                FileEntry entry;
-                entry.full_path.assign((dir_base / fd.cFileName).native());
-                entry.set_directory(is_dir);
-                entries_.emplace_back(std::move(entry));
-            }
+        if (ShouldListEntry(fd)) {
+            FileEntry entry;
+            entry.full_path.assign((dir_base / fd.cFileName).native());
+            entry.set_directory((fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0);
+            entries_.emplace_back(std::move(entry));
         }
         if (entries_.size() - sort_begin >= MAX_ENTRIES) {
             break;

--- a/src/io/file_explorer.cpp
+++ b/src/io/file_explorer.cpp
@@ -52,28 +52,31 @@ void FileExplorer::Refresh()
 
     static constexpr size_t MAX_ENTRIES = 4096;
 
-    do {
+    for (;;) {
         const std::wstring_view name{ fd.cFileName };
-        if (name == L"." || name == L"..") {
-            continue;
-        }
-        if (fd.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM) {
-            continue;
+        const bool skip = (name == L"." || name == L"..") ||
+                          (fd.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM) != 0;
+        if (!skip) {
+            const bool is_dir = (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+            if (is_dir || IsMarkdownFile(fd.cFileName)) {
+                FileEntry entry;
+                entry.full_path.assign((dir_base / fd.cFileName).native());
+                entry.set_directory(is_dir);
+                entries_.emplace_back(std::move(entry));
+            }
         }
         if (entries_.size() - sort_begin >= MAX_ENTRIES) {
             break;
         }
-
-        const bool is_dir = (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
-        if (!is_dir && !IsMarkdownFile(fd.cFileName)) {
-            continue;
+        if (!FindNextFileW(hFind.get(), &fd)) {
+            // 列挙の途中失敗を正常終了 (ERROR_NO_MORE_FILES) と区別する。
+            // 中断時は部分結果を完全な一覧と誤認させないよう破棄する。
+            if (GetLastError() != ERROR_NO_MORE_FILES) {
+                entries_.resize(sort_begin);
+            }
+            break;
         }
-
-        FileEntry entry;
-        entry.full_path.assign((dir_base / fd.cFileName).native());
-        entry.set_directory(is_dir);
-        entries_.emplace_back(std::move(entry));
-    } while (FindNextFileW(hFind.get(), &fd));
+    }
 
     std::ranges::sort(entries_.begin() + static_cast<ptrdiff_t>(sort_begin), entries_.end(), [](const FileEntry& a, const FileEntry& b) noexcept {
         if (a.is_directory() != b.is_directory()) {

--- a/src/io/file_watcher.cpp
+++ b/src/io/file_watcher.cpp
@@ -115,7 +115,18 @@ void FileWatcher::CheckForChanges()
         const auto* buf_end = reinterpret_cast<const char*>(change_buf_) + bytes_returned;
         auto* info = reinterpret_cast<FILE_NOTIFY_INFORMATION*>(change_buf_);
         while (true) {
-            const std::wstring_view changed_name{ info->FileName, info->FileNameLength / sizeof(wchar_t) };
+            // カーネルが切り詰めた通知に備え、現在エントリの範囲を buf_end で検証してから
+            // 参照する (NextEntryOffset の検証は次エントリ用で先頭エントリを守らない)。
+            const auto* cur = reinterpret_cast<const char*>(info);
+            const auto* name_begin = cur + offsetof(FILE_NOTIFY_INFORMATION, FileName);
+            if (name_begin > buf_end) {
+                break;
+            }
+            const size_t name_bytes = info->FileNameLength;
+            if (name_begin + name_bytes > buf_end) {
+                break;
+            }
+            const std::wstring_view changed_name{ info->FileName, name_bytes / sizeof(wchar_t) };
             if (info->Action != FILE_ACTION_REMOVED &&
                 info->Action != FILE_ACTION_RENAMED_OLD_NAME &&
                 path_util::iequal(changed_name, watch_filename_)) {

--- a/src/io/file_watcher.cpp
+++ b/src/io/file_watcher.cpp
@@ -123,7 +123,10 @@ void FileWatcher::CheckForChanges()
                 break;
             }
             const size_t name_bytes = info->FileNameLength;
-            if (name_begin + name_bytes > buf_end) {
+            // name_begin <= buf_end は上で保証済み。巨大/破損した FileNameLength で
+            // OOB ポインタ (name_begin + name_bytes) を形成する前に、残りバッファ長と
+            // byte 数を比較する。
+            if (name_bytes > static_cast<size_t>(buf_end - name_begin)) {
                 break;
             }
             const std::wstring_view changed_name{ info->FileName, name_bytes / sizeof(wchar_t) };
@@ -136,11 +139,14 @@ void FileWatcher::CheckForChanges()
             if (info->NextEntryOffset == 0) {
                 break;
             }
-            auto* next = reinterpret_cast<char*>(info) + info->NextEntryOffset;
-            if (next + offsetof(FILE_NOTIFY_INFORMATION, FileName) > buf_end) {
+            // 次エントリも OOB ポインタを作る前に、残りバッファ長で NextEntryOffset を
+            // 検証する (固定部 offsetof(FileName) が収まることも要求する)。
+            const size_t remaining = static_cast<size_t>(buf_end - cur);
+            const size_t next_off = info->NextEntryOffset;
+            if (next_off > remaining || remaining - next_off < offsetof(FILE_NOTIFY_INFORMATION, FileName)) {
                 break;
             }
-            info = reinterpret_cast<FILE_NOTIFY_INFORMATION*>(next);
+            info = reinterpret_cast<FILE_NOTIFY_INFORMATION*>(reinterpret_cast<char*>(info) + next_off);
         }
     }
 

--- a/src/io/ini_parser.h
+++ b/src/io/ini_parser.h
@@ -44,6 +44,11 @@ inline IniData Parse(std::string_view text)
             if (close != std::string_view::npos) {
                 current_section = std::string(line.substr(1, close - 1));
             }
+            else {
+                // 未終端ブラケットは壊れたセクション開始。後続キーが直前セクションへ
+                // 誤混入するのを防ぐため無名セクションへ退避する。
+                current_section.clear();
+            }
             continue;
         }
 

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -268,6 +268,8 @@ public:
                 }
             }
             effects_generation_++;
+            // 差分エビクトが残置レイアウトを「破棄済み」と誤認して取り逃がすのを防ぐ。
+            ResetEvictionTracking();
         }
         else {
             // 縮小: Resize 経由で Fenwick もリセット (末尾の累積構造を保持できないため)

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -117,6 +117,11 @@ void MermaidRenderer::EnsureInitialized()
     }
 
     if (worker_count_ == 0) {
+        // ワーカーウィンドウを 1 つも作れなければ初期化済みフラグを戻し、
+        // 次回 RequestRender/RequestSvg で再試行できるようにする。
+        // 既にキューされた SVG リクエストは失敗で完了させ in-flight 固着を防ぐ。
+        lifecycle_.Reset();
+        FailPendingRequests();
         return;
     }
 
@@ -144,6 +149,10 @@ void MermaidRenderer::CreateWebView2Environment()
             if (env_retry_count_ < MAX_ENV_RETRIES && hwnd_) {
                 ++env_retry_count_;
                 SetTimer(hwnd_, std::to_underlying(app_timer::Id::MERMAID_INIT_RETRY), 500, nullptr);
+            }
+            else {
+                // リトライ上限。待機中リクエストを失敗で完了させ in-flight 固着を防ぐ。
+                FailPendingRequests();
             }
             return S_OK;
         }
@@ -311,6 +320,16 @@ void MermaidRenderer::InvokeSvgCallbackIfAny(RenderRequest& req, std::pmr::wstri
     }
     if (auto cb = std::move(req.svg_callback)) {
         cb(std::move(svg), cancelled);
+    }
+}
+
+void MermaidRenderer::FailPendingRequests()
+{
+    // 初期化が恒久的に失敗した場合に呼ぶ。待機中の SVG リクエストを失敗
+    // (cancelled=false) で完了させ、呼び出し元の in-flight フラグ固着を防ぐ。
+    while (!pending_requests_.empty()) {
+        InvokeSvgCallbackIfAny(pending_requests_.front(), {}, false);
+        pending_requests_.pop();
     }
 }
 

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -151,8 +151,14 @@ void MermaidRenderer::CreateWebView2Environment()
                 SetTimer(hwnd_, std::to_underlying(app_timer::Id::MERMAID_INIT_RETRY), 500, nullptr);
             }
             else {
-                // リトライ上限。待機中リクエストを失敗で完了させ in-flight 固着を防ぐ。
+                // リトライ上限。待機中リクエストを失敗で完了させてから状態を全リセットし、
+                // 次回 RequestRender/RequestSvg でクリーンに再初期化させる。リセットしないと
+                // initialized_ が立ったままで EnsureInitialized が二度と走らず、以後の
+                // リクエストが処理も失敗もされず in-flight 固着する。worker/env を残したまま
+                // 再 init するとリークするため Shutdown 経由で破棄する。
                 FailPendingRequests();
+                env_retry_count_ = 0;
+                Shutdown();
             }
             return S_OK;
         }

--- a/src/mermaid/mermaid.h
+++ b/src/mermaid/mermaid.h
@@ -105,6 +105,7 @@ private:
     void CreateWebView2Environment();
     void SetupWorker(int index);
     void ProcessQueue();
+    void FailPendingRequests();
     void RenderInWorker(Worker& worker);
     void OnRenderResult(int worker_idx, std::wstring_view json);
     // WebMessageReceived から受け取った parsed メッセージを worker[index] にディスパッチする。

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -486,8 +486,9 @@ void CommandGenerator::GenOverlayButton(DrawCommandList& cmds, D2D1_RECT_F btn, 
 
 void CommandGenerator::GenListBullet(DrawCommandList& cmds, const FrameContext& fc, const Node& node, const NodeLayoutEntry& entry, float x, float entry_text_top)
 {
-    if (const int32_t num = node.list_number(); num > 0) {
+    if (node.list_ordered()) {
         if (formats_.list_number) {
+            const int32_t num = node.list_number();
             const float first_line_h = GetFirstLineHeight(entry, theme_->font_size_body);
             wchar_t num_buf[16];
             const auto fmt_result = std::format_to_n(num_buf, std::size(num_buf), L"{}.", num);

--- a/src/render/d2d_render_backend.cpp
+++ b/src/render/d2d_render_backend.cpp
@@ -248,7 +248,10 @@ HRESULT D2DRenderBackend::Present() noexcept
         return E_FAIL;
     }
     const HRESULT hr = swap_chain_->Present(1, 0);
-    if (hr == DXGI_ERROR_DEVICE_REMOVED || hr == DXGI_ERROR_DEVICE_RESET) {
+    // TDR / ドライバ内部障害もデバイス再生成で復旧するため REMOVED/RESET と同様に扱う。
+    // OCCLUDED(成功) / WAS_STILL_DRAWING / INVALID_CALL は誤爆になるため拾わない。
+    if (hr == DXGI_ERROR_DEVICE_REMOVED || hr == DXGI_ERROR_DEVICE_RESET ||
+        hr == DXGI_ERROR_DEVICE_HUNG || hr == DXGI_ERROR_DRIVER_INTERNAL_ERROR) {
         device_lost_ = true;
     }
     return hr;

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -560,9 +560,10 @@ bool Renderer::CheckEndDraw()
         return false;
     }
     if (SUCCEEDED(hr)) {
-        const HRESULT hr_present = backend_.Present();
-        if (hr_present == DXGI_ERROR_DEVICE_REMOVED || hr_present == DXGI_ERROR_DEVICE_RESET) {
-            // backend 側で device_lost_ がセット済み。次フレーム冒頭の HandleDeviceLost で再作成。
+        backend_.Present();
+        if (backend_.IsDeviceLost()) {
+            // REMOVED/RESET/HUNG/DRIVER_INTERNAL_ERROR で backend が device_lost_ をセット済み。
+            // 次フレーム冒頭の HandleDeviceLost で再作成するため再描画を予約する。
             InvalidateRect(backend_.GetHwnd(), nullptr, FALSE);
             return false;
         }

--- a/src/ui/pane_layout.cpp
+++ b/src/ui/pane_layout.cpp
@@ -14,14 +14,34 @@ PaneLayout ComputePaneLayout(
         pane_height = 0.0f;
     }
 
+    // 保存幅がウィンドウより広い場合 (広いモニタで保存→狭い画面で起動した等) でも
+    // MD ペインとスプリッタを画面内に保つため、表示上の side 幅を clamp する。論理幅
+    // (PaneController::widths_) は変更しないので、ウィンドウを広げれば元に戻る。
+    // side がウィンドウに収まる通常時は no-op。
+    float fw = show_file ? file_pane_width : 0.0f;
+    float tw = show_toc ? toc_pane_width : 0.0f;
+    const float splitters = (show_file ? splitter_width : 0.0f) + (show_toc ? splitter_width : 0.0f);
+    const float avail_sides = total_width - md_min_width - splitters;
+    if (fw + tw > avail_sides) {
+        if (avail_sides <= 0.0f) {
+            fw = 0.0f;
+            tw = 0.0f;
+        }
+        else {
+            const float scale = avail_sides / (fw + tw); // fw + tw > avail_sides > 0
+            fw *= scale;
+            tw *= scale;
+        }
+    }
+
     if (show_file) {
-        layout.file_rect = { x, top_offset, file_pane_width, pane_height };
-        x += file_pane_width + splitter_width;
+        layout.file_rect = { x, top_offset, fw, pane_height };
+        x += fw + splitter_width;
     }
 
     if (show_toc) {
-        layout.toc_rect = { x, top_offset, toc_pane_width, pane_height };
-        x += toc_pane_width + splitter_width;
+        layout.toc_rect = { x, top_offset, tw, pane_height };
+        x += tw + splitter_width;
     }
 
     const float md_width = std::max(md_min_width, total_width - x);

--- a/src/ui/tooltip.cpp
+++ b/src/ui/tooltip.cpp
@@ -64,13 +64,15 @@ void Tooltip::Init(HWND parent_hwnd)
 bool Tooltip::Update(const TooltipTarget& target, int screen_x, int screen_y)
 {
     auto& s = *impl_;
+    // ターゲットが同一でも位置は更新する。表示前 (タイマー待ち) に同一ターゲット内で
+    // カーソルが動いた場合でも、最新のカーソル位置で表示させるため。
+    s.show_pos = POINT{ screen_x, screen_y };
     if (target == s.current) {
         return false;
     }
 
     Hide();
     s.current = target;
-    s.show_pos = POINT{ screen_x, screen_y };
 
     if (s.current.IsEmpty()) {
         return false;

--- a/src/ui/tooltip.cpp
+++ b/src/ui/tooltip.cpp
@@ -11,7 +11,6 @@ struct Tooltip::Impl {
     HWND hwnd = nullptr;
     HWND parent = nullptr;
     TooltipTarget current;
-    POINT show_pos{};
     bool visible = false;
 
     ~Impl()
@@ -61,12 +60,9 @@ void Tooltip::Init(HWND parent_hwnd)
     SendMessageW(s.hwnd, TTM_SETMAXTIPWIDTH, 0, 600);
 }
 
-bool Tooltip::Update(const TooltipTarget& target, int screen_x, int screen_y)
+bool Tooltip::Update(const TooltipTarget& target, [[maybe_unused]] int screen_x, [[maybe_unused]] int screen_y)
 {
     auto& s = *impl_;
-    // ターゲットが同一でも位置は更新する。表示前 (タイマー待ち) に同一ターゲット内で
-    // カーソルが動いた場合でも、最新のカーソル位置で表示させるため。
-    s.show_pos = POINT{ screen_x, screen_y };
     if (target == s.current) {
         return false;
     }
@@ -94,9 +90,14 @@ void Tooltip::Show()
     ti.lpszText = const_cast<LPWSTR>(s.current.text.c_str());
     SendMessageW(s.hwnd, TTM_UPDATETIPTEXTW, 0, reinterpret_cast<LPARAM>(&ti));
 
+    // 表示時点の実カーソル位置を使う。タイマー待機中に同一ターゲット内でカーソルが
+    // 動いても最新位置で表示するため (同一ターゲットでは reducer 側で抑止され Update は
+    // 呼ばれないので、保存した位置では陳腐化する)。
+    POINT pt{};
+    GetCursorPos(&pt);
     const UINT dpi = GetDpiForWindow(s.parent);
     const int offset_y = MulDiv(20, dpi, 96);
-    SendMessageW(s.hwnd, TTM_TRACKPOSITION, 0, MAKELPARAM(s.show_pos.x, s.show_pos.y + offset_y));
+    SendMessageW(s.hwnd, TTM_TRACKPOSITION, 0, MAKELPARAM(pt.x, pt.y + offset_y));
 
     SendMessageW(s.hwnd, TTM_TRACKACTIVATE, TRUE, reinterpret_cast<LPARAM>(&ti));
     s.visible = true;

--- a/src/util/clipboard_util.h
+++ b/src/util/clipboard_util.h
@@ -36,34 +36,50 @@ private:
     bool open_;
 };
 
+// EmptyClipboard より前にバッファを確保できるよう、構築と SetClipboardData を分離する。
+// 確保失敗時に既存クリップボードを破壊しないための土台 (WriteClipboardSvg 参照)。
+template <typename CharT>
+inline UniqueGlobalMem BuildGlobalZeroTerminated(std::basic_string_view<CharT> text) noexcept
+{
+    // text.size() + 1 が SIZE_MAX/sizeof(CharT) を超えると bytes 計算がオーバーフローする。
+    // GlobalAlloc は size_t 受けでも実用上数 GB が上限なので、UINT_MAX を実用上限とする。
+    if (text.size() > std::numeric_limits<UINT>::max() / sizeof(CharT) - 1) {
+        return {};
+    }
+    const size_t bytes = (text.size() + 1) * sizeof(CharT);
+    UniqueGlobalMem hMem{ GlobalAlloc(GMEM_MOVEABLE, bytes) };
+    if (!hMem) {
+        return {};
+    }
+    auto* dest = static_cast<CharT*>(GlobalLock(hMem.get()));
+    if (!dest) {
+        return {};
+    }
+    std::char_traits<CharT>::copy(dest, text.data(), text.size());
+    dest[text.size()] = CharT{};
+    GlobalUnlock(hMem.get());
+    return hMem;
+}
+
+inline bool CommitClipboardGlobal(UINT format, UniqueGlobalMem mem) noexcept
+{
+    if (format == 0 || !mem) {
+        return false;
+    }
+    if (!SetClipboardData(format, mem.get())) {
+        return false;
+    }
+    mem.release();
+    return true;
+}
+
 template <typename CharT>
 inline bool SetClipboardZeroTerminated(UINT format, std::basic_string_view<CharT> text) noexcept
 {
     if (format == 0) {
         return false;
     }
-    // text.size() + 1 が SIZE_MAX/sizeof(CharT) を超えると bytes 計算がオーバーフローする。
-    // GlobalAlloc は size_t 受けでも実用上数 GB が上限なので、UINT_MAX を実用上限とする。
-    if (text.size() > std::numeric_limits<UINT>::max() / sizeof(CharT) - 1) {
-        return false;
-    }
-    const size_t bytes = (text.size() + 1) * sizeof(CharT);
-    UniqueGlobalMem hMem{ GlobalAlloc(GMEM_MOVEABLE, bytes) };
-    if (!hMem) {
-        return false;
-    }
-    auto* dest = static_cast<CharT*>(GlobalLock(hMem.get()));
-    if (!dest) {
-        return false;
-    }
-    std::char_traits<CharT>::copy(dest, text.data(), text.size());
-    dest[text.size()] = CharT{};
-    GlobalUnlock(hMem.get());
-    if (!SetClipboardData(format, hMem.get())) {
-        return false;
-    }
-    hMem.release();
-    return true;
+    return CommitClipboardGlobal(format, BuildGlobalZeroTerminated<CharT>(text));
 }
 
 // Utf8ToWide 失敗時に EmptyClipboard で既存内容を破壊しないよう、変換成功後にセッションを開く。
@@ -136,21 +152,28 @@ inline bool WriteClipboardSvg(HWND hwnd, std::wstring_view svg_text) noexcept
     if (svg_text.empty()) {
         return false;
     }
+    // EmptyClipboard より前に各バッファを確保する。確保に失敗しても既存クリップボードを
+    // 破壊しない (HTML 経路と同様の「揃ってから開く」方針)。
+    UniqueGlobalMem unicode_mem = BuildGlobalZeroTerminated<wchar_t>(svg_text);
+    if (!unicode_mem) {
+        return false;
+    }
+    const std::string svg_utf8 = string_convert::WideToUtf8(svg_text);
+    UniqueGlobalMem svg_mem = svg_utf8.empty()
+        ? UniqueGlobalMem{}
+        : BuildGlobalZeroTerminated<char>(std::string_view(svg_utf8));
+
     ClipboardSession session(hwnd);
     if (!session) {
         return false;
     }
 
     bool any_set = false;
-
-    const std::string svg_utf8 = string_convert::WideToUtf8(svg_text);
-    if (!svg_utf8.empty()) {
+    if (svg_mem) {
         static const UINT cf_svg = RegisterClipboardFormatW(L"image/svg+xml");
-        any_set |= SetClipboardZeroTerminated<char>(cf_svg, svg_utf8);
+        any_set |= CommitClipboardGlobal(cf_svg, std::move(svg_mem));
     }
-
-    any_set |= SetClipboardZeroTerminated<wchar_t>(CF_UNICODETEXT, svg_text);
-
+    any_set |= CommitClipboardGlobal(CF_UNICODETEXT, std::move(unicode_mem));
     return any_set;
 }
 

--- a/src/util/clipboard_util.h
+++ b/src/util/clipboard_util.h
@@ -76,9 +76,7 @@ inline bool CommitClipboardGlobal(UINT format, UniqueGlobalMem mem) noexcept
 template <typename CharT>
 inline bool SetClipboardZeroTerminated(UINT format, std::basic_string_view<CharT> text) noexcept
 {
-    if (format == 0) {
-        return false;
-    }
+    // format==0 と確保失敗の判定は CommitClipboardGlobal 側に集約する。
     return CommitClipboardGlobal(format, BuildGlobalZeroTerminated<CharT>(text));
 }
 

--- a/src/util/file_io.cpp
+++ b/src/util/file_io.cpp
@@ -82,6 +82,9 @@ bool AtomicWriteAllBytes(const std::filesystem::path& path, const void* data, si
     tmp_path += L".tmp";
 
     if (!WriteAllBytes(tmp_path, data, size)) {
+        // 書き込み途中失敗でも CREATE_ALWAYS で tmp は生成済み。部分書き込みの
+        // 孤児 tmp を残さないよう掃除する。
+        DeleteFileW(tmp_path.c_str());
         return false;
     }
 

--- a/src/util/worker_latch.h
+++ b/src/util/worker_latch.h
@@ -11,7 +11,9 @@
 //   ...
 //   ~Owner() { latch_.Wait(); }            // 既に Post 済みの worker 完了を待つ
 //
-// Wait は in_flight が 0 の場合 lock を取らず即時 return する。
+// Wait は worker が cv/mutex へのアクセスを完了するまで待機する。lock-free fast-path を
+// 持つと「Wait が抜けた直後に latch 破棄 → worker が破棄済み cv/mutex を触る」破棄レースに
+// なるため、判定は常に mutex 下で行う。
 class WorkerLatch {
 public:
     class Guard {
@@ -46,11 +48,15 @@ public:
             if (!latch_) {
                 return;
             }
-            // fetch_sub の acq_rel は Wait 側 acquire load と対になり、worker が触った
-            // sink メモリの可視性を保証する。
-            if (latch_->in_flight_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            // デクリメントと notify を同一 mutex 区間で完結させる。これにより Wait が
+            // 抜けた時点で worker は cv/mutex へのアクセスを終えており、直後に latch が
+            // 破棄されても use-after-free にならない。acq_rel は worker が触った sink
+            // メモリの可視性を Wait 側へ保証する。
+            {
                 const std::lock_guard lock(latch_->mutex_);
-                latch_->cv_.notify_all();
+                if (latch_->in_flight_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+                    latch_->cv_.notify_all();
+                }
             }
             latch_ = nullptr;
         }
@@ -71,12 +77,9 @@ public:
 
     void Wait() noexcept
     {
-        if (in_flight_.load(std::memory_order_acquire) == 0) {
-            return;
-        }
         std::unique_lock lock(mutex_);
         cv_.wait(lock, [this] {
-            return in_flight_.load(std::memory_order_acquire) == 0;
+            return in_flight_.load(std::memory_order_relaxed) == 0;
         });
     }
 

--- a/tests/test_mouse_gesture.cpp
+++ b/tests/test_mouse_gesture.cpp
@@ -74,9 +74,9 @@ TEST_F(MouseGestureTest, LeftGestureReturnsBack)
     EXPECT_FALSE(gesture_.IsOverlayVisible());
 }
 
-// ─── 垂直移動 → None ───
+// ─── 垂直移動 (方向なし) → ShowContextMenu (右クリック扱いでメニュー表示) ───
 
-TEST_F(MouseGestureTest, VerticalGestureReturnsNone)
+TEST_F(MouseGestureTest, VerticalGestureReturnsShowContextMenu)
 {
     gesture_.OnRButtonDown(100.0f, 100.0f);
     gesture_.OnMouseMove(100.0f, 200.0f);  // 下に100px
@@ -85,8 +85,9 @@ TEST_F(MouseGestureTest, VerticalGestureReturnsNone)
     EXPECT_EQ(gesture_.GetDirection(), GestureDirection::None);
     EXPECT_FALSE(gesture_.IsOverlayVisible());
 
+    // 方向が確定しなかった右ドラッグはイベントを握り潰さず、コンテキストメニューを表示する。
     auto result = gesture_.OnRButtonUp();
-    EXPECT_EQ(result, GestureResult::None);
+    EXPECT_EQ(result, GestureResult::ShowContextMenu);
     EXPECT_EQ(gesture_.GetPhase(), GesturePhase::Idle);
 }
 

--- a/tests/test_pane_layout.cpp
+++ b/tests/test_pane_layout.cpp
@@ -277,6 +277,36 @@ TEST(ComputePaneLayout, VeryNarrowWindow)
     EXPECT_GE(layout.md_rect.width, 200.0f);
 }
 
+TEST(ComputePaneLayout, OversizedSavedWidthsKeepMdOnScreen)
+{
+    // 広いモニタで保存した side 幅 (合計がウィンドウ超過) で狭い画面に起動しても、
+    // MD ペインとスプリッタは画面内に収まり、操作不能ロックアウトにならない。
+    const float total = 700.0f;
+    const float md_min = 200.0f;
+    auto layout = ComputePaneLayout(total, 600.0f, 2000.0f, 2000.0f, 4.0f, true, true, md_min);
+
+    EXPECT_GE(layout.md_rect.width, md_min);
+    // MD ペイン左端が画面内に収まる (md_min 幅を確保できる位置)
+    EXPECT_LE(layout.md_rect.x, total - md_min);
+    // 両スプリッタが画面内に残る (ドラッグで回復可能)
+    const float splitter1_x = layout.file_rect.x + layout.file_rect.width;
+    const float splitter2_x = layout.toc_rect.x + layout.toc_rect.width;
+    EXPECT_LT(splitter1_x, total);
+    EXPECT_LT(splitter2_x, total);
+}
+
+TEST(ComputePaneLayout, SingleOversizedPaneKeepsSplitterOnScreen)
+{
+    // 片ペインの保存幅だけでウィンドウを超える場合でも、そのスプリッタは画面内に残る。
+    const float total = 600.0f;
+    const float md_min = 200.0f;
+    auto layout = ComputePaneLayout(total, 600.0f, 5000.0f, 0.0f, 4.0f, true, false, md_min);
+
+    EXPECT_GE(layout.md_rect.width, md_min);
+    const float splitter1_x = layout.file_rect.x + layout.file_rect.width;
+    EXPECT_LT(splitter1_x, total);
+}
+
 TEST(DetectPaneZone, ExactlySplitter1Edge)
 {
     auto layout = ComputePaneLayout(1200.0f, 600.0f, 220.0f, 220.0f, 4.0f, true, true);

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -218,7 +218,8 @@ TEST(Parser, UnorderedList)
     ASSERT_EQ(nodes.size(), 3u);
     for (const auto& node : nodes) {
         EXPECT_EQ(node.type, NodeType::ListItem);
-        EXPECT_EQ(node.list_number(), 0); // 順序なしリスト
+        EXPECT_EQ(node.list_number(), 0);  // 順序なしリスト
+        EXPECT_FALSE(node.list_ordered()); // ordered フラグも false
     }
     EXPECT_EQ(nodes[0].GetText(), "item1");
     EXPECT_EQ(nodes[1].GetText(), "item2");
@@ -365,6 +366,7 @@ TEST(Parser, OrderedList)
     ASSERT_EQ(nodes.size(), 3u);
     for (const auto& node : nodes) {
         EXPECT_EQ(node.type, NodeType::ListItem);
+        EXPECT_TRUE(node.list_ordered());
     }
     EXPECT_EQ(nodes[0].list_number(), 1);
     EXPECT_EQ(nodes[1].list_number(), 2);
@@ -377,6 +379,19 @@ TEST(Parser, OrderedListStartsFromN)
     ASSERT_EQ(nodes.size(), 2u);
     EXPECT_EQ(nodes[0].list_number(), 5);
     EXPECT_EQ(nodes[1].list_number(), 6);
+}
+
+// `0.` 始まりの順序リスト: 旧実装の list_number()>0 プロキシでは unordered と誤認される。
+// ordered フラグと番号 0 の保持を検証する (PR#249 Copilot レビュー指摘の回帰テスト)。
+TEST(Parser, OrderedListStartsFromZero)
+{
+    auto nodes = ParseMarkdown("0. zero\n1. one").nodes;
+    ASSERT_EQ(nodes.size(), 2u);
+    EXPECT_EQ(nodes[0].type, NodeType::ListItem);
+    EXPECT_TRUE(nodes[0].list_ordered());
+    EXPECT_EQ(nodes[0].list_number(), 0);
+    EXPECT_TRUE(nodes[1].list_ordered());
+    EXPECT_EQ(nodes[1].list_number(), 1);
 }
 
 TEST(Parser, ListIndentLevel)

--- a/tests/test_session_service.cpp
+++ b/tests/test_session_service.cpp
@@ -31,22 +31,22 @@ TEST_F(SessionServiceTest, SaveAndLoadPaneState)
     EXPECT_FLOAT_EQ(loaded.toc_width, 250.0f);
 }
 
-TEST_F(SessionServiceTest, LoadPaneStateClampsOutOfRangeValuesToDynamicMax)
+TEST_F(SessionServiceTest, LoadPaneStateKeepsSavedWidthWithoutWindowClamp)
 {
-    // 保存値が dynamic_max を超える場合、GetInt はデフォルト値 (PANE_DEFAULT_WIDTH=220) を
-    // 返す。狭いウィンドウでは既定値自体が dynamic_max を超えうるため、
-    // LoadPaneState 側で最終結果も clamp し、過剰な幅を返さない。
+    // 過剰幅の制限はレイアウト側 (md_width = max(md_min_width, total_width - x) で MD ペイン
+    // 下限を保証) に委ねるため、LoadPaneState は client_width に基づく上限 clamp を行わず、
+    // 保存値をそのまま返す。これにより狭いウィンドウ起動時に保存値が min へ潰れて
+    // 終了時の再保存で恒久喪失するのを防ぐ。
     config_.SaveInt("Pane", "FileWidth", 500);
     config_.SaveInt("Pane", "TocWidth", 500);
 
-    // client_width=300 → dynamic_max = max(100, 300-100) = 200
+    // 狭い client_width=300 でも保存値はそのまま保持される
     const auto loaded = session_.LoadPaneState(300.0f,
                                                PaneController::PANE_MIN_WIDTH,
                                                PaneController::PANE_DEFAULT_WIDTH);
 
-    // dynamic_max=200 で clamp される（fix 前は 220 が漏れていた）
-    EXPECT_FLOAT_EQ(loaded.file_width, 200.0f);
-    EXPECT_FLOAT_EQ(loaded.toc_width, 200.0f);
+    EXPECT_FLOAT_EQ(loaded.file_width, 500.0f);
+    EXPECT_FLOAT_EQ(loaded.toc_width, 500.0f);
 }
 
 TEST_F(SessionServiceTest, LoadPaneStateUsesDefaultWhenWindowFitsIt)


### PR DESCRIPTION
## 概要

アプリ全体のコードレビュー (`/code-review`) で検出した不具合・改善点をまとめて修正しました。各修正は独立した検証エージェントで CONFIRMED を確認し、誤検知 (REFUTED) や設計上意図的なものは除外しています。

## 修正内容

### 🔴 重大（クラッシュ / データ損失）
- **worker_latch**: `Wait()` の lock-free fast-path を撤去し、デクリメントと notify を同一 mutex 区間に統一。condition_variable/mutex の破棄レース (UAF) を解消。
- **図PNG保存**: `WriteAllBytes` → `AtomicWriteAllBytes` (tmp+rename)。上書き選択時に書き込み失敗で原本を破壊する問題を解消。
- **非同期リロード**: PrefixGrowth 経路で `ClearResolvedPaths()` を呼び、ノード index ずれによる別画像解決を防止。
- **file_watcher**: 先頭 `FILE_NOTIFY_INFORMATION` の FileName 範囲を `buf_end` で検証し、切り詰め通知での OOB 読み取りを防止。
- **クリップボード(SVG)**: バッファ確保を `EmptyClipboard` の前に行い、確保失敗時に既存内容を破壊しないよう構築と確定を分離。

### 🟠 機能不全
- **mermaid**: 全ワーカー生成失敗時に初期化フラグを戻して再試行可能化。初期化が恒久的に失敗した場合は待機中 SVG リクエストを失敗で完了させ、コピーUIの固着を防止。
- **右クリックジェスチャ**: 方向が確定しない右ドラッグを通常の右クリック扱いとし、コンテキストメニューを表示。
- **ファイル一覧**: `FindNextFileW` の失敗を `ERROR_NO_MORE_FILES` と区別し、列挙中断時は部分一覧を破棄。
- **レイアウトキャッシュ**: `ResizePreservingPrefix` 拡大時に eviction 追跡境界をリセットし、差分エビクトによる `IDWriteTextLayout` リークを防止。

### 🟡 表示 / 性能
- **mermaidキャッシュ**: オフスクリーン evict 時の全消去をやめ、二次キャッシュ(LRU 128件)の自前上限管理に委ねて再レンダの cliff を解消。
- **順序リスト**: `0.` 始まりの順序リストを番号付きで描画 (`NodeListData.ordered` を追加)。
- **シンタックス**: 生文字列 `R"..."` 判定を `LexerConfig.raw_string` で C/C++ に限定し、他言語の誤ハイライトを解消。
- **ホバー**: リフロー時にヒットキャッシュを無効化してカーソル形状の陳腐化を解消。`HitTest` overload でホバー毎のコンテキスト二重構築を解消。
- **ツールチップ**: 同一ターゲットでも表示位置を更新。
- **描画**: `Present` の TDR系 HRESULT (`DEVICE_HUNG`/`DRIVER_INTERNAL_ERROR`) をデバイスロスト扱いし、`IsDeviceLost()` で一元化。
- **ペイン幅**: 狭ウィンドウ起動時に保存値が最小値へ潰れて恒久喪失する問題を解消（上限 clamp は描画側の下限保証に委譲）。

## テスト

- `cmake --build build --config Release` → エラー/警告なし
- `mendo_tests.exe` → **2274 / 2274 PASSED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)