### PR TITLE
refactor: 確認済みの重複・冗長処理を統合

### DIFF
--- a/src/app/app.h
+++ b/src/app/app.h
@@ -210,6 +210,10 @@ private:
     void HandleSidePaneClick(PaneTarget target, float dip_x, float dip_y, const PaneLayout& layout);
     static bool IsOverPaneScrollbar(float dip_x, const PaneRect& rect, float total_content, const PaneScrollInfo& scroll_info) noexcept;
 
+    // サイドペインのホバー状態をリセットし、変化があれば invalidate する。
+    // reset_hover_index=true のとき hover index もリセット（タイトルバー移動時など）。
+    void ResetSidePaneHover(PaneTarget t, const ::PaneLayout& pane_layout, bool reset_hover_index);
+
     PaneScrollInfo ComputePaneScrollInfo(const PaneRect& rect, float total_content) const;
 
     void ScheduleDeferredLayoutIfNeeded();

--- a/src/app/app_mouse_hover.cpp
+++ b/src/app/app_mouse_hover.cpp
@@ -9,6 +9,22 @@
 #include "string_convert.h"
 #include "ui_constants.h"
 
+void App::ResetSidePaneHover(PaneTarget t, const PaneLayout& pane_layout, bool reset_hover_index)
+{
+    bool changed = false;
+    if (reset_hover_index) {
+        changed |= state_.view.panes.SetHoveredSideIndex(t, -1);
+    }
+    changed |= state_.view.panes.SetSideCloseHovered(t, false);
+    if (t == PaneTarget::File) {
+        changed |= state_.view.panes.SetSideRefreshHovered(t, false);
+    }
+    if (changed) {
+        renderer_.InvalidateSidePaneCache(t);
+        InvalidatePane(pane_layout.Get(t));
+    }
+}
+
 bool App::IsOverMdScrollbar(float dip_x, float dip_y, const PaneLayout& layout) const noexcept
 {
     const float total_h = ScrollableContentHeight();
@@ -178,15 +194,7 @@ void App::OnMouseHover(int px, int py)
         {
             const auto pane_layout = GetPaneLayout();
             for (auto t : { PaneTarget::File, PaneTarget::Toc }) {
-                bool changed = state_.view.panes.SetHoveredSideIndex(t, -1);
-                changed |= state_.view.panes.SetSideCloseHovered(t, false);
-                if (t == PaneTarget::File) {
-                    changed |= state_.view.panes.SetSideRefreshHovered(t, false);
-                }
-                if (changed) {
-                    renderer_.InvalidateSidePaneCache(t);
-                    InvalidatePane(pane_layout.Get(t));
-                }
+                ResetSidePaneHover(t, pane_layout, true);
             }
         }
         Dispatch(UpdateTooltipAction{ BuildTitleBarTooltip(tb_zone, IsZoomed(hwnd_)), px, py });
@@ -207,21 +215,11 @@ void App::OnMouseHover(int px, int py)
     const auto hovered_target = ToPaneTarget(zone);
 
     // ペインゾーン外に出たらヘッダーボタンのホバーをリセット（無効化忘れ防止）。
-    auto reset_pane_buttons = [&](PaneTarget t) {
-        bool changed = state_.view.panes.SetSideCloseHovered(t, false);
-        if (t == PaneTarget::File) {
-            changed |= state_.view.panes.SetSideRefreshHovered(t, false);
-        }
-        if (changed) {
-            renderer_.InvalidateSidePaneCache(t);
-            InvalidatePane(pane_layout.Get(t));
-        }
-    };
     if (hovered_target != PaneTarget::File) {
-        reset_pane_buttons(PaneTarget::File);
+        ResetSidePaneHover(PaneTarget::File, pane_layout, false);
     }
     if (hovered_target != PaneTarget::Toc) {
-        reset_pane_buttons(PaneTarget::Toc);
+        ResetSidePaneHover(PaneTarget::Toc, pane_layout, false);
     }
 
     int new_hover[2] = { -1, -1 };

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -858,7 +858,7 @@ void ScrollToAnchor(AppState& state, SideEffectList& effects, std::string_view a
     ScrollToResolvedAnchor(state, effects, state.document.doc.FindAnchorIndex(anchor_id));
 }
 
-// anchor_id() 由来など、既に正規化済み入力向け（ToLowerAscii の確保を回避する）。
+// anchor_id() 由来など、既に正規化済み入力向け（ToLowerAsciiCopy の確保を回避する）。
 void ScrollToNormalizedAnchor(AppState& state, SideEffectList& effects, std::string_view anchor_id)
 {
     ScrollToResolvedAnchor(state, effects, state.document.doc.FindNormalizedAnchorIndex(anchor_id));

--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -175,7 +175,7 @@ int Document::FindAnchorIndex(std::string_view anchor) const
         ascii_util::AsciiToLowerOnly(anchor.data(), stack_buf, anchor.size());
         return FindNormalizedAnchorIndex(std::string_view{ stack_buf, anchor.size() });
     }
-    const std::pmr::string target = ToLowerAscii(anchor);
+    const std::pmr::string target = ToLowerAsciiCopy(anchor);
     return FindNormalizedAnchorIndex(target);
 }
 

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -75,7 +75,7 @@ public:
     void ReplaceFromMarkdown(std::pmr::string text, size_t byte_size);
     int FindAnchorIndex(std::string_view anchor) const;
     // 既に anchor_id 形式（小文字 ASCII 正規化済み）と判明している入力向け。
