### PR TITLE
refactor: アプリ全体の重複・特殊ケースを共通ヘルパーに集約

### DIFF
--- a/src/app/app_mouse_hover.cpp
+++ b/src/app/app_mouse_hover.cpp
@@ -214,11 +214,10 @@ void App::OnMouseHover(int px, int py)
     const auto hovered_target = ToPaneTarget(zone);
 
     // ペインゾーン外に出たらヘッダーボタンのホバーをリセット（無効化忘れ防止）。
-    if (hovered_target != PaneTarget::File) {
-        ResetSidePaneHover(PaneTarget::File, pane_layout, false);
-    }
-    if (hovered_target != PaneTarget::Toc) {
-        ResetSidePaneHover(PaneTarget::Toc, pane_layout, false);
+    for (auto t : { PaneTarget::File, PaneTarget::Toc }) {
+        if (hovered_target != t) {
+            ResetSidePaneHover(t, pane_layout, false);
+        }
     }
 
     int new_hover[2] = { -1, -1 };

--- a/src/app/reducer.cpp
+++ b/src/app/reducer.cpp
@@ -50,7 +50,7 @@ void ClearSidePaneHoverState(AppState& state, SideEffectList& effects)
             pane_changed |= state.view.panes.SetSideRefreshHovered(t, false);
         }
         if (pane_changed) {
-            PushEffect(effects, effect::InvalidatePaneCache{ t == PaneTarget::File ? PaneZone::FilePane : PaneZone::TocPane });
+            PushEffect(effects, effect::InvalidatePaneCache{ ToPaneZone(t) });
             changed = true;
         }
     }
@@ -69,6 +69,12 @@ void EmitScrollChangedSideEffects(AppState& state, SideEffectList& effects, bool
     PushEffect(effects, effect::InvalidateMdPane{});
     PushEffect(effects, effect::BitmapManage{});
     PushEffect(effects, effect::SyncTocActive{ toc_auto_scroll });
+}
+
+void EmitSidePaneScrollChanged(SideEffectList& effects, PaneZone zone)
+{
+    PushEffect(effects, effect::InvalidatePaneCache{ zone });
+    PushEffect(effects, effect::InvalidateWindow{});
 }
 
 void EmitScrollEffects(AppState& state, SideEffectList& effects, float old_scroll)

--- a/src/app/reducer_input.cpp
+++ b/src/app/reducer_input.cpp
@@ -188,8 +188,7 @@ void ReducePaneScrollbarDragStarted(AppState& state, SideEffectList& effects, co
     PushEffect(effects, effect::SetCapture{});
     if (!grip.inside_thumb) {
         ctx.scroll.scroll_y = ScrollFromThumbY(ctx.info, a.dip_y - drag_offset);
-        PushEffect(effects, effect::InvalidatePaneCache{ ctx.pane_zone });
-        PushEffect(effects, effect::InvalidateWindow{});
+        EmitSidePaneScrollChanged(effects, ctx.pane_zone);
     }
 }
 
@@ -203,8 +202,7 @@ void ReducePaneScrollbarDragMoved(AppState& state, SideEffectList& effects, cons
     auto ctx = GetSidePaneContext(state, a.pane);
     const float new_thumb_y = a.dip_y - state.view.panes.GetDragScrollOffset();
     ctx.scroll.scroll_y = ScrollFromThumbY(ctx.info, new_thumb_y);
-    PushEffect(effects, effect::InvalidatePaneCache{ ctx.pane_zone });
-    PushEffect(effects, effect::InvalidateWindow{});
+    EmitSidePaneScrollChanged(effects, ctx.pane_zone);
 }
 
 void ReducePaneScrollbarDragEnded(AppState& state, SideEffectList& effects)

--- a/src/app/reducer_internal.h
+++ b/src/app/reducer_internal.h
@@ -18,6 +18,9 @@ void ClearSidePaneHoverState(AppState& state, SideEffectList& effects);
 // デフォルト引数にすると新経路が暗黙で true を拾うため、呼び出し側で必ず明示する。
 void EmitScrollChangedSideEffects(AppState& state, SideEffectList& effects, bool toc_auto_scroll);
 void EmitScrollEffects(AppState& state, SideEffectList& effects, float old_scroll);
