### PR TITLE
fix: リストバレット半径をズーム倍率に連動させる (#251)

### DIFF
--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -502,14 +502,14 @@ void CommandGenerator::GenListBullet(DrawCommandList& cmds, const FrameContext& 
         }
     }
     else {
-        // 大きい scroll_y を SetTransform で適用すると D2D が小半径 (LIST_BULLET_RADIUS=3 DIP)
+        // 大きい scroll_y を SetTransform で適用すると D2D が小半径 (list_bullet_radius≒3 DIP)
         // の楕円を bounding rect (長方形) に縮退させるため、bullet だけ Identity transform +
         // baked 座標で描画する。
         const float first_line_h = GetFirstLineHeight(entry, theme_->font_size_body);
         // X は Identity 化に伴い md_pane_x を手動で加算。Y は entry_text_top が既にローカル Y。
         const float bullet_x = SnapToPhysicalPixel(fc.md_pane_x + x - theme_->list_bullet_offset * LIST_BULLET_X_FACTOR, fc.dpi_scale);
         const float bullet_y = SnapToPhysicalPixel(entry_text_top + first_line_h * 0.5f, fc.dpi_scale);
-        const float r = LIST_BULLET_RADIUS;
+        const float r = theme_->list_bullet_radius;
         cmds.emplace_back(SetTransformCmd{ D2D1::Matrix3x2F::Identity() });
         if (node.indent_level <= 1) {
             cmds.emplace_back(FillEllipseCmd{ D2D1::Point2F(bullet_x, bullet_y), r, r, theme_->text_color, BrushId::Text });

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -502,9 +502,8 @@ void CommandGenerator::GenListBullet(DrawCommandList& cmds, const FrameContext& 
         }
     }
     else {
-        // 大きい scroll_y を SetTransform で適用すると D2D が小半径 (list_bullet_radius≒3 DIP)
-        // の楕円を bounding rect (長方形) に縮退させるため、bullet だけ Identity transform +
-        // baked 座標で描画する。
+        // 大きい scroll_y を SetTransform で適用すると D2D が小半径の楕円を bounding rect
+        // (長方形) に縮退させるため、bullet だけ Identity transform + baked 座標で描画する。
         const float first_line_h = GetFirstLineHeight(entry, theme_->font_size_body);
         // X は Identity 化に伴い md_pane_x を手動で加算。Y は entry_text_top が既にローカル Y。
         const float bullet_x = SnapToPhysicalPixel(fc.md_pane_x + x - theme_->list_bullet_offset * LIST_BULLET_X_FACTOR, fc.dpi_scale);

--- a/src/theme/theme.cpp
+++ b/src/theme/theme.cpp
@@ -19,6 +19,7 @@ static constexpr float Theme::* kScalableThemeFields[] = {
     &Theme::indent_width,
     &Theme::blockquote_bar_width,
     &Theme::list_bullet_offset,
+    &Theme::list_bullet_radius,
     &Theme::hr_thickness,
     &Theme::h2_underline_thickness,
     &Theme::pane_item_height,
@@ -83,6 +84,7 @@ static void ApplyCommonLayout(Theme& t)
     t.indent_width = 24.0f;
     t.blockquote_bar_width = 4.0f;
     t.list_bullet_offset = 20.0f;
+    t.list_bullet_radius = 3.0f;
     t.hr_thickness = 1.5f;
     t.h2_underline_thickness = 1.0f;
 

--- a/src/theme/theme.h
+++ b/src/theme/theme.h
@@ -54,6 +54,7 @@ struct Theme {
     float indent_width;
     float blockquote_bar_width;
     float list_bullet_offset;
+    float list_bullet_radius;
     float hr_thickness;
     float h2_underline_thickness;
 

--- a/src/util/ui_constants.h
+++ b/src/util/ui_constants.h
@@ -97,7 +97,6 @@ inline constexpr float INLINE_CODE_PAD_Y = 2.0f;
 inline constexpr float INLINE_CODE_CORNER = 3.0f;
 inline constexpr float CODE_BLOCK_CORNER = 4.0f;
 
-inline constexpr float LIST_BULLET_RADIUS = 3.0f;
 inline constexpr float LIST_BULLET_X_FACTOR = 0.6f;
 inline constexpr float LIST_NUMBER_PAD_LEFT = 4.0f;
 inline constexpr float LIST_NUMBER_PAD_RIGHT = 8.0f;

--- a/tests/test_theme.cpp
+++ b/tests/test_theme.cpp
@@ -328,6 +328,19 @@ TEST(Theme, ApplyZoomRepeatedRoundTripsAccumulateDrift)
     EXPECT_FALSE(std::isinf(t.font_size_body));
 }
 
+// ---- issue #251: リストバレット半径もズーム連動 ----
+
+TEST(Theme, ApplyZoomScalesBulletRadius)
+{
+    Theme t = GetLightTheme();
+    const float original_radius = t.list_bullet_radius;
+    EXPECT_GT(original_radius, 0.0f);
+
+    t.ApplyZoom(2.0f);
+
+    EXPECT_NEAR(t.list_bullet_radius, original_radius * 2.0f, 0.01f);
+}
+
 // ---- GitHub Alerts テーマ色テスト ----
 
 TEST(Theme, LightThemeAlertColorsAreDefined)


### PR DESCRIPTION
## 概要
issue #251 の対応。リスト先頭のバレット（ドット）半径が固定値でページ倍率に連動せず、倍率を上げるとドットが相対的に小さく、下げると相対的に大きく見える違和感があった。バレット半径をズーム連動させ、周囲の文字と同じ比率で拡縮するようにした。

Closes #251

## 原因
バレット半径だけが固定定数 `LIST_BULLET_RADIUS = 3.0f`（DIP）で、ズーム時に乗算されていなかった。一方で位置（`list_bullet_offset`）やフォント（`font_size_body`）等は `kScalableThemeFields[]` 経由で `ApplyZoom()` 時に倍率が掛かるため、バレットだけが取り残されていた。

## 対応（案B: 設計規約に沿った根本対応）
- `Theme` に `list_bullet_radius` フィールドを追加
- `kScalableThemeFields[]` に登録 → `ApplyZoom()` で他寸法と同じく自動スケール
- `ApplyCommonLayout` で初期値 `3.0f` を設定（ライト/ダーク両テーマ共通）
- `command_generator.cpp` の描画を `theme_->list_bullet_radius` に差し替え
- 不要になった固定定数 `LIST_BULLET_RADIUS` を `ui_constants.h` から削除

「スケーラブルな寸法は Theme フィールド + `kScalableThemeFields[]` で一元管理」という既存の設計規約に沿わせることで、固定値が例外的に外れていた状態を解消し、再発を構造的に防ぐ。

## テスト
`tests/test_theme.cpp` に `Theme.ApplyZoomScalesBulletRadius` を追加。`ApplyCommonLayout` での初期化漏れと `kScalableThemeFields[]` への登録漏れの両方を検知する。

- ビルド: 成功（警告なし）
- Theme / ThemeService スイート 36件: 全パス
- 全体 2296 件: 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)