### PR TITLE
test: WideViewCache と BlockHScrollGeometry のテストを追加

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,6 +80,7 @@ add_executable(mendo_tests
     test_preloader.cpp
     test_clipboard_util.cpp
     test_clipboard_manager.cpp
+    test_block_h_scroll.cpp
     app_search_bar_callbacks_stub.cpp
 )
 

--- a/tests/test_block_h_scroll.cpp
+++ b/tests/test_block_h_scroll.cpp
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+#include "block_h_scroll.h"
+#include "theme.h"
+
+// ─────────────────────────────────────────────
+// BlockHScrollGeometry::can_scroll / scroll_max（純粋な境界ロジック）
+// ─────────────────────────────────────────────
+
+TEST(BlockHScrollGeometry, ScrollableWhenNaturalExceedsVisible)
+{
+    constexpr BlockHScrollGeometry g{ .natural_width = 200.0f, .visible_width = 100.0f };
+    EXPECT_TRUE(g.can_scroll());
+    EXPECT_FLOAT_EQ(g.scroll_max(), 100.0f);
+}
+
+TEST(BlockHScrollGeometry, NotScrollableWhenEqual)
+{
+    constexpr BlockHScrollGeometry g{ .natural_width = 100.0f, .visible_width = 100.0f };
+    EXPECT_FALSE(g.can_scroll());
+    EXPECT_FLOAT_EQ(g.scroll_max(), 0.0f);
+}
+
+TEST(BlockHScrollGeometry, NotScrollableWhenNaturalSmaller)
+{
+    constexpr BlockHScrollGeometry g{ .natural_width = 50.0f, .visible_width = 100.0f };
+    EXPECT_FALSE(g.can_scroll());
+    EXPECT_FLOAT_EQ(g.scroll_max(), 0.0f);
+}
+
+// visible_width が 0（未レイアウト）のとき can_scroll は false。scroll_max は
+// can_scroll でガードされる前提のため、ここでは natural をそのまま返す挙動を固定する。
+TEST(BlockHScrollGeometry, NotScrollableWhenVisibleZero)
+{
+    constexpr BlockHScrollGeometry g{ .natural_width = 200.0f, .visible_width = 0.0f };
+    EXPECT_FALSE(g.can_scroll());
+    EXPECT_FLOAT_EQ(g.scroll_max(), 200.0f);
+}
+
+TEST(BlockHScrollGeometry, DefaultIsNotScrollable)
+{
+    constexpr BlockHScrollGeometry g;
+    EXPECT_FALSE(g.can_scroll());
+    EXPECT_FLOAT_EQ(g.scroll_max(), 0.0f);
+}
+
+// ─────────────────────────────────────────────
+// GetBlockHScrollGeometry: ノード種別ごとの natural_width 選択 / visible_width 計算
+// ─────────────────────────────────────────────
+
+// CodeBlock（diagram でない）は natural_code_width を採用する。
+TEST(GetBlockHScrollGeometry, ScrollableCodeBlockUsesNaturalCodeWidth)
+{
+    const Theme theme = GetLightTheme();
+    Node node;
+    node.type = NodeType::CodeBlock; // code_language()==None → IsScrollableCodeBlock
+    NodeLayoutEntry entry;
+    entry.natural_code_width = 1234.0f;
+
+    constexpr float kPaneWidth = 800.0f;
+    const auto g = GetBlockHScrollGeometry(node, entry, theme, kPaneWidth);
+    EXPECT_FLOAT_EQ(g.natural_width, 1234.0f);
+    EXPECT_FLOAT_EQ(g.visible_width, theme.ContentWidth(kPaneWidth));
+}
+
+// Table は table_layout->natural_total_width を採用する。
+TEST(GetBlockHScrollGeometry, TableUsesNaturalTotalWidth)
+{
+    const Theme theme = GetLightTheme();
+    Node node;
+    node.type = NodeType::Table;
+    NodeLayoutEntry entry;
+    entry.ensure_table_layout().natural_total_width = 2048.0f;
+
+    const auto g = GetBlockHScrollGeometry(node, entry, theme, 800.0f);
+    EXPECT_FLOAT_EQ(g.natural_width, 2048.0f);
+}
+
+// table_layout 未確保（未計測）の Table は natural_width=0 でスクロール不可。
+TEST(GetBlockHScrollGeometry, TableWithoutLayoutHasZeroNatural)
+{
+    const Theme theme = GetLightTheme();
+    Node node;
+    node.type = NodeType::Table;
+    NodeLayoutEntry entry;
+
+    const auto g = GetBlockHScrollGeometry(node, entry, theme, 800.0f);
+    EXPECT_FLOAT_EQ(g.natural_width, 0.0f);
+    EXPECT_FALSE(g.can_scroll());
+}
+
+// 段落はスクロール非対象。natural_code_width をセットしても無視される。
+TEST(GetBlockHScrollGeometry, ParagraphIsNotScrollable)
+{
+    const Theme theme = GetLightTheme();
+    Node node;
+    node.type = NodeType::Paragraph;
+    NodeLayoutEntry entry;
+    entry.natural_code_width = 9999.0f;
+
+    const auto g = GetBlockHScrollGeometry(node, entry, theme, 800.0f);
+    EXPECT_FLOAT_EQ(g.natural_width, 0.0f);
+    EXPECT_FALSE(g.can_scroll());
+}
+
+// indent_level の分だけ visible_width が縮む（ネストしたコードブロック）。
+TEST(GetBlockHScrollGeometry, IndentReducesVisibleWidth)
+{
+    const Theme theme = GetLightTheme();
+    Node node;
+    node.type = NodeType::CodeBlock;
+    node.indent_level = 2;
+    NodeLayoutEntry entry;
+    entry.natural_code_width = 1000.0f;
+
+    constexpr float kPaneWidth = 800.0f;
+    const auto g = GetBlockHScrollGeometry(node, entry, theme, kPaneWidth);
+    EXPECT_FLOAT_EQ(g.visible_width, theme.ContentWidth(kPaneWidth) - 2 * theme.indent_width);
+}

