### PR TITLE
refactor: /simplify レビュー指摘を解消 (スクロールバー座標の一元化・キャッシュ状態の構造体化)

### DIFF
--- a/src/app/app_mouse_click.cpp
+++ b/src/app/app_mouse_click.cpp
@@ -136,7 +136,7 @@ void App::HandleMdPaneClick(float dip_x, float dip_y, int px, int py, const Pane
 bool App::IsOverPaneScrollbar(float dip_x, const PaneRect& rect, float total_content, const PaneScrollInfo& scroll_info) noexcept
 {
     const float local_x = dip_x - rect.x;
-    const float hit_left = rect.width - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN - PANE_SCROLLBAR_HIT_PADDING;
+    const float hit_left = VScrollbarLeftX(rect.width) - PANE_SCROLLBAR_HIT_PADDING;
     return local_x >= hit_left && total_content > scroll_info.content_height;
 }
 

--- a/src/app/app_mouse_hover.cpp
+++ b/src/app/app_mouse_hover.cpp
@@ -35,7 +35,7 @@ bool App::IsOverMdScrollbar(float dip_x, float dip_y, const PaneLayout& layout) 
         return false;
     }
     const float md_right = layout.md_rect.x + layout.md_rect.width;
-    const float sb_left = md_right - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+    const float sb_left = VScrollbarLeftX(md_right);
     const float sb_right = md_right - PANE_SCROLLBAR_MARGIN;
     return dip_x >= sb_left - PANE_SCROLLBAR_HIT_PADDING && dip_x <= sb_right;
 }

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -123,13 +123,11 @@ void Renderer::PrepareVisibleEffects(std::pmr::vector<Node>& nodes, LayoutCache&
     const uint32_t effects_gen = cache.GetEffectsGeneration();
     // テーブル行の effects は viewport 範囲に依存するため、スクロール追従が必要。
     // 4px 単位に量子化してサブピクセルスクロールでの過剰再実行を抑制する。
-    const int viewport_bottom_q = static_cast<int>(viewport_bottom) >> 2;
-    if (effects_gen != last_effects_gen_ || first_visible != last_effects_first_ || viewport_bottom_q != last_effects_bottom_q_) {
+    const EffectsKey key{ effects_gen, first_visible, static_cast<int>(viewport_bottom) >> 2 };
+    if (key != last_effects_) {
         MENDO_PROFILE("PrepareVisibleEffects");
         ApplyVisibleEffects(nodes, cache, first_visible, viewport_top, viewport_bottom);
-        last_effects_gen_ = effects_gen;
-        last_effects_first_ = first_visible;
-        last_effects_bottom_q_ = viewport_bottom_q;
+        last_effects_ = key;
     }
 }
 

--- a/src/render/renderer.h
+++ b/src/render/renderer.h
@@ -180,31 +180,51 @@ private:
     std::pmr::wstring cached_toast_text_{ GetThreadLocalPoolResource() };
 
     // 検索バーの入力テキストレイアウトキャッシュ。
-    // キー: (query, ime_composition, caret_pos, input 幅)
-    // 値:   cached_search_layout_ と合成済み表示テキスト cached_search_text_。
+    // キー: (query, ime_comp, caret_pos, width) 入力 height は定数なのでキーに含めない。
     // キャレット点滅や同一入力継続フレームで CreateTextLayout と
-    // 表示テキスト合成の双方を回避する。入力 height は定数なのでキーに含めない。
-    mutable Microsoft::WRL::ComPtr<IDWriteTextLayout> cached_search_layout_;
-    mutable std::pmr::wstring cached_search_text_{ GetThreadLocalPoolResource() };     // 合成後の表示テキスト (IME 未使用時は query と同一)
-    mutable std::pmr::wstring cached_search_query_{ GetThreadLocalPoolResource() };    // 直近フレームの sb.query
-    mutable std::pmr::wstring cached_search_ime_comp_{ GetThreadLocalPoolResource() }; // 直近フレームの sb.ime_composition
-    mutable int cached_search_caret_pos_ = -1;                                         // IME 合成時の挿入位置（無いとき -1）
-    mutable float cached_search_width_ = -1.0f;
-    mutable bool cached_search_has_underline_ = false;
-    // キャレット x 位置のフレーム間キャッシュ。点滅フレームのみ caret_visible が変わる
-    // ケースで HitTestTextPosition の COM 越境呼び出しを省く。
-    // 有効性は (cached_search_layout_, effective_pos) 一致で判定する。
-    mutable int cached_search_effective_pos_ = -2; // -2 = 未確定
-    mutable float cached_search_caret_x_ = 0.0f;
+    // 表示テキスト合成の双方を回避する。
+    struct SearchLayoutCache {
+        Microsoft::WRL::ComPtr<IDWriteTextLayout> layout;
+        std::pmr::wstring text{ GetThreadLocalPoolResource() };     // 合成後の表示テキスト (IME 未使用時は query と同一)
+        std::pmr::wstring query{ GetThreadLocalPoolResource() };    // 直近フレームの sb.query
+        std::pmr::wstring ime_comp{ GetThreadLocalPoolResource() }; // 直近フレームの sb.ime_composition
+        int caret_pos = -1;                                         // IME 合成時の挿入位置（無いとき -1）
+        float width = -1.0f;
+        bool has_underline = false;
+        // キャレット x 位置のフレーム間キャッシュ。点滅フレームのみ caret_visible が変わる
+        // ケースで HitTestTextPosition の COM 越境呼び出しを省く。
+        // 有効性は (layout, effective_pos) 一致で判定する。
+        int effective_pos = -2; // -2 = 未確定
+        float caret_x = 0.0f;
+
+        void Reset()
+        {
+            layout.Reset();
+            text.clear();
+            query.clear();
+            ime_comp.clear();
+            caret_pos = -1;
+            width = -1.0f;
+            has_underline = false;
+            effective_pos = -2;
+            caret_x = 0.0f;
+        }
+    };
+    mutable SearchLayoutCache search_cache_;
     Microsoft::WRL::ComPtr<ID2D1Bitmap> app_icon_bitmap_;
     void LoadAppIconBitmap();
     Microsoft::WRL::ComPtr<ID2D1StrokeStyle> gesture_stroke_style_;
 
     PaneCache pane_caches_[2];
 
-    uint32_t last_effects_gen_ = std::numeric_limits<uint32_t>::max();
-    int last_effects_first_ = -1;
-    int last_effects_bottom_q_ = -1;
+    // 直近フレームで ApplyVisibleEffects を実行したキー。(世代, 可視域) が一致すれば再適用を省く。
+    struct EffectsKey {
+        uint32_t gen = std::numeric_limits<uint32_t>::max();
+        int first_visible = -1;
+        int viewport_bottom_q = -1;
+        bool operator==(const EffectsKey&) const = default;
+    };
+    EffectsKey last_effects_;
 
     Theme theme_;
     DWriteTextMeasurer measurer_;

--- a/src/render/renderer_pane.cpp
+++ b/src/render/renderer_pane.cpp
@@ -48,7 +48,7 @@ static void DrawPaneScrollbar(
     const float thumb_height = info.thumb_height;
     const float thumb_y = ComputeThumbY(info, scroll_y);
 
-    const float thumb_x = pane_width - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+    const float thumb_x = VScrollbarLeftX(pane_width);
 
     D2D1_ROUNDED_RECT thumb_rect;
     thumb_rect.rect = D2D1::RectF(thumb_x, thumb_y, thumb_x + PANE_SCROLLBAR_WIDTH, thumb_y + thumb_height);
@@ -303,7 +303,7 @@ void Renderer::DrawMdScrollbar(const PaneRect& md_pane_rect, float scroll_y, flo
 
     const auto info = ComputeScrollInfo(md_pane_rect, 0.0f, total_content_height);
     const float thumb_y = ComputeThumbY(info, scroll_y);
-    const float track_x = md_pane_rect.x + md_pane_rect.width - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+    const float track_x = VScrollbarLeftX(md_pane_rect.x + md_pane_rect.width);
 
     D2D1_ROUNDED_RECT thumb_rect;
     thumb_rect.rect = D2D1::RectF(track_x, thumb_y, track_x + PANE_SCROLLBAR_WIDTH, thumb_y + info.thumb_height);

--- a/src/render/renderer_resources.cpp
+++ b/src/render/renderer_resources.cpp
@@ -240,15 +240,7 @@ void Renderer::RecreatePaneFormats()
     gesture_forward_layout_.Reset();
     cached_toast_layout_.Reset();
     cached_toast_text_.clear();
-    cached_search_layout_.Reset();
-    cached_search_text_.clear();
-    cached_search_query_.clear();
-    cached_search_ime_comp_.clear();
-    cached_search_caret_pos_ = -1;
-    cached_search_width_ = -1.0f;
-    cached_search_has_underline_ = false;
-    cached_search_effective_pos_ = -2;
-    cached_search_caret_x_ = 0.0f;
+    search_cache_.Reset();
 
     for (auto& c : pane_caches_) {
         c.Reset();

--- a/src/render/renderer_search.cpp
+++ b/src/render/renderer_search.cpp
@@ -81,15 +81,15 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
 
         // 比較は scalar → 空になりやすい ime_comp → query の順で短絡させる
         Microsoft::WRL::ComPtr<IDWriteTextLayout> text_layout;
-        const bool cache_hit = cached_search_layout_ && cached_search_width_ == input_w && cached_search_caret_pos_ == key_caret_pos && cached_search_ime_comp_ == sb.ime_composition && cached_search_query_ == sb.query;
+        const bool cache_hit = search_cache_.layout && search_cache_.width == input_w && search_cache_.caret_pos == key_caret_pos && search_cache_.ime_comp == sb.ime_composition && search_cache_.query == sb.query;
         if (cache_hit) {
-            text_layout = cached_search_layout_;
-            display_text = cached_search_text_;
+            text_layout = search_cache_.layout;
+            display_text = search_cache_.text;
             // 前フレームの下線範囲と異なる可能性があるため、キャッシュ上に下線が残っていれば
             // 常に全体をクリアする。IME 非アクティブ継続時はクリアも発行されない。
-            if (cached_search_has_underline_) {
-                text_layout->SetUnderline(FALSE, DWRITE_TEXT_RANGE{ 0, static_cast<UINT32>(cached_search_text_.size()) });
-                cached_search_has_underline_ = false;
+            if (search_cache_.has_underline) {
+                text_layout->SetUnderline(FALSE, DWRITE_TEXT_RANGE{ 0, static_cast<UINT32>(search_cache_.text.size()) });
+                search_cache_.has_underline = false;
             }
         }
         else {
@@ -109,13 +109,13 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
                 input_h,
                 &text_layout);
             if (text_layout) {
-                cached_search_layout_ = text_layout;
-                cached_search_text_.assign(display_text);
-                cached_search_query_.assign(sb.query);
-                cached_search_ime_comp_.assign(sb.ime_composition);
-                cached_search_caret_pos_ = key_caret_pos;
-                cached_search_width_ = input_w;
-                cached_search_has_underline_ = false;
+                search_cache_.layout = text_layout;
+                search_cache_.text.assign(display_text);
+                search_cache_.query.assign(sb.query);
+                search_cache_.ime_comp.assign(sb.ime_composition);
+                search_cache_.caret_pos = key_caret_pos;
+                search_cache_.width = input_w;
+                search_cache_.has_underline = false;
             }
         }
         if (text_layout) {
@@ -125,7 +125,7 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
                     static_cast<UINT32>(comp_len)
                 };
                 text_layout->SetUnderline(TRUE, range);
-                cached_search_has_underline_ = true;
+                search_cache_.has_underline = true;
             }
 
             // テキストの背面に描画
@@ -176,17 +176,17 @@ void Renderer::DrawSearchBar(const SearchBarRenderState& sb, const PaneRect& md_
             // 直前と同じ入力）は HitTestTextPosition を省く。layout 失効時は cache_hit が
             // false になり、その経路で text_layout を作り直す前に effective_pos キャッシュも
             // 落としておく必要があるため、ここでは layout 一致を直前 update 済み
-            // cached_search_layout_ で判定する。
-            if (cache_hit && cached_search_effective_pos_ == effective_pos) {
-                caret_x = cached_search_caret_x_;
+            // search_cache_.layout で判定する。
+            if (cache_hit && search_cache_.effective_pos == effective_pos) {
+                caret_x = search_cache_.caret_x;
             }
             else {
                 FLOAT px, py;
                 DWRITE_HIT_TEST_METRICS htm{};
                 text_layout->HitTestTextPosition(static_cast<UINT32>(effective_pos), false, &px, &py, &htm);
                 caret_x = text_left + px;
-                cached_search_effective_pos_ = effective_pos;
-                cached_search_caret_x_ = caret_x;
+                search_cache_.effective_pos = effective_pos;
+                search_cache_.caret_x = caret_x;
             }
         }
     }
@@ -264,14 +264,14 @@ int Renderer::HitTestSearchInput(std::wstring_view query, float local_x, float m
         return 0;
     }
     Microsoft::WRL::ComPtr<IDWriteTextLayout> layout;
-    // DrawSearchBar が直前に作成した cached_search_layout_ を再利用できるケース
+    // DrawSearchBar が直前に作成した search_cache_.layout を再利用できるケース
     // （IME コンポジションが無く、query と表示テキストが一致）を高速パスに。
     // IME 合成中は表示テキスト = query + comp string となり layout のヒット判定対象が
-    // ずれるため、cached_search_caret_pos_ != -1 (= 合成中) の場合は安全側でキャッシュを捨てて
+    // ずれるため、search_cache_.caret_pos != -1 (= 合成中) の場合は安全側でキャッシュを捨てて
     // 再生成する。クリック応答性は損なわない (IME 合成中はキャレット移動を主に DefSubclassProc が処理)。
-    const bool cache_hit = cached_search_layout_ && cached_search_width_ == max_width && cached_search_caret_pos_ == -1 && cached_search_query_ == query;
+    const bool cache_hit = search_cache_.layout && search_cache_.width == max_width && search_cache_.caret_pos == -1 && search_cache_.query == query;
     if (cache_hit) {
-        layout = cached_search_layout_;
+        layout = search_cache_.layout;
     }
     else {
         backend_.GetDWriteFactory()->CreateTextLayout(

--- a/src/util/ui_constants.h
+++ b/src/util/ui_constants.h
@@ -49,6 +49,13 @@ inline constexpr float TABLE_STRIPE_ALPHA_LIGHT = 0.02f;
 // Shift+Wheel / WM_MOUSEHWHEEL の delta (WHEEL_DELTA = 120 単位) を DIP に換算する。
 inline constexpr float HSCROLL_DIP_PER_NOTCH = 60.0f;
 
+// 縦スクロールバーの左端 X。right_edge はペイン右端 (ローカル/スクリーンどちらの系でも可)。
+// 描画 (renderer_pane) とヒットテスト (app_mouse_*) で同じ式を共有する。
+inline constexpr float VScrollbarLeftX(float right_edge) noexcept
+{
+    return right_edge - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN;
+}
+
 // ブロック横スクロールバーの bar 上端 Y 座標 (ペインローカル document Y)。
 // extra_padding は CodeBlock の背景下端 padding 内に置く場合に渡す (Table は 0)。
 inline constexpr float BlockHScrollbarBarY(float entry_text_top, float entry_height, float extra_padding) noexcept


### PR DESCRIPTION
## 概要

アプリ全体 (`src/` 約3.2万行) に対して /simplify レビュー（再利用・単純化・効率・抽象度の4観点）を実施し、検証の結果確度が高かった3件を適用しました。

## 変更内容

### 1. 縦スクロールバー左端 X の一元化（抽象度）

`右端 - PANE_SCROLLBAR_WIDTH - PANE_SCROLLBAR_MARGIN` という同一式が、ヒットテスト側 (`app_mouse_hover.cpp`, `app_mouse_click.cpp`) と描画側 (`renderer_pane.cpp` の2箇所) に散在していました。`ui_constants.h` に `VScrollbarLeftX()` を追加して4箇所を置き換え、定数変更時にクリック判定と見た目がズレるリスクを排除しました。

### 2. `last_effects_*` 3変数を `EffectsKey` 構造体に集約（単純化）

常にセットで比較・更新される3つのキャッシュキー (世代・先頭可視ノード・量子化ビューポート下端) を `operator==` 付き構造体にまとめ、`PrepareVisibleEffects` の複合条件を `key != last_effects_` の1比較にしました。フィールド更新漏れが構造的に起きなくなります。

### 3. `cached_search_*` 9変数を `SearchLayoutCache` 構造体に集約（単純化）

検索バーの入力テキストレイアウトキャッシュを構成する9つの mutable メンバを1つの構造体 + `Reset()` にまとめ、`renderer_resources.cpp` の9行リセットを1呼び出しにしました。挙動は不変です。

## スキップした指摘

- 効率系の指摘の大半は検証の結果誤検知（「選択範囲キャッシュ無効化が毎フレーム走る」→ 実際は範囲変更時のみ、等）またはコンパイラが処理するマイクロ最適化でした
- `DrawSearchBar` / `HitTestSearchInput` のキャッシュ判定条件の差異は意図的（IME 合成中を安全側で捨てる）でありコメント済みのため統一せず
- 再利用観点は指摘ゼロ（`src/util/` の一元化がよく守られている）

## テスト

- `cmake --build build --config Release` 警告なし
- `mendo_tests.exe`: 2331 tests / 147 suites 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wx28zMiHoRoZezxk6Gi7Ze