### PR TITLE
feat: 目次クリック時の自動スクロールを抑制し追従を中央固定に変更 (issue#259)

### DIFF
--- a/src/app/app.h
+++ b/src/app/app.h
@@ -228,7 +228,7 @@ private:
     void RefreshFilePane();
     void OnDeferredLayout();
 
-    void SyncTocActiveAndAutoScroll(bool auto_scroll = true);
+    void SyncTocActiveAndAutoScroll(bool auto_scroll);
 
     void ReloadCurrentFile();
     void DoReloadCurrentFile();

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -228,7 +228,7 @@ private:
     void RefreshFilePane();
     void OnDeferredLayout();
 
-    void SyncTocActiveAndAutoScroll();
+    void SyncTocActiveAndAutoScroll(bool auto_scroll = true);
 
     void ReloadCurrentFile();
     void DoReloadCurrentFile();

--- a/src/app/app_scroll.cpp
+++ b/src/app/app_scroll.cpp
@@ -13,7 +13,7 @@ void App::InvalidateHitPositions()
     Dispatch(ClearTooltipAction{});
 }
 
-void App::SyncTocActiveAndAutoScroll()
+void App::SyncTocActiveAndAutoScroll(bool auto_scroll)
 {
     if (!state_.view.panes.IsSidePaneVisible(PaneTarget::Toc)) {
         return;
@@ -29,27 +29,19 @@ void App::SyncTocActiveAndAutoScroll()
     state_.active_toc_index = new_active;
     renderer_.InvalidateSidePaneCache(PaneTarget::Toc);
 
-    if (new_active < 0) {
+    // auto_scroll=false (目次クリック由来) ではハイライト更新のみ。
+    // ユーザーが操作中の目次ペインのスクロール位置を勝手に動かさない (issue#259)。
+    if (!auto_scroll || new_active < 0) {
         return;
     }
 
-    // アクティブ見出しが目次ペインの表示範囲から外れていたら、自動スクロールで追従する。
+    // アクティブ見出しを目次ペインの中央に保つように追従スクロールする。
     const float item_y = static_cast<float>(new_active) * theme.pane_item_height;
     const float total = SidePaneContentHeight(state_.document.doc.GetToc().GetEntries().size(), theme.pane_item_height);
     const auto info = ComputePaneScrollInfo(layout.toc_rect, total);
-    auto& toc_scroll = state_.view.panes.SidePaneScroll(PaneTarget::Toc);
-    float& sy = toc_scroll.scroll_y;
-    sy = std::clamp(sy, 0.0f, info.max_scroll);
     if (info.content_height > 0.0f) {
-        // フォーカスを表示領域の 1/5〜4/5 帯に留める（端ぴったりだと前後が見えにくい）。
-        const float zone_upper = info.content_height * (1.0f / 5.0f);
-        const float zone_lower = info.content_height * (4.0f / 5.0f);
-        if (item_y < sy + zone_upper) {
-            sy = std::clamp(item_y - zone_upper, 0.0f, info.max_scroll);
-        }
-        else if (item_y + theme.pane_item_height > sy + zone_lower) {
-            sy = std::clamp(item_y + theme.pane_item_height - zone_lower, 0.0f, info.max_scroll);
-        }
+        state_.view.panes.SidePaneScroll(PaneTarget::Toc).scroll_y =
+            CenterPaneScrollY(item_y, theme.pane_item_height, info);
     }
 }
 

--- a/src/app/app_side_effect_callbacks.cpp
+++ b/src/app/app_side_effect_callbacks.cpp
@@ -109,9 +109,9 @@ void AppSideEffectCallbacks::show_context_menu(int x, int y)
     app->OnContextMenu(x, y);
 }
 
-void AppSideEffectCallbacks::sync_toc_active()
+void AppSideEffectCallbacks::sync_toc_active(bool auto_scroll)
 {
-    app->SyncTocActiveAndAutoScroll();
+    app->SyncTocActiveAndAutoScroll(auto_scroll);
 }
 
 void AppSideEffectCallbacks::schedule_bitmap_manage()

--- a/src/app/app_side_effect_callbacks.h
+++ b/src/app/app_side_effect_callbacks.h
@@ -32,7 +32,7 @@ struct AppSideEffectCallbacks {
     void destroy();
     void handle_parse_complete();
     void show_context_menu(int x, int y);
-    void sync_toc_active();
+    void sync_toc_active(bool auto_scroll);
 
     void schedule_bitmap_manage();
     void on_app_image_loaded();

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -62,30 +62,30 @@ void ClearSidePaneHoverState(AppState& state, SideEffectList& effects)
 // スクロール位置が変わった時に共通で発火する副作用列。
 // InvalidateMdPane → BitmapManage の順序は test_reducer の HasEffectInOrder で契約として担保。
 // MD ペイン限定無効化により、タイトルバー/サイドペインビットマップキャッシュの再描画を避ける。
-void EmitScrollChangedSideEffects(AppState& state, SideEffectList& effects)
+void EmitScrollChangedSideEffects(AppState& state, SideEffectList& effects, bool toc_auto_scroll)
 {
     state.interaction.hover_throttle.Reset();
     ClearTooltip(state, effects);
     PushEffect(effects, effect::InvalidateMdPane{});
     PushEffect(effects, effect::BitmapManage{});
-    PushEffect(effects, effect::SyncTocActive{});
+    PushEffect(effects, effect::SyncTocActive{ toc_auto_scroll });
 }
 
 void EmitScrollEffects(AppState& state, SideEffectList& effects, float old_scroll)
 {
     if (state.view.viewport.GetScrollY() != old_scroll) {
-        EmitScrollChangedSideEffects(state, effects);
+        EmitScrollChangedSideEffects(state, effects, /*toc_auto_scroll=*/true);
     }
 }
 
-void ApplyScrollTargetAndEmit(AppState& state, SideEffectList& effects, int node, float offset)
+void ApplyScrollTargetAndEmit(AppState& state, SideEffectList& effects, int node, float offset, bool toc_auto_scroll)
 {
     state.view.viewport.SetScrollTarget(node, offset);
     state.view.viewport.ApplyScrollTarget(state.document.layout_cache);
     // 末尾セクションへのジャンプで scroll_y > max_scroll になると、後続の DirectScrollBy で
     // 位置が一気に飛ぶ。事前クランプ + target 無効化で範囲外への復帰を抑える。
     state.view.viewport.ClampAndDetach();
-    EmitScrollChangedSideEffects(state, effects);
+    EmitScrollChangedSideEffects(state, effects, toc_auto_scroll);
 }
 
 constexpr PaneController::DragTarget SidePaneDragTargetImpl(PaneTarget pane) noexcept

--- a/src/app/reducer_internal.h
+++ b/src/app/reducer_internal.h
@@ -14,9 +14,11 @@
 void ClearTooltip(AppState& state, SideEffectList& effects);
 void ClearSidePaneHoverState(AppState& state, SideEffectList& effects);
 
-void EmitScrollChangedSideEffects(AppState& state, SideEffectList& effects);
+// toc_auto_scroll は発火元がスクロール先を決める: 目次ペイン操作由来のみ false (issue#259)。
+// デフォルト引数にすると新経路が暗黙で true を拾うため、呼び出し側で必ず明示する。
+void EmitScrollChangedSideEffects(AppState& state, SideEffectList& effects, bool toc_auto_scroll);
 void EmitScrollEffects(AppState& state, SideEffectList& effects, float old_scroll);
-void ApplyScrollTargetAndEmit(AppState& state, SideEffectList& effects, int node, float offset);
+void ApplyScrollTargetAndEmit(AppState& state, SideEffectList& effects, int node, float offset, bool toc_auto_scroll);
 
 // つまみ上クリック → 位置維持 (オフセットのみ記録)、つまみ外 → 中心へジャンプ。
 struct ScrollbarDragGrip {

--- a/src/app/reducer_navigation.cpp
+++ b/src/app/reducer_navigation.cpp
@@ -12,7 +12,7 @@ void ApplyNavResult(AppState& state, SideEffectList& effects, NavEntry&& entry)
         PushEffect(effects, effect::LoadFile{ std::move(entry.file_path) });
     }
     else {
-        ApplyScrollTargetAndEmit(state, effects, entry.node, entry.offset);
+        ApplyScrollTargetAndEmit(state, effects, entry.node, entry.offset, /*toc_auto_scroll=*/true);
     }
 }
 
@@ -52,7 +52,7 @@ void ReduceFilePaneFileClicked(AppState& state, SideEffectList& effects, const F
 }
 
 namespace {
-void ScrollToResolvedAnchor(AppState& state, SideEffectList& effects, int idx)
+void ScrollToResolvedAnchor(AppState& state, SideEffectList& effects, int idx, bool toc_auto_scroll)
 {
     if (idx < 0) {
         return;
@@ -61,18 +61,18 @@ void ScrollToResolvedAnchor(AppState& state, SideEffectList& effects, int idx)
         idx,
         state.theme->heading_spacing_above,
         state.pane_layout_cache.Get().md_rect.y);
-    ApplyScrollTargetAndEmit(state, effects, target.node, target.offset);
+    ApplyScrollTargetAndEmit(state, effects, target.node, target.offset, toc_auto_scroll);
 }
 
 void ScrollToAnchor(AppState& state, SideEffectList& effects, std::string_view anchor_id)
 {
-    ScrollToResolvedAnchor(state, effects, state.document.doc.FindAnchorIndex(anchor_id));
+    ScrollToResolvedAnchor(state, effects, state.document.doc.FindAnchorIndex(anchor_id), /*toc_auto_scroll=*/true);
 }
 
 // anchor_id() 由来など、既に正規化済み入力向け（ToLowerAsciiCopy の確保を回避する）。
-void ScrollToNormalizedAnchor(AppState& state, SideEffectList& effects, std::string_view anchor_id)
+void ScrollToNormalizedAnchor(AppState& state, SideEffectList& effects, std::string_view anchor_id, bool toc_auto_scroll)
 {
-    ScrollToResolvedAnchor(state, effects, state.document.doc.FindNormalizedAnchorIndex(anchor_id));
+    ScrollToResolvedAnchor(state, effects, state.document.doc.FindNormalizedAnchorIndex(anchor_id), toc_auto_scroll);
 }
 } // namespace
 
@@ -80,7 +80,8 @@ void ReduceTocItemClicked(AppState& state, SideEffectList& effects, const TocIte
 {
     PushCurrentNavEntry(state);
     // TOC は anchor_id() を直接渡すため、改めての正規化は不要。
-    ScrollToNormalizedAnchor(state, effects, a.anchor_id);
+    // 目次クリック由来では目次ペインの自動スクロールを抑制する (issue#259)。
+    ScrollToNormalizedAnchor(state, effects, a.anchor_id, /*toc_auto_scroll=*/false);
 }
 
 void ReduceNavigateAnchor(AppState& state, SideEffectList& effects, const NavigateAnchorAction& a)

--- a/src/app/side_effect.h
+++ b/src/app/side_effect.h
@@ -99,6 +99,9 @@ struct RefreshPaneLayout {};
 struct SyncTocActive {
     // false: ハイライト更新のみで目次ペインの自動スクロールを行わない。
     // 目次ペイン操作由来のジャンプでクリック先が動く混乱を防ぐ (issue#259)。
+    // ジャンプ由来の判断は reducer 層 (EmitScrollChangedSideEffects) が明示引数で担い、
+    // SyncTocActive{} で発火する App 側の再同期 (リサイズ/ロード等) は常に追従で正しい。
+    // デフォルトを外すと {} が値初期化で false になり挙動が静かに反転するため維持する。
     bool auto_scroll = true;
 };
 // 可視範囲のレイアウトを即時計測する。md_width/md_height はペインレイアウトのキャッシュ値。

--- a/src/app/side_effect.h
+++ b/src/app/side_effect.h
@@ -96,7 +96,11 @@ struct InvalidatePaneCache {
     PaneZone pane;
 };
 struct RefreshPaneLayout {};
-struct SyncTocActive {};
+struct SyncTocActive {
+    // false: ハイライト更新のみで目次ペインの自動スクロールを行わない。
+    // 目次ペイン操作由来のジャンプでクリック先が動く混乱を防ぐ (issue#259)。
+    bool auto_scroll = true;
+};
 // 可視範囲のレイアウトを即時計測する。md_width/md_height はペインレイアウトのキャッシュ値。
 struct ViewportLayout {
     float md_width;

--- a/src/app/side_effect_executor.h
+++ b/src/app/side_effect_executor.h
@@ -143,8 +143,8 @@ public:
             [this](const effect::RefreshPaneLayout&) {
                 cb_.refresh_pane_layout();
             },
-            [this](const effect::SyncTocActive&) {
-                cb_.sync_toc_active();
+            [this](const effect::SyncTocActive& ev) {
+                cb_.sync_toc_active(ev.auto_scroll);
             },
             [this](const effect::ViewportLayout& ev) {
                 deps_.layout_service->ViewportLayout(

--- a/src/util/pane_layout.h
+++ b/src/util/pane_layout.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "ui_constants.h"
 #include "ui_types.h"
+#include <algorithm>
 #include <optional>
 
 enum class PaneZone : uint8_t {
@@ -90,6 +91,12 @@ private:
 constexpr float SidePaneContentHeight(size_t item_count, float pane_item_height) noexcept
 {
     return static_cast<float>(item_count) * pane_item_height;
+}
+
+// 指定項目をペイン表示域の縦中央に置くスクロール位置。先頭/末尾付近は端にクランプする (issue#259)。
+constexpr float CenterPaneScrollY(float item_y, float item_height, const PaneScrollInfo& info) noexcept
+{
+    return std::clamp(item_y - (info.content_height - item_height) * 0.5f, 0.0f, info.max_scroll);
 }
 
 PaneLayout ComputePaneLayout(

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -153,6 +153,19 @@ inline std::optional<size_t> IndexOfEffect(const SideEffectList& effects) noexce
     return std::nullopt;
 }
 
+// SideEffectList の中で型 T が最初に現れる要素を返す。無ければ nullptr。
+// フィールド値の検証 (HasEffect では型の有無しか見られない) に使う。
+template <typename T>
+inline const T* FindEffect(const SideEffectList& effects) noexcept
+{
+    for (const auto& se : effects) {
+        if (const T* p = GetEffect<T>(se)) {
+            return p;
+        }
+    }
+    return nullptr;
+}
+
 enum class EffectOrdering {
     Before, // A が先、B が後
     After,  // B が先、A が後

--- a/tests/test_pane_layout.cpp
+++ b/tests/test_pane_layout.cpp
@@ -171,6 +171,40 @@ TEST(ComputeScrollInfo, ZeroContent)
 }
 
 // ============================================================
+// CenterPaneScrollY (issue#259: アクティブ項目の中央追従)
+// ============================================================
+
+TEST(CenterPaneScrollY, CentersItemInViewport)
+{
+    PaneScrollInfo info{};
+    info.content_height = 400.0f;
+    info.max_scroll = 600.0f;
+
+    // 500 - (400 - 20) / 2 = 310
+    EXPECT_FLOAT_EQ(CenterPaneScrollY(500.0f, 20.0f, info), 310.0f);
+}
+
+TEST(CenterPaneScrollY, ClampsAtTop)
+{
+    PaneScrollInfo info{};
+    info.content_height = 400.0f;
+    info.max_scroll = 600.0f;
+
+    // 先頭付近の項目は中央に置けないので 0 で止める
+    EXPECT_FLOAT_EQ(CenterPaneScrollY(50.0f, 20.0f, info), 0.0f);
+}
+
+TEST(CenterPaneScrollY, ClampsAtBottom)
+{
+    PaneScrollInfo info{};
+    info.content_height = 400.0f;
+    info.max_scroll = 600.0f;
+
+    // 900 - 190 = 710 > max_scroll → 末尾で止める
+    EXPECT_FLOAT_EQ(CenterPaneScrollY(900.0f, 20.0f, info), 600.0f);
+}
+
+// ============================================================
 // ComputeThumbY
 // ============================================================
 

--- a/tests/test_reducer.cpp
+++ b/tests/test_reducer.cpp
@@ -1190,6 +1190,59 @@ TEST_F(ReducerTest, TocItemClicked_TailSection_ClampsToMaxScroll)
     EXPECT_FALSE(state.view.viewport.HasScrollTarget());
 }
 
+// issue#259: 目次クリック由来のジャンプでは目次ペインの自動スクロールを抑制する
+// (ハイライト更新のみ)。クリック先の項目が画面内で動いて見失う混乱を防ぐ契約。
+TEST_F(ReducerTest, TocItemClicked_SuppressesTocAutoScroll)
+{
+    state.document.doc = Document::FromMarkdown(std::pmr::string("# First\n\n# Second"), L"C:\\file.md");
+    auto& cache = state.document.layout_cache;
+    const auto& nodes = state.document.doc.GetNodes();
+    cache.Resize(nodes.size());
+    cache[1].text_top = 100.0f;
+
+    const auto anchor = nodes[1].anchor_id();
+    if (anchor.empty()) {
+        GTEST_SKIP() << "anchor_id が空のため検証できない";
+    }
+
+    auto effects = Reduce(state, TocItemClickedAction{ std::pmr::string(anchor) });
+
+    const auto* sync = FindEffect<effect::SyncTocActive>(effects);
+    ASSERT_NE(sync, nullptr);
+    EXPECT_FALSE(sync->auto_scroll);
+}
+
+// MD ペインのスクロール由来では従来通り目次が追従する。
+TEST_F(ReducerTest, KeyScroll_KeepsTocAutoScroll)
+{
+    auto effects = Reduce(state, KeyScrollAction{ ScrollType::LineDown });
+
+    const auto* sync = FindEffect<effect::SyncTocActive>(effects);
+    ASSERT_NE(sync, nullptr);
+    EXPECT_TRUE(sync->auto_scroll);
+}
+
+// MD ペイン内のアンカーリンク由来でも追従を維持する (抑制は目次クリックのみ)。
+TEST_F(ReducerTest, NavigateAnchor_KeepsTocAutoScroll)
+{
+    state.document.doc = Document::FromMarkdown(std::pmr::string("# First\n\n# Second"), L"C:\\file.md");
+    auto& cache = state.document.layout_cache;
+    const auto& nodes = state.document.doc.GetNodes();
+    cache.Resize(nodes.size());
+    cache[1].text_top = 100.0f;
+
+    const auto anchor = nodes[1].anchor_id();
+    if (anchor.empty()) {
+        GTEST_SKIP() << "anchor_id が空のため検証できない";
+    }
+
+    auto effects = Reduce(state, NavigateAnchorAction{ std::pmr::string(anchor) });
+
+    const auto* sync = FindEffect<effect::SyncTocActive>(effects);
+    ASSERT_NE(sync, nullptr);
+    EXPECT_TRUE(sync->auto_scroll);
+}
+
 // ---- 副作用順序ヘルパーの利用例 (test_helpers.h::HasEffectInOrder) ----
 // EmitScrollEffects は InvalidateMdPane → BitmapManage の順で push する契約。
 // 順序が逆転すると BitmapManage 側が古い viewport で動くなどの実害があるため、

--- a/tests/test_side_effect_executor.cpp
+++ b/tests/test_side_effect_executor.cpp
@@ -117,7 +117,7 @@ struct CallbackTracker {
     int handle_parse_complete_count = 0;
     std::pair<int, int> last_context_menu_pos{ 0, 0 };
     int show_context_menu_count = 0;
-    int sync_toc_active_count = 0;
+    std::vector<bool> sync_toc_auto_scroll_calls;
 };
 
 struct TestSideEffectCallbacks {
@@ -203,9 +203,9 @@ struct TestSideEffectCallbacks {
         t->last_context_menu_pos = { x, y };
         t->show_context_menu_count++;
     }
-    void sync_toc_active()
+    void sync_toc_active(bool auto_scroll)
     {
-        t->sync_toc_active_count++;
+        t->sync_toc_auto_scroll_calls.push_back(auto_scroll);
     }
 
     void schedule_bitmap_manage()
@@ -302,6 +302,15 @@ TEST_F(SideEffectExecutorTest, RefreshPaneLayoutDispatchesToCallback)
 {
     exec_.ExecuteOne(effect::RefreshPaneLayout{});
     EXPECT_EQ(refresh_pane_layout_count_, 1);
+}
+
+TEST_F(SideEffectExecutorTest, SyncTocActiveForwardsAutoScrollFlag)
+{
+    exec_.ExecuteOne(effect::SyncTocActive{});
+    exec_.ExecuteOne(effect::SyncTocActive{ /*auto_scroll=*/false });
+    ASSERT_EQ(tracker_.sync_toc_auto_scroll_calls.size(), 2u);
+    EXPECT_TRUE(tracker_.sync_toc_auto_scroll_calls[0]);
+    EXPECT_FALSE(tracker_.sync_toc_auto_scroll_calls[1]);
 }
 
 TEST_F(SideEffectExecutorTest, RendererResizeForwardsDimensions)


### PR DESCRIPTION
## 概要

Closes #259

目次ペインのハイライト追従スクロールについて、2つの挙動を変更します。

1. **目次リンククリック時の自動スクロールを抑制**
   クリックした項目がクランプ動作で画面内を動いてしまい操作対象を見失う問題を解消。`effect::SyncTocActive` に `auto_scroll` フラグを追加し、`TocItemClickedAction` 由来のジャンプのみ目次ペインのスクロールを抑制する（`active_toc_index` の更新＝ハイライトは維持）。
2. **上下20%帯クランプ → 常に中央配置**
   従来の 1/5〜4/5 帯の分岐を、純粋関数 `CenterPaneScrollY()` (`src/util/pane_layout.h`) による中央固定クランプに置き換え。文書の先頭・末尾付近は `[0, max_scroll]` のクランプで自然に端へ寄る。

## 設計メモ

- 抑制の条件は「mdペインのスクロールのみ」ではなく「**目次ペイン操作由来のみ**」。mdペイン内アンカーリンク (`NavigateAnchor`) や戻る/進む (`ApplyNavResult`) ではユーザーが目次を見ていないため、追従を維持するのが正しい挙動と判断
- `toc_auto_scroll` はデフォルト引数にせず全呼び出し側で明示。将来ペイン操作由来の新経路が暗黙で `true` を拾い、本 issue と同種の混乱を再導入するのを防ぐ
- 中央固定はアクティブ見出しが切り替わるたびに目次が1項目分動くトレードオフがあるが、ハイライト位置の予測可能性を優先（issue 起票時に合意済み）

## テスト

全 2327 件パス（新規 7 件）。

- `CenterPaneScrollY`: 中央配置・上端/下端クランプ
- reducer: `TocItemClicked` は `auto_scroll=false`、`KeyScroll` / `NavigateAnchor` は `true` を維持する契約
- executor: フラグがコールバックまで転送されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)