### PR TITLE
refactor: デストラクタ専用構造体を汎用 ScopeGuard に統一

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include "i18n.h"
 #include "memory_resource.h"
 #include "profiler.h"
+#include "scope_guard.h"
 #include <windows.h>
 #include <shellapi.h>
 #include <shellscalingapi.h>
@@ -38,6 +39,9 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nC
     if (FAILED(hr)) {
         return 1;
     }
+    // CoUninitialize は Win32Window 破棄（COM オブジェクト解放）より後に走らせる必要がある。
+    // window より先にこのガードを宣言することで、全 return 経路でこの順序を保証する。
+    auto com_guard = ScopeGuard([] { CoUninitialize(); });
     INITCOMMONCONTROLSEX icc{};
     icc.dwSize = sizeof(icc);
     icc.dwICC = ICC_STANDARD_CLASSES;
@@ -106,7 +110,6 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nC
         {
             MENDO_PROFILE("wWinMain - Create Window");
             if (!window.Create(hInstance, nCmdShow)) {
-                CoUninitialize();
                 return 1;
             }
         }
@@ -120,8 +123,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR /*lpCmdLine*/, int nC
         }
 
         result = window.RunMessageLoop();
-    } // Win32Window破棄（COMオブジェクト解放）をCoUninitializeの前に完了させる
+    } // Win32Window破棄（COMオブジェクト解放）を com_guard の CoUninitialize より前に完了させる
 
-    CoUninitialize();
     return result;
 }

--- a/src/mermaid/mermaid_file_cache.cpp
+++ b/src/mermaid/mermaid_file_cache.cpp
@@ -2,6 +2,7 @@
 #include "profiler.h"
 #include "task_scheduler.h"
 #include "file_io.h"
+#include "scope_guard.h"
 #include <algorithm>
 #include <cmath>
 #include <cstring>
