### PR TITLE
fix: アプリ全体レビューで確認されたバグ16件を修正

### DIFF
--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -86,10 +86,12 @@ bool App::Init(HWND hwnd)
         image_loader_.CancelPending();
         image_loader_.SetRenderTarget(new_rt);
         image_loader_.ClearCache();
-        resource_manager_.LoadImages();
         // IDWriteTextLayout が SetDrawingEffect 経由で AddRef した旧 RT 由来のブラシと、
-        // DiagramEntry::bitmap が新 RT で描画拒否されるのを防ぐ。
+        // DiagramEntry::bitmap が新 RT で描画拒否されるのを防ぐ。ApplyCachedImages は
+        // bitmap 残存ノードをスキップするため、LoadImages の前に破棄する必要がある。
         state_.document.layout_cache.InvalidateEffectsAndDiagramBitmaps(state_.document.doc.GetNodes());
+        state_.document.layout_cache.InvalidateAllDiagramBitmaps();
+        resource_manager_.LoadImages();
     });
 
     theme_service_.LoadDarkMode();

--- a/src/app/app_mouse.cpp
+++ b/src/app/app_mouse.cpp
@@ -180,7 +180,11 @@ bool App::OnRButtonDown(int px, int py)
     if (!IsRenderReady()) {
         return false;
     }
-    if (state_.view.viewport.IsDragging()) {
+    // 左ドラッグ進行中にジェスチャを開始すると、完了時の ReleaseCapture が
+    // 進行中ドラッグのキャプチャを破壊する。
+    if (state_.view.viewport.IsDragging() ||
+        state_.view.panes.GetDragTarget() != PaneController::DragTarget::None ||
+        state_.view.h_drag_node >= 0) {
         return false;
     }
     const auto dip = PixelToDip(px, py);

--- a/src/app/app_mouse_hover.cpp
+++ b/src/app/app_mouse_hover.cpp
@@ -80,7 +80,10 @@ void App::HandleMdPaneHover(float dip_x, float dip_y, int px, int py, const Pane
 
     const auto emit_button_hover = [&](TooltipTarget::Zone zone, std::wstring_view text) {
         SetCursor(cursors_.Hand());
-        Dispatch(UpdateTooltipAction{ TooltipTarget{ zone, text }, px, py });
+        Dispatch(UpdateTooltipAction{
+            TooltipTarget{ zone, text },
+            px, py
+        });
     };
     if (new_hover.copy >= 0) {
         emit_button_hover(TooltipTarget::Zone::CopyButton, i18n::S().tooltip_copy);
@@ -171,6 +174,21 @@ void App::OnMouseHover(int px, int py)
         if (state_.window.titlebar.SetHovered(tb_zone)) {
             InvalidateTitleBar();
         }
+        // サイドペインから直接タイトルバーへ移動すると後段のホバー解除に到達しない
+        {
+            const auto pane_layout = GetPaneLayout();
+            for (auto t : { PaneTarget::File, PaneTarget::Toc }) {
+                bool changed = state_.view.panes.SetHoveredSideIndex(t, -1);
+                changed |= state_.view.panes.SetSideCloseHovered(t, false);
+                if (t == PaneTarget::File) {
+                    changed |= state_.view.panes.SetSideRefreshHovered(t, false);
+                }
+                if (changed) {
+                    renderer_.InvalidateSidePaneCache(t);
+                    InvalidatePane(pane_layout.Get(t));
+                }
+            }
+        }
         Dispatch(UpdateTooltipAction{ BuildTitleBarTooltip(tb_zone, IsZoomed(hwnd_)), px, py });
         return;
     }
@@ -243,8 +261,7 @@ void App::OnMouseHover(int px, int py)
                     // 同一 TOC 項目のホバー継続中は reducer 側で no-op になるため
                     // UTF-8→UTF-16 変換を省く (移動 1 回ごとの pmr::wstring 確保を回避)。
                     const auto& current = state_.interaction.tooltip.GetCurrent();
-                    if (idx == state_.view.panes.GetHoveredSideIndex(PaneTarget::Toc)
-                        && current.zone == TooltipTarget::Zone::TocPaneItem) {
+                    if (idx == state_.view.panes.GetHoveredSideIndex(PaneTarget::Toc) && current.zone == TooltipTarget::Zone::TocPaneItem) {
                         return current;
                     }
                     const auto text = state_.document.doc.GetNodes()[toc_entries[idx].node_index].GetText();
@@ -255,6 +272,7 @@ void App::OnMouseHover(int px, int py)
             }
             return {};
         };
+        // clang-format off
         const auto hr = ProcessSidePaneHover(
             dip_x,
             dip_y,
@@ -263,14 +281,20 @@ void App::OnMouseHover(int px, int py)
             renderer_.GetTheme().pane_item_height,
             is_file,
             state_.view.panes.SidePaneScroll(target).scroll_y,
-            [this, target](bool v) noexcept { return state_.view.panes.SetSideCloseHovered(target, v); },
-            [this, target](bool v) noexcept { return state_.view.panes.SetSideRefreshHovered(target, v); },
+            [this, target](bool v) noexcept {
+                return state_.view.panes.SetSideCloseHovered(target, v);
+            },
+            [this, target](bool v) noexcept {
+                return state_.view.panes.SetSideRefreshHovered(target, v);
+            },
             [this, is_file](float y, float h) noexcept {
                 return is_file
                     ? state_.file_explorer.HitTest(y, h)
                     : state_.document.doc.GetToc().HitTest(y, h);
             },
-            tooltip);
+            tooltip
+        );
+        // clang-format on
         SetCursor(hr.any_button_hit ? cursors_.Hand() : cursors_.Arrow());
         if (hr.button_changed) {
             renderer_.InvalidateSidePaneCache(target);

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -27,6 +27,10 @@ NavEntry CurrentNavEntry(const AppState& state)
 
 void PushCurrentNavEntry(AppState& state)
 {
+    // doc 未ロード (パス空) の状態は戻り先にならないため積まない
+    if (state.document.doc.GetFilePath().empty()) {
+        return;
+    }
     state.view.nav_history.Push(CurrentNavEntry(state));
 }
 
@@ -37,6 +41,27 @@ void ClearTooltip(AppState& state, SideEffectList& effects)
     state.interaction.tooltip.Hide();
     state.interaction.tooltip.ResetTarget();
     PushEffect(effects, effect::ClearTooltip{});
+}
+
+// マウスがペイン上を経由せずに離れた経路 (ウィンドウ外退出等) で呼ばないと
+// ホバーハイライトが残留する。
+void ClearSidePaneHoverState(AppState& state, SideEffectList& effects)
+{
+    bool changed = false;
+    for (auto t : { PaneTarget::File, PaneTarget::Toc }) {
+        bool pane_changed = state.view.panes.SetHoveredSideIndex(t, -1);
+        pane_changed |= state.view.panes.SetSideCloseHovered(t, false);
+        if (t == PaneTarget::File) {
+            pane_changed |= state.view.panes.SetSideRefreshHovered(t, false);
+        }
+        if (pane_changed) {
+            PushEffect(effects, effect::InvalidatePaneCache{ t == PaneTarget::File ? PaneZone::FilePane : PaneZone::TocPane });
+            changed = true;
+        }
+    }
+    if (changed) {
+        PushEffect(effects, effect::InvalidateWindow{});
+    }
 }
 
 // スクロール位置が変わった時に共通で発火する副作用列。