+
+// サイドペイン (ファイル/目次) のスクロール位置が変わった際の無効化副作用。
+void EmitSidePaneScrollChanged(SideEffectList& effects, PaneZone zone);
 void ApplyScrollTargetAndEmit(AppState& state, SideEffectList& effects, int node, float offset, bool toc_auto_scroll);
 
 // つまみ上クリック → 位置維持 (オフセットのみ記録)、つまみ外 → 中心へジャンプ。

--- a/src/app/reducer_navigation.cpp
+++ b/src/app/reducer_navigation.cpp
@@ -41,8 +41,7 @@ void ReduceFilePaneDirectoryClicked(AppState& state, SideEffectList& effects, co
         state.file_explorer.SetCurrentFile(state.document.doc.GetFilePath());
     }
     state.view.panes.SidePaneScroll(PaneTarget::File) = {};
-    PushEffect(effects, effect::InvalidatePaneCache{ PaneZone::FilePane });
-    PushEffect(effects, effect::InvalidateWindow{});
+    EmitSidePaneScrollChanged(effects, PaneZone::FilePane);
 }
 
 void ReduceFilePaneFileClicked(AppState& state, SideEffectList& effects, const FilePaneFileClickedAction& a)

--- a/src/app/reducer_scroll.cpp
+++ b/src/app/reducer_scroll.cpp
@@ -50,8 +50,7 @@ void ReduceScrollPane(AppState& state, SideEffectList& effects, const ScrollPane
     }
     const auto ctx = GetSidePaneContext(state, *target);
     if (state.view.panes.ScrollSidePaneBy(*target, a.delta, ctx.info.max_scroll)) {
-        PushEffect(effects, effect::InvalidatePaneCache{ ctx.pane_zone });
-        PushEffect(effects, effect::InvalidateWindow{});
+        EmitSidePaneScrollChanged(effects, ctx.pane_zone);
     }
 }
 

