### PR TITLE
fix: アプリ全体コードレビューの指摘10件を解消

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -14,7 +14,6 @@
 #include "ui_constants.h"
 #include "d2d_util.h"
 #include <windowsx.h>
-#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <utility>
@@ -418,9 +417,8 @@ void App::OnFileWatchEvent()
 
 void App::HandleTimer(UINT_PTR timer_id)
 {
-    const auto it = std::ranges::find(app_timer::ALL_TIMERS, static_cast<app_timer::Id>(timer_id));
-    if (it != std::ranges::end(app_timer::ALL_TIMERS)) {
-        Dispatch(TimerAction{ *it });
+    if (timer_id >= std::to_underlying(app_timer::kFirstTimer) && timer_id <= std::to_underlying(app_timer::kLastTimer)) {
+        Dispatch(TimerAction{ static_cast<app_timer::Id>(timer_id) });
     }
 }
 
@@ -475,8 +473,8 @@ void App::OnDestroy()
     // 個別 Save 呼び出しでは write が遅延されるため、終了前に明示 flush で
     // すべての設定値を 1 度のディスク書き込みにまとめる。
     config_.Flush();
-    for (app_timer::Id id : app_timer::ALL_TIMERS) {
-        KillTimer(hwnd_, std::to_underlying(id));
+    for (UINT_PTR id = std::to_underlying(app_timer::kFirstTimer); id <= std::to_underlying(app_timer::kLastTimer); ++id) {
+        KillTimer(hwnd_, id);
     }
 }
 

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -285,6 +285,7 @@ private:
     TaskScheduler scheduler_;
     TaskScheduler layout_scheduler_;
     MermaidFileCache file_cache_; // mermaid_renderer_ より先に宣言する（mermaid_renderer_ は破棄時に file_cache_ を参照する）
+    ClipboardManager clipboard_manager_; // mermaid_renderer_ より先に宣言する（~MermaidRenderer の CancelPending が in-flight コールバック経由で clipboard_manager_ に触るため、後に破棄させる）
     MermaidRenderer mermaid_renderer_;
     ImageLoader image_loader_;
     FileWatcher file_watcher_;
@@ -302,6 +303,4 @@ private:
     SideEffectExecutor effect_executor_;
 
     void ShowToast(std::wstring_view message);
-
-    ClipboardManager clipboard_manager_;
 };

