### PR TITLE
feat: mermaid 描画エラーをプレースホルダに表示 (#271)

### DIFF
--- a/src/app/resource_manager.h
+++ b/src/app/resource_manager.h
@@ -220,7 +220,8 @@ public:
             const size_t i = *it;
             auto& node = deps_.doc->GetNodesMut()[i];
             auto& diagram = deps_.cache->GetDiagram(i);
-            if (diagram.bitmap) {
+            // エラー確定 (error 非空) の図は再リクエストしない。失敗レンダの無限リトライを防ぐ。
+            if (diagram.bitmap || !diagram.error.empty()) {
                 continue;
             }
 
@@ -308,7 +309,7 @@ public:
             auto& node = deps_.doc->GetNodesMut()[i];
             auto& diagram = deps_.cache->GetDiagram(i);
 
-            if (!diagram.bitmap) {
+            if (!diagram.bitmap && diagram.error.empty()) {
                 deps_.mermaid->RequestRender(node, (*deps_.cache)[i], diagram, content_width, dark_mode, [this] { OnMermaidRenderComplete(); });
                 if (diagram.bitmap) {
                     any_loaded = true;
@@ -458,6 +459,8 @@ private:
                 diagram.bitmap.Reset();
                 diagram.width = 0;
                 diagram.height = 0;
+                // 幅が変わればエラー結果も変わりうるためクリアし、再試行させる。
+                diagram.error.clear();
                 any_invalidated = true;
             }
             if (any_invalidated) {

--- a/src/app/resource_manager.h
+++ b/src/app/resource_manager.h
@@ -220,8 +220,8 @@ public:
             const size_t i = *it;
             auto& node = deps_.doc->GetNodesMut()[i];
             auto& diagram = deps_.cache->GetDiagram(i);
-            // エラー確定 (error 非空) の図は再リクエストしない。失敗レンダの無限リトライを防ぐ。
-            if (diagram.bitmap || !diagram.error.empty()) {
+            // エラー確定した図も NeedsRender()=false で弾き、失敗レンダの無限リトライを防ぐ。
+            if (!diagram.NeedsRender()) {
                 continue;
             }
 
@@ -309,7 +309,7 @@ public:
             auto& node = deps_.doc->GetNodesMut()[i];
             auto& diagram = deps_.cache->GetDiagram(i);
 
-            if (!diagram.bitmap && diagram.error.empty()) {
+            if (diagram.NeedsRender()) {
                 deps_.mermaid->RequestRender(node, (*deps_.cache)[i], diagram, content_width, dark_mode, [this] { OnMermaidRenderComplete(); });
                 if (diagram.bitmap) {
                     any_loaded = true;
@@ -456,11 +456,8 @@ private:
                     diagram.width + 1.0f < min_width) {
                     continue;
                 }
-                diagram.bitmap.Reset();
-                diagram.width = 0;
-                diagram.height = 0;
-                // 幅が変わればエラー結果も変わりうるためクリアし、再試行させる。
-                diagram.error.clear();
+                // 幅が変わればエラー結果も変わりうるため、error 込みで破棄して再試行させる。
+                diagram.ResetForRetry();
                 any_invalidated = true;
             }
             if (any_invalidated) {

--- a/src/layout/layout_cache.cpp
+++ b/src/layout/layout_cache.cpp
@@ -231,6 +231,7 @@ void LayoutCache::InvalidateAllDiagramBitmaps() noexcept
 {
     for (auto& d : diagrams_) {
         d.bitmap.Reset();
+        d.error.clear();
     }
 }
 
@@ -243,6 +244,7 @@ void LayoutCache::InvalidateDiagramBitmaps(const std::pmr::vector<Node>& nodes) 
         }
         if (IsDiagramLanguage(node.code_language())) {
             diagrams_[static_cast<size_t>(idx)].bitmap.Reset();
+            diagrams_[static_cast<size_t>(idx)].error.clear();
         }
     }
 }

--- a/src/layout/layout_cache.cpp
+++ b/src/layout/layout_cache.cpp
@@ -230,8 +230,7 @@ void LayoutCache::InvalidateEffectsAndDiagramBitmaps(const std::pmr::vector<Node
 void LayoutCache::InvalidateAllDiagramBitmaps() noexcept
 {
     for (auto& d : diagrams_) {
-        d.bitmap.Reset();
-        d.error.clear();
+        d.ResetForRetry();
     }
 }
 
@@ -243,8 +242,7 @@ void LayoutCache::InvalidateDiagramBitmaps(const std::pmr::vector<Node>& nodes) 
             continue;
         }
         if (IsDiagramLanguage(node.code_language())) {
-            diagrams_[static_cast<size_t>(idx)].bitmap.Reset();
-            diagrams_[static_cast<size_t>(idx)].error.clear();
+            diagrams_[static_cast<size_t>(idx)].ResetForRetry();
         }
     }
 }

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -217,6 +217,10 @@ struct DiagramEntry {
     // クリップボードコピー用の元 PNG。bitmap と同時に設定/破棄されるため、
     // コピーボタンの表示条件 (bitmap 有無) とデータの有無が常に一致する。
     std::shared_ptr<const std::pmr::vector<uint8_t>> png;
+    // レンダリング失敗時のエラーメッセージ (表示用整形済み)。非空 = 失敗確定で、
+    // プレースホルダにこの文言を表示し再リクエストを止める。リロード・幅変更・
+    // テーマ変更でクリアされ再試行の契機になる。オフスクリーン evict では保持する。
+    std::pmr::wstring error;
 };
 
 class LayoutCache {

--- a/src/layout/layout_cache.h
+++ b/src/layout/layout_cache.h
@@ -221,6 +221,23 @@ struct DiagramEntry {
     // プレースホルダにこの文言を表示し再リクエストを止める。リロード・幅変更・
     // テーマ変更でクリアされ再試行の契機になる。オフスクリーン evict では保持する。
     std::pmr::wstring error;
+
+    // 未確定 (成功も失敗もしていない) でレンダ要求すべき状態か。
+    bool NeedsRender() const noexcept
+    {
+        return !bitmap && error.empty();
+    }
+
+    // レンダ結果 (成功/失敗とも) を破棄し再試行可能に戻す。幅変更・テーマ変更用。
+    // オフスクリーン evict は bitmap のみ破棄する別意図なのでこれを使わない。
+    void ResetForRetry() noexcept
+    {
+        bitmap.Reset();
+        width = 0.0f;
+        height = 0.0f;
+        png.reset();
+        error.clear();
+    }
 };
 
 class LayoutCache {

--- a/src/mermaid/mermaid.cpp
+++ b/src/mermaid/mermaid.cpp
@@ -11,6 +11,7 @@
 #include "wic_util.h"
 #include "resource.h"
 #include "ascii_util.h"
+#include "i18n.h"
 #include <wrl/event.h>
 #include <filesystem>
 #include <functional>
@@ -329,6 +330,20 @@ void MermaidRenderer::ClearCache()
     cache_.Clear();
 }
 
+void MermaidRenderer::SetDiagramError(RenderRequest& req, std::wstring_view msg)
+{
+    if (req.svg_only || !req.diagram_entry) {
+        return;
+    }
+    // DrawTextCmd の 255 文字上限とプレースホルダ高さ (約3行) に収まる長さ。
+    constexpr size_t MAX_ERROR_LEN = 200;
+    auto sanitized = mermaid_util::SanitizeErrorMessage(msg, MAX_ERROR_LEN);
+    if (sanitized.empty()) {
+        sanitized = i18n::S().diagram_error;
+    }
+    req.diagram_entry->error = std::move(sanitized);
+}
+
 void MermaidRenderer::InvokeSvgCallbackIfAny(RenderRequest& req, std::pmr::wstring svg, bool cancelled)
 {
     if (!req.svg_only) {
@@ -377,9 +392,18 @@ void MermaidRenderer::RecoverWorker(int index)
     // 契機が無く図が Loading のまま固着するためキューに戻す。クラッシュを誘発する
     // 入力での再起動ループは retried で 1 回に打ち切る。
     InvokeSvgCallbackIfAny(w.current_request, {}, false);
-    if (!w.current_request.svg_only && w.current_request.node && !w.current_request.retried) {
-        w.current_request.retried = true;
-        pending_requests_.push(std::move(w.current_request));
+    Callback failed_cb;
+    if (!w.current_request.svg_only && w.current_request.node) {
+        if (!w.current_request.retried) {
+            w.current_request.retried = true;
+            pending_requests_.push(std::move(w.current_request));
+        }
+        else {
+            // リトライ済みの再クラッシュ。エラー確定にしないと Loading 固着かつ
+            // 完了通知も出ないため、汎用エラーを設定し on_complete で再描画させる。
+            SetDiagramError(w.current_request, {});
+            failed_cb = std::move(w.current_request.on_complete);
+        }
     }
     w.current_request = {};
     w.rendering = false;
@@ -394,6 +418,10 @@ void MermaidRenderer::RecoverWorker(int index)
     if (webview_env_ && w.init_retries < MAX_WORKER_RETRIES) {
         ++w.init_retries;
         SetupWorker(index);
+    }
+    // ワーカー状態の復旧が済んでから呼び、再入 (recompute → RequestRender) を安全にする。
+    if (failed_cb) {
+        failed_cb();
     }
 }
 
@@ -644,6 +672,7 @@ void MermaidRenderer::DispatchWebMessage(int index, const mermaid_util::ParsedWe
         return;
     case WebMessageKind::RenderError:
         if (req_id_match) {
+            SetDiagramError(w.current_request, req.has_payload ? req.payload : std::wstring_view{});
             InvokeSvgCallbackIfAny(w.current_request, {}, false);
             FinishWorkerRequest(w);
         }
@@ -675,6 +704,9 @@ void MermaidRenderer::OnRenderResult(int worker_idx, std::wstring_view json)
     const bool ok = mermaid_util::ParseJsonTrueFlag(json, L"\"ok\"");
 
     if (!ok || dw <= 0 || dh <= 0) {
+        // JS 側 renderMermaid が返す {ok:false, error:...} の内容をプレースホルダに
+        // 表示させる。放置すると「読み込み中」のまま固着する (issue #271)。
+        SetDiagramError(w.current_request, mermaid_util::ParseJsonString(json, L"\"error\""));
         FinishWorkerRequest(w);
         return;
     }

--- a/src/mermaid/mermaid.h
+++ b/src/mermaid/mermaid.h
@@ -101,6 +101,10 @@ private:
     // 同じパターン（cancel / render-error / svg-result の各経路）を1か所に集約する。
     static void InvokeSvgCallbackIfAny(RenderRequest& req, std::pmr::wstring svg, bool cancelled);
 
+    // 表示用リクエストの diagram_entry にエラーを確定させる。msg が空なら i18n の
+    // 汎用文言を入れ、「非空 = 失敗」の不変条件を保つ (issue #271)。
+    static void SetDiagramError(RenderRequest& req, std::wstring_view msg);
+
     struct CachedBitmap;
     // キャッシュヒット時に layout_entry / diagram_entry の各フィールドを更新する。
     static void ApplyCachedBitmap(NodeLayoutEntry& layout_entry, DiagramEntry& diagram_entry, const CachedBitmap& cached) noexcept;

--- a/src/mermaid/mermaid_util.cpp
+++ b/src/mermaid/mermaid_util.cpp
@@ -323,8 +323,10 @@ std::pmr::wstring mermaid_util::SanitizeErrorMessage(std::wstring_view msg, size
         }
         prev_space = false;
         result += c;
-        if (result.size() >= max_len && i + 1 < msg.size()) {
-            truncated = true;
+        if (result.size() >= max_len) {
+            // 残りが空白のみなら実質切り詰め無しなので省略記号を付けない。
+            const auto rest = msg.substr(i + 1);
+            truncated = std::ranges::any_of(rest, [](wchar_t r) { return r > L' '; });
             break;
         }
     }

--- a/src/mermaid/mermaid_util.cpp
+++ b/src/mermaid/mermaid_util.cpp
@@ -285,16 +285,7 @@ std::pmr::wstring mermaid_util::ParseJsonString(std::wstring_view json, std::wst
                 break;
             }
             unsigned int cp = 0;
-            bool valid = true;
-            for (int i = 0; i < 4; ++i) {
-                const wchar_t h = json[pos + i];
-                cp <<= 4;
-                if (h >= L'0' && h <= L'9') { cp |= static_cast<unsigned int>(h - L'0'); }
-                else if (h >= L'a' && h <= L'f') { cp |= static_cast<unsigned int>(h - L'a' + 10); }
-                else if (h >= L'A' && h <= L'F') { cp |= static_cast<unsigned int>(h - L'A' + 10); }
-                else { valid = false; break; }
-            }
-            if (!valid) {
+            if (ascii_util::from_chars(json.data() + pos, 4, cp, 16u) != json.data() + pos + 4) {
                 return result;
             }
             pos += 4;
@@ -322,7 +313,8 @@ std::pmr::wstring mermaid_util::SanitizeErrorMessage(std::wstring_view msg, size
     bool truncated = false;
     for (size_t i = 0; i < msg.size(); ++i) {
         const wchar_t c = msg[i];
-        if (c == L'\n' || c == L'\r' || c == L'\t' || c == L' ') {
+        // 改行・タブに加え、JSON の \u00XX から復元された制御文字 (豆腐表示になる) も空白に潰す。
+        if (c <= L' ') {
             if (!prev_space) {
                 result += L' ';
                 prev_space = true;

--- a/src/mermaid/mermaid_util.cpp
+++ b/src/mermaid/mermaid_util.cpp
@@ -243,6 +243,108 @@ bool mermaid_util::ParseJsonTrueFlag(std::wstring_view json, std::wstring_view k
     return json.compare(pos, kTrue.size(), kTrue) == 0;
 }
 
+std::pmr::wstring mermaid_util::ParseJsonString(std::wstring_view json, std::wstring_view key)
+{
+    std::pmr::wstring result;
+    auto pos = ascii_util::Find(json, key);
+    if (pos == ascii_util::npos) {
+        return result;
+    }
+    pos = json.find_first_not_of(L": "sv, pos + key.size());
+    if (pos == std::wstring_view::npos || json[pos] != L'"') {
+        return result;
+    }
+    ++pos;
+
+    std::pmr::wstring buf;
+    bool closed = false;
+    while (pos < json.size()) {
+        const wchar_t c = json[pos];
+        if (c == L'"') {
+            closed = true;
+            break;
+        }
+        if (c != L'\\') {
+            buf += c;
+            ++pos;
+            continue;
+        }
+        if (++pos >= json.size()) {
+            break;
+        }
+        const wchar_t esc = json[pos++];
+        switch (esc) {
+        case L'n': buf += L'\n'; break;
+        case L'r': buf += L'\r'; break;
+        case L't': buf += L'\t'; break;
+        case L'b': buf += L'\b'; break;
+        case L'f': buf += L'\f'; break;
+        case L'u': {
+            if (json.size() - pos < 4) {
+                pos = json.size();
+                break;
+            }
+            unsigned int cp = 0;
+            bool valid = true;
+            for (int i = 0; i < 4; ++i) {
+                const wchar_t h = json[pos + i];
+                cp <<= 4;
+                if (h >= L'0' && h <= L'9') { cp |= static_cast<unsigned int>(h - L'0'); }
+                else if (h >= L'a' && h <= L'f') { cp |= static_cast<unsigned int>(h - L'a' + 10); }
+                else if (h >= L'A' && h <= L'F') { cp |= static_cast<unsigned int>(h - L'A' + 10); }
+                else { valid = false; break; }
+            }
+            if (!valid) {
+                return result;
+            }
+            pos += 4;
+            // サロゲートペアもそのまま格納する (wchar_t は UTF-16)。
+            buf += static_cast<wchar_t>(cp);
+            break;
+        }
+        default:
+            // \" \\ \/ およびその他は文字そのまま。
+            buf += esc;
+            break;
+        }
+    }
+    if (closed) {
+        result = std::move(buf);
+    }
+    return result;
+}
+
+std::pmr::wstring mermaid_util::SanitizeErrorMessage(std::wstring_view msg, size_t max_len)
+{
+    std::pmr::wstring result;
+    result.reserve((std::min)(msg.size(), max_len));
+    bool prev_space = true; // 先頭の空白は落とす
+    bool truncated = false;
+    for (size_t i = 0; i < msg.size(); ++i) {
+        const wchar_t c = msg[i];
+        if (c == L'\n' || c == L'\r' || c == L'\t' || c == L' ') {
+            if (!prev_space) {
+                result += L' ';
+                prev_space = true;
+            }
+            continue;
+        }
+        prev_space = false;
+        result += c;
+        if (result.size() >= max_len && i + 1 < msg.size()) {
+            truncated = true;
+            break;
+        }
+    }
+    while (!result.empty() && result.back() == L' ') {
+        result.pop_back();
+    }
+    if (truncated && !result.empty()) {
+        result.back() = L'…';
+    }
+    return result;
+}
+
 uint64_t mermaid_util::NodeDiagramHash(const Node& node, float max_width, bool dark_mode) noexcept
 {
     // LatexMath を Mermaid とキャッシュ衝突させないためのソルト（任意の定数）。

--- a/src/mermaid/mermaid_util.h
+++ b/src/mermaid/mermaid_util.h
@@ -27,6 +27,14 @@ uint64_t HashCode(std::string_view code, float max_width, bool dark_mode) noexce
 float ParseJsonNumber(std::wstring_view json, std::wstring_view key) noexcept;
 bool ParseJsonTrueFlag(std::wstring_view json, std::wstring_view key) noexcept;
 
+// JSON 文字列値を取り出し、エスケープ (\" \\ \/ \n \r \t \b \f \uXXXX) を復元する。
+// キーが無い・値が文字列でない・閉じ引用符が無い場合は空を返す。
+std::pmr::wstring ParseJsonString(std::wstring_view json, std::wstring_view key);
+
+// エラーメッセージの表示用整形: 改行・タブを空白1個に潰し、max_len で切り詰める
+// (DrawTextCmd の 255 文字上限内に収める)。切り詰め時は末尾に U+2026 を付ける。
+std::pmr::wstring SanitizeErrorMessage(std::wstring_view msg, size_t max_len);
+
 struct RequestPrefix {
     unsigned int id = 0;
     std::wstring_view payload;

--- a/src/mermaid/mermaid_util.h
+++ b/src/mermaid/mermaid_util.h
@@ -31,8 +31,8 @@ bool ParseJsonTrueFlag(std::wstring_view json, std::wstring_view key) noexcept;
 // キーが無い・値が文字列でない・閉じ引用符が無い場合は空を返す。
 std::pmr::wstring ParseJsonString(std::wstring_view json, std::wstring_view key);
 
-// エラーメッセージの表示用整形: 改行・タブを空白1個に潰し、max_len で切り詰める
-// (DrawTextCmd の 255 文字上限内に収める)。切り詰め時は末尾に U+2026 を付ける。
+// エラーメッセージの表示用整形: 空白・改行・制御文字の連続を空白1個に潰し、max_len で
+// 切り詰める (DrawTextCmd の 255 文字上限内に収める)。切り詰め時は末尾に U+2026 を付ける。
 std::pmr::wstring SanitizeErrorMessage(std::wstring_view msg, size_t max_len);
 
 struct RequestPrefix {

--- a/src/render/command_generator.cpp
+++ b/src/render/command_generator.cpp
@@ -261,7 +261,7 @@ void CommandGenerator::GenerateNode(
                 GenDiagramCopyButton(cmds, bmp.right, bmp.top, node_index == fc.hovered.diagram_copy);
             }
             else {
-                GenDiagramPlaceholder(cmds, x, entry_text_top, cw, entry.height);
+                GenDiagramPlaceholder(cmds, x, entry_text_top, cw, entry.height, diagram.error);
             }
             return;
         }
@@ -622,13 +622,18 @@ void CommandGenerator::GenBlockQuoteGroupDecorations(DrawCommandList& cmds, cons
     }
 }
 
-void CommandGenerator::GenDiagramPlaceholder(DrawCommandList& cmds, float x, float y, float w, float h)
+void CommandGenerator::GenDiagramPlaceholder(DrawCommandList& cmds, float x, float y, float w, float h, std::wstring_view error)
 {
     const D2D1_RECT_F bg = D2D1::RectF(x, y, x + w, y + h);
     cmds.emplace_back(FillRoundedRectCmd{ bg, CODE_BLOCK_CORNER, CODE_BLOCK_CORNER, theme_->code_bg_color, BrushId::CodeBg });
-    if (formats_.placeholder_text) {
-        const auto loading_text = i18n::S().loading;
-        cmds.emplace_back(MakeTextCmd(loading_text.data(), loading_text.size(), bg, formats_.placeholder_text, theme_->blockquote_text_color, BrushId::BlockquoteText));
+    if (!formats_.placeholder_text) {
+        return;
     }
+    if (!error.empty()) {
+        cmds.emplace_back(MakeTextCmd(error.data(), error.size(), bg, formats_.placeholder_text, theme_->alert_color[AlertColorIndex(AlertType::Caution)], BrushId::AlertCaution));
+        return;
+    }
+    const auto loading_text = i18n::S().loading;
+    cmds.emplace_back(MakeTextCmd(loading_text.data(), loading_text.size(), bg, formats_.placeholder_text, theme_->blockquote_text_color, BrushId::BlockquoteText));
 }
 

--- a/src/render/command_generator.h
+++ b/src/render/command_generator.h
@@ -186,7 +186,8 @@ private:
     void EmitBlockHScrollbarIfActive(DrawCommandList& cmds, const FrameContext& fc, int node_index, float block_x, float bar_y, const BlockHScrollGeometry& geom, float scroll_x);
     void GenListBullet(DrawCommandList& cmds, const FrameContext& fc, const Node& node, const NodeLayoutEntry& entry, float x, float entry_text_top);
     void GenBlockQuoteGroupDecorations(DrawCommandList& cmds, const FrameContext& fc, const std::pmr::vector<Node>& nodes, const LayoutCache& cache, int node_count, int first_visible);
-    void GenDiagramPlaceholder(DrawCommandList& cmds, float x, float y, float w, float h);
+    // error 非空時は「読み込み中...」の代わりにエラーメッセージを表示する (issue #271)。
+    void GenDiagramPlaceholder(DrawCommandList& cmds, float x, float y, float w, float h, std::wstring_view error = {});
     void EmitHighlightRects(DrawCommandList& cmds, IDWriteTextLayout* layout, uint32_t start, uint32_t length, float origin_x, float origin_y, D2D1_COLOR_F color, BrushId brush_id = BrushId::Custom);
     // HitTestTextRange の結果をレイアウト原点相対の D2D1_RECT_F に変換し out へ append する。
     // SearchHlCache / SelectionHlCache の rebuild に共用する。

--- a/src/util/i18n.h
+++ b/src/util/i18n.h
@@ -71,6 +71,9 @@ struct Strings {
     // ローディング
     std::wstring_view loading;
 
+    // ダイアグラム描画エラー (詳細メッセージが取れなかった場合のフォールバック)
+    std::wstring_view diagram_error;
+
     // ヘルプリソースID
     UINT help_resource_id;
 };
@@ -128,6 +131,8 @@ inline constexpr Strings kJa = {
     L"コピーに失敗しました",
     // ローディング
     L"読み込み中...",
+    // ダイアグラム描画エラー
+    L"図の描画に失敗しました",
     // ヘルプリソースID
     IDR_HELP_MD,
 };
@@ -185,6 +190,8 @@ inline constexpr Strings kEn = {
     L"Copy failed",
     // ローディング
     L"Loading...",
+    // ダイアグラム描画エラー
+    L"Failed to render diagram",
     // ヘルプリソースID
     IDR_HELP_EN_MD,
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,7 @@ add_executable(mendo_tests
     test_command_generator_frame.cpp
     test_command_generator_content.cpp
     test_command_generator_highlight.cpp
+    test_diagram_placeholder.cpp
     test_measurer_parity.cpp
     test_command_executor.cpp
     test_resource_manager.cpp

--- a/tests/test_diagram_placeholder.cpp
+++ b/tests/test_diagram_placeholder.cpp
@@ -1,0 +1,89 @@
+// ダイアグラムプレースホルダのエラー表示 (issue #271)。
+// DrawTextCmd の内容検証に実 IDWriteTextFormat が必要なため DWriteTestBase を使う。
+#include <gtest/gtest.h>
+#include "dwrite_test_base.h"
+#include "command_generator.h"
+#include "draw_command.h"
+#include "i18n.h"
+#include "syntax.h"
+#include <variant>
+
+using Microsoft::WRL::ComPtr;
+
+namespace {
+
+class DiagramPlaceholderTest : public DWriteTestBase {
+protected:
+    CommandGenerator gen_;
+    ComPtr<IDWriteTextFormat> placeholder_fmt_;
+    std::pmr::vector<DWRITE_HIT_TEST_METRICS> hit_test_buffer_;
+
+    void SetUp() override
+    {
+        DWriteTestBase::SetUp();
+        const HRESULT hr = dwrite_factory_->CreateTextFormat(
+            theme_.font_family.c_str(), nullptr,
+            DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STYLE_NORMAL,
+            DWRITE_FONT_STRETCH_NORMAL, theme_.font_size_body,
+            L"ja-jp", &placeholder_fmt_);
+        ASSERT_TRUE(SUCCEEDED(hr));
+        gen_.SetTheme(&theme_);
+        gen_.SetFormats({ nullptr, nullptr, nullptr, placeholder_fmt_.Get() });
+        gen_.SetHitTestBuffer(&hit_test_buffer_);
+    }
+
+    // 生成コマンドから最初の DrawTextCmd のテキストを返す (無ければ空)。
+    static std::wstring_view FirstDrawText(const DrawCommandList& cmds)
+    {
+        for (const auto& c : cmds) {
+            if (auto* t = std::get_if<DrawTextCmd>(&c)) {
+                return { t->text(), t->text_len };
+            }
+        }
+        return {};
+    }
+};
+
+} // namespace
+
+TEST_F(DiagramPlaceholderTest, NoErrorShowsLoadingText)
+{
+    auto pl = ParseAndLayout("```mermaid\ngraph TD;A-->B\n```\n");
+    ASSERT_FALSE(pl.nodes.empty());
+
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
+    auto& cmds = gen_.GenerateMdPane(pl.nodes, pl.cache, pane, 0.0f, TextSelection{});
+
+    EXPECT_EQ(FirstDrawText(cmds), i18n::S().loading);
+}
+
+TEST_F(DiagramPlaceholderTest, ErrorShowsErrorMessageInCautionColor)
+{
+    auto pl = ParseAndLayout("```mermaid\ngraph TD;A-->B\n```\n");
+    ASSERT_FALSE(pl.nodes.empty());
+
+    // 最初の diagram ノードにエラーを設定
+    bool found = false;
+    for (size_t i = 0; i < pl.nodes.size(); ++i) {
+        if (pl.nodes[i].type == NodeType::CodeBlock && IsDiagramLanguage(pl.nodes[i].code_language())) {
+            pl.cache.GetDiagram(i).error = L"Parse error on line 1";
+            found = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(found);
+
+    const PaneRect pane{ 0.0f, 0.0f, 800.0f, 600.0f };
+    auto& cmds = gen_.GenerateMdPane(pl.nodes, pl.cache, pane, 0.0f, TextSelection{});
+
+    const DrawTextCmd* error_cmd = nullptr;
+    for (const auto& c : cmds) {
+        if (auto* t = std::get_if<DrawTextCmd>(&c)) {
+            error_cmd = t;
+            break;
+        }
+    }
+    ASSERT_NE(error_cmd, nullptr);
+    EXPECT_EQ(std::wstring_view(error_cmd->text(), error_cmd->text_len), L"Parse error on line 1");
+    EXPECT_EQ(error_cmd->brush_id, BrushId::AlertCaution);
+}

--- a/tests/test_layout_cache.cpp
+++ b/tests/test_layout_cache.cpp
@@ -93,6 +93,22 @@ TEST(LayoutCacheTest, InvalidateAllLayoutsPreservesDiagramEntries)
     EXPECT_FLOAT_EQ(cache.GetDiagram(1).height, 250.0f);
 }
 
+// テーマ変更等の全ダイアグラム無効化でエラー状態もクリアされ、
+// 再試行の契機になることを検証する (issue #271)。
+TEST(LayoutCacheTest, InvalidateAllDiagramBitmapsClearsError)
+{
+    LayoutCache cache;
+    cache.Resize(2);
+
+    cache.GetDiagram(0).error = L"Parse error on line 1";
+    cache.GetDiagram(1).error = L"Parse error on line 3";
+
+    cache.InvalidateAllDiagramBitmaps();
+
+    EXPECT_TRUE(cache.GetDiagram(0).error.empty());
+    EXPECT_TRUE(cache.GetDiagram(1).error.empty());
+}
+
 // SetBlockHeight 経由で Fenwick が更新され、GetBlockTop /
 // GetTotalHeightFromFenwick が margin_top を考慮した正しい値を返すことを検証する。
 TEST(LayoutCacheTest, BlockHeightFenwickRoundTrip)

--- a/tests/test_mermaid_util.cpp
+++ b/tests/test_mermaid_util.cpp
@@ -485,6 +485,12 @@ TEST(SanitizeErrorMessage, CollapsesWhitespaceRuns)
               L"Parse error on line 2: ----^ got 'X'");
 }
 
+TEST(SanitizeErrorMessage, CollapsesControlChars)
+{
+    // JSON の \u00XX から復元された制御文字 (垂直タブ・ESC 等) も豆腐表示にせず空白に潰す
+    EXPECT_EQ(mermaid_util::SanitizeErrorMessage(L"got\x0b\x1bhere", 100), L"got here");
+}
+
 TEST(SanitizeErrorMessage, TrimsLeadingAndTrailingWhitespace)
 {
     EXPECT_EQ(mermaid_util::SanitizeErrorMessage(L"  \n boom \n ", 100), L"boom");

--- a/tests/test_mermaid_util.cpp
+++ b/tests/test_mermaid_util.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 #include "mermaid_util.h"
 
+using namespace std::literals;
+
 // ============================================================
 // JsEscape テスト
 // ============================================================
@@ -403,6 +405,105 @@ TEST(ParseJsonTrueFlag, KeyWithoutColonReturnsFalse)
 {
     // キー直後にコロンが来ない異常形式は false
     EXPECT_FALSE(mermaid_util::ParseJsonTrueFlag(L"\"ok\" true", L"\"ok\""));
+}
+
+// ============================================================
+// ParseJsonString テスト
+// ============================================================
+
+TEST(ParseJsonString, MissingKeyReturnsEmpty)
+{
+    EXPECT_TRUE(mermaid_util::ParseJsonString(L"{\"ok\":false}", L"\"error\"").empty());
+}
+
+TEST(ParseJsonString, EmptyJsonReturnsEmpty)
+{
+    EXPECT_TRUE(mermaid_util::ParseJsonString(L"", L"\"error\"").empty());
+}
+
+TEST(ParseJsonString, BasicString)
+{
+    EXPECT_EQ(mermaid_util::ParseJsonString(L"{\"ok\":false,\"error\":\"boom\"}", L"\"error\""), L"boom");
+}
+
+TEST(ParseJsonString, AllowsSpaceAfterColon)
+{
+    EXPECT_EQ(mermaid_util::ParseJsonString(L"{\"error\": \"boom\"}", L"\"error\""), L"boom");
+}
+
+TEST(ParseJsonString, NonStringValueReturnsEmpty)
+{
+    EXPECT_TRUE(mermaid_util::ParseJsonString(L"{\"error\":123}", L"\"error\"").empty());
+}
+
+TEST(ParseJsonString, UnterminatedStringReturnsEmpty)
+{
+    EXPECT_TRUE(mermaid_util::ParseJsonString(L"{\"error\":\"boom", L"\"error\"").empty());
+}
+
+TEST(ParseJsonString, UnescapesCommonEscapes)
+{
+    EXPECT_EQ(mermaid_util::ParseJsonString(L"{\"error\":\"a\\nb\\t\\\"c\\\"\\\\d\"}", L"\"error\""),
+              L"a\nb\t\"c\"\\d");
+}
+
+TEST(ParseJsonString, UnescapesUnicodeEscape)
+{
+    EXPECT_EQ(mermaid_util::ParseJsonString(L"{\"error\":\"\\u0041\\u3042\"}", L"\"error\""), L"Aあ");
+}
+
+TEST(ParseJsonString, InvalidUnicodeEscapeReturnsEmpty)
+{
+    EXPECT_TRUE(mermaid_util::ParseJsonString(L"{\"error\":\"\\uZZZZ\"}", L"\"error\"").empty());
+}
+
+TEST(ParseJsonString, MermaidParseErrorMessage)
+{
+    // JSON.stringify が生成する実際のエラー形式 (改行は \n にエスケープされる)
+    const auto json = L"{\"ok\":false,\"error\":\"Parse error on line 2:\\n...graph TD\\n----^\\nExpecting 'SEMI'\"}"sv;
+    EXPECT_EQ(mermaid_util::ParseJsonString(json, L"\"error\""),
+              L"Parse error on line 2:\n...graph TD\n----^\nExpecting 'SEMI'");
+}
+
+// ============================================================
+// SanitizeErrorMessage テスト
+// ============================================================
+
+TEST(SanitizeErrorMessage, EmptyReturnsEmpty)
+{
+    EXPECT_TRUE(mermaid_util::SanitizeErrorMessage(L"", 100).empty());
+}
+
+TEST(SanitizeErrorMessage, PlainTextUnchanged)
+{
+    EXPECT_EQ(mermaid_util::SanitizeErrorMessage(L"simple error", 100), L"simple error");
+}
+
+TEST(SanitizeErrorMessage, CollapsesWhitespaceRuns)
+{
+    EXPECT_EQ(mermaid_util::SanitizeErrorMessage(L"Parse error on line 2:\n\n----^\t got 'X'", 100),
+              L"Parse error on line 2: ----^ got 'X'");
+}
+
+TEST(SanitizeErrorMessage, TrimsLeadingAndTrailingWhitespace)
+{
+    EXPECT_EQ(mermaid_util::SanitizeErrorMessage(L"  \n boom \n ", 100), L"boom");
+}
+
+TEST(SanitizeErrorMessage, TruncatesWithEllipsis)
+{
+    const auto result = mermaid_util::SanitizeErrorMessage(L"abcdefghij", 5);
+    EXPECT_EQ(result, L"abcd…");
+}
+
+TEST(SanitizeErrorMessage, ExactMaxLenNotTruncated)
+{
+    EXPECT_EQ(mermaid_util::SanitizeErrorMessage(L"abcde", 5), L"abcde");
+}
+
+TEST(SanitizeErrorMessage, WhitespaceOnlyReturnsEmpty)
+{
+    EXPECT_TRUE(mermaid_util::SanitizeErrorMessage(L" \n\t ", 100).empty());
 }
 
 // ============================================================

--- a/tests/test_mermaid_util.cpp
+++ b/tests/test_mermaid_util.cpp
@@ -507,6 +507,12 @@ TEST(SanitizeErrorMessage, ExactMaxLenNotTruncated)
     EXPECT_EQ(mermaid_util::SanitizeErrorMessage(L"abcde", 5), L"abcde");
 }
 
+TEST(SanitizeErrorMessage, TrailingWhitespaceOnlyAfterMaxLenNotTruncated)
+{
+    // max_len 到達後の残りが空白のみなら実質切り詰め無し → 省略記号を付けない
+    EXPECT_EQ(mermaid_util::SanitizeErrorMessage(L"abcde \n\t ", 5), L"abcde");
+}
+
 TEST(SanitizeErrorMessage, WhitespaceOnlyReturnsEmpty)
 {
     EXPECT_TRUE(mermaid_util::SanitizeErrorMessage(L" \n\t ", 100).empty());

--- a/tests/test_resource_manager.cpp
+++ b/tests/test_resource_manager.cpp
@@ -379,6 +379,46 @@ TEST_F(ResourceManagerTest, RequestMermaidRendersZeroWidthIsNoOp)
     EXPECT_EQ(mock_mermaid_.request_render_count, 0);
 }
 
+// エラー確定 (error 非空) の図は再リクエストされない (issue #271: 失敗レンダの無限リトライ防止)。
+TEST_F(ResourceManagerTest, RequestMermaidRendersSkipsErroredDiagram)
+{
+    LoadMarkdown("```mermaid\ngraph TD;A-->B\n```\n");
+    ASSERT_FALSE(doc_.GetDiagramNodeIndices().empty());
+    cache_.GetDiagram(doc_.GetDiagramNodeIndices()[0]).error = L"Parse error on line 1";
+
+    EXPECT_EQ(rm_.RequestMermaidRenders(), 0);
+    EXPECT_EQ(mock_mermaid_.request_render_count, 0);
+}
+
+TEST_F(ResourceManagerTest, ProcessMermaidBatchSkipsErroredDiagram)
+{
+    LoadMarkdown("```mermaid\ngraph TD;A-->B\n```\n");
+    ASSERT_FALSE(doc_.GetDiagramNodeIndices().empty());
+    cache_.GetDiagram(doc_.GetDiagramNodeIndices()[0]).error = L"Parse error on line 1";
+
+    rm_.ProcessMermaidBatch();
+    EXPECT_EQ(mock_mermaid_.request_render_count, 0);
+}
+
+// 量子化幅の変化でエラーがクリアされ、再試行される (issue #271)。
+TEST_F(ResourceManagerTest, InvalidateMermaidForWidthChangeClearsError)
+{
+    LoadMarkdown("```mermaid\ngraph TD;A-->B\n```\n");
+    ASSERT_FALSE(doc_.GetDiagramNodeIndices().empty());
+    const size_t diagram_index = doc_.GetDiagramNodeIndices()[0];
+
+    tracker_.content_width = 800.0f;
+    rm_.RequestMermaidRenders();
+    ASSERT_EQ(mock_mermaid_.request_render_count, 1);
+
+    cache_.GetDiagram(diagram_index).error = L"Parse error on line 1";
+
+    tracker_.content_width = 1000.0f;
+    rm_.RequestMermaidRenders();
+    EXPECT_TRUE(cache_.GetDiagram(diagram_index).error.empty());
+    EXPECT_EQ(mock_mermaid_.request_render_count, 2);
+}
+
 TEST_F(ResourceManagerTest, RequestMermaidRendersUsesDarkModeFromThemeService)
 {
     LoadMarkdown("```mermaid\ngraph TD;A-->B\n```\n");


### PR DESCRIPTION
Closes #271

## 概要

mermaid 図の描画でエラーが出た際、プレースホルダが「読み込み中...」のまま固着して失敗が分からない問題を修正し、エラーメッセージを表示するようにした。

## 変更内容

- **`DiagramEntry` に `error` を追加** — 非空 = 失敗確定の3状態化 (未完了 / 成功 / 失敗)。プレースホルダは error 非空時に AlertCaution 色でメッセージを表示する
- **エラーの伝搬** — JS 側 `renderMermaid` が返す `{ok:false, error:...}` と `render-error:` postMessage の payload を、新設の `mermaid_util::ParseJsonString` (JSON エスケープ復元) + `SanitizeErrorMessage` (改行潰し + 200 文字切り詰め) で整形して格納
- **`RecoverWorker` のリトライ切れ対応** — WebView2 再クラッシュ時に汎用エラーを確定させ `on_complete` を発火 (従来は完了通知も出ず Loading 固着)
- **無限リトライ防止** — エラー確定した図は `RequestMermaidRenders` / `ProcessMermaidBatch` で再リクエストしない (従来はスクロール等のたびに失敗レンダを繰り返していた)
- **再試行契機** — 量子化幅の変更・テーマ変更・リロードで error をクリアし、自然に再試行させる。オフスクリーン evict では保持

## テスト

- `ParseJsonString` / `SanitizeErrorMessage` の単体テスト (エスケープ復元・切り詰め等)
- エラー確定図の再リクエストスキップ / 幅変更でのクリア (test_resource_manager)
- テーマ変更でのクリア (test_layout_cache)
- プレースホルダのエラーテキスト描画 (test_diagram_placeholder, 実 DWrite)

全 2367 テスト成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QJFwU2YmYtotiXHTputDd