--- a/tests/test_doc_dwrite_bridge.cpp
+++ b/tests/test_doc_dwrite_bridge.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include "doc_dwrite_bridge.h"
 
+using mendo::WideViewCache;
 using mendo::WideViewForDWrite;
 
 // ─────────────────────────────────────────────
@@ -121,4 +122,106 @@ TEST(WideViewForDWrite, WideRangeForCjk)
     const auto r = wv.WideRange(3, 3);
     EXPECT_EQ(r.startPosition, 1u);
     EXPECT_EQ(r.length, 1u);
+}
+
+// ─────────────────────────────────────────────
+// WideViewCache: (data ポインタ + size) identity ベースの decode キャッシュ
+// ─────────────────────────────────────────────
+
+TEST(WideViewCache, ReturnsCorrectWideForText)
+{
+    WideViewCache cache;
+    EXPECT_EQ(cache.Get("Hello").wide(), L"Hello");
+    EXPECT_EQ(cache.Get("テスト").wide(), L"テスト");
+}
+
+TEST(WideViewCache, EmptyText)
+{
+    WideViewCache cache;
+    EXPECT_TRUE(cache.Get("").wide().empty());
+}
+
+// identity (data ポインタ + size) が一致する限り再 decode しない。バッファ内容を
+// 破壊的に書き換えても旧結果が返ることでキャッシュヒットを観測する。
+TEST(WideViewCache, ReusesResultForSameBuffer)
+{
+    WideViewCache cache;
+    char buf[] = "Hello";
+    const std::string_view sv{ buf, 5 };
+    EXPECT_EQ(cache.Get(sv).wide(), L"Hello");
+
+    buf[0] = 'J'; // "Jello" だが data/size 不変なのでキャッシュヒット
+    EXPECT_EQ(cache.Get(sv).wide(), L"Hello");
+}
+
+TEST(WideViewCache, RebuildsForDifferentBuffer)
+{
+    WideViewCache cache;
+    char a[] = "Hello";
+    char b[] = "World";
+    EXPECT_EQ(cache.Get(std::string_view{ a, 5 }).wide(), L"Hello");
+    EXPECT_EQ(cache.Get(std::string_view{ b, 5 }).wide(), L"World");
+}
+
+// data ポインタが同一でも size が違えば別文字列として再構築する。
+TEST(WideViewCache, RebuildsForSamePointerDifferentSize)
+{
+    WideViewCache cache;
+    char buf[] = "Hello";
+    EXPECT_EQ(cache.Get(std::string_view{ buf, 5 }).wide(), L"Hello");
+    EXPECT_EQ(cache.Get(std::string_view{ buf, 3 }).wide(), L"Hel");
+}
+
+TEST(WideViewCache, ResetForcesRebuild)
+{
+    WideViewCache cache;
+    char buf[] = "Hello";
+    const std::string_view sv{ buf, 5 };
+    EXPECT_EQ(cache.Get(sv).wide(), L"Hello");
+
+    buf[0] = 'J'; // "Jello"
+    cache.Reset();
+    EXPECT_EQ(cache.Get(sv).wide(), L"Jello");
+}
+
+TEST(WideViewCache, WideRangeDelegatesToGet)
+{
+    WideViewCache cache;
+    // [3, 6) byte = 「ス」 = wide [1, 2)
+    const auto r = cache.WideRange("テスト", 3, 3);
+    EXPECT_EQ(r.startPosition, 1u);
+    EXPECT_EQ(r.length, 1u);
+}
+
+// owner identity が不変ならキャッシュを保持する。
+TEST(WideViewCache, ResetIfBufferChangedKeepsCacheForSameOwner)
+{
+    WideViewCache cache;
+    char buf[] = "Hello";
+    const std::string_view sv{ buf, 5 };
+    int owner = 0;
+
+    cache.ResetIfBufferChanged(&owner, 1);
+    EXPECT_EQ(cache.Get(sv).wide(), L"Hello");
+
+    buf[0] = 'J';
+    cache.ResetIfBufferChanged(&owner, 1); // 同一 owner → Reset しない
+    EXPECT_EQ(cache.Get(sv).wide(), L"Hello");
+}
+
+// owner identity が変われば Reset し、次の Get で再構築する。
+TEST(WideViewCache, ResetIfBufferChangedClearsCacheForNewOwner)
+{
+    WideViewCache cache;
+    char buf[] = "Hello";
+    const std::string_view sv{ buf, 5 };
+    int owner_a = 0;
+    int owner_b = 0;
+
+    cache.ResetIfBufferChanged(&owner_a, 1);
+    EXPECT_EQ(cache.Get(sv).wide(), L"Hello");
+
+    buf[0] = 'J';
+    cache.ResetIfBufferChanged(&owner_b, 1); // 別 owner → Reset
+    EXPECT_EQ(cache.Get(sv).wide(), L"Jello");
 }


### PR DESCRIPTION
## 概要
アプリ全体を確認し、純粋ロジックで未検証だった 2 箇所にユニットテストを追加しました（計 19 ケース）。既存テストは 2277 個・139 スイートと既に高品質なため、本当に穴があった箇所のみに絞っています。

## 追加内容
### WideViewCache (`doc_dwrite_bridge.h`) — 9 ケース
UTF-8→UTF-16 decode の identity(data ポインタ + size) ベースキャッシュ。`WideViewForDWrite` 本体は手厚くテストされていたが、それをキャッシュするクラスが未検証だった。
- 「同一バッファを破壊的に書き換えても旧結果が返る」性質でキャッシュヒットを観測
- `Reset` / `ResetIfBufferChanged`（owner identity 追跡）/ `WideRange` の挙動

### BlockHScrollGeometry / GetBlockHScrollGeometry (`block_h_scroll.h`) — 10 ケース
ブロック横スクロールのジオメトリ計算。
- `can_scroll` / `scroll_max` の境界（visible=0、natural==visible 等）
- CodeBlock / Table / 段落のノード種別ごとの `natural_width` 選択
- indent_level による `visible_width` の縮小

## テスト結果
全 **2296 tests passed**（既存 2277 + 新規 19、回帰なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)