@@ -482,8 +507,30 @@ void ReduceSearchStep(AppState& state, bool forward)
 void ReduceCaptureChanged(AppState& state, SideEffectList& effects)
 {
     state.search.search_bar_ctrl.OnCaptureChanged();
+    bool invalidate = false;
     if (state.interaction.gesture.GetPhase() != GesturePhase::Idle) {
         state.interaction.gesture.Reset();
+        invalidate = true;
+    }
+    // キャプチャ喪失時 (Alt+Tab・他アプリの SetCapture 等) は WM_LBUTTONUP が
+    // 届かないため、進行中の全ドラッグ状態をここで解除する
+    if (state.view.viewport.IsDragging()) {
+        state.view.viewport.SetDragging(false);
+        invalidate = true;
+    }
+    if (state.view.viewport.IsScrollbarTracking()) {
+        state.view.viewport.SetScrollbarTracking(false);
+        invalidate = true;
+    }
+    if (state.view.panes.GetDragTarget() != PaneController::DragTarget::None) {
+        state.view.panes.EndDrag();
+        invalidate = true;
+    }
+    if (state.view.h_drag_node >= 0) {
+        state.view.h_drag_node = -1;
+        invalidate = true;
+    }
+    if (invalidate) {
         PushEffect(effects, effect::InvalidateWindow{});
     }
 }
@@ -1010,6 +1057,7 @@ SideEffectList Reduce(AppState& state, const AppAction& action)
         [&](const MouseLeaveAction&) {
             state.interaction.hover_throttle.Reset();
             ClearTooltip(state, effects);
+            ClearSidePaneHoverState(state, effects);
         },
         [&](const CaptureChangedAction&) { ReduceCaptureChanged(state, effects); },
         [&](const MdPaneNavHoverAction& a) { ReduceMdPaneNavHover(state, effects, a); },

--- a/src/core/document_utils.cpp
+++ b/src/core/document_utils.cpp
@@ -167,11 +167,21 @@ constexpr auto kAsciiSlugTable = [] {
 }();
 
 // CJK ・ 全角文字範囲の句読点・記号はアンカーに含めない。
