### PR TITLE
refactor: アプリ全体の重複コード抽出と dead code 削除

### DIFF
--- a/src/app/resource_manager.h
+++ b/src/app/resource_manager.h
@@ -364,10 +364,8 @@ public:
         const auto evict_outside_keep = [&](const std::pmr::vector<size_t>& indices) {
             const auto keep = VisibleSlice(indices, static_cast<size_t>(first_keep), static_cast<size_t>(last_keep));
             const auto reset_bitmap = [&](size_t i) {
-                auto& diagram = deps_.cache->GetDiagram(i);
-                if (diagram.bitmap) {
-                    diagram.bitmap.Reset();
-                }
+                // ComPtr::Reset() は null でも安全な no-op。
+                deps_.cache->GetDiagram(i).bitmap.Reset();
             };
             for (auto it = indices.begin(); it != keep.begin; ++it) {
                 reset_bitmap(*it);

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -25,7 +25,7 @@ public:
     ~Document() = default;
 
     // ファクトリ。本体は (text, byte_size, path) の 3 引数版。
-    // 2 引数版は BOM 除去 + byte_size 計算を内蔵した便利ラッパー (テスト / Help リソース経路)。
+    // 2 引数版は byte_size 計算を内蔵した便利ラッパー (テスト / Help リソース経路、入力は BOM 無し前提)。
     // default-constructed の stop_token はキャンセル不可で従来通り動作。
     static Document FromMarkdown(std::pmr::string text, size_t byte_size, std::wstring_view path,
                                  std::stop_token stop_token = {});

--- a/src/nav/nav.cpp
+++ b/src/nav/nav.cpp
@@ -90,41 +90,34 @@ void NavHistory::Push(const NavEntry& current)
     }
 }
 