--- a/src/app/app_constants.h
+++ b/src/app/app_constants.h
@@ -8,38 +8,29 @@
 namespace app_timer {
 
 // Win32 API に渡す際は std::to_underlying でキャスト。
+// 先頭のみ明示値。自動インクリメントにより 1 からのギャップなし連番が言語保証され、
+// kFirstTimer/kLastTimer の範囲判定の前提が崩れない。
 enum class Id : UINT_PTR {
     DEFERRED_LAYOUT = 1,
-    LOADING_ANIM = 2,
-    SWIPE_OVERLAY = 3,
-    TOAST = 4,
-    SEARCH_CARET = 5,
-    TOOLTIP = 6,
-    SEARCH_DEBOUNCE = 7,
-    MERMAID_BATCH = 8,
-    BITMAP_MANAGE = 9,
-    MERMAID_INIT_RETRY = 10,
-    FILE_RELOAD_DEBOUNCE = 11,
+    LOADING_ANIM,
+    SWIPE_OVERLAY,
+    TOAST,
+    SEARCH_CARET,
+    TOOLTIP,
+    SEARCH_DEBOUNCE,
+    MERMAID_BATCH,
+    BITMAP_MANAGE,
+    MERMAID_INIT_RETRY,
+    FILE_RELOAD_DEBOUNCE,
+    END, // 番兵。タイマーとしては使わない。新規タイマーはこの直前に追加する。
 };
 
 inline constexpr UINT FRAME_INTERVAL_MS = 16;        // ~60fps アニメーション用
 inline constexpr UINT FILE_RELOAD_DEBOUNCE_MS = 200; // ファイル変更通知のデバウンス
 inline constexpr UINT FILE_RELOAD_RETRY_MS = 50;     // truncate→rewrite 検出後の短縮リトライ
 
-// 新規タイマーを足したらここに追加すること。
-inline constexpr Id ALL_TIMERS[] = {
-    Id::DEFERRED_LAYOUT,
-    Id::LOADING_ANIM,
-    Id::SWIPE_OVERLAY,
-    Id::TOAST,
-    Id::SEARCH_CARET,
-    Id::SEARCH_DEBOUNCE,
-    Id::TOOLTIP,
-    Id::MERMAID_BATCH,
-    Id::BITMAP_MANAGE,
-    Id::MERMAID_INIT_RETRY,
-    Id::FILE_RELOAD_DEBOUNCE,
-};
+inline constexpr Id kFirstTimer = Id::DEFERRED_LAYOUT;
+inline constexpr Id kLastTimer = static_cast<Id>(std::to_underlying(Id::END) - 1);
 
 } // namespace app_timer
 

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -179,15 +179,26 @@ void App::OnParseComplete()
 {
     MENDO_PROFILE("OnParseComplete");
 
+    auto result = file_load_service_.TakeAsyncResult();
+    std::optional<FileLoadError> err;
+    if (!result) {
+        err = file_load_service_.TakeAsyncError();
+        // 結果もエラーも無いのに別のロードが進行中 → Start の ResetSinks で無効化された
+        // stale メッセージ。進行中ロードのアニメーションや FileWatcher 状態に触らず無視する。
+        if (!err && file_load_service_.IsAsyncLoading()) {
+            MENDO_TRACE("OnParseComplete: stale message ignored (new load in progress)");
+            return;
+        }
+    }
+
     EmitEffect(effect::KillTimer{ app_timer::Id::LOADING_ANIM });
     file_load_service_.StopLoading();
 
-    auto result = file_load_service_.TakeAsyncResult();
     if (!result) {
         MENDO_TRACE("OnParseComplete: no result (cancelled or load failed)");
         // 失敗パスでも paused 状態の FileWatcher を必ず再開させる。
         EmitEffect(effect::ResumeFileWatch{});
-        if (auto err = file_load_service_.TakeAsyncError()) {
+        if (err) {
             ShowToast(FileLoadErrorMessage(*err, i18n::S()));
         }
         HandleLoadFailureFallback();

--- a/src/core/syntax.cpp
+++ b/src/core/syntax.cpp
@@ -390,29 +390,7 @@ std::pmr::vector<SyntaxToken> TokenizeImpl(
 
         // 5. 文字列リテラル
         if (c == '"' || (c == '\'' && !Cfg.skip_single_quote)) {
-            // C++生文字列の確認: R"(...)"。raw_string 対応言語 (C/C++) のみで判定する。
-            // 他言語で識別子末尾の R + 文字列を誤って生文字列扱いしないようゲートする。
-            if (Cfg.raw_string && c == '"' && i > 0 && text[i - 1] == 'R' && (i < 2 || !IsIdentChar(text[i - 2]))) {
-                // 調整: Rは既にプレーンバッファにあるので除去する。
-                if (in_plain) {
-                    if (static_cast<uint32_t>(i - 1) > plain_start) {
-                        EmitToken(tokens, plain_start, static_cast<uint32_t>(i - 1) - plain_start, SyntaxTokenType::Plain);
-                    }
-                    in_plain = false;
-                }
-                const size_t start = i - 1;
-                // デリミタを検索: R"DELIM( ... )DELIM"
-                const size_t paren = text.find('(', i + 1);
-                if (paren != std::string_view::npos) {
-                    i = ScanCppRawString(text, i, paren);
-                }
-                else {
-                    i = ScanString(text, i, c, false);
-                }
-                EmitToken(tokens, static_cast<uint32_t>(start), static_cast<uint32_t>(i - start), SyntaxTokenType::String);
-                at_line_start = false;
-                continue;
-            }
+            // 生文字列 R"(...)" の R は識別子として step 8 で消費されるため、ここでは通常の文字列として扱う。
             flush_plain();
             const size_t start = i;
             i = ScanString(text, i, c, false);
@@ -452,6 +430,24 @@ std::pmr::vector<SyntaxToken> TokenizeImpl(
             }
 
             const std::string_view word(text.data() + start, i - start);
+
+            if constexpr (Cfg.raw_string) {
+                // R"..." の R はプレフィックスとして String トークンに含める。
+                // word == "R" なら直前が非識別子文字であることも保証される。
+                if (word == "R" && i < text.size() && text[i] == '"') {
+                    const size_t paren = text.find('(', i + 1);
+                    if (paren != std::string_view::npos) {
+                        i = ScanCppRawString(text, i, paren);
+                    }
+                    else {
+                        i = ScanString(text, i, '"', false);
+                    }
+                    EmitToken(tokens, static_cast<uint32_t>(start), static_cast<uint32_t>(i - start), SyntaxTokenType::String);
+                    at_line_start = false;
+                    continue;
+                }
+            }
+
             std::string_view lookup_word = word;
             if constexpr (Cfg.case_insensitive) {
                 if (ascii_util::HasAsciiUpper(word.data(), word.size())) {

--- a/src/io/file_load_service.cpp
+++ b/src/io/file_load_service.cpp
@@ -29,6 +29,9 @@ std::expected<void, FileLoadError> FileLoadService::ExecuteLoad(Document& doc, L
 
 void FileLoadService::StartAsyncLoad(TaskScheduler& scheduler, HWND hwnd, UINT msg_id, const Theme& theme)
 {
+    // 新しいロードが preload を置き換える。放置すると TakeAsyncResult が preload 結果を
+    // 優先返却し、表示中ドキュメントを上書きする。
+    preloader_.Cancel();
     coordinator_.Start(scheduler, loading_path_, hwnd, msg_id, theme);
 }
 

--- a/src/io/file_load_service.h
+++ b/src/io/file_load_service.h
@@ -57,6 +57,7 @@ public:
     void CancelAsyncLoad() noexcept
     {
         coordinator_.Cancel();
+        preloader_.Cancel();
     }
 
     // App::Init 前から走らせる経路。

--- a/src/io/file_watcher.cpp
+++ b/src/io/file_watcher.cpp
@@ -15,6 +15,16 @@ void FileWatcher::StartWatching(const std::pmr::wstring& file_path, ChangeCallba
     const std::filesystem::path p(file_path);
     watch_filename_ = std::pmr::wstring{ p.filename().native() };
 
+    watch_filename_short_.clear();
+    wchar_t short_buf[MAX_PATH];
+    const DWORD short_len = GetShortPathNameW(file_path.c_str(), short_buf, MAX_PATH);
+    if (short_len > 0 && short_len < MAX_PATH) {
+        std::pmr::wstring short_name{ std::filesystem::path(short_buf).filename().native() };
+        if (!path_util::iequal(short_name, watch_filename_)) {
+            watch_filename_short_ = std::move(short_name);
+        }
+    }
+
     const auto dir = p.parent_path();
     if (dir.empty()) {
         return;
@@ -130,9 +140,11 @@ void FileWatcher::CheckForChanges()
                 break;
             }
             const std::wstring_view changed_name{ info->FileName, name_bytes / sizeof(wchar_t) };
+            const bool name_matches = path_util::iequal(changed_name, watch_filename_) ||
+                (!watch_filename_short_.empty() && path_util::iequal(changed_name, watch_filename_short_));
             if (info->Action != FILE_ACTION_REMOVED &&
                 info->Action != FILE_ACTION_RENAMED_OLD_NAME &&
-                path_util::iequal(changed_name, watch_filename_)) {
+                name_matches) {
                 target_changed = true;
                 break;
             }

--- a/src/io/file_watcher.h
+++ b/src/io/file_watcher.h
@@ -28,6 +28,8 @@ private:
     void BeginRead();
 
     std::pmr::wstring watch_filename_;
+    // 通知は 8.3 短縮名で来ることがある (未規定)。長い名前と一致しない場合のみ保持。
+    std::pmr::wstring watch_filename_short_;
     ChangeCallback on_change_;
     bool watching_ = false;
 

--- a/src/io/preloader.cpp
+++ b/src/io/preloader.cpp
@@ -32,19 +32,26 @@ void Preloader::Start(std::pmr::wstring path)
 
         // stop_token なしだと Parse 完走まで終了時の join が数百 ms ブロックする。
         auto load_result = DocumentService::LoadFile(path, st);
-        // sink 書き込み前に abort 確認。直後の publish + main 側即破棄を回避。
         if (st.stop_requested()) {
             return;
         }
+        LayoutCache cache;
         if (load_result) {
-            LayoutCache cache;
             cache.Reset(load_result->GetNodes().size(), /* shrink = */ false);
-            const std::lock_guard lock(sink_mutex_);
-            result_.emplace(AsyncLoadResult{ std::move(*load_result), std::move(cache), /* heights_estimated = */ false });
         }
-        else {
+        {
             const std::lock_guard lock(sink_mutex_);
-            error_ = load_result.error();
+            // Cancel の sink クリアと同一 mutex 上で直列化し、クリア後の再 publish を防ぐ
+            // (coordinator の try_publish と同じパターン)。
+            if (st.stop_requested()) {
+                return;
+            }
+            if (load_result) {
+                result_.emplace(AsyncLoadResult{ std::move(*load_result), std::move(cache), /* heights_estimated = */ false });
+            }
+            else {
+                error_ = load_result.error();
+            }
         }
 
         std::unique_lock lk(ctx->mtx);
@@ -67,10 +74,11 @@ bool Preloader::IsDoneLocked() const
 
 void Preloader::Join()
 {
-    if (!ctx_) {
-        return;
+    // Cancel 済み (ctx_ が null) でも worker が走行中のことがあるため、
+    // joinable のみで判定する。
+    if (ctx_) {
+        ctx_->SignalAbort();
     }
-    ctx_->SignalAbort();
     if (thread_.joinable()) {
         thread_.request_stop();
         thread_.join();
@@ -126,4 +134,19 @@ std::optional<AsyncLoadResult> Preloader::TakeResult()
 std::optional<FileLoadError> Preloader::TakeError()
 {
     return TakeFromSink(error_);
+}
+
+void Preloader::Cancel() noexcept
+{
+    // join しない: worker が Parse 中だと UI スレッドが数百 ms ブロックするため。
+    // 以後の publish は worker 側の lock 内 stop 確認で弾かれ、走行中スレッドは
+    // 次の Start() か破棄時の Join() が回収する。
+    if (ctx_) {
+        ctx_->SignalAbort();
+        thread_.request_stop();
+        ctx_.reset();
+    }
+    const std::lock_guard lock(sink_mutex_);
+    result_.reset();
+    error_.reset();
 }

--- a/src/io/preloader.h
+++ b/src/io/preloader.h
@@ -45,6 +45,9 @@ public:
     std::optional<AsyncLoadResult> TakeResult();
     std::optional<FileLoadError> TakeError();
 
+    // 進行中の preload を非ブロッキングで中断し、取り込まれていない結果も破棄する。
+    void Cancel() noexcept;
+
 private:
     // worker は cv.wait で hwnd セットを待ってから PostMessage する。
     // main 側の早期終了時は aborted=true + cv.notify_all でデッドロックを避ける。

--- a/src/util/file_io.cpp
+++ b/src/util/file_io.cpp
@@ -53,7 +53,7 @@ bool IsFileLargerThan(const std::filesystem::path& path, size_t reference_size, 
     return current_size > static_cast<uint64_t>(reference_size) + tolerance;
 }
 
-bool WriteAllBytes(const std::filesystem::path& path, const void* data, size_t size)
+bool WriteAllBytes(const std::filesystem::path& path, const void* data, size_t size, bool flush_buffers)
 {
     if (size > std::numeric_limits<uint32_t>::max()) {
         return false;
@@ -67,6 +67,9 @@ bool WriteAllBytes(const std::filesystem::path& path, const void* data, size_t s
         bytes_written != static_cast<DWORD>(size)) {
         return false;
     }
+    if (flush_buffers && !FlushFileBuffers(hFile.get())) {
+        return false;
+    }
     return true;
 }
 
@@ -75,14 +78,17 @@ bool AtomicWriteAllBytes(const std::filesystem::path& path, const void* data, si
     std::filesystem::path tmp_path = path;
     tmp_path += L".tmp";
 
-    if (!WriteAllBytes(tmp_path, data, size)) {
+    // tmp のデータブロックを flush してから write-through rename する。
+    // rename のメタデータだけが先にディスクへコミットされると、電源断時に
+    // 対象ファイルが 0 バイト化し旧内容が復元不能になるため。
+    if (!WriteAllBytes(tmp_path, data, size, /* flush_buffers = */ true)) {
         // 書き込み途中失敗でも CREATE_ALWAYS で tmp は生成済み。部分書き込みの
         // 孤児 tmp を残さないよう掃除する。
         DeleteFileW(tmp_path.c_str());
         return false;
     }
 
-    if (MoveFileExW(tmp_path.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING)) {
+    if (MoveFileExW(tmp_path.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
         return true;
     }
 

--- a/src/util/file_io.h
+++ b/src/util/file_io.h
@@ -67,7 +67,9 @@ struct OpenedFile {
 // 16 バイトの許容範囲を持たせる。
 bool IsFileLargerThan(const std::filesystem::path& path, size_t reference_size, size_t tolerance = 16) noexcept;
 
-[[nodiscard]] bool WriteAllBytes(const std::filesystem::path& path, const void* data, size_t size);
+// flush_buffers: true の場合、close 前に FlushFileBuffers でデータブロックを
+// ディスクへコミットする。rename と組み合わせて使う経路 (AtomicWriteAllBytes) 向け。
+[[nodiscard]] bool WriteAllBytes(const std::filesystem::path& path, const void* data, size_t size, bool flush_buffers = false);
 
 // tmp ファイルへ書いてから MoveFileExW(REPLACE_EXISTING) で原子的に置き換える。
 // rename が失敗 (クロスボリューム等) した場合は tmp を削除し false を返す。直書きフォールバックは

--- a/src/util/viewport_manager.h
+++ b/src/util/viewport_manager.h
@@ -203,8 +203,10 @@ public:
             return;
         }
         const int last = static_cast<int>(nodes.size()) - 1;
+        // Table は GetText() が空 (実体は concat_text)。
+        // 抽出側 (ExtractSelectedText) と同じ LinearizedText で終端を取る。
         selection_ = TextSelection::MakeOrdered(
-            0, 0, last, static_cast<uint32_t>(nodes[last].GetText().size()));
+            0, 0, last, static_cast<uint32_t>(nodes[last].LinearizedText().size()));
     }
 
     // ---- ズーム ----

--- a/tests/test_file_load_service.cpp
+++ b/tests/test_file_load_service.cpp
@@ -1,10 +1,34 @@
 #include <gtest/gtest.h>
 #include "file_load_service.h"
+#include "test_helpers.h"
+#include "theme.h"
 
 class FileLoadServiceTest : public ::testing::Test {
 protected:
     FileLoadService service_;
 };
+
+namespace {
+constexpr auto kPollTimeout = std::chrono::seconds(5);
+} // namespace
+
+// preload と StartAsyncLoad を跨ぐキャンセル挙動は実 scheduler が要るため専用 fixture。
+class FileLoadServicePreloadTest : public ::testing::Test {
+protected:
+    static TaskScheduler scheduler_;
+    FileLoadService service_;
+
+    static void SetUpTestSuite()
+    {
+        scheduler_.Init(1);
+    }
+    static void TearDownTestSuite()
+    {
+        scheduler_.Shutdown();
+    }
+};
+
+TaskScheduler FileLoadServicePreloadTest::scheduler_;
 
 TEST_F(FileLoadServiceTest, InitiallyNotLoading)
 {
@@ -104,4 +128,23 @@ TEST_F(FileLoadServiceTest, CancelAsyncLoadDoesNotCrash)
     // 非同期ロードが進行中でなくてもキャンセルは安全
     service_.CancelAsyncLoad();
     EXPECT_FALSE(service_.TakeAsyncResult().has_value());
+}
+
+TEST_F(FileLoadServicePreloadTest, StartAsyncLoadCancelsPreloadResult)
+{
+    TempFile preload_file(L"fls_preload", "# preload doc\n");
+    TempFile new_file(L"fls_newload", "# new doc\n");
+
+    service_.StartPreloadAsync(preload_file.PmrPath());
+    // preload worker が結果を sink に積んで cv.wait (hwnd 待ち) に入るまで待つ。
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+
+    service_.SetLoadingPath(new_file.PmrPath());
+    service_.StartAsyncLoad(scheduler_, nullptr, 0, GetLightTheme());
+
+    std::optional<AsyncLoadResult> result;
+    PollUntil([&] { result = service_.TakeAsyncResult(); return result.has_value(); }, kPollTimeout);
+    ASSERT_TRUE(result.has_value());
+    // preload 結果 (fls_preload) ではなく StartAsyncLoad の結果 (fls_newload) を返すこと。
+    EXPECT_EQ(result->doc.GetFilePath(), new_file.PmrPath());
 }

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -17,6 +17,7 @@
 #include "document_types.h"
 #include "layout_cache.h"
 #include "side_effect.h"
+#include "theme.h"
 
 // Node::view_ は実バッファへの非 null ポインタを必要とする。テストでは中身が
 // 任意で十分大きい固定 base を返し、SetSourceOffset(base, offset) と SourceOffsetFrom(base)
@@ -94,6 +95,29 @@ inline LayoutCache MakeUniformCache(int count, float node_height = 100.0f)
         cache.BuildBlockHeights(std::span<const float>(block_heights.data(), block_heights.size()));
     }
     return cache;
+}
+
+// レイアウト系テスト共通の Theme。Theme は zoom 以外初期化子なしの集約のため、
+// value-init + 明示設定で未初期化読み（flaky の温床）を防ぐ。
+inline Theme MakeLayoutTestTheme()
+{
+    Theme theme{};
+    theme.margin_top = 10.0f;
+    theme.heading_spacing_above = 8.0f;
+    theme.heading_spacing_below = 4.0f;
+    theme.heading_spacing_below_h1h2 = 6.0f;
+    theme.code_block_spacing_above = 12.0f;
+    theme.paragraph_spacing = 5.0f;
+    theme.font_size_body = 14.0f;
+    theme.font_size_code = 12.0f;
+    for (int i = 0; i < 6; ++i) {
+        theme.font_size_h[i] = 18.0f - static_cast<float>(i);
+    }
+    theme.list_item_spacing = 3.0f;
+    theme.code_block_padding = 4.0f;
+    theme.indent_width = 16.0f;
+    theme.hr_thickness = 1.0f;
+    return theme;
 }
 
 // テストケースごとに temp ディレクトリを自動で用意・破棄するフィクスチャ基底。

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -1668,8 +1668,12 @@ TEST_F(LayoutTest, LooseTaskListCheckboxIsEmitted)
     for (const auto& cmd : cmds) {
         if (auto* t = std::get_if<DrawTextCmd>(&cmd); t && t->text_len == 1) {
             const wchar_t ch = t->text()[0];
-            if (ch == L'☐') ++unchecked;
-            else if (ch == L'☑') ++checked;
+            if (ch == L'☐') {
+                ++unchecked;
+            }
+            else if (ch == L'☑') {
+                ++checked;
+            }
         }
     }
     EXPECT_EQ(unchecked, 1);
@@ -1708,22 +1712,7 @@ TEST(RecomputeYPositionsTest, DISABLED_BenchLargeDocument)
         }
     }
 
-    Theme theme;
-    theme.margin_top = 10.0f;
-    theme.heading_spacing_above = 8.0f;
-    theme.heading_spacing_below = 4.0f;
-    theme.heading_spacing_below_h1h2 = 6.0f;
-    theme.code_block_spacing_above = 12.0f;
-    theme.paragraph_spacing = 5.0f;
-    theme.font_size_body = 14.0f;
-    theme.font_size_code = 12.0f;
-    for (int i = 0; i < 6; ++i) {
-        theme.font_size_h[i] = 18.0f - static_cast<float>(i);
-    }
-    theme.list_item_spacing = 3.0f;
-    theme.code_block_padding = 4.0f;
-    theme.indent_width = 16.0f;
-    theme.hr_thickness = 1.0f;
+    Theme theme = MakeLayoutTestTheme();
 
     LayoutCache cache;
     cache.Resize(N);

--- a/tests/test_layout_cache.cpp
+++ b/tests/test_layout_cache.cpp
@@ -177,22 +177,7 @@ TEST(LayoutCacheTest, TextTopMatchesFenwickDerivedValue)
     LayoutCache cache;
     cache.Resize(5);
 
-    Theme theme;
-    theme.margin_top = 10.0f;
-    theme.heading_spacing_above = 8.0f;
-    theme.heading_spacing_below = 4.0f;
-    theme.heading_spacing_below_h1h2 = 6.0f;
-    theme.code_block_spacing_above = 12.0f;
-    theme.paragraph_spacing = 5.0f;
-    theme.font_size_body = 14.0f;
-    theme.font_size_code = 12.0f;
-    for (int i = 0; i < 6; ++i) {
-        theme.font_size_h[i] = 18.0f - static_cast<float>(i);
-    }
-    theme.list_item_spacing = 3.0f;
-    theme.code_block_padding = 4.0f;
-    theme.indent_width = 16.0f;
-    theme.hr_thickness = 1.0f;
+    Theme theme = MakeLayoutTestTheme();
 
     std::pmr::vector<Node> nodes;
     nodes.resize(5);
@@ -227,7 +212,7 @@ TEST(LayoutCacheTest, RecomputeYPositionsEarlyExitKeepsFenwickAndTextTopInSync)
     LayoutCache cache;
     cache.Resize(8);
 
-    Theme theme;
+    Theme theme{};
     theme.margin_top = 5.0f;
     theme.paragraph_spacing = 4.0f;
     theme.font_size_body = 14.0f;

--- a/tests/test_nav_history.cpp
+++ b/tests/test_nav_history.cpp
@@ -164,7 +164,9 @@ TEST_F(NavHistoryTest, MaxHistoryCapsForwardStack)
     // 全件GoBackして進むスタックに移す
     NavEntry out;
     for (size_t i = 0; i < NavHistory::MAX_HISTORY; ++i) {
-        if (!hist_.GoBack({ L"cur.md", 0, 0.0f }, out)) break;
+        if (!hist_.GoBack({ L"cur.md", 0, 0.0f }, out)) {
+            break;
+        }
     }
     EXPECT_LE(hist_.ForwardSize(), NavHistory::MAX_HISTORY);
 }

--- a/tests/test_preloader.cpp
+++ b/tests/test_preloader.cpp
@@ -147,3 +147,31 @@ TEST(Preloader, TakeAfterFinalizeReturnsNullopt)
     EXPECT_FALSE(p.TakeResult().has_value());
     EXPECT_FALSE(p.TakeError().has_value());
 }
+
+TEST(Preloader, CancelDiscardsCompletedResult)
+{
+    TempFile tmp(L"preload_cancel", "# will be cancelled\n");
+    Preloader p;
+    p.Start(tmp.PmrPath());
+    std::this_thread::sleep_for(kWorkerCompleteWait);
+
+    p.Cancel();
+
+    EXPECT_FALSE(p.IsActive());
+    EXPECT_FALSE(p.TakeResult().has_value());
+    EXPECT_FALSE(p.TakeError().has_value());
+}
+
+TEST(Preloader, CancelAbortsInFlightWorker)
+{
+    TempFile tmp(L"preload_cancel_inflight", "# in flight\n");
+    Preloader p;
+    p.Start(tmp.PmrPath());
+    // Cancel は join しないが、worker がどの段階にいても stop 要求 + lock 内再確認で
+    // publish は弾かれるため、結果は決定的に空になる。
+    p.Cancel();
+
+    EXPECT_FALSE(p.IsActive());
+    EXPECT_FALSE(p.TakeResult().has_value());
+    EXPECT_FALSE(p.TakeError().has_value());
+}

--- a/tests/test_syntax.cpp
+++ b/tests/test_syntax.cpp
@@ -713,6 +713,31 @@ TEST(Syntax, CppRawString)
     EXPECT_TRUE(has_string);
 }
 
+// バグ修正: R"(...)"はRを含めて単一のStringトークンになるべき（PlainとStringの重複禁止）
+TEST(Syntax, CppRawStringRPrefixMergedIntoSingleToken)
+{
+    std::string code = "R\"(abc)\"";
+    auto tokens = Tokenize(code, SyntaxLanguage::Cpp);
+    // 連続・非重複であることを確認（gapless coverageは重複がないことも保証する）
+    AssertTokensCoverText(tokens, code.size());
+
+    ASSERT_EQ(tokens.size(), 1u);
+    EXPECT_EQ(tokens[0].type, SyntaxTokenType::String);
+    EXPECT_EQ(tokens[0].start, 0u);
+    EXPECT_EQ(tokens[0].length, 8u);
+}
+
+// トークンがstart昇順・非重複であることを確認（複数の生文字列を含む入力）
+TEST(Syntax, CppRawStringTokensAreOrderedAndNonOverlapping)
+{
+    std::string code = "R\"(one)\" + R\"delim(two)delim\" + normalCall()";
+    auto tokens = Tokenize(code, SyntaxLanguage::Cpp);
+    AssertTokensCoverText(tokens, code.size());
+    for (size_t i = 1; i < tokens.size(); i++) {
+        EXPECT_LE(tokens[i - 1].start + tokens[i - 1].length, tokens[i].start);
+    }
+}
+
 // C++ 8進数
 TEST(Syntax, CppNumberOctal)
 {
@@ -923,11 +948,12 @@ TEST(Syntax, CppRawStringWithDelimiter)
 {
     std::string code = "R\"delim(hello \"world\")delim\"";
     auto tokens = Tokenize(code, SyntaxLanguage::Cpp);
-    // Rは別の識別子として出力され、その後に生文字列が続く
+    AssertTokensCoverText(tokens, code.size());
+    // RはStringトークンに含まれ、R"delim(...)delim"全体が単一のStringトークンになる
     auto* str = FindToken(tokens, SyntaxTokenType::String);
     ASSERT_NE(str, nullptr);
-    // R"delim(...)delim"全体がキャプチャされる（Rはプレーン + 文字列本体）
-    EXPECT_GT(str->length, 10u);
+    EXPECT_EQ(str->start, 0u);
+    EXPECT_EQ(str->length, static_cast<uint32_t>(code.size()));
 }
 
 // ============================================================
@@ -1075,6 +1101,31 @@ TEST(Syntax, CppRawStringAfterSpaceR)
     auto tokens = Tokenize(code, SyntaxLanguage::Cpp);
     auto* str = FindToken(tokens, SyntaxTokenType::String);
     ASSERT_NE(str, nullptr);
+}
+
+TEST(Syntax, CppRawStringNotTriggeredWhenRIsPartOfLongerIdentifier)
+{
+    // "xR\"(a)\"" — 識別子が"R"単独でない（"xR"）ため生文字列扱いされず、
+    // "(a)"は通常の文字列として解釈される
+    std::string code = "xR\"(a)\"";
+    auto tokens = Tokenize(code, SyntaxLanguage::Cpp);
+    AssertTokensCoverText(tokens, code.size());
+
+    bool found_xr = false;
+    bool found_string = false;
+    for (const auto& t : tokens) {
+        std::string text = GetTokenText(code, t);
+        if (text == "xR") {
+            found_xr = true;
+            EXPECT_NE(t.type, SyntaxTokenType::String);
+        }
+        if (text == "\"(a)\"") {
+            found_string = true;
+            EXPECT_EQ(t.type, SyntaxTokenType::String);
+        }
+    }
+    EXPECT_TRUE(found_xr) << "xRが独立したトークンとして見つかるべき";
+    EXPECT_TRUE(found_string) << "\"(a)\"が通常の文字列トークンとして見つかるべき";
 }
 
 // ============================================================

--- a/tests/test_viewport_manager.cpp
+++ b/tests/test_viewport_manager.cpp
@@ -241,6 +241,24 @@ TEST(ViewportManagerTest, SelectAllEmpty)
     EXPECT_FALSE(vm.GetSelection().active);
 }
 
+// 最終ノードが Table のとき、GetText() は空なので LinearizedText (= concat_text) を終端に使う必要がある。
+TEST(ViewportManagerTest, SelectAllLastNodeIsTable)
+{
+    std::pmr::vector<Node> nodes;
+    nodes.push_back(MakeTextNode("hello"));
+    nodes.push_back(MakeTableNode("cell0", "cell1"));
+
+    ViewportManager vm;
+    vm.SelectAll(nodes);
+
+    EXPECT_TRUE(vm.GetSelection().active);
+    EXPECT_EQ(vm.GetSelection().start_node, 0);
+    EXPECT_EQ(vm.GetSelection().start_pos, 0u);
+    EXPECT_EQ(vm.GetSelection().end_node, 1);
+    EXPECT_EQ(vm.GetSelection().end_pos, static_cast<uint32_t>(nodes[1].LinearizedText().size()));
+    EXPECT_GT(vm.GetSelection().end_pos, static_cast<uint32_t>(nodes[1].GetText().size()));
+}
+
 // ---- ズームテスト ----
 
 TEST(ViewportManagerTest, ZoomInAdvancesIndex)


### PR DESCRIPTION
## 概要

`/code-review` によるアプリ全体（`third_party/` 除く）のレビューで確定した指摘10件（正確性7件＋クリーンアップ3件）をすべて解消する。適用後に `/simplify` の4観点レビューも実施し、指摘3件を反映済み。

## 正確性の修正

| # | 問題 | 修正 |
|---|---|---|
| 1 | 起動時 preload がキャンセルされず、後着した preload 結果が表示中ドキュメントを上書き | `Preloader::Cancel()` を新設し `CancelAsyncLoad`/`StartAsyncLoad` で破棄。Cancel は非ブロッキング（stop 要求＋worker の lock 内再確認で publish を拒否）で、Parse 中の UI フリーズなし |
| 2 | 新ロード開始で無効化された stale な `PARSE_COMPLETE` が「結果なし」パスに落ち、進行中ロードを誤キャンセル | `OnParseComplete` に stale ガードを追加（結果もエラーも無く別ロード進行中なら無視） |
| 3 | 最終ノードが Table のとき Ctrl+A のコピーから内容が丸ごと脱落 | `SelectAll` の終端を `GetText()` → `LinearizedText()` に変更し抽出側と統一 |
| 4 | C++ 生文字列 `R"(...)"` で Plain/String の重複トークンが生成されトークン列の非重複不変条件が破壊 | 生文字列処理を識別子ステップに移動し、`R` を含む単一 String トークンとして emit |
| 5 | `AtomicWriteAllBytes` が電源断に非耐久（rename が先にコミットされ 0 バイト化） | tmp を `FlushFileBuffers` してから `MOVEFILE_WRITE_THROUGH` 付き rename |
| 6 | 破棄順により `~MermaidRenderer` の in-flight コールバックが破棄済み `ClipboardManager` へ書き込む UAF | `clipboard_manager_` を `mermaid_renderer_` より先に宣言 |
| 7 | `ReadDirectoryChangesW` が 8.3 短縮名で通知すると自動リロードが発火しない | 監視開始時に短縮名も取得し、通知名を両方と比較 |

## クリーンアップ

- タイマー enum を自動インクリメント＋番兵 `END` に変更し、手動同期の `ALL_TIMERS` 配列を範囲判定に置換（連番が言語保証になり追記漏れが構造的に不可能）
- レイアウト系テストで3箇所に重複していた Theme 設定を `MakeLayoutTestTheme()` に抽出（value-init で既知の未初期化 flaky も防止）
- テストの中括弧なし if/else を規約に合わせて修正

## テスト

- 追加: Preloader Cancel ×2、preload 破棄の統合テスト、生文字列の非重複検証 ×3（既存1件の期待値も厳密化）、SelectAll テーブル終端
- `mendo_tests.exe` 全 2338 テストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQaFHjDacxc9vudMNgNSrr