### PR TITLE
fix: 検索バーのフォントをズーム倍率に追従しないよう固定 (#255)

### DIFF
--- a/src/render/renderer_resources.cpp
+++ b/src/render/renderer_resources.cpp
@@ -213,8 +213,8 @@ void Renderer::RecreatePaneFormats()
         { &fmt_.nav_button,       body_font, W,                            theme_.pane_font_size,        L"ja-jp", TA_CTR,  PA_CTR, true  },
         { &fmt_.gesture_overlay,  body_font, DWRITE_FONT_WEIGHT_BOLD,      32.0f * theme_.zoom,          L"ja-JP", TA_CTR,  PA_CTR, false },
         { &fmt_.toast_text,       body_font, DWRITE_FONT_WEIGHT_SEMI_BOLD, theme_.pane_font_size * 1.1f, L"ja-JP", TA_CTR,  PA_CTR, true  },
-        { &fmt_.search_input,     body_font, W,                            theme_.pane_font_size,        L"ja-jp", TA_LEAD, PA_CTR, true  },
-        { &fmt_.search_count,     body_font, W,                            theme_.pane_font_size * 0.9f, L"ja-jp", TA_CTR,  PA_CTR, true  },
+        { &fmt_.search_input,     body_font, W,                            SEARCH_INPUT_FONT_SIZE,       L"ja-jp", TA_LEAD, PA_CTR, true  },
+        { &fmt_.search_count,     body_font, W,                            SEARCH_COUNT_FONT_SIZE,       L"ja-jp", TA_CTR,  PA_CTR, true  },
         { &fmt_.search_icon,      icon_font, W,                            14.0f,                        L"en-us", TA_CTR,  PA_CTR, true  },
     };
 

--- a/src/util/ui_constants.h
+++ b/src/util/ui_constants.h
@@ -160,6 +160,11 @@ inline constexpr float SEARCH_INPUT_TEXT_PAD_LEFT = 6.0f;
 inline constexpr float SEARCH_INPUT_TEXT_PAD_RIGHT = 4.0f;
 inline constexpr float SEARCH_MATCH_COUNT_WIDTH = 80.0f;
 
+// 検索バーのフォントサイズ（DIP）。pane_font_size と共有すると Zoom に追従し、
+// 固定サイズの検索バー枠から文字がはみ出すため、専用の固定値を用意する。
+inline constexpr float SEARCH_INPUT_FONT_SIZE = 13.0f;
+inline constexpr float SEARCH_COUNT_FONT_SIZE = SEARCH_INPUT_FONT_SIZE * 0.9f;
+
 // 検索バーの各要素の矩形を保持する構造体。
 // 描画・ヒットテスト・ホバー判定の3箇所で共有し、レイアウト計算の重複を防ぐ。
 struct SearchBarLayout {


### PR DESCRIPTION
## 概要

検索バーの「Aa」トグルがアプリのズーム倍率に合わせて大きさが変わってしまう問題 (#255) を修正します。

## 原因

- 検索バーの枠・ボタン寸法 (`SEARCH_BAR_HEIGHT`, `SEARCH_BTN_SIZE`, `SEARCH_INPUT_HEIGHT` …) は `ui_constants.h` の固定 `constexpr` 値で、ズームに追従しない。
- 一方、`fmt_.search_input` / `fmt_.search_count`(=「Aa」・「N / M」カウント・入力テキスト）のフォントサイズは `theme_.pane_font_size` 由来。`pane_font_size` は `Theme::ApplyZoom` のスケール対象 (`theme.cpp:28`) なので倍率に追従して膨らんでいた。
- 「枠は固定なのに中の文字だけ大きくなる」不一致が症状の実体。

## 修正

`TITLEBAR_TEXT_FONT_SIZE` と同じ前例パターンに倣い、検索バー専用の固定フォントサイズ定数を導入して切り替える。

- `SEARCH_INPUT_FONT_SIZE = 13.0f`（検索入力テキスト）
- `SEARCH_COUNT_FONT_SIZE = SEARCH_INPUT_FONT_SIZE * 0.9f`（Aa / N・M カウント）

ベース値は従来の `pane_font_size`(13.0)と一致させているため、ズーム100%時の見た目は不変。ズーム時のみ検索バー内の文字が膨らまなくなる。`fmt_.search_icon` は既に固定 `14.0f` のため変更なし。

検索欄の枠が固定である点に合わせ、Aa だけでなく検索バー全体（カウント・入力テキスト含む）を倍率非追従に統一。

## テスト

- ビルド成功（警告なし）
- `mendo_tests.exe` 全 2307 件 PASSED

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)