### PR TITLE
feat: 検索バーの閉じるボタンを右寄せにする (#253)

### DIFF
--- a/src/util/ui_constants.h
+++ b/src/util/ui_constants.h
@@ -224,7 +224,9 @@ inline SearchBarLayout ComputeSearchBarLayout(float md_left, float md_width, flo
     x += btn + gap;
     l.highlight_btn = D2D1::RectF(x, center_y, x + btn, center_y + input_h);
     x += btn + gap;
-    l.close_btn = D2D1::RectF(x, center_y, x + btn, center_y + input_h);
+    // close_btn だけバー右端へ寄せる。狭幅で左側ボタン群と重なる場合は従来の左詰め位置 x へフォールバック
+    const float close_x = std::max(x, bar_right - SEARCH_BAR_PADDING - btn);
+    l.close_btn = D2D1::RectF(close_x, center_y, close_x + btn, center_y + input_h);
 
     return l;
 }

--- a/tests/test_ui_constants.cpp
+++ b/tests/test_ui_constants.cpp
@@ -365,16 +365,30 @@ TEST(SearchBarLayoutTest, CloseButtonFallsBackToLeftPackedWhenNarrow)
     EXPECT_GT(l.close_btn.left, right_aligned_x);
 }
 
-// しきい値幅(≈576 DIP)の前後で右寄せ⇔フォールバックが切り替わる。
-// std::max の選択方向 (min への誤改変や不等号ミス) を検出する遷移テスト。
+// 右寄せ⇔フォールバックの遷移を検証する。しきい値幅は SEARCH_* 定数やボタン構成に依存して
+// 動くため、560/600 のようなマジックナンバーではなく ComputeSearchBarLayout 自身を走査して
+// 遷移点を発見し、その前後で挙動が切り替わることを確認する。
+// std::max の選択方向ミス (min 化・不等号反転) を検出するのが狙い。
 TEST(SearchBarLayoutTest, RightAlignTogglesAroundThresholdWidth)
 {
-    auto narrow = ComputeSearchBarLayout(0.0f, 560.0f, 900.0f, true);
-    auto wide = ComputeSearchBarLayout(0.0f, 600.0f, 900.0f, true);
-    // 狭側: 左詰めフォールバック (highlight 直後に並ぶ)
-    EXPECT_FLOAT_EQ(narrow.close_btn.left, narrow.highlight_btn.right + SEARCH_BAR_GAP);
-    // 広側: バー右端寄せ
-    EXPECT_FLOAT_EQ(wide.close_btn.right, 600.0f - SEARCH_BAR_PADDING);
+    // 右寄せなら close は highlight から離れ、フォールバックなら highlight 直後に密着する
+    auto right_aligned = [](float w) {
+        auto l = ComputeSearchBarLayout(0.0f, w, 900.0f, true);
+        return l.close_btn.left > l.highlight_btn.right + SEARCH_BAR_GAP + 0.5f;
+    };
+    // 十分狭ければフォールバック、十分広ければ右寄せ (遷移が存在する両端)
+    ASSERT_FALSE(right_aligned(MD_PANE_MIN_WIDTH));
+    ASSERT_TRUE(right_aligned(SEARCH_INPUT_MAX_WIDTH * 4.0f));
+    // 遷移点を発見し、その直下がフォールバック・しきい値以上が右寄せであることを確認
+    float threshold = MD_PANE_MIN_WIDTH;
+    for (float w = MD_PANE_MIN_WIDTH; w <= SEARCH_INPUT_MAX_WIDTH * 4.0f; w += 1.0f) {
+        if (right_aligned(w)) {
+            threshold = w;
+            break;
+        }
+    }
+    EXPECT_FALSE(right_aligned(threshold - 1.0f));
+    EXPECT_TRUE(right_aligned(threshold));
 }
 
 // 件数表示なし (has_query=false) では count_rect が消えてレイアウトが詰まるが、

--- a/tests/test_ui_constants.cpp
+++ b/tests/test_ui_constants.cpp
@@ -299,3 +299,110 @@ TEST(PaneRefreshButtonRectTest, ButtonSizeScalesWithHeaderHeight)
     float size2 = r2.right - r2.left;
     EXPECT_GT(size2, size1);
 }