-bool NavHistory::GoBack(const NavEntry& current, NavEntry& out)
+bool NavHistory::Move(std::pmr::deque<InternalEntry>& from, std::pmr::deque<InternalEntry>& to, const NavEntry& current, NavEntry& out)
 {
-    if (back_stack_.empty()) {
+    if (from.empty()) {
         return false;
     }
 
-    forward_stack_.emplace_back(ToInternal(current));
-    if (forward_stack_.size() > MAX_HISTORY) {
-        ReleasePath(forward_stack_.front().path_index);
-        forward_stack_.pop_front();
+    // 現在地を反対側スタックへ。容量超過時は最古を解放して捨てる
+    // (放置すると往復で容量超過 + path slot 参照が滞留する)。
+    to.emplace_back(ToInternal(current));
+    if (to.size() > MAX_HISTORY) {
+        ReleasePath(to.front().path_index);
+        to.pop_front();
     }
-    const auto top = back_stack_.back();
+    const auto top = from.back();
     out = ToExternal(top);
-    back_stack_.pop_back();
+    from.pop_back();
     ReleasePath(top.path_index);
     return true;
 }
 
+bool NavHistory::GoBack(const NavEntry& current, NavEntry& out)
+{
+    return Move(back_stack_, forward_stack_, current, out);
+}
+
 bool NavHistory::GoForward(const NavEntry& current, NavEntry& out)
 {
-    if (forward_stack_.empty()) {
-        return false;
-    }
-
-    back_stack_.emplace_back(ToInternal(current));
-    // 抜けると往復で容量超過 + path slot 参照が滞留する。
-    if (back_stack_.size() > MAX_HISTORY) {
-        ReleasePath(back_stack_.front().path_index);
-        back_stack_.pop_front();
-    }
-    const auto top = forward_stack_.back();
-    out = ToExternal(top);
-    forward_stack_.pop_back();
-    ReleasePath(top.path_index);
-    return true;
+    return Move(forward_stack_, back_stack_, current, out);
 }
 
 void NavHistory::Clear() noexcept

--- a/src/nav/nav.h
+++ b/src/nav/nav.h
@@ -75,6 +75,9 @@ private:
     InternalEntry ToInternal(const NavEntry& e);
     NavEntry ToExternal(const InternalEntry& e) const;
 
+    // GoBack/GoForward の対称処理を集約する。
+    bool Move(std::pmr::deque<InternalEntry>& from, std::pmr::deque<InternalEntry>& to, const NavEntry& current, NavEntry& out);
+
     // path_pool_ は deque にして emplace_back での参照安定性を保証し、
     // path_index_ のキー (std::wstring_view) が pool 内の文字列を指し続けるようにする。
     // 典型的なセッションのエントリ数は数十〜数百で、文字列ハッシュの計算コストと

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -1,5 +1,6 @@
 #include "command_generator.h"
 #include "command_generator_internal.h"
+#include "render_params.h"
 #include "i18n.h"
 #include "layout.h"
 #include "layout_computer.h"
@@ -104,10 +105,7 @@ const DrawCommandList& CommandGenerator::GenerateMdPane(
         cmds.reserve(last_cmds_size_ + last_cmds_size_ / 8 + 16);
     }
 
-    const D2D1_RECT_F md_clip = D2D1::RectF(
-        md_pane_rect.x, md_pane_rect.y,
-        md_pane_rect.x + md_pane_rect.width, md_pane_rect.y + md_pane_rect.height);
-    cmds.emplace_back(PushClipCmd{ md_clip });
+    cmds.emplace_back(PushClipCmd{ ToD2DRect(md_pane_rect) });
     // スクロール位置を物理ピクセル境界にスナップし、ClearTypeヒンティングの
     // フレーム間変動によるテキストのガタつきを防止する。スナップは描画 Y のみに
     // 適用し、二分探索 (FindFirstVisibleNodeIndex) には未スナップ scroll_y を渡す。

--- a/src/render/command_generator_table.cpp
+++ b/src/render/command_generator_table.cpp
@@ -5,12 +5,16 @@
 
 void CommandGenerator::GenTableRowBg(DrawCommandList& cmds, const TableRowGeom& g, bool is_header, bool is_even_row)
 {
-    if (is_header) {
-        cmds.emplace_back(FillRectCmd{ D2D1::RectF(g.x, g.y, g.x + g.table_width, g.y + g.row_h + g.border), theme_->code_bg_color, BrushId::CodeBg });
+    if (!is_header && !is_even_row) {
+        return;
     }
-    else if (is_even_row) {
+    const D2D1_RECT_F rect = D2D1::RectF(g.x, g.y, g.x + g.table_width, g.y + g.row_h + g.border);
+    if (is_header) {
+        cmds.emplace_back(FillRectCmd{ rect, theme_->code_bg_color, BrushId::CodeBg });
+    }
+    else {
         // cached_stripe_color_ と Renderer の brushes_[TableStripe] は同じ式 (renderer_resources.cpp) で算出する。
-        cmds.emplace_back(FillRectCmd{ D2D1::RectF(g.x, g.y, g.x + g.table_width, g.y + g.row_h + g.border), cached_stripe_color_, BrushId::TableStripe });
+        cmds.emplace_back(FillRectCmd{ rect, cached_stripe_color_, BrushId::TableStripe });
     }
 }
 

--- a/src/render/render_params.h
+++ b/src/render/render_params.h
@@ -70,6 +70,12 @@ inline D2D1_RECT_F ToD2DRect(const DipRect& r) noexcept
     return std::bit_cast<D2D1_RECT_F>(r);
 }
 
+// PaneRect は {x,y,width,height} で D2D1_RECT_F とビット等価ではないため計算で変換する。
+inline D2D1_RECT_F ToD2DRect(const PaneRect& r) noexcept
+{
+    return D2D1::RectF(r.x, r.y, r.x + r.width, r.y + r.height);
+}
+
 // File / TOC ペインの対称な状態をまとめた値型。SidePaneState::panes[2] の要素。
 struct SidePaneInstance {
     PaneRect rect{};

--- a/src/render/renderer_pane.cpp
+++ b/src/render/renderer_pane.cpp
@@ -163,8 +163,7 @@ static void DrawSidePaneImpl(const SidePaneDrawContext& sp, DrawItemFn draw_item
     }
 
     if (sp.cache.cached_bitmap) {
-        const D2D1_RECT_F dest = D2D1::RectF(sp.rect.x, sp.rect.y, sp.rect.x + sp.rect.width, sp.rect.y + sp.rect.height);
-        sp.main_rt->DrawBitmap(sp.cache.cached_bitmap.Get(), dest);
+        sp.main_rt->DrawBitmap(sp.cache.cached_bitmap.Get(), ToD2DRect(sp.rect));
     }
 }
 

--- a/src/ui/search_state.cpp
+++ b/src/ui/search_state.cpp
@@ -4,6 +4,15 @@
 #include <algorithm>
 #include <limits>
 
+namespace {
+// ビットマップ描画ノード (画像 / ダイアグラムコードブロック) はテキストハイライト不可のため検索対象外。
+bool IsNonSearchableDrawNode(const Node& node) noexcept
+{
+    return node.type == NodeType::Image ||
+           (node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language()));
+}
+} // namespace
+
 void SearchState::SetQuery(std::string_view query)
 {
     query_.assign(query);
@@ -54,9 +63,7 @@ void SearchState::ExecuteSearch(const std::pmr::vector<Node>& nodes)
             }
         }
         else if (const auto& text = node.GetText(); !text.empty()) {
-            // ビットマップ描画ノードはテキストハイライト不可のため検索対象外
-            if (node.type == NodeType::Image ||
-                (node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language()))) {
+            if (IsNonSearchableDrawNode(node)) {
                 continue;
             }
             const auto search_text = case_sensitive_ ? text : lower_cache_.GetText(i);
@@ -105,7 +112,7 @@ void SearchState::EnsureLowercaseCache(const std::pmr::vector<Node>& nodes)
             table.offsets = std::span<const uint32_t>{ tbl->cell_text_starts.data(), tbl->cell_text_starts.size() };
             lower_cache_.tables.emplace(static_cast<int>(i), std::move(table));
         }
-        else if (node.type == NodeType::Image || (node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language()))) {
+        else if (IsNonSearchableDrawNode(node)) {
             // 検索対象外ノードは空スライス
             lower_cache_.offsets.push_back(static_cast<uint32_t>(lower_cache_.buffer.size()));
         }

--- a/src/util/ascii_util.h
+++ b/src/util/ascii_util.h
@@ -29,23 +29,9 @@ struct ToLowerAsciiFn {
 inline constexpr ToLowerAsciiFn ToLowerAscii{};
 
 template <typename Char>
-constexpr Char ToUpperAscii(Char c) noexcept
-{
-    return (c >= static_cast<Char>('a') && c <= static_cast<Char>('z')) ? static_cast<Char>(c - static_cast<Char>('a') + static_cast<Char>('A')) : c;
-}
-
-template <typename Char>
 constexpr bool IsAsciiDigit(Char c) noexcept
 {
     return c >= static_cast<Char>('0') && c <= static_cast<Char>('9');
-}
-
-template <typename Char>
-constexpr bool IsAsciiHexDigit(Char c) noexcept
-{
-    return IsAsciiDigit(c) ||
-           (c >= static_cast<Char>('a') && c <= static_cast<Char>('f')) ||
-           (c >= static_cast<Char>('A') && c <= static_cast<Char>('F'));
 }
 
 // CJK は対象外。

--- a/src/util/fenwick.h
+++ b/src/util/fenwick.h
@@ -59,13 +59,7 @@ public:
             }
         }
         tree_.resize(n, 0.0f);