--- a/src/layout/dwrite_measurer.cpp
+++ b/src/layout/dwrite_measurer.cpp
@@ -240,7 +240,7 @@ void DWriteTextMeasurer::MeasureNode(
     // ダイアグラム系コードブロック: ビットマップがレンダリングされるまでのプレースホルダー高さ
     if (node.type == NodeType::CodeBlock && IsDiagramLanguage(node.code_language())) {
         if (entry.height <= 0) {
-            entry.height = std::max(MIN_DIAGRAM_PLACEHOLDER_HEIGHT, theme_->font_size_body * 3.0f);
+            entry.height = mendo::layout::PlaceholderHeight(*theme_);
         }
         entry.layout_dirty = false;
         return;
@@ -258,7 +258,7 @@ void DWriteTextMeasurer::MeasureNode(
             entry.height = h;
         }
         else if (entry.height <= 0) {
-            entry.height = std::max(MIN_DIAGRAM_PLACEHOLDER_HEIGHT, theme_->font_size_body * 3.0f);
+            entry.height = mendo::layout::PlaceholderHeight(*theme_);
         }
         entry.layout_dirty = false;
         return;
@@ -463,8 +463,9 @@ void DWriteTextMeasurer::FinalizeTableLayout(
     const auto* tbl = node.table_data();
     const auto row_count = tbl->row_count;
     bool any_row_unrestored = false;
+    const float base_row_height = theme_->font_size_body * TABLE_ROW_HEIGHT_FACTOR;
     for (size_t r = 0; r < row_count; r++) {
-        float row_height = theme_->font_size_body * TABLE_ROW_HEIGHT_FACTOR;
+        float row_height = base_row_height;
         bool row_has_null_cell = false;
         for (size_t c = 0; c < col_count; c++) {
             const float cw = (c < tl.col_widths.size()) ? tl.col_widths[c] : DEFAULT_COLUMN_WIDTH;

--- a/src/layout/layout_cache.cpp
+++ b/src/layout/layout_cache.cpp
@@ -92,19 +92,24 @@ void LayoutCache::ResetTableLayoutGeometry(TableLayoutData& tl) noexcept
     tl.cells_partially_evicted = false;
 }
 
-void LayoutCache::EvictEntryLayout(NodeLayoutEntry& e) noexcept
+void LayoutCache::ResetEntryTextLayout(NodeLayoutEntry& e) noexcept
 {
-    if (!e.text_layout && !e.table_layout) {
-        return;
-    }
     e.text_layout.Reset();
     e.effects_applied = false;
     e.first_line_height = 0.0f;
     e.natural_code_width = 0.0f;
     e.clear_inline_code_bgs();
+    e.invalidate_per_frame_hl_caches();
+}
+
+void LayoutCache::EvictEntryLayout(NodeLayoutEntry& e) noexcept
+{
+    if (!e.text_layout && !e.table_layout) {
+        return;
+    }
+    ResetEntryTextLayout(e);
     e.table_layout.reset();
     e.layout_dirty = true;
-    e.invalidate_per_frame_hl_caches();
 }
 
 void LayoutCache::EvictTableRow(TableLayoutData& tl, size_t row_index) noexcept
@@ -192,12 +197,7 @@ void LayoutCache::Reset(size_t node_count, bool shrink)
 void LayoutCache::InvalidateAllLayouts() noexcept
 {
     for (auto& e : entries_) {
-        e.text_layout.Reset();
-        e.effects_applied = false;
-        e.first_line_height = 0.0f;
-        e.natural_code_width = 0.0f;
-        e.clear_inline_code_bgs();
-        e.invalidate_per_frame_hl_caches();
+        ResetEntryTextLayout(e);
         if (e.table_layout) {
             ResetTableLayoutGeometry(*e.table_layout);
             e.table_layout->cell_inline_code_bgs.clear();

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -362,6 +362,9 @@ private:
     // (DPI 変更パスは bg を作り直すまで維持する設計)。
     static void ResetTableLayoutGeometry(TableLayoutData& tl) noexcept;
 
+    // table_layout / layout_dirty の扱いは呼び出し側ごとに異なるため触らない。
+    static void ResetEntryTextLayout(NodeLayoutEntry& e) noexcept;
+
     static void EvictEntryLayout(NodeLayoutEntry& e) noexcept;
 
     // 1 行分の cell_layouts を Reset し、cell_heights / cell_applied_widths を再計測待ちに戻す。

--- a/src/layout/layout_computer.cpp
+++ b/src/layout/layout_computer.cpp
@@ -115,7 +115,7 @@ float EstimateNodeHeight(const Node& node, const Theme& theme) noexcept
         return line_height * 1.5f * static_cast<float>(row_count);
     }
     case NodeType::Image:
-        return std::max(MIN_DIAGRAM_PLACEHOLDER_HEIGHT, theme.font_size_body * 3.0f);
+        return PlaceholderHeight(theme);
     case NodeType::ListItem:
     case NodeType::TaskListItem:
         // 空 LI に高さを与えると bullet と直下 P の文字 Y が分離する (issue#237)。

--- a/src/layout/layout_computer.h
+++ b/src/layout/layout_computer.h
@@ -2,6 +2,8 @@
 #include "document_types.h"
 #include "layout_cache.h"
 #include "theme.h"
+#include "ui_constants.h"
+#include <algorithm>
 #include <limits>
 #include <memory_resource>
 #include <stop_token>
@@ -16,6 +18,12 @@ inline float NodeIndent(const Node& node, const Theme& theme) noexcept
 inline float NodeTextXOffset(const Node& node, const Theme& theme) noexcept
 {
     return (node.type == NodeType::CodeBlock) ? theme.code_block_padding : 0.0f;
+}
+
+// ダイアグラム/画像ノードのビットマップ未確定時に使うプレースホルダー高さ。
+inline float PlaceholderHeight(const Theme& theme) noexcept
+{
+    return std::max(MIN_DIAGRAM_PLACEHOLDER_HEIGHT, theme.font_size_body * 3.0f);
 }
 
 float GetSpacingAbove(const Node& node, const Theme& theme) noexcept;

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -339,24 +339,26 @@ void MermaidRenderer::InvokeSvgCallbackIfAny(RenderRequest& req, std::pmr::wstri
     }
 }
 
-void MermaidRenderer::FailPendingRequests()
+void MermaidRenderer::DrainPendingRequests(bool cancelled)
 {
-    // 初期化が恒久的に失敗した場合に呼ぶ。待機中の SVG リクエストを失敗
-    // (cancelled=false) で完了させ、呼び出し元の in-flight フラグ固着を防ぐ。
+    // 待機中の SVG リクエストを完了させ、呼び出し元の in-flight フラグ固着を防ぐ。
     while (!pending_requests_.empty()) {
-        InvokeSvgCallbackIfAny(pending_requests_.front(), {}, false);
+        InvokeSvgCallbackIfAny(pending_requests_.front(), {}, cancelled);
         pending_requests_.pop();
     }
+}
+
+void MermaidRenderer::FailPendingRequests()
+{
+    // 初期化が恒久的に失敗した場合に呼ぶ。
+    DrainPendingRequests(false);
 }
 
 void MermaidRenderer::CancelPending()
 {
     // SVG 専用リクエストのコールバックは cancelled=true で呼び、呼び出し元の状態をリセットさせる。
     // PNG レンダリング (on_complete) は無引数のため呼び出し元側でフラグを持っていない前提。
-    while (!pending_requests_.empty()) {
-        InvokeSvgCallbackIfAny(pending_requests_.front(), {}, true);
-        pending_requests_.pop();
-    }
+    DrainPendingRequests(true);
 
     // current_request の request_id が 0 に戻るため、処理中の非同期コールバックは
     // ID 不一致で自動的に無視される。

--- a/src/mermaid/mermaid.h
+++ b/src/mermaid/mermaid.h
@@ -109,6 +109,7 @@ private:
     // WebView2 プロセス障害 (ProcessFailed) からワーカーを復旧する。
     void RecoverWorker(int index);
     void ProcessQueue();
+    void DrainPendingRequests(bool cancelled);
     void FailPendingRequests();
     void RenderInWorker(Worker& worker);
     void OnRenderResult(int worker_idx, std::wstring_view json);

--- a/src/render/brush_id.h
+++ b/src/render/brush_id.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <cstdint>
 
 // 描画系で使う固定色ブラシの ID。CommandExecutor は brushes_[BrushId::*] を
@@ -52,3 +53,24 @@ enum class BrushId : uint8_t {
     // 動的色を意味するセンチネル。brush_pool 経由でブラシを解決する。
     Custom = 0xFF,
 };
+
+// Alert 種別 (AlertNote..AlertCaution) の数。document_types.h の ALERT_TYPE_COUNT と
+// 一致する必要があり、その検証は両方を見られる command_generator.cpp で static_assert する
+// (brush_id.h は core ヘッダへ依存させないため、ここでは ALERT_TYPE_COUNT を参照しない)。
+inline constexpr size_t ALERT_BRUSH_COUNT = 5;
+
+// Alert 種別インデックス (AlertColorIndex の 0..ALERT_BRUSH_COUNT-1) → 対応する固定ブラシ ID。
+// command_generator / renderer が同じ写像を共有し、BrushId enum の並び順に依存した
+// 連番算術を持たないようにする。idx は呼び出し側で範囲内を保証すること。
+constexpr BrushId AlertBrushIdFromIndex(size_t idx) noexcept
+{
+    constexpr BrushId table[] = {
+        BrushId::AlertNote,
+        BrushId::AlertTip,
+        BrushId::AlertImportant,
+        BrushId::AlertWarning,
+        BrushId::AlertCaution,
+    };
+    static_assert(sizeof(table) / sizeof(table[0]) == ALERT_BRUSH_COUNT);
+    return table[idx];
+}

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -34,6 +34,10 @@ void PublishCmdGenStats() noexcept
 // 値を小さくすると下線は見出し文字に近づき、下線と次行の間隔が広がる。
 static constexpr float HEADING_UNDERLINE_OFFSET_RATIO = 0.25f;
 
+// AlertBrushIdFromIndex (brush_id.h) の table が AlertType 全種を網羅することを担保する。
+// 旧 renderer.cpp の static_assert に代わり、core 側 ALERT_TYPE_COUNT との一致をここで検証する。
+static_assert(ALERT_BRUSH_COUNT == ALERT_TYPE_COUNT, "AlertBrushIdFromIndex table must cover every AlertType");
+
 namespace {
 
 // ブロックローカル横スクロールの clip と Translate を RAII で囲み、push/pop の対称性を強制する。
@@ -584,11 +588,8 @@ void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds, cons
             const float bar_x = offset_x + bar_indent_x - theme_->indent_width * 0.5f;
             const bool is_alert_bar = (level == 1 && alert_type != AlertType::None);
             const D2D1_COLOR_F bar_color = is_alert_bar ? theme_->alert_color[AlertColorIndex(alert_type)] : theme_->blockquote_bar_color;
-            // BrushId::AlertNote..AlertCaution は AlertColorIndex(0..4) で連番に並んでいる。
             const BrushId bar_brush =
-                is_alert_bar
-                    ? static_cast<BrushId>(std::to_underlying(BrushId::AlertNote) + AlertColorIndex(alert_type))
-                    : BrushId::BlockquoteBar;
+                is_alert_bar ? AlertBrushIdFromIndex(AlertColorIndex(alert_type)) : BrushId::BlockquoteBar;
 
             const auto emit_bar = [&](float top, float bottom) {
                 cmds.emplace_back(DrawLineCmd{

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -367,18 +367,10 @@ void Renderer::ApplyNodeEffects(Node& node, NodeLayoutEntry& entry, float entry_
     }
 
     if (node.type == NodeType::BlockQuote && node.alert_type != AlertType::None && node.alert_label_length() > 0) {
-        static constexpr BrushId ALERT_BRUSH[] = {
-            BrushId::AlertNote,
-            BrushId::AlertTip,
-            BrushId::AlertImportant,
-            BrushId::AlertWarning,
-            BrushId::AlertCaution,
-        };
-        static_assert(std::size(ALERT_BRUSH) == ALERT_TYPE_COUNT);
         const auto idx = AlertColorIndex(node.alert_type);
         if (idx < ALERT_TYPE_COUNT) {
             const auto range = wv.WideRange(0, node.alert_label_length());
-            entry.text_layout->SetDrawingEffect(Brush(ALERT_BRUSH[idx]), range);
+            entry.text_layout->SetDrawingEffect(Brush(AlertBrushIdFromIndex(idx)), range);
             MENDO_COUNT_INC(g_effect_stats.set_drawing_effect);
         }
     }

--- a/src/ui/context_menu.cpp
+++ b/src/ui/context_menu.cpp
@@ -2,6 +2,7 @@
 #include "d2d_util.h"
 #include "theme.h"
 #include "resource.h"
+#include "ui_constants.h"
 #include <cmath>
 #include <mutex>
 
@@ -289,7 +290,7 @@ bool ContextMenu::Impl::EnsureRenderTarget(float dpi)
 
 bool ContextMenu::Impl::RecreateDeviceResources()
 {
-    if (!EnsureRenderTarget(dpi_scale * 96.0f)) {
+    if (!EnsureRenderTarget(dpi_scale * DEFAULT_DPI)) {
         return false;
     }
     CreateBrushes();


### PR DESCRIPTION
## 概要

`/simplify` レビュー（再利用・単純化・効率・抽象度の4観点）でアプリ全体を点検し、検出した品質改善を適用しました。バグ修正ではなく、重複・特殊ケース・マジックナンバーの集約が目的です。さらに `/code-review` (xhigh) で挙動が厳密に保たれていることを検証し、検出された回帰防止の不足（`static_assert` 喪失）も補っています。

## 変更内容

### 重複・特殊ケースの集約
- **Alert種別→ブラシ**: `BrushId` enum の並び順に依存した連番算術と、別実装の配列方式という二重実装を `AlertBrushIdFromIndex` に集約。`ALERT_TYPE_COUNT` との一致を `static_assert` で担保（core 非依存を維持）
- **プレースホルダー高さ**: ダイアグラム/画像のビットマップ未確定時の高さ式が3ファイルに散在 → `PlaceholderHeight(theme)` に集約
- **サイドペインスクロール無効化**: `InvalidatePaneCache + InvalidateWindow` のコピペ4箇所 → `EmitSidePaneScrollChanged`
- **layout_cache**: `EvictEntryLayout`/`InvalidateAllLayouts` のフィールドリセット重複 → `ResetEntryTextLayout`
- **mermaid**: `FailPendingRequests`/`CancelPending` のコピペループ → `DrainPendingRequests(bool)`

### 単純化・再利用
- `app_mouse_hover`: 個別 if 2本 → for ループ（同ファイル既存パターンに統一）
- `reducer`: 手書き三項式 → 既存 `ToPaneZone(t)`
- `dwrite_measurer`: テーブル計測のループ不変式を巻き上げ
- `context_menu`: マジックナンバー `96.0f` → 既存定数 `DEFAULT_DPI`

## 検証
- ビルド: Release 構成でエラー・警告なし
- テスト: 全 2327 件通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjgMSu2YmiWMJeresLYa7