@@ -289,15 +290,10 @@ void MermaidFileCache::StoreAsync(uint64_t key, float css_width, float css_heigh
     auto path = GetPngPath(key);
     const bool posted = scheduler_->Post([this, key, path = std::move(path), data = std::move(png_data), gen, latch_guard = latch_.Acquire()] {
         // タスク完遂・キャンセルどちらの場合も pending を必ず解除する
-        struct PendingGuard {
-            MermaidFileCache* self;
-            uint64_t key;
-            ~PendingGuard()
-            {
-                std::lock_guard lock(self->pending_mutex_);
-                self->pending_writes_.erase(key);
-            }
-        } guard{ this, key };
+        auto guard = ScopeGuard([this, key] {
+            std::lock_guard lock(pending_mutex_);
+            pending_writes_.erase(key);
+        });
 
         if (write_gen_.load() != gen) {
             return;
@@ -321,9 +317,9 @@ void MermaidFileCache::StoreAsync(uint64_t key, float css_width, float css_heigh
         (void)WriteAllBytes(path, data.data(), data.size());
     });
     if (!posted) {
-        // lambda が走らないので latch::Guard / PendingGuard は capture 内で destruct され
-        // 自動 Release。pending_writes_ に key を残すと Lookup が stale 扱いを抑止し続けるため
-        // ここで巻き戻す。
+        // lambda 本体が走らず body 内 ScopeGuard は構築されないため pending_writes_ は解除されない。
+        // capture の latch::Guard は closure 破棄時に自動 Release されるので、ここでは Post 前に
+        // insert した key だけを巻き戻す (残すと Lookup が stale 扱いを抑止し続ける)。
         std::lock_guard lock(pending_mutex_);
         pending_writes_.erase(key);
     }

--- a/src/ui/context_menu.cpp
+++ b/src/ui/context_menu.cpp
@@ -3,6 +3,7 @@
 #include "theme.h"
 #include "resource.h"
 #include "ui_constants.h"
+#include "scope_guard.h"
 #include <cmath>
 #include <mutex>
 
@@ -153,10 +154,11 @@ int ContextMenu::Show(HWND owner_hwnd, const ContextMenuParams& params)
     s.owner = owner_hwnd;
     s.theme = params.theme;
     s.dpi_scale = params.dpi_scale;
+    // theme は呼び出し側 Theme の借用ポインタ。Show 終了後にダングリングさせないよう必ず手放す。
+    auto theme_guard = ScopeGuard([&s] { s.theme = nullptr; });
 
     s.PrepareContent(params);
     if (!s.CreatePopupWindow(params.screen_x, params.screen_y)) {
-        s.theme = nullptr;
         return 0;
     }
     s.RunModalLoop();
@@ -167,7 +169,6 @@ int ContextMenu::Show(HWND owner_hwnd, const ContextMenuParams& params)
         s.hwnd = nullptr;
     }
     s.rt.Reset();
-    s.theme = nullptr;
 
     return s.selected_id;
 }

--- a/src/util/file_io.h
+++ b/src/util/file_io.h
@@ -14,8 +14,7 @@ namespace path_util {
 // 外部エディタとの同時アクセスを許容する共有モード。
 // 編集中のファイルを mendo で開いたまま再読込できるようにするため、
 // Markdown / 画像ファイルを扱う経路ではこれを指定する。
-inline constexpr DWORD kFileShareRWDelete =
-    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
+inline constexpr DWORD kFileShareRWDelete = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
 
 // ReadAllBytes が許容する最大サイズ。ReadFile は DWORD (32bit unsigned) で
 // バイト数を扱うので、それを超えるサイズは 1 回の ReadFile で読み切れない。
@@ -44,8 +43,7 @@ struct OpenedFile {
 [[nodiscard]] OpenedFile OpenFileForReadShared(const std::filesystem::path& path, DWORD share_mode, LONGLONG max_size, DWORD* out_error = nullptr) noexcept;
 
 // out_error が非 null の場合、CreateFileW 失敗時の GetLastError() を格納する。
-[[nodiscard]] std::pair<std::unique_ptr<uint8_t[]>, size_t> ReadAllBytes(
-    const std::filesystem::path& path, DWORD* out_error = nullptr);
+[[nodiscard]] std::pair<std::unique_ptr<uint8_t[]>, size_t> ReadAllBytes(const std::filesystem::path& path, DWORD* out_error = nullptr);
 
 // 指定バイト数を ReadFile の DWORD 上限でチャンク分割して読み切る。
 // EOF・パイプ切断 (bytes_read == 0) は失敗として false を返す。

--- a/src/util/scope_guard.h
+++ b/src/util/scope_guard.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <type_traits>
+#include <utility>
+
+// スコープ離脱時にクリーンアップ関数を一度だけ実行する汎用 RAII ガード。
+// デストラクタのためだけの構造体をその場で定義する代わりに使う。Dismiss() で取り消せる。
+template <typename F>
+class ScopeGuard {
+public:
+    explicit ScopeGuard(F f) noexcept(std::is_nothrow_move_constructible_v<F>)
+        : f_(std::move(f))
+    {}
+    ~ScopeGuard()
+    {
+        if (active_) {
+            f_();
+        }
+    }
+    ScopeGuard(ScopeGuard&& other) noexcept(std::is_nothrow_move_constructible_v<F>)
+        : f_(std::move(other.f_)),
+          active_(other.active_)
+    {
+        other.active_ = false;
+    }
+    ScopeGuard(const ScopeGuard&) = delete;
+    ScopeGuard& operator=(const ScopeGuard&) = delete;
+    ScopeGuard& operator=(ScopeGuard&&) = delete;
+
+    void Dismiss() noexcept
+    {
+        active_ = false;
+    }
+
+private:
+    F f_;
+    bool active_ = true;
+};
+
+template <typename F>
+ScopeGuard(F) -> ScopeGuard<F>;


### PR DESCRIPTION
## 概要

RAII クリーンアップを「デストラクタのためだけ」に定義していた構造体を汎用スコープガード `ScopeGuard` に集約しました。これを土台にアプリ全体の手動クリーンアップを見直し、可読性が向上する箇所も併せて書き換えています。

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/util/scope_guard.h` | **新設**。スコープ離脱時に cleanup を一度だけ実行する汎用 RAII ガード。`Dismiss()` で取り消し可・move 可（`std::experimental::scope_exit` / `gsl::final_action` 相当のイディオム） |
| `src/mermaid/mermaid_file_cache.cpp` | コードベース唯一のデストラクタ専用 `struct PendingGuard` を `ScopeGuard` に置換 |
| `src/main.cpp` | 失敗経路と通常終了の **2 箇所に重複していた `CoUninitialize()`** を 1 つのガードに集約（`Win32Window` 破棄より後に走る順序は宣言位置で担保） |
| `src/ui/context_menu.cpp` | 借用ポインタ `theme` の二重リセット（`= nullptr`）をガード化し重複を解消 |

## 全体調査の結果

デストラクタ専用構造体は `PendingGuard` のみでした。他の RAII 型（`OpacityScope` / `BlockHScrollScope` / `ClipboardSession` / `WorkerLatch::Guard` / `InlineTagScope` 等）は構築時にも処理・状態を持つため対象外としています。手動クリーンアップ箇所も精査し、可読性が実際に上がる上記 2 箇所（main / context_menu）のみ書き換えました（`stream_util` の GlobalUnlock や `task_scheduler` の COM ペアは線形で利得なしのため据え置き）。

## レビュー指摘への対応

- **行末コード**: 新規ファイルが LF だったため `.gitattributes`（`*.h text eol=crlf`）に合わせ CRLF へ修正済み
- **noexcept デストラクタ**: 標準イディオム通り（cleanup は noexcept 前提）。旧 `PendingGuard` と同挙動で退行なし

## テスト

- ✅ `cmake --build build --config Release`
- ✅ `mendo_tests.exe` — 2327 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)