-        // 個別値配列から Fenwick を再構築 (Build(span) と同じ本体)。
-        for (std::size_t i = 1; i <= n; ++i) {
-            const std::size_t parent = i + (i & (~i + 1));
-            if (parent <= n) {
-                tree_[parent - 1] += tree_[i - 1];
-            }
-        }
+        BuildFromPoints(n);
     }
 
     constexpr std::size_t size() const noexcept
@@ -139,12 +133,7 @@ public:
         if (n > 0) {
             std::copy_n(values.data(), n, tree_.data());
         }
-        for (std::size_t i = 1; i <= n; ++i) {
-            const std::size_t parent = i + (i & (~i + 1));
-            if (parent <= n) {
-                tree_[parent - 1] += tree_[i - 1];
-            }
-        }
+        BuildFromPoints(n);
     }
 
 private:
@@ -158,6 +147,17 @@ private:
         const std::size_t n = tree_.size();
         for (std::size_t k = i + 1; k <= n; k += k & (~k + 1)) {
             tree_[k - 1] += diff;
+        }
+    }
+
+    // 個別値が tree_[0..n) に入っている状態から Fenwick 構造へ in-place 変換する。
+    void BuildFromPoints(std::size_t n) noexcept
+    {
+        for (std::size_t i = 1; i <= n; ++i) {
+            const std::size_t parent = i + (i & (~i + 1));
+            if (parent <= n) {
+                tree_[parent - 1] += tree_[i - 1];
+            }
         }
     }
 


### PR DESCRIPTION
## 概要

`/simplify` でアプリ全体 (src/ 約31,500行) をレビューし、**挙動不変**の簡素化を適用しました。重複コードの共通化・dead code 削除・コメント修正が中心で、新機能や挙動変更はありません。

その後 `/code-review` (xhigh recall) で全変更を多角的に検証し、**correctness バグ 0 件**・ビルド緑・全テスト (2327件) パスを確認済みです。

## 変更内容

| ファイル | 内容 |
|---|---|
| `util/ascii_util.h` | 未使用の `ToUpperAscii` / `IsAsciiHexDigit` を削除 (dead code) |
| `util/fenwick.h` | `GrowTo`/`Build` で重複していた再構築ループを `BuildFromPoints` に集約 |
| `nav/nav.{cpp,h}` | 対称コピペだった `GoBack`/`GoForward` を `Move` ヘルパーに統合 |
| `render/render_params.h` 他 | `PaneRect`→`D2D1_RECT_F` の手書き変換を `ToD2DRect(PaneRect)` に集約 (2箇所置換) |
| `render/command_generator_table.cpp` | `GenTableRowBg` の矩形コピペを共通変数に括り出し |
| `app/resource_manager.h` | `ComPtr::Reset` の冗長な null ガードを削除 (null安全な no-op) |
| `ui/search_state.cpp` | 2箇所に重複していた検索除外条件を `IsNonSearchableDrawNode` に単一化 |
| `core/document.h` | 実装と食い違っていた「BOM 除去」コメントを修正 |

## 検証

- `cmake --build build --config Release` : 成功
- `mendo_tests.exe` : 2327 tests PASSED

## 補足 (今回は見送った改善)

- `IsNonSearchableDrawNode` の `document_types.h` 昇格: 完全同一式は現状1箇所のみで YAGNI のため見送り
- `DipRect`/`PaneRect` 矩形型の統一: 本 PR のスコープを超える設計課題のため別途

🤖 Generated with [Claude Code](https://claude.com/claude-code)