+
+// ═══════════════════════════════════════════════
+// ComputeSearchBarLayout — close ボタンの右寄せ (issue #253)
+// ═══════════════════════════════════════════════
+
+// 十分な幅では close ボタンがバー右端に寄せられる
+TEST(SearchBarLayoutTest, CloseButtonRightAlignedWhenWide)
+{
+    const float md_left = 0.0f;
+    const float md_width = 1600.0f;
+    const float md_bottom = 900.0f;
+    auto l = ComputeSearchBarLayout(md_left, md_width, md_bottom, true);
+
+    const float bar_right = md_left + md_width;
+    EXPECT_FLOAT_EQ(l.close_btn.right, bar_right - SEARCH_BAR_PADDING);
+    EXPECT_FLOAT_EQ(l.close_btn.left, bar_right - SEARCH_BAR_PADDING - SEARCH_BTN_SIZE);
+}
+
+// close ボタンは幅=BTN_SIZE・高さ=INPUT_HEIGHT を維持する
+TEST(SearchBarLayoutTest, CloseButtonKeepsButtonSize)
+{
+    auto l = ComputeSearchBarLayout(0.0f, 1600.0f, 900.0f, true);
+    EXPECT_FLOAT_EQ(l.close_btn.right - l.close_btn.left, SEARCH_BTN_SIZE);
+    EXPECT_FLOAT_EQ(l.close_btn.bottom - l.close_btn.top, SEARCH_INPUT_HEIGHT);
+}
+
+// close ボタンは他ボタンと同じ垂直位置に揃う
+TEST(SearchBarLayoutTest, CloseButtonVerticallyAlignedWithOthers)
+{
+    auto l = ComputeSearchBarLayout(0.0f, 1600.0f, 900.0f, true);
+    EXPECT_FLOAT_EQ(l.close_btn.top, l.highlight_btn.top);
+    EXPECT_FLOAT_EQ(l.close_btn.bottom, l.highlight_btn.bottom);
+}
+
+// 右寄せにより highlight と close の間に隙間が空く
+TEST(SearchBarLayoutTest, GapBetweenHighlightAndCloseWhenWide)
+{
+    auto l = ComputeSearchBarLayout(0.0f, 1600.0f, 900.0f, true);
+    // 単に隣接 (gap 分) ではなく、明確に離れている
+    EXPECT_GT(l.close_btn.left, l.highlight_btn.right + SEARCH_BAR_GAP);
+}
+
+// 右寄せしても left 側のボタン位置は従来の左詰めのまま
+TEST(SearchBarLayoutTest, LeftButtonsUnaffectedByRightAlign)
+{
+    auto l = ComputeSearchBarLayout(0.0f, 1600.0f, 900.0f, true);
+    // up/down/case/highlight は icon 起点で gap 刻みに左詰めされ、互いに重ならない
+    EXPECT_LT(l.up_btn.right, l.down_btn.left);
+    EXPECT_LT(l.down_btn.right, l.case_btn.left);
+    EXPECT_LT(l.case_btn.right, l.highlight_btn.left);
+    EXPECT_LT(l.highlight_btn.right, l.close_btn.left);
+}
+
+// 狭幅では右寄せをやめ、highlight の右隣 (左詰め) にフォールバックする
+TEST(SearchBarLayoutTest, CloseButtonFallsBackToLeftPackedWhenNarrow)
+{
+    const float md_width = 300.0f;
+    auto l = ComputeSearchBarLayout(0.0f, md_width, 900.0f, true);
+
+    // フォールバック時は highlight の直後 (gap 分だけ離れて) に並ぶ
+    EXPECT_FLOAT_EQ(l.close_btn.left, l.highlight_btn.right + SEARCH_BAR_GAP);
+    // 右寄せ位置よりも右側に居る = フォールバックが発動している証拠
+    const float right_aligned_x = md_width - SEARCH_BAR_PADDING - SEARCH_BTN_SIZE;
+    EXPECT_GT(l.close_btn.left, right_aligned_x);
+}
+
+// しきい値幅(≈576 DIP)の前後で右寄せ⇔フォールバックが切り替わる。
+// std::max の選択方向 (min への誤改変や不等号ミス) を検出する遷移テスト。
+TEST(SearchBarLayoutTest, RightAlignTogglesAroundThresholdWidth)
+{
+    auto narrow = ComputeSearchBarLayout(0.0f, 560.0f, 900.0f, true);
+    auto wide = ComputeSearchBarLayout(0.0f, 600.0f, 900.0f, true);
+    // 狭側: 左詰めフォールバック (highlight 直後に並ぶ)
+    EXPECT_FLOAT_EQ(narrow.close_btn.left, narrow.highlight_btn.right + SEARCH_BAR_GAP);
+    // 広側: バー右端寄せ
+    EXPECT_FLOAT_EQ(wide.close_btn.right, 600.0f - SEARCH_BAR_PADDING);
+}
+
+// 件数表示なし (has_query=false) では count_rect が消えてレイアウトが詰まるが、
+// 狭幅では依然フォールバックする (フォールバック境界は has_query で変わる)
+TEST(SearchBarLayoutTest, CloseButtonFallsBackWhenNarrowWithoutQuery)
+{
+    auto l = ComputeSearchBarLayout(0.0f, 300.0f, 900.0f, false);
+    EXPECT_FLOAT_EQ(l.close_btn.left, l.highlight_btn.right + SEARCH_BAR_GAP);
+}
+
+// ═══════════════════════════════════════════════
+// HitTestSearchBar — 右寄せ close ボタンのヒット判定
+// ═══════════════════════════════════════════════
+
+// 右寄せされた close ボタンの中心はちゃんと Close と判定される
+TEST(SearchBarHitTestTest, CenterOfRightAlignedCloseHitsClose)
+{
+    auto l = ComputeSearchBarLayout(0.0f, 1600.0f, 900.0f, true);
+    const float cx = (l.close_btn.left + l.close_btn.right) / 2.0f;
+    const float cy = (l.close_btn.top + l.close_btn.bottom) / 2.0f;
+    EXPECT_EQ(HitTestSearchBar(l, cx, cy), SearchBarHitZone::Close);
+}
+
+// highlight と close の間の空白はどのゾーンにも当たらない
+TEST(SearchBarHitTestTest, GapBetweenHighlightAndCloseHitsNone)
+{
+    auto l = ComputeSearchBarLayout(0.0f, 1600.0f, 900.0f, true);
+    const float gap_x = (l.highlight_btn.right + l.close_btn.left) / 2.0f;
+    const float cy = (l.close_btn.top + l.close_btn.bottom) / 2.0f;
+    EXPECT_EQ(HitTestSearchBar(l, gap_x, cy), SearchBarHitZone::None);
+}