-    // 呼び出し側で正規化が保証されていれば、ToLowerAscii の確保を回避できる。
+    // 呼び出し側で正規化が保証されていれば、ToLowerAsciiCopy の確保を回避できる。
     int FindNormalizedAnchorIndex(std::string_view anchor) const;
     constexpr const std::pmr::vector<size_t>& GetImageNodeIndices() const noexcept
     {

--- a/src/core/document_utils.cpp
+++ b/src/core/document_utils.cpp
@@ -9,7 +9,7 @@
 #include <iterator>
 #include <ranges>
 
-std::pmr::string ToLowerAscii(std::string_view text)
+std::pmr::string ToLowerAsciiCopy(std::string_view text)
 {
     std::pmr::string result;
     result.resize_and_overwrite(text.size(), [&text](char* buf, size_t count) noexcept -> size_t {

--- a/src/core/document_utils.h
+++ b/src/core/document_utils.h
@@ -19,7 +19,7 @@ struct WordBoundary {
 WordBoundary FindWordBoundaries(std::string_view text, uint32_t pos) noexcept;
 WordBoundary FindWordBoundaries(std::wstring_view text, uint32_t pos) noexcept;
 
-std::pmr::string ToLowerAscii(std::string_view text);
+std::pmr::string ToLowerAsciiCopy(std::string_view text);
 
 // GitHub スタイル: ASCII 小文字化、空白→'-'、CJK 保持、句読点スキップ。
 std::pmr::string GenerateAnchorId(std::string_view text);

--- a/src/core/selection_html.cpp
+++ b/src/core/selection_html.cpp
@@ -38,6 +38,11 @@ std::pmr::string ExtractSelectedText(const std::pmr::vector<Node>& nodes, const 
 
 namespace {
 
+constexpr uint32_t ClampEndToText(uint32_t end, size_t text_size) noexcept
+{
+    return end > text_size ? static_cast<uint32_t>(text_size) : end;
+}
+
 constexpr void AppendHtmlEscaped(std::pmr::string& out, std::string_view text)
 {
     for (const char c : text) {
@@ -157,9 +162,7 @@ constexpr void AppendInlineHtml(
     std::span<const std::pmr::string> link_urls,
     uint32_t start, uint32_t end)
 {
-    if (end > text.size()) {
-        end = static_cast<uint32_t>(text.size());
-    }
+    end = ClampEndToText(end, text.size());
     if (start >= end) {
         return;
     }
@@ -299,9 +302,7 @@ void AppendCodeBlockHtml(std::pmr::string& out, const Node& node, uint32_t start
     }
     out.append(kStyleTail);
     const auto& text = node.GetText();
-    if (end > text.size()) {
-        end = static_cast<uint32_t>(text.size());
-    }
+    end = ClampEndToText(end, text.size());
     if (start < end) {
         const std::string_view text_view{ text };
         const auto& tokens = node.syntax_tokens();
@@ -426,9 +427,7 @@ void AppendTableHtml(std::pmr::string& out, const Node& node, uint32_t start, ui
     const auto* tbl = node.table_data();
     if (!tbl || tbl->row_count == 0) {
         const auto& text = node.GetText();
-        if (end > text.size()) {
-            end = static_cast<uint32_t>(text.size());
-        }
+        end = ClampEndToText(end, text.size());
         out.append("<pre>");
         if (start < end) {
             AppendHtmlEscaped(out, std::string_view(text).substr(start, end - start));

--- a/src/input/hit_test_service.cpp
+++ b/src/input/hit_test_service.cpp
@@ -26,16 +26,11 @@ TableRowHit FindTableRow(const Node& node, const NodeLayoutEntry& entry, float e
 
     // row_cum_y[r]: 行 r の上端（サイズ row_count+1）。
     if (tl.row_cum_y.size() == row_count + 1) {
-        const float local_y = dip_y - entry_text_top;
-        const auto it = std::ranges::upper_bound(tl.row_cum_y, local_y);
-        if (it == tl.row_cum_y.begin()) {
+        const int idx = tl.RowIndexAt(dip_y - entry_text_top);
+        if (idx < 0) {
             return { -1, 0.0f };
         }
-        const auto idx = std::ranges::distance(tl.row_cum_y.begin(), it) - 1;
-        if (static_cast<size_t>(idx) >= row_count) {
-            return { -1, 0.0f };
-        }
-        return { static_cast<int>(idx), entry_text_top + tl.row_cum_y[static_cast<size_t>(idx)] };
+        return { idx, entry_text_top + tl.row_cum_y[static_cast<size_t>(idx)] };
     }
 
     const float border = TABLE_BORDER_WIDTH;

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <ranges>
 #include <span>
+#include <utility>
 
 struct Theme;
 
@@ -64,6 +65,49 @@ struct TableLayoutData {
     {
         const size_t idx = CellIndex(row, col);
         return (idx < cell_layouts.size()) ? cell_layouts[idx].Get() : nullptr;
+    }
+
+    // [local_top, local_bottom] に重なる行帯 [r_begin, r_end) を二分探索で返す。
+    // 座標はいずれもエントリ上端からのローカル系。row_cum_y が空なら [0, 0)。
+    std::pair<size_t, size_t> VisibleRowRange(float local_top, float local_bottom) const noexcept
+    {
+        if (row_cum_y.empty()) {
+            return { 0, 0 };
+        }
+        const size_t row_count = row_cum_y.size() - 1;
+        size_t r_begin = 0;
+        size_t r_end = row_count;
+        // row_cum_y[r+1] は行 r の下端 (= 次行の上端、border 込み)。最初に local_top を
+        // 超える境界点を upper_bound で求め、その 1 つ手前が viewport 先頭にかかる行。
+        const auto upper = std::ranges::upper_bound(row_cum_y, local_top);
+        if (upper != row_cum_y.begin()) {
+            r_begin = static_cast<size_t>(std::ranges::distance(row_cum_y.begin(), upper)) - 1;
+        }
+        const auto lower = std::ranges::lower_bound(row_cum_y, local_bottom);
+        if (lower != row_cum_y.end()) {
+            const auto idx = static_cast<size_t>(std::ranges::distance(row_cum_y.begin(), lower));
+            r_end = std::min(row_count, idx);
+        }
+        return { r_begin, r_end };
+    }
+
+    // local_y がヒットする行インデックスを返す。ヒットなしは -1。
+    // 座標はエントリ上端からのローカル系。row_cum_y が空でもヒットなし扱い。
+    int RowIndexAt(float local_y) const noexcept
+    {
+        if (row_cum_y.empty()) {
+            return -1;
+        }
+        const size_t row_count = row_cum_y.size() - 1;
+        const auto it = std::ranges::upper_bound(row_cum_y, local_y);
+        if (it == row_cum_y.begin()) {
+            return -1;
+        }
+        const auto idx = std::ranges::distance(row_cum_y.begin(), it) - 1;
+        if (static_cast<size_t>(idx) >= row_count) {
+            return -1;
+        }
+        return static_cast<int>(idx);
     }
 };
 

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -769,7 +769,7 @@ void MermaidRenderer::OnCaptureComplete(int worker_idx, uint64_t code_hash, IStr
 
         if (file_cache_ && w.current_request.node) {
             const uint64_t fkey = mermaid_util::NodeDiagramHash(*w.current_request.node, w.current_request.max_width, w.current_request.dark_mode);
-            auto png_bytes = stream_util::ReadAllBytes(png_stream);
+            auto png_bytes = stream_util::ReadStreamToEnd(png_stream);
             if (!png_bytes.empty()) {
                 file_cache_->StoreAsync(fkey, draw_w, draw_h, std::move(png_bytes));
             }

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -885,16 +885,9 @@ void CommandGenerator::GenTable(
     size_t r_end = row_count;
     const bool has_row_geometry = tl.row_cum_y.size() == row_count + 1;
     if (has_row_geometry) {
-        const float local_top = viewport_top - entry_text_top;
-        const float local_bottom = viewport_bottom - entry_text_top;
-        const auto upper = std::ranges::upper_bound(tl.row_cum_y, local_top);
-        if (upper != tl.row_cum_y.begin()) {
-            r_begin = static_cast<size_t>(std::ranges::distance(tl.row_cum_y.begin(), upper)) - 1;
-        }
-        const auto lower = std::ranges::lower_bound(tl.row_cum_y, local_bottom);
-        if (lower != tl.row_cum_y.end()) {
-            r_end = std::min(static_cast<size_t>(row_count), static_cast<size_t>(std::ranges::distance(tl.row_cum_y.begin(), lower)));
-        }
+        const auto [rb, re] = tl.VisibleRowRange(viewport_top - entry_text_top, viewport_bottom - entry_text_top);
+        r_begin = rb;
+        r_end = re;
         y = entry_text_top + tl.row_cum_y[r_begin];
         // bg リストは追記順が乱れうるため二分探索せず、既存セマンティクス
         // (前進スキップ) で r_begin 直前まで進める。サイズは bg 持ちセル数のみ。

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -206,19 +206,9 @@ void Renderer::ApplyTableEffects(Node& node, NodeLayoutEntry& entry, float entry
     size_t r_end = row_count;
     const bool cull_by_viewport = !first_pass && viewport_top >= 0.0f && tl.row_cum_y.size() == row_count + 1;
     if (cull_by_viewport) {
-        const float local_top = viewport_top - entry_text_top;
-        const float local_bottom = viewport_bottom - entry_text_top;
-        // row_cum_y[r+1] は行 r の下端 (= 次行の上端、border 込み)。最初に local_top を超える
-        // 境界点を upper_bound で求め、その 1 つ手前が viewport 先頭にかかる行。
-        auto upper = std::ranges::upper_bound(tl.row_cum_y, local_top);
-        if (upper != tl.row_cum_y.begin()) {
-            r_begin = static_cast<size_t>(std::ranges::distance(tl.row_cum_y.begin(), upper)) - 1;
-        }
-        auto lower = std::ranges::lower_bound(tl.row_cum_y, local_bottom);
-        if (lower != tl.row_cum_y.end()) {
-            const auto idx = static_cast<size_t>(std::ranges::distance(tl.row_cum_y.begin(), lower));
-            r_end = std::min(row_count, idx);
-        }
+        const auto [rb, re] = tl.VisibleRowRange(viewport_top - entry_text_top, viewport_bottom - entry_text_top);
+        r_begin = rb;
+        r_end = re;
     }
 
     float row_y = entry_text_top;

--- a/src/ui/context_menu.cpp
+++ b/src/ui/context_menu.cpp
@@ -63,8 +63,8 @@ bool ContextMenu::Impl::CreatePopupWindow(int screen_x, int screen_y)
     }
     rt.Reset();
 
-    const int pixel_w = static_cast<int>(std::ceil(menu_width * dpi_scale));
-    const int pixel_h = static_cast<int>(std::ceil(menu_height * dpi_scale));
+    const int pixel_w = DipToPixelCeil(menu_width, dpi_scale);
+    const int pixel_h = DipToPixelCeil(menu_height, dpi_scale);
 
     // 画面外にはみ出さないよう調整
     const HMONITOR monitor = MonitorFromPoint({ screen_x, screen_y }, MONITOR_DEFAULTTONEAREST);
@@ -105,7 +105,7 @@ bool ContextMenu::Impl::CreatePopupWindow(int screen_x, int screen_y)
 
     // 角丸クリッピング用リージョン
     // SetWindowRgn は成功時のみ rgn の所有権を OS に移譲する。失敗時は呼び出し側で DeleteObject。
-    const int corner_px = static_cast<int>(MENU_CORNER * dpi_scale);
+    const int corner_px = DipToPixel(MENU_CORNER, dpi_scale);
     const HRGN rgn = CreateRoundRectRgn(0, 0, pixel_w + 1, pixel_h + 1, corner_px, corner_px);
     if (rgn && !SetWindowRgn(hwnd, rgn, FALSE)) {
         DeleteObject(rgn);
@@ -183,8 +183,8 @@ LRESULT ContextMenu::Impl::HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam)
     }
 
     case WM_MOUSEMOVE: {
-        const float x = static_cast<short>(LOWORD(lParam)) / dpi_scale;
-        const float y = static_cast<short>(HIWORD(lParam)) / dpi_scale;
+        const float x = PixelToDip(static_cast<float>(static_cast<short>(LOWORD(lParam))), dpi_scale);
+        const float y = PixelToDip(static_cast<float>(static_cast<short>(HIWORD(lParam))), dpi_scale);
 
         const int old_hovered = hovered_id;
         const int old_nav = hovered_nav;
@@ -213,8 +213,8 @@ LRESULT ContextMenu::Impl::HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam)
 
     case WM_LBUTTONDOWN:
     case WM_RBUTTONDOWN: {
-        const float x = static_cast<short>(LOWORD(lParam)) / dpi_scale;
-        const float y = static_cast<short>(HIWORD(lParam)) / dpi_scale;
+        const float x = PixelToDip(static_cast<float>(static_cast<short>(LOWORD(lParam))), dpi_scale);
+        const float y = PixelToDip(static_cast<float>(static_cast<short>(HIWORD(lParam))), dpi_scale);
 
         if (x < 0 || y < 0 || x >= menu_width || y >= menu_height) {
             done = true;
@@ -365,7 +365,7 @@ void ContextMenu::Impl::DrawNavRow()
     auto draw_btn = [&](const DipRect& dr, const wchar_t* glyph, bool enabled, bool hovered) {
         const D2D1_RECT_F rc{ dr.left, dr.top, dr.right, dr.bottom };
         if (hovered) {
-            const D2D1_ROUNDED_RECT rr = { rc, NAV_BTN_CORNER, NAV_BTN_CORNER };
+            const D2D1_ROUNDED_RECT rr = { rc, CTX_NAV_BTN_CORNER, CTX_NAV_BTN_CORNER };
             rt->FillRoundedRectangle(rr, brush_hover.Get());
         }
         auto* brush = enabled ? brush_text.Get() : brush_gray.Get();

--- a/src/ui/context_menu_impl.h
+++ b/src/ui/context_menu_impl.h
@@ -3,6 +3,7 @@
 // context_menu.cpp（Win32/D2D 本体）の両方からインクルードする。
 // 本ヘッダ自体は Impl 構造体の定義（D2D フィールドを含む）を提供する。
 #include "context_menu.h"
+#include "ui_constants.h"
 #include <d2d1.h>
 #include <dwrite.h>
 #include <wrl/client.h>
@@ -12,10 +13,10 @@
 
 namespace context_menu_constants {
 inline constexpr float ITEM_HEIGHT = 28.0f;
-inline constexpr float NAV_BTN_SIZE = 28.0f;
-inline constexpr float NAV_BTN_GAP = 16.0f;
-inline constexpr float NAV_ROW_PAD_Y = 5.0f;
-inline constexpr float NAV_BTN_CORNER = 4.0f;
+inline constexpr float CTX_NAV_BTN_SIZE = 28.0f;
+inline constexpr float CTX_NAV_BTN_GAP = 16.0f;
+inline constexpr float CTX_NAV_ROW_PAD_Y = 5.0f;
+inline constexpr float CTX_NAV_BTN_CORNER = 4.0f;
 inline constexpr float SEPARATOR_HEIGHT = 9.0f;
 inline constexpr float PAD_X = 28.0f;
 inline constexpr float PAD_Y = 4.0f;

--- a/src/ui/context_menu_logic.cpp
+++ b/src/ui/context_menu_logic.cpp
@@ -143,7 +143,7 @@ void ContextMenu::Impl::ComputeLayout()
         }
     }
 
-    const float nav_row_w = 2 * NAV_BTN_SIZE + NAV_BTN_GAP + 2 * PAD_X;
+    const float nav_row_w = 2 * CTX_NAV_BTN_SIZE + CTX_NAV_BTN_GAP + 2 * PAD_X;
     const float text_w = CHECK_WIDTH + max_text_w + PAD_X * 2;
     menu_width = std::max({ nav_row_w, text_w, MIN_MENU_WIDTH });
 
@@ -151,15 +151,15 @@ void ContextMenu::Impl::ComputeLayout()
     for (auto& item : items) {
         switch (item.type) {
         case ItemType::NavRow: {
-            const float row_h = NAV_BTN_SIZE + 2 * NAV_ROW_PAD_Y;
+            const float row_h = CTX_NAV_BTN_SIZE + 2 * CTX_NAV_ROW_PAD_Y;
             item.rect = { 0, y, menu_width, y + row_h };
 
             const float cx = menu_width / 2.0f;
-            const float total_w = 2 * NAV_BTN_SIZE + NAV_BTN_GAP;
+            const float total_w = 2 * CTX_NAV_BTN_SIZE + CTX_NAV_BTN_GAP;
             const float bx = cx - total_w / 2.0f;
-            const float by = y + NAV_ROW_PAD_Y;
-            nav_layout.back_rect = { bx, by, bx + NAV_BTN_SIZE, by + NAV_BTN_SIZE };
-            nav_layout.fwd_rect = { bx + NAV_BTN_SIZE + NAV_BTN_GAP, by, bx + total_w, by + NAV_BTN_SIZE };
+            const float by = y + CTX_NAV_ROW_PAD_Y;
+            nav_layout.back_rect = { bx, by, bx + CTX_NAV_BTN_SIZE, by + CTX_NAV_BTN_SIZE };
+            nav_layout.fwd_rect = { bx + CTX_NAV_BTN_SIZE + CTX_NAV_BTN_GAP, by, bx + total_w, by + CTX_NAV_BTN_SIZE };
             y += row_h;
             break;
         }

--- a/src/util/stream_util.h
+++ b/src/util/stream_util.h
@@ -9,7 +9,7 @@
 
 namespace stream_util {
 
-inline std::pmr::vector<uint8_t> ReadAllBytes(IStream* stream)
+inline std::pmr::vector<uint8_t> ReadStreamToEnd(IStream* stream)
 {
     if (!stream) {
         return {};

--- a/src/util/ui_constants.h
+++ b/src/util/ui_constants.h
@@ -144,6 +144,24 @@ inline float SnapToPhysicalPixel(float v, float dpi_scale) noexcept
     return std::round(v * dpi_scale) / dpi_scale;
 }
 
+// DIP → ピクセル変換（切り捨て）。ウィンドウサイズ・クリッピング等の整数ピクセル値に使う。
+inline int DipToPixel(float v, float dpi_scale) noexcept
+{
+    return static_cast<int>(v * dpi_scale);
+}
+
+// DIP → ピクセル変換（切り上げ）。ウィンドウサイズのはみ出し防止等に使う。
+inline int DipToPixelCeil(float v, float dpi_scale) noexcept
+{
+    return static_cast<int>(std::ceil(v * dpi_scale));
+}
+
+// ピクセル → DIP 変換。Win32 メッセージ座標を DIP 座標系に戻す際に使う。
+inline float PixelToDip(float v, float dpi_scale) noexcept
+{
+    return v / dpi_scale;
+}
+
 // タイトルバーのテキストフォントサイズ（DIP）。
 // pane_font_size と共有すると Zoom に追従してしまうため、専用の固定値を用意する。
 inline constexpr float TITLEBAR_TEXT_FONT_SIZE = 13.0f;

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -260,7 +260,7 @@ LRESULT Win32Window::HitTestResizeFrame(POINT pt) const noexcept
     if (pt.x >= rc.right - right_border) {
         if (pt.x < rc.right - border) {
             const float dpi_scale = app_->GetDpiScale();
-            if (app_->IsOverMdScrollbar(pt.x / dpi_scale, pt.y / dpi_scale)) {
+            if (app_->IsOverMdScrollbar(PixelToDip(static_cast<float>(pt.x), dpi_scale), PixelToDip(static_cast<float>(pt.y), dpi_scale))) {
                 return HTCLIENT;
             }
         }
@@ -273,8 +273,8 @@ LRESULT Win32Window::HitTestResizeFrame(POINT pt) const noexcept
 LRESULT Win32Window::HitTestTitleBar(POINT pt) const noexcept
 {
     const float dpi_scale = app_->GetDpiScale();
-    const float dip_x = pt.x / dpi_scale;
-    const float dip_y = pt.y / dpi_scale;
+    const float dip_x = PixelToDip(static_cast<float>(pt.x), dpi_scale);
+    const float dip_y = PixelToDip(static_cast<float>(pt.y), dpi_scale);
     const float titlebar_height = app_->GetTitleBarHeightDip();
 
     if (dip_y >= titlebar_height) {
@@ -422,7 +422,7 @@ LRESULT Win32Window::HandleMouseMessage(UINT msg, WPARAM wParam, LPARAM lParam)
             POINT pt = { sx, sy };
             ScreenToClient(hwnd_, &pt);
             const float dpi_scale = app_->GetDpiScale();
-            const float dip_y = pt.y / dpi_scale;
+            const float dip_y = PixelToDip(static_cast<float>(pt.y), dpi_scale);
             if (dip_y < app_->GetTitleBarHeightDip()) {
                 return 0;
             }

--- a/tests/document_test_helpers.h
+++ b/tests/document_test_helpers.h
@@ -31,7 +31,7 @@ inline int FindAnchorNodeIndexLinear(const std::pmr::vector<Node>& nodes, std::s
     if (anchor.empty()) {
         return -1;
     }
-    const std::pmr::string target = ToLowerAscii(anchor);
+    const std::pmr::string target = ToLowerAsciiCopy(anchor);
     for (const auto& [i, node] : nodes | std::views::enumerate) {
         if (node.type == NodeType::Heading && node.anchor_id() == target) {
             return static_cast<int>(i);

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -352,7 +352,7 @@ TEST(DocumentTest, BuildIndicesNoSpecialNodes)
 TEST(DocumentTest, FindAnchorIndexUppercaseQueryNormalized)
 {
     // parser 側スラグは小文字確定だが、クエリ引数に大文字混在があっても
-    // ToLowerAscii 経由で hit すること。
+    // ToLowerAsciiCopy 経由で hit すること。
     auto doc = Document::FromMarkdown("# Hello World", L"test.md");
     EXPECT_EQ(doc.FindAnchorIndex("hello-world"), 0);
     EXPECT_EQ(doc.FindAnchorIndex("Hello-World"), 0);
@@ -368,7 +368,7 @@ TEST(DocumentTest, FindAnchorIndexEmptyQuery)
 TEST(DocumentTest, FindNormalizedAnchorIndexHitsLowercase)
 {
     // anchor_id() は parser で小文字 ASCII へ正規化済み。
-    // FindNormalizedAnchorIndex は ToLowerAscii を介さず直接 hit する。
+    // FindNormalizedAnchorIndex は ToLowerAsciiCopy を介さず直接 hit する。
     auto doc = Document::FromMarkdown("# Hello World", L"test.md");
     EXPECT_EQ(doc.FindNormalizedAnchorIndex("hello-world"), 0);
     EXPECT_EQ(doc.FindNormalizedAnchorIndex(""), -1);

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -2004,43 +2004,43 @@ TEST(CalcScrollYForDiff, ReadsCachedTextTopFieldNotFenwick)
 }
 
 // ============================================================
-// ToLowerAscii
+// ToLowerAsciiCopy
 // ============================================================
 
-TEST(ToLowerAscii, AllUppercase)
+TEST(ToLowerAsciiCopy, AllUppercase)
 {
-    EXPECT_EQ(ToLowerAscii("HELLO"), "hello");
+    EXPECT_EQ(ToLowerAsciiCopy("HELLO"), "hello");
 }
 
-TEST(ToLowerAscii, AllLowercase)
+TEST(ToLowerAsciiCopy, AllLowercase)
 {
-    EXPECT_EQ(ToLowerAscii("hello"), "hello");
+    EXPECT_EQ(ToLowerAsciiCopy("hello"), "hello");
 }
 
-TEST(ToLowerAscii, MixedCase)
+TEST(ToLowerAsciiCopy, MixedCase)
 {
-    EXPECT_EQ(ToLowerAscii("HeLLo WoRLd"), "hello world");
+    EXPECT_EQ(ToLowerAsciiCopy("HeLLo WoRLd"), "hello world");
 }
 
-TEST(ToLowerAscii, Empty)
+TEST(ToLowerAsciiCopy, Empty)
 {
-    EXPECT_TRUE(ToLowerAscii("").empty());
+    EXPECT_TRUE(ToLowerAsciiCopy("").empty());
 }
 
-TEST(ToLowerAscii, NonAsciiUnchanged)
+TEST(ToLowerAsciiCopy, NonAsciiUnchanged)
 {
-    EXPECT_EQ(ToLowerAscii("日本語"), "日本語");
+    EXPECT_EQ(ToLowerAsciiCopy("日本語"), "日本語");
 }
 
-TEST(ToLowerAscii, DigitsAndSymbols)
+TEST(ToLowerAsciiCopy, DigitsAndSymbols)
 {
-    EXPECT_EQ(ToLowerAscii("ABC-123_XYZ"), "abc-123_xyz");
+    EXPECT_EQ(ToLowerAsciiCopy("ABC-123_XYZ"), "abc-123_xyz");
 }
 
-TEST(ToLowerAscii, BoundaryChars)
+TEST(ToLowerAsciiCopy, BoundaryChars)
 {
     // A(0x41)の直前@(0x40)、Z(0x5A)の直後[(0x5B)は変換されないこと
-    EXPECT_EQ(ToLowerAscii("@A[Z"), "@a[z");
+    EXPECT_EQ(ToLowerAsciiCopy("@A[Z"), "@a[z");
 }
 
 // ============================================================


### PR DESCRIPTION
## 概要

アプリ全体の冗長・重複処理調査で確認された7件を統合・整理した。挙動の変更はなし。

## 変更内容

### 重複ロジックの統合
- **テーブル可視行範囲の二分探索を一元化**: `TableLayoutData` に `VisibleRowRange()` / `RowIndexAt()` を新設し、renderer.cpp・command_generator.cpp・hit_test_service.cpp に重複していた `row_cum_y` の upper_bound/lower_bound 境界処理を統合
- **サイドペインのホバーリセットを統合**: `App::ResetSidePaneHover()` を新設し、app_mouse_hover.cpp の2形態(タイトルバー移動時のインライン記述 / `reset_pane_buttons` ラムダ)を置き換え。hover index リセット有無の差は引数で維持
- **selection_html.cpp の範囲クランプを共通化**: 3箇所の同形クランプを `ClampEndToText()` に集約

### 同名別物の曖昧さ解消
- 文字列版 `ToLowerAscii` → `ToLowerAsciiCopy`(ascii_util の1文字版関数オブジェクトと区別)
- `stream_util::ReadAllBytes` → `ReadStreamToEnd`(file_io::ReadAllBytes のパス版と区別)
- コンテキストメニューの `NAV_BTN_*` → `CTX_NAV_*`(ui_constants の同名・別値定数と区別。値は不変)

### ヘルパー導入
- `ui_constants.h` に `DipToPixel` / `DipToPixelCeil` / `PixelToDip` を追加し、context_menu.cpp と window.cpp の手書き DPI 変換を置き換え(丸め挙動は箇所ごとに維持)

## 意図的に見送った箇所

- `dwrite_measurer.cpp` の線形ループ可視判定: `VisibleRowRange` と境界一致時の包含判定が異なり、セルレイアウト生成漏れのリスクがあるため現状維持
- `InvalidateDipRect` 内の変換式: `+1` オーバースキャン込みの複合式のため置き換え対象外
- `App::PixelToDip`(DipPoint を返す2点版): シグネチャ・用途が異なるため維持

## テスト

- Release ビルド成功
- mendo_tests.exe: 2315件全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)