-// code point 単位で判定 (0x3000 以降の Unicode コードポイント)。
+// アンカー (GitHub 互換スラグ) に採用しない記号・句読点か。非 ASCII コードポイント単位で判定。
+// Unicode 全カテゴリテーブルは持たないため、主要な記号ブロックの近似で判定する
+// (文字 (Letter) を誤って落とすより、稀な記号を通す方向に倒す)。
 constexpr bool IsAnchorSkippableSymbol(uint32_t cp) noexcept
 {
+    // ラテン1補助の記号 (U+00A0–U+00BF)
+    if (cp >= 0x00A0 && cp <= 0x00BF) {
+        return true;
+    }
+    // 一般句読点・通貨・矢印・数学記号等 (U+2000–U+2BFF)、補助句読点 (U+2E00–U+2E7F)
+    if ((cp >= 0x2000 && cp <= 0x2BFF) || (cp >= 0x2E00 && cp <= 0x2E7F)) {
+        return true;
+    }
     // CJK 記号と句読点 (U+3000–U+303F)
-    if (cp <= 0x303F) {
+    if (cp >= 0x3000 && cp <= 0x303F) {
         return true;
     }
     // 全角 ASCII 対応の記号関連
@@ -212,8 +222,7 @@ void GenerateAnchorIdInto(std::string_view text, std::pmr::string& slug)
             }
             const auto decoded = utf8_codec::DecodeAt(text, static_cast<uint32_t>(pos));
             // U+FFFD は不正/truncated バイト由来。アンカーには採用しない。
-            if (decoded.cp != utf8_codec::kReplacement &&
-                decoded.cp >= 0x3000 && !IsAnchorSkippableSymbol(decoded.cp)) {
+            if (decoded.cp != utf8_codec::kReplacement && !IsAnchorSkippableSymbol(decoded.cp)) {
                 for (uint32_t i = 0; i < decoded.len; ++i) {
                     *dst++ = text[pos + i];
                 }

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -130,7 +130,9 @@ struct ParseContext {
     std::pmr::unordered_map<std::pmr::string, int, mendo::StringTransparentHash, std::equal_to<>> anchor_counts{ &pool };
 
     // 画像スパンの src 蓄積バッファ。NodeImageData::src へは allocator 不一致を避けるため assign(view) でコピー。
+    // ネスト画像 (![a ![b](inner)](outer)) では最外側の src を採用するため深度を追跡する。
     std::pmr::string pending_image_src{ &pool };
+    int image_span_depth = 0;
 
     // display math スパンが 1 個だけで他の内容が無い段落を LatexMath コードブロックに昇格する状態
     bool in_display_math = false;
@@ -247,6 +249,11 @@ struct ParseContext {
                 current_link_url_index = static_cast<int16_t>(i);
                 return;
             }
+        }
+        // link_url_index (int16_t) を超える URL はリンクなしとして扱う
+        if (n >= static_cast<size_t>(std::numeric_limits<int16_t>::max())) {
+            current_link_url_index = -1;
+            return;
         }
         auto& urls = current_node->ensure_link_urls();
         const int16_t new_index = static_cast<int16_t>(urls.size());
@@ -687,7 +694,7 @@ int OnEnterSpan(MD_SPANTYPE type, void* detail, void* userdata)
     }
     case MD_SPAN_IMG: {
         auto* const img = static_cast<MD_SPAN_IMG_DETAIL*>(detail);
-        if (img->src.text && img->src.size > 0) {
+        if (++ctx->image_span_depth == 1 && img->src.text && img->src.size > 0) {
             ctx->pending_image_src.assign(img->src.text, static_cast<size_t>(img->src.size));
         }
         break;
@@ -749,12 +756,20 @@ int OnLeaveSpan(MD_SPANTYPE type, void* /*detail*/, void* userdata)
         ctx->current_link_url_index = -1;
         break;
     case MD_SPAN_IMG:
-        if (auto* cn = ctx->current_node; cn && !ctx->pending_image_src.empty()) {
-            // pending_image_src は pool allocator で、NodeImageData::src は default 。
-            // allocator 不一致で std::move しても内部的にコピーされるので、明示的に assign(view) する。
-            cn->ensure_image()->src.assign(ctx->pending_image_src.data(), ctx->pending_image_src.size());
+        if (--ctx->image_span_depth == 0) {
+            // Table / Heading で ensure_image を呼ぶと variant の既存データが破壊され、
+            // テーブルでは active_text_buffer がダングリングになるため、Image 昇格候補と
+            // リスト項目 (型を保ったまま src を持つ既存仕様) に限定する。
+            if (auto* cn = ctx->current_node;
+                cn && !ctx->pending_image_src.empty() &&
+                (cn->type == NodeType::Paragraph || cn->type == NodeType::BlockQuote ||
+                 cn->type == NodeType::ListItem || cn->type == NodeType::TaskListItem)) {
+                // pending_image_src は pool allocator で、NodeImageData::src は default 。
+                // allocator 不一致で std::move しても内部的にコピーされるので、明示的に assign(view) する。
+                cn->ensure_image()->src.assign(ctx->pending_image_src.data(), ctx->pending_image_src.size());
+            }
+            ctx->pending_image_src.clear();
         }
-        ctx->pending_image_src.clear();
         break;
     case MD_SPAN_LATEXMATH_DISPLAY:
         ctx->in_display_math = false;

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -174,7 +174,9 @@ HitTestService::HitResult HitTestService::HitTest(const MdPaneHitContext& ctx) c
             }
         }
     }
-    else {
+    // candidate より前に非空ノードが無い場合 (文頭が HR/Image 等) も含め、
+    // 先頭の非空ノードの先頭へ倒して常に有効なヒットを返す。
+    if (result.node_index < 0) {
         for (const auto& [i, node] : ctx.nodes | std::views::enumerate) {
             if (!node.GetText().empty()) {
                 result.node_index = static_cast<int>(i);

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -163,11 +163,24 @@ HitTestService::HitResult HitTestService::HitTest(const MdPaneHitContext& ctx) c
         }
     }
 
-    for (const auto& [i, node] : ctx.nodes | std::views::enumerate | std::views::reverse) {
-        if (const auto& text = node.GetText(); !text.empty()) {
-            result.node_index = static_cast<int>(i);
-            result.text_pos = static_cast<uint32_t>(text.size());
-            break;
+    // 高さ範囲外 (ノード間の余白等) は最寄りの非空ノードにクランプする。
+    // 文書全体の末尾へ飛ばすと、余白クリックからのドラッグで巨大選択になる。
+    if (candidate >= 0) {
+        for (int i = candidate; i >= 0; --i) {
+            if (const auto& text = ctx.nodes[static_cast<size_t>(i)].GetText(); !text.empty()) {
+                result.node_index = i;
+                result.text_pos = static_cast<uint32_t>(text.size());
+                break;
+            }
+        }
+    }
+    else {
+        for (const auto& [i, node] : ctx.nodes | std::views::enumerate) {
+            if (!node.GetText().empty()) {
+                result.node_index = static_cast<int>(i);
+                result.text_pos = 0;
+                break;
+            }
         }
     }
     last_md_hit_.Store(ctx, gen, result);

--- a/src/io/config_service.cpp
+++ b/src/io/config_service.cpp
@@ -88,7 +88,12 @@ void ConfigService::Load()
     if (!buf) {
         return;
     }
-    data_ = ini::Parse(std::string_view(reinterpret_cast<const char*>(buf.get()), size));
+    std::string_view content(reinterpret_cast<const char*>(buf.get()), size);
+    // 手編集ツールが付ける UTF-8 BOM を除去しないと先頭セクションが認識されない
+    if (content.starts_with("\xEF\xBB\xBF")) {
+        content.remove_prefix(3);
+    }
+    data_ = ini::Parse(content);
 }
 
 void ConfigService::Flush()

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -583,7 +583,9 @@ void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float 
     // セル幅・行高さ・累積位置・行オフセットすべて変化しないため、layout_dirty を倒すだけで終える。
     // 検索ハイライト矩形・effects・inline_code_bgs もテキスト位置に依存するので保持できる。
     // cells_partially_evicted 時は null セルの再生成が必要なので素通り禁止。
-    if (has_compatible_layouts && !tl_existing->cells_partially_evicted && tl_existing->last_applied_max_width >= 0.0f && std::abs(tl_existing->last_applied_max_width - max_width) < CELL_WIDTH_EPSILON) {
+    // col_widths が空 (EstimateInvisibleNodeHeight が幾何を破棄済み) のまま通すと
+    // GenTable が空テーブルを描画し続ける。
+    if (has_compatible_layouts && !tl_existing->cells_partially_evicted && !tl_existing->col_widths.empty() && tl_existing->last_applied_max_width >= 0.0f && std::abs(tl_existing->last_applied_max_width - max_width) < CELL_WIDTH_EPSILON) {
         entry.layout_dirty = false;
         return;
     }
@@ -596,6 +598,9 @@ void DWriteTextMeasurer::MeasureTable(Node& node, NodeLayoutEntry& entry, float 
     entry.effects_applied = false;
     auto& tl = entry.ensure_table_layout();
     tl.cell_inline_code_bgs.clear();
+    // 計算済みフラグを残すと、幅変更時に画面外だった行の inline code 背景が
+    // 再計算されずに欠落する (ApplyTableEffects の resize は既存要素を保持するため)。
+    tl.row_bgs_computed.clear();
     tl.row_heights.resize(row_count);
 
     // セルレイアウトが既に存在し、かつストライドが現在の列数と一致する場合のみ

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -154,7 +154,8 @@ bool LayoutEngine::EnsureVisibleLayout(std::pmr::vector<Node>& nodes, LayoutCach
     bool any_updated = false;
     int last_measured = -1;
 
-    const auto node_count = nodes.size();
+    // doc 差し替え直後などの過渡状態では nodes.size() > cache.size() になりうる
+    const auto node_count = std::min(nodes.size(), cache.size());
     const int lo = FindFirstVisibleNodeIndex(cache, node_count, viewport_top);
 
     for (int i = lo; i < static_cast<int>(node_count); i++) {

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -374,6 +374,15 @@ public:
         InvalidateDiagramBitmaps(nodes);
     }
 
+    // デバイスロスト時用。旧デバイス上のビットマップは新 RT で描画できず、
+    // 残すと EndDraw が D2DERR_WRONG_RESOURCE_DOMAIN で失敗し続ける。
+    void InvalidateAllDiagramBitmaps() noexcept
+    {
+        for (auto& d : diagrams_) {
+            d.bitmap.Reset();
+        }
+    }
+
     // ダイアグラム系ノードのビットマップを無効化する。
     // ダークモード切替時に text_layout とエフェクトを保持したまま図だけ再描画したい場合に使う。
     void InvalidateDiagramBitmaps(const std::pmr::vector<Node>& nodes) noexcept

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -218,6 +218,16 @@ void MermaidRenderer::SetupWorker(int index)
             LogHrFailure(L"add_WebMessageReceived", w.webview->add_WebMessageReceived(Microsoft::WRL::Callback<ICoreWebView2WebMessageReceivedEventHandler>(f).Get(), nullptr));
         }
 
+        // レンダラ/ブラウザプロセスのクラッシュを放置するとワーカーが rendering=true の
+        // まま恒久的にビジー扱いになり、全ワーカー喪失で以後の図が Loading 固着する。
+        {
+            const auto f = [this, index](ICoreWebView2*, ICoreWebView2ProcessFailedEventArgs*) -> HRESULT {
+                RecoverWorker(index);
+                return S_OK;
+            };
+            LogHrFailure(L"add_ProcessFailed", w.webview->add_ProcessFailed(Microsoft::WRL::Callback<ICoreWebView2ProcessFailedEventHandler>(f).Get(), nullptr));
+        }
+
         // ナビゲーションを制限: app.local以外へのナビゲーションをブロック
         {
             const auto f = [](ICoreWebView2*, ICoreWebView2NavigationStartingEventArgs* args) static -> HRESULT {
@@ -355,6 +365,28 @@ void MermaidRenderer::CancelPending()
         InvokeSvgCallbackIfAny(w.current_request, {}, true);
         w.rendering = false;
         w.current_request = {};
+    }
+}
+
+void MermaidRenderer::RecoverWorker(int index)
+{
+    auto& w = workers_[index];
+    // SVG 呼び出し元の in-flight 固着を防ぐ。PNG リクエストはプレースホルダのまま
+    // 残り、次の RequestRender で再試行される。
+    InvokeSvgCallbackIfAny(w.current_request, {}, false);
+    w.current_request = {};
+    w.rendering = false;
+    w.ready = false;
+    // 死んだプロセスの webview/controller は再利用できない
+    if (w.controller) {
+        w.controller->Close();
+    }
+    w.controller.Reset();
+    w.webview.Reset();
+    // init_retries は ready 受信で 0 に戻る。連続クラッシュ時の無限再作成はここで止める。
+    if (webview_env_ && w.init_retries < MAX_WORKER_RETRIES) {
+        ++w.init_retries;
+        SetupWorker(index);
     }
 }
 

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -371,9 +371,14 @@ void MermaidRenderer::CancelPending()
 void MermaidRenderer::RecoverWorker(int index)
 {
     auto& w = workers_[index];
-    // SVG 呼び出し元の in-flight 固着を防ぐ。PNG リクエストはプレースホルダのまま
-    // 残り、次の RequestRender で再試行される。
+    // SVG は失敗完了で呼び出し元の in-flight 固着を防ぐ。PNG は捨てると再リクエストの
+    // 契機が無く図が Loading のまま固着するためキューに戻す。クラッシュを誘発する
+    // 入力での再起動ループは retried で 1 回に打ち切る。
     InvokeSvgCallbackIfAny(w.current_request, {}, false);
+    if (!w.current_request.svg_only && w.current_request.node && !w.current_request.retried) {
+        w.current_request.retried = true;
+        pending_requests_.push(std::move(w.current_request));
+    }
     w.current_request = {};
     w.rendering = false;
     w.ready = false;

--- a/src/mermaid/mermaid.h
+++ b/src/mermaid/mermaid.h
@@ -104,6 +104,8 @@ private:
     void EnsureInitialized();
     void CreateWebView2Environment();
     void SetupWorker(int index);
+    // WebView2 プロセス障害 (ProcessFailed) からワーカーを復旧する。
+    void RecoverWorker(int index);
     void ProcessQueue();
     void FailPendingRequests();
     void RenderInWorker(Worker& worker);

--- a/src/mermaid/mermaid.h
+++ b/src/mermaid/mermaid.h
@@ -70,6 +70,8 @@ private:
         float css_height = 0.0f;
         float dpr = 1.0f;            // JSから取得したdevicePixelRatio
         unsigned int request_id = 0; // リクエスト固有のID（JS側のpostMessageと照合）
+        // プロセス障害からの requeue 済みフラグ。クラッシュ誘発入力での再起動ループを防ぐ。
+        bool retried = false;
 
         // SVGクリップボードコピー用リクエスト。true の場合 layout/diagram は使わず、
         // SVG文字列を svg_callback で返す。

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -397,10 +397,28 @@ LRESULT Win32Window::HandleMouseMessage(UINT msg, WPARAM wParam, LPARAM lParam)
         if (in_sys_menu_) {
             return 0;
         }
-        const int sx = GET_X_LPARAM(lParam);
-        const int sy = GET_Y_LPARAM(lParam);
-        // マウス由来の場合、タイトルバー上の右クリックは抑制する
-        if (sx != -1 || sy != -1) {
+        int sx = GET_X_LPARAM(lParam);
+        int sy = GET_Y_LPARAM(lParam);
+        if (sx == -1 && sy == -1) {
+            // キーボード起動 (VK_APPS / Shift+F10) は lParam が座標を持たない
+            RECT rc{};
+            GetClientRect(hwnd_, &rc);
+            POINT pt{};
+            bool use_cursor = false;
+            if (GetCursorPos(&pt)) {
+                POINT client = pt;
+                ScreenToClient(hwnd_, &client);
+                use_cursor = PtInRect(&rc, client) != FALSE;
+            }
+            if (!use_cursor) {
+                pt = { (rc.left + rc.right) / 2, (rc.top + rc.bottom) / 2 };
+                ClientToScreen(hwnd_, &pt);
+            }
+            sx = pt.x;
+            sy = pt.y;
+        }
+        else {
+            // マウス由来の場合、タイトルバー上の右クリックは抑制する
             POINT pt = { sx, sy };
             ScreenToClient(hwnd_, &pt);
             const float dpi_scale = app_->GetDpiScale();
@@ -595,7 +613,10 @@ LRESULT Win32Window::HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam)
         return DefWindowProcW(hwnd_, msg, wParam, lParam);
 
     case WM_CAPTURECHANGED:
-        app_->OnCaptureChanged();
+        // 自分自身への SetCapture (ドラッグ開始) でも届くため、喪失時のみ処理する
+        if (reinterpret_cast<HWND>(lParam) != hwnd_) {
+            app_->OnCaptureChanged();
+        }
         return 0;
 
     case WM_DESTROY:

--- a/tests/test_anchor.cpp
+++ b/tests/test_anchor.cpp
@@ -46,6 +46,24 @@ TEST(AnchorId, CjkCharactersPreserved)
     EXPECT_EQ(GenerateAnchorId("見出しレベル2"), "見出しレベル2");
 }
 
+TEST(AnchorId, LatinAccentPreserved)
+{
+    // U+0080–U+2FFF の文字 (アクセント付きラテン等) が脱落しないこと。
+    // ASCII 以外は小文字化されない (FindAnchorIndex 側も ASCII のみ小文字化)。
+    EXPECT_EQ(GenerateAnchorId("Café"), "café");
+}
+
+TEST(AnchorId, CyrillicPreserved)
+{
+    EXPECT_EQ(GenerateAnchorId("Привет"), "Привет");
+}
+
+TEST(AnchorId, GeneralPunctuationStripped)
+{
+    // 一般句読点 (U+2000–U+206F) は記号として除外される
+    EXPECT_EQ(GenerateAnchorId("em—dash…"), "emdash");
+}
+
 TEST(AnchorId, MixedAsciiAndCjk)
 {
     EXPECT_EQ(GenerateAnchorId("Step 1: テスト"), "step-1-テスト");

--- a/tests/test_config_service.cpp
+++ b/tests/test_config_service.cpp
@@ -183,6 +183,18 @@ TEST_F(ConfigServiceTest, LoadEmptyDirectoryProducesDefaults)
     EXPECT_FALSE(config_.LoadBool("View", "DarkMode"));
 }
 
+TEST_F(ConfigServiceTest, LoadSkipsUtf8Bom)
+{
+    // メモ帳等の BOM 付き UTF-8 で手編集された settings.ini でも
+    // 先頭セクションが無言で失われないこと
+    {
+        std::ofstream out(temp_dir_ / L"settings.ini", std::ios::binary);
+        out << "\xEF\xBB\xBF[Window]\r\nX=42\r\n";
+    }
+    config_.Load();
+    EXPECT_EQ(config_.LoadInt("Window", "X", 0, 0, 100), 42);
+}
+
 // ---- 複数セクションの独立性 ----
 
 TEST_F(ConfigServiceTest, MultipleSectionsIndependent)

--- a/tests/test_hit_test_service.cpp
+++ b/tests/test_hit_test_service.cpp
@@ -223,6 +223,27 @@ TEST_F(HitTestServiceTest, HitTest_GapBetweenNodesClampsToPrecedingNodeEnd)
     EXPECT_EQ(r.text_pos, pr.nodes[0].GetText().size());
 }
 
+TEST_F(HitTestServiceTest, HitTest_TextlessCandidateFallsForwardToFirstNonEmpty)
+{
+    // candidate がテキストを持たないノード (alt 空の画像) の場合、
+    // 後方探索が外れても -1 ではなく先頭の非空ノードに倒れること
+    auto pr = Parse("![](x.png)\n\nHello");
+    ASSERT_GE(pr.nodes.size(), 2u);
+    ASSERT_TRUE(pr.nodes[0].GetText().empty());
+    ASSERT_FALSE(pr.nodes[1].GetText().empty());
+    ASSERT_GT(pr.cache[0].height, 0.0f);
+
+    // 画像ノードの範囲内クリック (text_layout が無いためフォールバック経路に入る)
+    const float mid_y = pr.cache[0].text_top + pr.cache[0].height * 0.5f;
+    MdPaneHitContext ctx{
+        pr.nodes, pr.cache, theme_,
+        mid_y, 0.0f, 1.0f, 50, 0
+    };
+    auto r = hit_test_.HitTest(ctx);
+    EXPECT_EQ(r.node_index, 1);
+    EXPECT_EQ(r.text_pos, 0u);
+}
+
 // ---- HitTestTable ----
 
 TEST_F(HitTestServiceTest, HitTestTable_NoLayoutDataReturnsTextEnd)

--- a/tests/test_hit_test_service.cpp
+++ b/tests/test_hit_test_service.cpp
@@ -188,29 +188,39 @@ TEST_F(HitTestServiceTest, HitTest_BelowAllNodesReturnsLastNonEmpty)
               static_cast<uint32_t>(pr.nodes[expected_idx].GetText().size()));
 }
 
-TEST_F(HitTestServiceTest, HitTest_TextLayoutNullFallsBackToLastNode)
+TEST_F(HitTestServiceTest, HitTest_AboveFirstNodeClampsToFirstNodeStart)
 {
     // MockTextMeasurer は text_layout=nullptr を設定する。
-    // ノード範囲内をクリックしても entry.text_layout 経由の分岐に入らず、
-    // 末尾フォールバック（最後の非空ノード末尾）が返る。
+    // 先頭ノードより上 (margin_top 内) のクリックは先頭の非空ノードの先頭に返る。
     auto pr = Parse("Hello\n\nWorld");
-    ASSERT_GE(pr.nodes.size(), 1u);
+    ASSERT_GE(pr.nodes.size(), 2u);
 
     MdPaneHitContext ctx{
         pr.nodes, pr.cache, theme_,
-        0.0f, 0.0f, 1.0f, 50, 5
+        0.0f, 0.0f, 1.0f, 50, 0
     };
     auto r = hit_test_.HitTest(ctx);
+    EXPECT_EQ(r.node_index, 0);
+    EXPECT_EQ(r.text_pos, 0u);
+}
 
-    int expected_idx = -1;
-    for (int i = static_cast<int>(pr.nodes.size()) - 1; i >= 0; --i) {
-        if (!pr.nodes[i].GetText().empty()) {
-            expected_idx = i;
-            break;
-        }
-    }
-    ASSERT_GE(expected_idx, 0);
-    EXPECT_EQ(r.node_index, expected_idx);
+TEST_F(HitTestServiceTest, HitTest_GapBetweenNodesClampsToPrecedingNodeEnd)
+{
+    // ノード間の余白クリックは直前の非空ノード末尾に返る。
+    // 文書全体の末尾へ飛ばすと、余白からのドラッグで巨大選択が作られてしまう。
+    auto pr = Parse("Hello\n\nWorld");
+    ASSERT_GE(pr.nodes.size(), 2u);
+    const float node0_bottom = pr.cache[0].text_top + pr.cache[0].height;
+    ASSERT_LT(node0_bottom, pr.cache[1].text_top) << "ノード間に余白があること";
+
+    const float gap_y = (node0_bottom + pr.cache[1].text_top) * 0.5f;
+    MdPaneHitContext ctx{
+        pr.nodes, pr.cache, theme_,
+        gap_y, 0.0f, 1.0f, 50, 0
+    };
+    auto r = hit_test_.HitTest(ctx);
+    EXPECT_EQ(r.node_index, 0);
+    EXPECT_EQ(r.text_pos, pr.nodes[0].GetText().size());
 }
 
 // ---- HitTestTable ----

--- a/tests/test_image.cpp
+++ b/tests/test_image.cpp
@@ -116,6 +116,37 @@ TEST(ParserImage, ImageInBlockquoteBecomesImageNode)
     EXPECT_EQ(nodes[0].image_data()->src, "img.png");
 }
 
+TEST(ParserImage, ImageInTableCellDoesNotCorruptTable)
+{
+    // テーブルセル内の画像が variant の NodeTableData を破壊しないこと。
+    // 破壊されると active_text_buffer がダングリングになり UAF / クラッシュする。
+    auto nodes = ParseMarkdown("| ![badge](a.png) text | b |\n|---|---|\n| c | d |").nodes;
+    ASSERT_EQ(nodes.size(), 1u);
+    EXPECT_EQ(nodes[0].type, NodeType::Table);
+    ASSERT_NE(nodes[0].table_data(), nullptr);
+    EXPECT_EQ(nodes[0].table_data()->row_count, 2u);
+    EXPECT_FALSE(nodes[0].has_image());
+}
+
+TEST(ParserImage, ImageInHeadingKeepsHeadingLevel)
+{
+    // 見出し内の画像バッジが NodeHeadingData を破壊しないこと
+    auto nodes = ParseMarkdown("# ![logo](l.png) Title").nodes;
+    ASSERT_EQ(nodes.size(), 1u);
+    EXPECT_EQ(nodes[0].type, NodeType::Heading);
+    EXPECT_EQ(nodes[0].heading_level(), 1);
+    EXPECT_FALSE(nodes[0].has_image());
+}
+
+TEST(ParserImage, NestedImageUsesOutermostSrc)
+{
+    // CommonMark では画像説明内に画像記法を書ける。ノードの src は最外側を採用する
+    auto nodes = ParseMarkdown("![outer ![inner](inner.png)](outer.png)").nodes;
+    ASSERT_EQ(nodes.size(), 1u);
+    EXPECT_EQ(nodes[0].type, NodeType::Image);
+    EXPECT_EQ(nodes[0].image_data()->src, "outer.png");
+}
+
 TEST(ParserImage, ImageInTightListStaysListItem)
 {
     // タイトリスト内の画像はP生成されないため、ListItem のまま

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "parser.h"
+#include <limits>
 #include <stop_token>
 #include <string>
 
@@ -167,6 +168,38 @@ TEST(Parser, ParagraphWithNoLink)
     for (const auto& run : nodes[0].runs) {
         EXPECT_FALSE(run.has_link());
     }
+}
+
+TEST(Parser, LinkUrlCountCappedAtInt16Max)
+{
+    // link_url_index は int16_t。上限を超えた URL はリンクなしとして扱われ、
+    // wrap して別 URL へ誤マッピングしないこと。テーブルは全体が 1 ノードで
+    // link_urls を共有するため上限へ到達しうる。
+    constexpr int kUrls = 32769;
+    std::string md = "| col |\n|---|\n";
+    md.reserve(md.size() + static_cast<size_t>(kUrls) * 20);
+    for (int i = 0; i < kUrls; ++i) {
+        md += "| [t](u";
+        md += std::to_string(i);
+        md += ") |\n";
+    }
+    auto nodes = ParseMarkdown(md).nodes;
+    ASSERT_EQ(nodes.size(), 1u);
+    const auto urls = nodes[0].view_link_urls();
+    EXPECT_EQ(urls.size(), static_cast<size_t>(std::numeric_limits<int16_t>::max()));
+    // 上限超過後の run はリンクなし。全 run の index が urls 範囲内に収まること
+    const auto* tbl = nodes[0].table_data();
+    ASSERT_NE(tbl, nullptr);
+    bool found_unlinked = false;
+    for (const auto& run : tbl->all_runs) {
+        if (run.has_link()) {
+            EXPECT_LT(static_cast<size_t>(run.link_url_index), urls.size());
+        }
+        else {
+            found_unlinked = true;
+        }
+    }
+    EXPECT_TRUE(found_unlinked);
 }
 
 // ---- コードブロック ----

--- a/tests/test_reducer.cpp
+++ b/tests/test_reducer.cpp
@@ -450,6 +450,34 @@ TEST_F(ReducerTest, CaptureChanged_ResetsGesture)
     EXPECT_FALSE(HasEffect<effect::InvalidateWindow>(effects));
 }
 
+TEST_F(ReducerTest, CaptureChanged_ResetsTextSelectionDrag)
+{
+    // キャプチャ喪失 (Alt+Tab 等) では WM_LBUTTONUP が来ないため、ここで解除しないと
+    // IsDragging 残留でファイル自動リロードが永久延期される
+    state.view.viewport.SetDragging(true);
+    auto effects = Reduce(state, CaptureChangedAction{});
+    EXPECT_FALSE(state.view.viewport.IsDragging());
+    EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
+}
+
+TEST_F(ReducerTest, CaptureChanged_ResetsScrollbarDrag)
+{
+    state.view.panes.StartDrag(PaneController::DragTarget::MdScrollbar);
+    state.view.viewport.SetScrollbarTracking(true);
+    auto effects = Reduce(state, CaptureChangedAction{});
+    EXPECT_EQ(state.view.panes.GetDragTarget(), PaneController::DragTarget::None);
+    EXPECT_FALSE(state.view.viewport.IsScrollbarTracking());
+    EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
+}
+
+TEST_F(ReducerTest, CaptureChanged_ResetsBlockHScrollDrag)
+{
+    state.view.h_drag_node = 3;
+    auto effects = Reduce(state, CaptureChangedAction{});
+    EXPECT_EQ(state.view.h_drag_node, -1);
+    EXPECT_TRUE(HasEffect<effect::InvalidateWindow>(effects));
+}
+
 // ---- タイマーテスト（代表ケース） ----
 
 TEST_F(ReducerTest, Timer_Toast_EmitsInvalidate)


### PR DESCRIPTION
## 概要

アプリ全体を対象としたコードレビュー (7観点の並列調査 + 候補ごとの検証) で CONFIRMED と判定されたバグ 15 件と、防御欠落が事実と確認された PLAUSIBLE 1 件の計 16 件を修正する。

## 修正内容

### パーサ (クラッシュ・データ破壊)
- **テーブルセル/見出し内の画像で variant 破壊 (heap UAF)**: `| ![badge](a.png) text |` のパースで `ensure_image()` が `NodeTableData` を破棄し、`active_text_buffer` がダングリング化 → 後続書き込みで UAF、次セルで null デリファレンス。`ensure_image` を Image 昇格候補 (Paragraph/BlockQuote) とリスト項目 (型を保ったまま src を持つ既存仕様) に限定
- **ネスト画像 `![a ![b](inner)](outer)` で内側 src が採用される**: 深度カウンタで最外側を採用
- **リンク URL index の int16_t wrap**: 1 ノード内 32768 URL 以上で別 URL へ誤マッピング。INT16_MAX で打ち止めし超過分はリンクなし扱い

### コア / IO
- **アンカー生成で U+0080–U+2FFF が脱落**: `## Café` → `caf` となり GitHub 互換のページ内リンクが解決不能。記号ブロックの近似除外に変更し文字は保持
- **settings.ini の UTF-8 BOM で設定が無言喪失**: メモ帳等の BOM 付き保存で先頭セクションが認識されない。BOM スキップを追加

### app 層 (状態残留)
- **WM_CAPTURECHANGED でドラッグ状態が残留**: Alt+Tab 等でキャプチャを失うと `viewport.IsDragging` 残留で自動リロードが永久延期、`drag_target` 残留で次クリックが誤分岐。全ドラッグ状態を解除し、自己 SetCapture による誤発火は window 側で `lParam != hwnd` フィルタ
- **左ドラッグ中に右クリックジェスチャを開始できる**: 完了時の `ReleaseCapture` が進行中ドラッグのキャプチャを破壊するためガード追加
- **空パスの NavEntry が履歴に積まれる**: `PushCurrentNavEntry` 自体にガードを入れ、呼び出し側 6 箇所の不揃いを根本解決
- **サイドペインのホバーハイライト残留**: タイトルバー直行・ウィンドウ外退出の経路で解除されなかった
- **VK_APPS / Shift+F10 でメニューがプライマリモニタ左上に出る**: lParam=-1 をカーソル位置 (クライアント外なら中央) に補正

### 入力 / レイアウト / 描画
- **余白クリックで選択アンカーが文書末尾になる**: ドラッグで画面外まで跨ぐ巨大選択が発生。近傍ノードへのクランプに変更
- **`EnsureVisibleLayout` の範囲外アクセス**: doc 差し替え直後の過渡状態 (`nodes.size() > cache.size()`) で OOB read/write。同ファイル他関数と同じ min クランプを追加
- **デバイスロスト後に画像で描画が恒久失敗**: 旧デバイス産の画像ビットマップが破棄されず `ApplyCachedImages` も再生成をスキップ。`InvalidateAllDiagramBitmaps()` を追加し `LoadImages()` の前に破棄
- **画面外テーブルが空白固定化**: 幅 W1→W2→W1 で MeasureTable 超高速パスが空の `col_widths` のまま `layout_dirty` を倒す。幾何の実在チェックを追加
- **テーブルのインラインコード背景欠落**: 幅変更時に `row_bgs_computed` がクリアされず画面外行の計算済みフラグが残留

### Mermaid
- **WebView2 プロセスクラッシュで図が Loading 固着**: `add_ProcessFailed` を購読し、ワーカーを破棄・再作成する `RecoverWorker()` を追加。進行中リクエストは失敗完了させ、連続クラッシュは `MAX_WORKER_RETRIES` で打ち止め

## テスト

- 全 2319 テストがパス (Release ビルド)
- 回帰テスト 11 件を追加 (variant 保護・ネスト画像・リンク数上限・アンカーの文字保持・BOM 付き ini・CaptureChanged のドラッグ解除・ヒットテストのクランプ)
- 既存テスト 1 件 (`HitTest_TextLayoutNullFallsBackToLastNode`) は旧仕様 (文書末尾フォールバック) を期待していたため、新仕様の 2 件に書き直し

🤖 Generated with [Claude Code](https://claude.com/claude-code)