### PR TITLE
fix: 同期リロードの diff 比較前に新テキストを LF 正規化 (#273)

### DIFF
--- a/example/test.md
+++ b/example/test.md
@@ -2752,7 +2752,7 @@ public:
 };
 ```
 
-`raw_text_` はパース入力の UTF-8 テキストを常時保持する。これは `CalcScrollYForDiff` の比較用で、ノードレベルでは検出できない編集（空行追加・末尾空白・改行種別変更等）も UTF-8 byte オフセット精度で差分位置を求めるため。
+`raw_text_` はパース入力の UTF-8 テキストを常時保持する。これは `CalcScrollYForDiff` の比較用で、ノードレベルでは検出できない編集（空行追加・末尾空白等）も UTF-8 byte オフセット精度で差分位置を求めるため。`raw_text_` は `NormalizeNewlines` により常に LF 正規化済みなので、リロード diff の新テキストも比較前に同じ正規化を通す（`DoReloadCurrentFile`）。これによりファイル全体の改行コードを変換して保存するエディタ（issue #273）でも差分位置が編集行を正しく指し、改行コード変換のみの保存は NoChange としてスクロール位置が維持される。
 
 ### 4.4 NodeType / AlertType
 

--- a/src/app/app_file.cpp
+++ b/src/app/app_file.cpp
@@ -374,6 +374,12 @@ void App::DoReloadCurrentFile()
     const size_t byte_size = load_result->byte_size;
     std::pmr::string new_text = std::move(load_result->text);
 
+    // old (raw_text_) は FromMarkdown / ReplaceFromMarkdown で常に LF 正規化済み。
+    // 新テキストも比較前に揃えないと、CRLF ファイルで全行が差分になり diff が
+    // 1 行目末尾を指してしまう (issue #273: 改行コードを変換して保存するエディタ)。
+    // ReplaceFromMarkdown 内の再正規化は LF-only 高速パスで素通りする。
+    NormalizeNewlines(new_text);
+
     const std::string_view old_view(state_.document.doc.GetRawText());
     const std::string_view new_view(new_text);
     const auto decision = AnalyzeReloadDiff(old_view, new_view);

--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -18,7 +18,8 @@ inline char* FindDocCr(char* p, size_t len) noexcept
     return static_cast<char*>(std::memchr(p, mendo::doc_cr, len));
 }
 
-// CRLF / 旧式 CR を LF に正規化する (in-place)。
+} // namespace
+
 // 改行を LF に揃えておくと、パーサ中の current_text と raw_text_ の memcmp 一致判定が成立し、
 // 大半の code block / 複数行 paragraph で view モード化 (owned_text_ 確保ゼロ) が選べる。
 // CR まで一気にスキップし、その間は memmove でブロックコピーする (MSVC UCRT で SIMD)。
@@ -62,8 +63,6 @@ void NormalizeNewlines(std::pmr::string& s)
     s.resize(static_cast<size_t>(dst - data));
     MENDO_STATF("NormalizeNewlines: in={} out={} shrunk={}", n, s.size(), n - s.size());
 }
-
-} // namespace
 
 Document::Document(Document&& other) noexcept
 {

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -12,6 +12,11 @@
 #include <vector>
 #include <memory_resource>
 
+// CRLF / 旧式 CR を LF に正規化する (in-place)。FromMarkdown / ReplaceFromMarkdown が
+// パース前に必ず通すため raw_text_ は常に LF-only。リロード diff (AnalyzeReloadDiff) の
+// 新テキストも比較前にこれで揃えないと、CRLF ファイルで全行が差分扱いになる (issue #273)。
+void NormalizeNewlines(std::pmr::string& s);
+
 class Document {
 public:
     constexpr Document() noexcept = default;

--- a/src/core/reload.cpp
+++ b/src/core/reload.cpp
@@ -89,6 +89,9 @@ float CalcScrollYForDiff(
     float viewport_height,
     float fallback_scroll) noexcept
 {
+    if (diff_pos == std::string_view::npos) {
+        return fallback_scroll;
+    }
     const char* const raw_base = content.data();
     const auto changed_node = FindNodeBySourceOffset(nodes, raw_base, diff_pos);
     if (changed_node < 0 || changed_node >= static_cast<int>(cache.size())) {

--- a/src/core/reload.h
+++ b/src/core/reload.h
@@ -15,6 +15,8 @@
 class LayoutCache;
 
 // 新旧コンテンツの最初の差分 UTF-8 byte 位置を返す。同一の場合は npos。
+// 前提: 両テキストとも LF 正規化済みであること (NormalizeNewlines)。old は raw_text_
+// 由来で常に正規化済み、new は呼び出し側で比較前に揃える (issue #273)。
 size_t FindFirstDifference(std::string_view old_text, std::string_view new_text) noexcept;
 
 // diff_pos が短い方の末尾と一致するかを判定する。
@@ -45,7 +47,8 @@ ReloadDecision AnalyzeReloadDiff(std::string_view old_text, std::string_view new
 [[nodiscard]] int FindNodeBySourceOffset(const std::pmr::vector<Node>& nodes, const char* raw_base, size_t diff_offset) noexcept;
 
 // diff 位置のノードに基づくスクロールY座標を計算する。
-// ノードが見つからない場合は fallback_scroll を返す。
+// diff_pos が npos (差分位置なし = スクロール維持) またはノードが見つからない場合は
+// fallback_scroll を返す。
 float CalcScrollYForDiff(
     const std::pmr::vector<Node>& nodes,
     const LayoutCache& cache,

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -13,6 +13,43 @@ void ReplaceMarkdown(Document& doc, std::string_view text)
 }
 } // namespace
 
+// リロード diff (AnalyzeReloadDiff) は raw_text_ と同じ LF 正規化を新テキストにも
+// 適用してから比較する前提 (issue #273)。その契約を担保する。
+TEST(NormalizeNewlines, CrlfToLf)
+{
+    std::pmr::string s{ "a\r\nb\r\nc\r\n" };
+    NormalizeNewlines(s);
+    EXPECT_EQ(s, "a\nb\nc\n");
+}
+
+TEST(NormalizeNewlines, LoneCrToLf)
+{
+    std::pmr::string s{ "a\rb\rc" };
+    NormalizeNewlines(s);
+    EXPECT_EQ(s, "a\nb\nc");
+}
+
+TEST(NormalizeNewlines, LfOnlyUnchanged)
+{
+    std::pmr::string s{ "a\nb\nc\n" };
+    NormalizeNewlines(s);
+    EXPECT_EQ(s, "a\nb\nc\n");
+}
+
+TEST(NormalizeNewlines, EmptyUnchanged)
+{
+    std::pmr::string s;
+    NormalizeNewlines(s);
+    EXPECT_TRUE(s.empty());
+}
+
+TEST(NormalizeNewlines, MixedAndTrailingCr)
+{
+    std::pmr::string s{ "a\r\nb\nc\r" };
+    NormalizeNewlines(s);
+    EXPECT_EQ(s, "a\nb\nc\n");
+}
+
 TEST(DocumentTest, DefaultIsEmpty)
 {
     Document doc;

--- a/tests/test_document_utils.cpp
+++ b/tests/test_document_utils.cpp
@@ -1816,6 +1816,16 @@ TEST(CalcScrollYForDiff, FallbackWhenNoNodes)
     EXPECT_FLOAT_EQ(CalcScrollYForDiff(nodes, cache, "content", 0, 500.0f, 42.0f), 42.0f);
 }
 
+TEST(CalcScrollYForDiff, FallbackWhenDiffPosIsNpos)
+{
+    // npos = 差分位置なし (改行コード変換のみのリロード等)。現在位置を維持する。
+    std::string content(300, 'x');
+    auto nodes = MakeNodes(content.data(), 3, 100);
+    auto cache = MakeUniformCache(3, 100.0f);
+    EXPECT_FLOAT_EQ(
+        CalcScrollYForDiff(nodes, cache, content, std::string_view::npos, 500.0f, 123.0f), 123.0f);
+}
+
 TEST(CalcScrollYForDiff, FallbackWhenNodeNotFound)
 {
     // すべてのノードの source_offset が diff_pos より大きい。


### PR DESCRIPTION
## 概要

Fixes #273

GitHub Copilot CLI 等、ファイル全体の改行コードを変換して保存するエディタで編集すると、リロード時に編集箇所ではなくファイル先頭へスクロールする問題を修正します。

## 原因

`raw_text_` (diff の old 側) は `FromMarkdown` / `ReplaceFromMarkdown` 内の `NormalizeNewlines` で常に LF 正規化されていますが、同期リロード経路 (`DoReloadCurrentFile`) だけはディスクから読んだ未正規化テキストをそのまま `AnalyzeReloadDiff` に渡していました。

このため CRLF のファイルでは全行が差分扱いになり、`FindFirstDifference` が 1 行目末尾を差分位置として返し、常に先頭付近へスクロールしていました。Copilot CLI には編集ファイルの改行コードを全変換する既知バグ ([copilot-cli#1148](https://github.com/github/copilot-cli/issues/1148)) があり、LF ファイルが CRLF 化されることでこの経路に入ります。改行コードを保持するエディタ (VSCode / サクラエディタ / vim / Claude Code) では差分が編集箇所と一致するため発症しません。

## 変更内容

- `NormalizeNewlines` を document.cpp の無名 namespace から公開し、同期リロードの diff 比較前に新テキストへ適用 (本質的な修正はこの 1 行)
- `CalcScrollYForDiff` に npos ガードを追加 (npos が二分探索で最終ノードに解決される罠への防御)
- `FindFirstDifference` / `NormalizeNewlines` に LF 正規化前提の契約コメントを追記
- `NormalizeNewlines` の単体テスト 5 本と npos フォールバックテスト 1 本を追加
- 仕様書 example/test.md を同期

## 副次効果

CRLF ファイルではこれまで `NoChange` / `PrefixGrowth` 判定が一度も機能せず常に FullReload に落ちていましたが、正規化後の比較により本来の判定が働くようになります。「改行コード変換のみで内容不変」の保存は NoChange としてパース自体をスキップし、スクロール位置を維持します。

## テスト

- `build/tests/Release/mendo_tests.exe --gtest_brief=1` : 全 2344 テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QJFwU2YmYtotiXHTputDd