### PR DESCRIPTION
## 概要

issue #253 対応。検索バーの閉じる（✕）ボタンをバー右端へ右寄せにする。他のボタン位置は変更なし。

```
変更前: [🔍] [入力欄] [▲] [▼] [N/M] [Aa] [ハイライト] [✕]
変更後: [🔍] [入力欄] [▲] [▼] [N/M] [Aa] [ハイライト] ……… [✕]
```

## 実装

`ComputeSearchBarLayout` の `close_btn` 配置のみ変更（`src/util/ui_constants.h`）:

```cpp
const float close_x = std::max(x, bar_right - SEARCH_BAR_PADDING - btn);
l.close_btn = D2D1::RectF(close_x, center_y, close_x + btn, center_y + input_h);
```

- 描画・クリック・ホバーは同じ `ComputeSearchBarLayout` を共有しているため、レイアウト1箇所の変更で全経路が自動追従する（座標の別管理なし）。
- 狭幅でボタン群がバー幅を超える場合は `std::max` で従来の左詰め位置へフォールバックし、ハイライトボタンとの重なりを回避。フォールバック時の座標は変更前と完全に一致するため回帰なし。

## テスト

`tests/test_ui_constants.cpp` にレイアウト/ヒットテスト計10件を追加:

- 広幅での右端寄せ・正方サイズ維持・垂直位置・隙間生成
- 狭幅フォールバック（`has_query` 有無の両方）
- しきい値幅（≈576 DIP）前後での右寄せ⇔フォールバック切替の遷移テスト
- 右寄せ後の✕中心が `Close` を返す／中央空白が `None` を返すヒット判定

全 2307 テスト合格。

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)
